### PR TITLE
[bugfix] Sort market prices and params when getAll

### DIFF
--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"sort"
+
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -87,6 +89,11 @@ func (k Keeper) GetAllMarketParams(ctx sdk.Context) []types.MarketParam {
 		k.cdc.MustUnmarshal(iterator.Value(), &marketParam)
 		marketParams = append(marketParams, marketParam)
 	}
+
+	// Sort the market params to return them in ascending order based on Id.
+	sort.Slice(marketParams, func(i, j int) bool {
+		return marketParams[i].Id < marketParams[j].Id
+	})
 
 	return marketParams
 }

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"math/big"
+	"sort"
 	"time"
 
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
@@ -136,6 +137,11 @@ func (k Keeper) GetAllMarketPrices(ctx sdk.Context) []types.MarketPrice {
 		k.cdc.MustUnmarshal(iterator.Value(), &marketPrice)
 		marketPrices = append(marketPrices, marketPrice)
 	}
+
+	// Sort the market prices to return them in ascending order based on Id.
+	sort.Slice(marketPrices, func(i, j int) bool {
+		return marketPrices[i].Id < marketPrices[j].Id
+	})
 
 	return marketPrices
 }


### PR DESCRIPTION
test-sim-multi-seed-short seems to be failing.

```
panic: failed to generate and deliver tx: market price updates must be sorted by market id in ascending order and cannot contain duplicates: Market price update is invalid: stateless. 
```
Root cause seems to be PR #56 where we reworked how `GetAllMarketParamPrices` works.
