### PR TITLE
[IND-335] Add untriggered orders to initial payload for subaccount messages.

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/orders-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/orders-controller.test.ts
@@ -503,8 +503,36 @@ describe('orders-controller#V4', () => {
         })}`,
       });
 
-      // Best effort opened order should be only order in response.
+      // Untriggered order should be only order in response.
       expect(response.body).toEqual([
+        postgresOrderToResponseObject({
+          ...untriggeredOrder,
+          id: OrderTable.uuid(
+            untriggeredOrder.subaccountId,
+            untriggeredOrder.clientId,
+            untriggeredOrder.clobPairId,
+            untriggeredOrder.orderFlags,
+          ),
+        }),
+      ]);
+
+      response = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/orders?${getQueryString({
+          ...defaultQueryParams,
+          status: [APIOrderStatusEnum.UNTRIGGERED, APIOrderStatusEnum.OPEN],
+        })}`,
+      });
+
+      // Untriggered order and open order should be in response.
+      expect(response.body).toEqual([
+        postgresAndRedisOrderToResponseObject(
+          {
+            ...testConstants.defaultOrder,
+            id: testConstants.defaultOrderId,
+          },
+          redisTestConstants.defaultRedisOrder,
+        ),
         postgresOrderToResponseObject({
           ...untriggeredOrder,
           id: OrderTable.uuid(

--- a/indexer/services/comlink/__tests__/helpers/helpers.ts
+++ b/indexer/services/comlink/__tests__/helpers/helpers.ts
@@ -89,10 +89,15 @@ export async function sendRequest({
   });
 }
 
-export function getQueryString(params: {[name: string]: string | number | undefined}): string {
+export function getQueryString(
+  params: {[name: string]: string | number | string[] | undefined},
+): string {
   const queryStrings: string[] = [];
-  _.forOwn(params, (value: string | number | undefined, key: string): void => {
-    if (value !== undefined) {
+  _.forOwn(params, (value: string | number | string[] | undefined, key: string): void => {
+    if (Array.isArray(value)) {
+      const commaSeparatedList: string = value.join(',');
+      queryStrings.push(`${key}=${commaSeparatedList}`);
+    } else if (value !== undefined) {
       queryStrings.push(`${key}=${value}`);
     }
   });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -928,7 +928,7 @@ fetch('https://indexer.v4testnet2.dydx.exchange/v4/orders?address=string&subacco
 |ticker|query|string|false|none|
 |side|query|[OrderSide](#schemaorderside)|false|none|
 |type|query|[OrderType](#schemaordertype)|false|none|
-|status|query|[APIOrderStatus](#schemaapiorderstatus)|false|none|
+|status|query|array[any]|false|none|
 |goodTilBlockBeforeOrAt|query|number(double)|false|none|
 |goodTilBlockTimeBeforeOrAt|query|[IsoString](#schemaisostring)|false|none|
 |returnLatestOrders|query|boolean|false|none|

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -1495,7 +1495,10 @@
             "name": "status",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/APIOrderStatus"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/APIOrderStatus"
+              }
             }
           },
           {

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -359,7 +359,7 @@ export interface GetOrderRequest {
 export interface ListOrderRequest extends SubaccountRequest, LimitRequest, TickerRequest {
   side?: OrderSide,
   type?: OrderType,
-  status?: OrderStatus,
+  status?: OrderStatus[],
   goodTilBlockBeforeOrAt?: number,
   goodTilBlockTimeBeforeOrAt?: IsoString,
   returnLatestOrders?: boolean,

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -45,7 +45,10 @@ describe('Subscriptions', () => {
     [Channel.V4_TRADES]: [invalidTicker],
   };
   const initialResponseUrlPatterns: Record<Channel, string[] | undefined> = {
-    [Channel.V4_ACCOUNTS]: ['/v4/addresses/.+/subaccountNumber/.+', '/v4/orders?.+OPEN'],
+    [Channel.V4_ACCOUNTS]: [
+      '/v4/addresses/.+/subaccountNumber/.+',
+      '/v4/orders?.+OPEN,UNTRIGGERED',
+    ],
     [Channel.V4_CANDLES]: ['/v4/candles/perpetualMarkets/.+?resolution=.+'],
     [Channel.V4_MARKETS]: ['/v4/perpetualMarkets'],
     [Channel.V4_ORDERBOOK]: ['/v4/orderbooks/perpetualMarket/.+'],

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -504,7 +504,7 @@ export class Subscriptions {
         // TODO(DEC-1462): Use the /active-orders endpoint once it's added.
         axiosRequest({
           method: RequestMethod.GET,
-          url: `${COMLINK_URL}/v4/orders?address=${address}&subaccountNumber=${subaccountNumber}&status=OPEN`,
+          url: `${COMLINK_URL}/v4/orders?address=${address}&subaccountNumber=${subaccountNumber}&status=OPEN,UNTRIGGERED`,
           timeout: config.INITIAL_GET_TIMEOUT_MS,
           transformResponse: (res) => res,
         }),


### PR DESCRIPTION
- Update the `orders` endpoint to take in an array of statuses when filtering orders
- Update `socks` to query for all `OPEN` and `UNTRIGGERED` orders when fetching the initial payload for the subaccounts channel