### PR TITLE
Remove unnecessary protocol pushes

### DIFF
--- a/.github/workflows/protocol-build-and-push-snapshot.yml
+++ b/.github/workflows/protocol-build-and-push-snapshot.yml
@@ -1,9 +1,6 @@
 name: Protocol Build & Push Image to AWS ECR
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
-    paths:
-      - 'protocol/**'
   push:
     branches:
       - main


### PR DESCRIPTION
What this line did was for every pull request where there was a change to the `protocol/` directory, we would upload a snapshot to all dev and staging environments. This is superfluous and unnecessary.

Example:
https://github.com/dydxprotocol/v4-chain/pull/72
<img width="828" alt="CleanShot 2023-08-23 at 16 52 05@2x" src="https://github.com/dydxprotocol/v4-chain/assets/7007116/60e02b99-5918-4ca9-8288-376ceb91e2cc">

Also look at how often we push images now:
<img width="1410" alt="CleanShot 2023-08-23 at 16 57 37@2x" src="https://github.com/dydxprotocol/v4-chain/assets/7007116/a09054ab-0607-4f4d-bba0-8901597239d9">
