### PR TITLE
Remove race flag and reduce test search to specific package.

### DIFF
--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -232,7 +232,7 @@ test-cover:
 	@VERSION=$(VERSION) go test -mod=readonly -timeout 12m -coverprofile=coverage.out -covermode=atomic -coverpkg=github.com/dydxprotocol/v4-chain/protocol/... -tags='test_ledger_mock $(build_tags)' ./...
 
 test-exchanges:
-	@VERSION=$(VERSION) go test -mod=readonly -race -tags='test_ledger_mock exchange_tests $(build_tags)' ./... -run "TestQueryingActualExchanges"
+	@VERSION=$(VERSION) go test -mod=readonly -tags='test_ledger_mock exchange_tests $(build_tags)' github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/handler -run "TestQueryingActualExchanges"
 
 test-unit-and-integration:
 	@VERSION=$(VERSION) go test -mod=readonly -tags='integration_test test_ledger_mock $(build_tags)' ./...


### PR DESCRIPTION
Modify test_exchanges makefile target according to issues surfaced in [this thread](https://dydx-team.slack.com/archives/GTGEVSCUU/p1692891929566319).

This change eliminates the package scanning that takes up so much time [here](https://github.com/dydxprotocol/v4-chain/actions/runs/5967752828/job/16190083757). I also remove the race flag, which isn't really needed for such a simple test.