### PR TITLE
Fix sim test: assign perp id to genesis perpetuals

### DIFF
--- a/protocol/x/perpetuals/simulation/genesis.go
+++ b/protocol/x/perpetuals/simulation/genesis.go
@@ -203,6 +203,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 
 		perpetuals[i] = types.Perpetual{
 			Params: types.PerpetualParams{
+				Id:                uint32(i),
 				Ticker:            genTicker(r),
 				MarketId:          marketId,
 				AtomicResolution:  genAtomicResolution(r, isReasonableGenesis),


### PR DESCRIPTION
Broken since https://github.com/dydxprotocol/v4-chain/pull/131.