### PR TITLE
Remove github action changes

### DIFF
--- a/.github/workflows/indexer-build-and-push-testnet.yml
+++ b/.github/workflows/indexer-build-and-push-testnet.yml
@@ -3,9 +3,9 @@ name: Indexer Build & Push Images to AWS ECR for Testnet Branch
 on: # yamllint disable-line rule:truthy
   push:
     branches:
-      - releases/indexer/testnet
-      - 'release/indexer/[a-z]+/v[0-9]+.[0-9]+.x'  # e.g. release/ibctestnet/v1.0.x
-      - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
+      - releases/testnet
+      - 'release/[a-z]+/v[0-9]+.[0-9]+.x'  # e.g. release/ibctestnet/v1.0.x
+      - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
     # TODO(DEC-837): Customize github build and push to ECR by service with paths
 
 jobs:


### PR DESCRIPTION
Reverting [these changes](https://github.com/dydxprotocol/v4-chain/commit/6b10046bd4ed6e60317491b41948ab34858f3e3a), upon further inspection `release/indexer/v0.1.x` is covered previously by the second option. The problem with pushing tesnet images was the lack of a `testnet2` environment