### PR TITLE
Add twine to publish requirements

### DIFF
--- a/dydxpy/requirements-publish.txt
+++ b/dydxpy/requirements-publish.txt
@@ -2,3 +2,4 @@ protobuf>=4.23
 grpcio-tools>=1.54
 grpcio>=1.54
 poetry>=1.5.1
+twine>=4.0.2


### PR DESCRIPTION
Publish workflow failing because it needs twine.