### PR TITLE
[CORE-475] Remove obsolete TODO

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/genaccounts.go
+++ b/protocol/cmd/dydxprotocold/cmd/genaccounts.go
@@ -62,7 +62,6 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 					clientCtx.HomeDir,
 					inBuf,
 					clientCtx.Codec,
-					// TODO(DEC-1131): specify options.
 				)
 				if err != nil {
 					return err


### PR DESCRIPTION
Originally, we thought supporting different signing algorithms was necessary when adding genesis accounts. However, the default signing algorithms should be sufficient. 

The default is `Secp256k1`. [See reference](https://github.com/cosmos/cosmos-sdk/blob/a429238fc267da88a8548bfebe0ba7fb28b82a13/crypto/keyring/keyring.go#L225-L226)