### PR TITLE
add or fix github workflow concurrency

### DIFF
--- a/.github/workflows/indexer-build-docker-image-check.yml
+++ b/.github/workflows/indexer-build-docker-image-check.yml
@@ -9,6 +9,11 @@ on:  # yamllint disable-line rule:truthy
       - main
       - 'release/[a-z]+/v[0-9]+.[0-9]+.x'  # e.g. release/ibctestnet/v1.0.x
       - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Build and push
   call-build-ecs-service-ender:

--- a/.github/workflows/indexer-build-test-coverage.yml
+++ b/.github/workflows/indexer-build-test-coverage.yml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
 # Ensure only a single instance of this workflow is running, and cancel any that are in-progress
 # before this workflow instance starts
 concurrency:
-  group: ${{ github.ref }}-build-test-coverage
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/indexer-lint.yml
+++ b/.github/workflows/indexer-lint.yml
@@ -8,10 +8,11 @@ on:  # yamllint disable-line rule:truthy
       - main
       - 'release/[a-z]+/v[0-9]+.[0-9]+.x'  # e.g. release/ibctestnet/v1.0.x
       - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
+
 # Ensure only a single instance of this workflow is running, and cancel any that are in-progress
 # before this workflow instance starts
 concurrency:
-  group: ${{ github.ref }}-lint
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -6,6 +6,11 @@ on:  # yamllint disable-line rule:truthy
       - main
       - 'release/[a-z]+/v[0-9]+.[0-9]+.x'  # e.g. release/ibctestnet/v1.0.x
       - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/protocol-container-tests.yml
+++ b/.github/workflows/protocol-container-tests.yml
@@ -9,6 +9,10 @@ on:  # yamllint disable-line rule:truthy
       - 'release/[a-z]+/v[0-9]+.[0-9]+.x'  # e.g. release/ibctestnet/v1.0.x
       - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   container-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/protocol-exchange-tests.yml
+++ b/.github/workflows/protocol-exchange-tests.yml
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
       - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/protocol-lint.yml
+++ b/.github/workflows/protocol-lint.yml
@@ -11,6 +11,12 @@ on:  # yamllint disable-line rule:truthy
       - 'release/[a-z]+/v[0-9]+.[0-9]+.x'  # e.g. release/ibctestnet/v1.0.x
       - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
 
+# Ensure only a single instance of this workflow is running, and cancel any that are in-progress
+# before this workflow instance starts
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Validates that the YAML files in the V4 repository are formatted properly.
   # The `validate-yaml` job will pass without running if no YAML files have been modified.

--- a/.github/workflows/protocol-release.yml
+++ b/.github/workflows/protocol-release.yml
@@ -8,7 +8,6 @@ on:  # yamllint disable-line rule:truthy
       - "v[0-9]+.[0-9]+.[0-9]+"  # e.g.: v1.0.1
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"  # e.g.: v1.0.1-rc1
 
-
 jobs:
   protocol-release:
     name: Create Release
@@ -88,7 +87,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-      
+
       - name: Install buf
         run: |
           BIN="/usr/local/bin" && \

--- a/.github/workflows/protocol-sim.yml
+++ b/.github/workflows/protocol-sim.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
       - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/protocol-test.yml
+++ b/.github/workflows/protocol-test.yml
@@ -9,6 +9,10 @@ on:  # yamllint disable-line rule:truthy
       - 'release/[a-z]+/v[0-9]+.[0-9]+.x'  # e.g. release/ibctestnet/v1.0.x
       - 'release/v[0-9]+.[0-9]+.x'  # e.g. release/v0.0.x
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Runs all unit tests and end-to-end cli tests
   unit-end-to-end-and-integration:

--- a/protocol/.github/workflows/release-sims.yml
+++ b/protocol/.github/workflows/release-sims.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       - "rc**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
I think some of our concurrency is broken. I will try to add/fix it. Right now it’s gated on `{{ github.ref }}` which I believe would limit it to 1 concurrent run per PR but also limits it to 1 concurrent run on `main`.

This PR should still allow only a single job to run at one time per PR (canceling the previous) but any number to run in-parallel on `main`