### PR TITLE
[CORE-360] Specially handle 429s from exchanges

### DIFF
--- a/protocol/daemons/pricefeed/client/constants/messages.go
+++ b/protocol/daemons/pricefeed/client/constants/messages.go
@@ -1,5 +1,11 @@
 package constants
 
+import "fmt"
+
 const (
 	UnexpectedResponseStatusMessage = "Unexpected response status code of:"
+)
+
+var (
+	RateLimitingError = fmt.Errorf("status 429 - rate limit exceeded")
 )

--- a/protocol/daemons/pricefeed/client/handler/exchange_query_handler.go
+++ b/protocol/daemons/pricefeed/client/handler/exchange_query_handler.go
@@ -141,6 +141,10 @@ func (eqh *ExchangeQueryHandlerImpl) Query(
 		},
 	)
 
+	if response.StatusCode == 429 {
+		return nil, nil, constants.RateLimitingError
+	}
+
 	// Verify response is not 4xx or 5xx.
 	if response.StatusCode < 200 || response.StatusCode > 299 {
 		return nil, nil, fmt.Errorf("%s %v", constants.UnexpectedResponseStatusMessage, response.StatusCode)


### PR DESCRIPTION
We don't have any code that tests logs/telemetry, so this is difficult to test. Locally, I was not able to produce 429s, but I did validate that other errors from the encoder are handled as expected and the protocol operates as normal.