### PR TITLE
Disable sims workflow on PR

### DIFF
--- a/.github/workflows/protocol-sim.yml
+++ b/.github/workflows/protocol-sim.yml
@@ -2,9 +2,6 @@ name: Protocol Sims
 # Sims workflow runs multiple types of simulations (nondeterminism, import-export, after-import, multi-seed-short)
 # This workflow will run on all pushes to main, if a .go, .mod or .sum file have been changed
 on:  # yamllint disable-line rule:truthy
-  pull_request:
-    paths:
-      - 'protocol/**'
   push:
     branches:
       - main


### PR DESCRIPTION
In the old repo we didn't run this workflow on PRs to main (probably because it takes too long).

In the old repo we ran it on PRs to release branches, but we typically cp and push directly to release branch. So I feel good just running it on the branch. We can always reevaluate in the future.