### PR TITLE
[CORE-513] Return sorted list in GetAllClobPairs

### DIFF
--- a/protocol/mocks/ClobKeeper.go
+++ b/protocol/mocks/ClobKeeper.go
@@ -113,8 +113,8 @@ func (_m *ClobKeeper) DeleteLongTermOrderPlacement(ctx types.Context, orderId cl
 	_m.Called(ctx, orderId)
 }
 
-// GetAllClobPair provides a mock function with given fields: ctx
-func (_m *ClobKeeper) GetAllClobPair(ctx types.Context) []clobtypes.ClobPair {
+// GetAllClobPairs provides a mock function with given fields: ctx
+func (_m *ClobKeeper) GetAllClobPairs(ctx types.Context) []clobtypes.ClobPair {
 	ret := _m.Called(ctx)
 
 	var r0 []clobtypes.ClobPair

--- a/protocol/x/clob/genesis.go
+++ b/protocol/x/clob/genesis.go
@@ -55,7 +55,7 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 
 	// Read the CLOB pairs from state.
-	genesis.ClobPairs = k.GetAllClobPair(ctx)
+	genesis.ClobPairs = k.GetAllClobPairs(ctx)
 
 	// Read the liquidations config from state.
 	genesis.LiquidationsConfig = k.GetLiquidationsConfig(ctx)

--- a/protocol/x/clob/keeper/clob_pair.go
+++ b/protocol/x/clob/keeper/clob_pair.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -209,7 +210,7 @@ func (k Keeper) setClobPair(ctx sdk.Context, clobPair types.ClobPair) {
 // InitMemClobOrderbooks initializes the memclob with `ClobPair`s from state.
 // This is called during app initialization in `app.go`, before any ABCI calls are received.
 func (k Keeper) InitMemClobOrderbooks(ctx sdk.Context) {
-	clobPairs := k.GetAllClobPair(ctx)
+	clobPairs := k.GetAllClobPairs(ctx)
 	for _, clobPair := range clobPairs {
 		// Create the corresponding orderbook in the memclob.
 		k.createOrderbook(
@@ -279,8 +280,8 @@ func (k Keeper) RemoveClobPair(
 	))
 }
 
-// GetAllClobPair returns all clobPair
-func (k Keeper) GetAllClobPair(ctx sdk.Context) (list []types.ClobPair) {
+// GetAllClobPairs returns all clobPair, sorted by ClobPair id.
+func (k Keeper) GetAllClobPairs(ctx sdk.Context) (list []types.ClobPair) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ClobPairKeyPrefix))
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})
 
@@ -291,6 +292,10 @@ func (k Keeper) GetAllClobPair(ctx sdk.Context) (list []types.ClobPair) {
 		k.cdc.MustUnmarshal(iterator.Value(), &val)
 		list = append(list, val)
 	}
+
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Id < list[j].Id
+	})
 
 	return
 }

--- a/protocol/x/clob/keeper/mev.go
+++ b/protocol/x/clob/keeper/mev.go
@@ -333,7 +333,7 @@ func (k Keeper) GetClobMetadata(
 	clobMidPrices = make(map[types.ClobPairId]types.Subticks)
 	clobPairs = make(map[types.ClobPairId]types.ClobPair)
 
-	for _, clobPair := range k.GetAllClobPair(ctx) {
+	for _, clobPair := range k.GetAllClobPairs(ctx) {
 		clobPairId := clobPair.GetClobPairId()
 		var midPriceSubticks types.Subticks
 

--- a/protocol/x/clob/module_test.go
+++ b/protocol/x/clob/module_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
-	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 
@@ -344,7 +345,7 @@ func TestAppModule_InitExportGenesis(t *testing.T) {
 	result := am.InitGenesis(ctx, cdc, gs)
 	require.Equal(t, 0, len(result))
 
-	clobPairs := keeper.GetAllClobPair(ctx)
+	clobPairs := keeper.GetAllClobPairs(ctx)
 	require.Equal(t, 1, len(clobPairs))
 	require.Equal(t, uint32(0), clobPairs[0].Id)
 	require.Equal(t, uint32(0), clobPairs[0].GetPerpetualClobMetadata().PerpetualId)

--- a/protocol/x/clob/simulation/cancel_orders.go
+++ b/protocol/x/clob/simulation/cancel_orders.go
@@ -46,7 +46,7 @@ func SimulateMsgCancelOrder(
 		subaccountId := *subAccount.GetId()
 
 		// Get all clob pairs.
-		clobPairs := k.GetAllClobPair(ctx)
+		clobPairs := k.GetAllClobPairs(ctx)
 		if len(clobPairs) < 1 {
 			panic(fmt.Errorf("SimulateMsgCancelOrder: Simulation has no CLOB pairs available"))
 		}

--- a/protocol/x/clob/simulation/place_order.go
+++ b/protocol/x/clob/simulation/place_order.go
@@ -81,7 +81,7 @@ func SimulateMsgPlaceOrder(
 		subaccountId := *subAccount.GetId()
 
 		// Get all clob pairs.
-		clobPairs := k.GetAllClobPair(ctx)
+		clobPairs := k.GetAllClobPairs(ctx)
 		if len(clobPairs) < 1 {
 			panic(fmt.Errorf("SimulateMsgPlaceOrder: Simulation has no CLOB pairs available"))
 		}

--- a/protocol/x/clob/types/clob_keeper.go
+++ b/protocol/x/clob/types/clob_keeper.go
@@ -33,7 +33,7 @@ type ClobKeeper interface {
 		ClobPair,
 		error,
 	)
-	GetAllClobPair(ctx sdk.Context) (list []ClobPair)
+	GetAllClobPairs(ctx sdk.Context) (list []ClobPair)
 	GetClobPair(ctx sdk.Context, id ClobPairId) (val ClobPair, found bool)
 	PlaceShortTermOrder(ctx sdk.Context, msg *MsgPlaceOrder) (
 		orderSizeOptimisticallyFilledFromMatchingQuantums satypes.BaseQuantums,


### PR DESCRIPTION
Per offline discussion with @BrendanChou , while current `GetAllClobPairs` is deterministic, we should add a sort to readability and ensure no hidden logic breaks because of the ordering assumption.
`GetAllClobPairs` is not run on hot path


https://linear.app/dydx/issue/CORE-513/return-sorted-list-in-getallclobpairs