### PR TITLE
[CORE-504] Implement `MsgCreateClobPair`

### DIFF
--- a/protocol/testutil/clob/clob_pair.go
+++ b/protocol/testutil/clob/clob_pair.go
@@ -52,6 +52,16 @@ func WithPerpetualMetadata(metadata *clobtypes.ClobPair_PerpetualClobMetadata) C
 	}
 }
 
+func WithPerpetualId(perpetualId uint32) ClobModifierOption {
+	return func(cp *clobtypes.ClobPair) {
+		cp.Metadata = &clobtypes.ClobPair_PerpetualClobMetadata{
+			PerpetualClobMetadata: &clobtypes.PerpetualClobMetadata{
+				PerpetualId: perpetualId,
+			},
+		}
+	}
+}
+
 func WithSpotMetadata(metadata *clobtypes.ClobPair_SpotClobMetadata) ClobModifierOption {
 	return func(cp *clobtypes.ClobPair) {
 		cp.Metadata = metadata

--- a/protocol/testutil/keeper/clob.go
+++ b/protocol/testutil/keeper/clob.go
@@ -6,6 +6,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	delaymsgmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/rate_limit"
@@ -29,6 +30,7 @@ import (
 	rewardskeeper "github.com/dydxprotocol/v4-chain/protocol/x/rewards/keeper"
 	statskeeper "github.com/dydxprotocol/v4-chain/protocol/x/stats/keeper"
 	subkeeper "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
 type ClobKeepersTestContext struct {
@@ -212,4 +214,25 @@ func createClobKeeper(
 	k.SetAnteHandler(constants.EmptyAnteHandler)
 
 	return k, storeKey, memKey
+}
+
+func CreateTestClobPairs(
+	t *testing.T,
+	ctx sdk.Context,
+	clobKeeper *keeper.Keeper,
+	clobPairs []types.ClobPair,
+) {
+	for _, clobPair := range clobPairs {
+		_, err := clobKeeper.CreatePerpetualClobPair(
+			ctx,
+			clobPair.Id,
+			clobPair.MustGetPerpetualId(),
+			satypes.BaseQuantums(clobPair.MinOrderBaseQuantums),
+			satypes.BaseQuantums(clobPair.StepBaseQuantums),
+			clobPair.QuantumConversionExponent,
+			clobPair.SubticksPerTick,
+			clobPair.Status,
+		)
+		require.NoError(t, err)
+	}
 }

--- a/protocol/testutil/keeper/clob.go
+++ b/protocol/testutil/keeper/clob.go
@@ -5,6 +5,9 @@ import (
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
+	"github.com/dydxprotocol/v4-chain/protocol/mocks"
+	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
 	delaymsgmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	"github.com/stretchr/testify/require"
 
@@ -235,4 +238,66 @@ func CreateTestClobPairs(
 		)
 		require.NoError(t, err)
 	}
+}
+
+func CreateNClobPair(
+	t *testing.T,
+	keeper *keeper.Keeper,
+	perpKeeper *perpkeeper.Keeper,
+	pricesKeeper *priceskeeper.Keeper,
+	ctx sdk.Context,
+	n int,
+	mockIndexerEventManager *mocks.IndexerEventManager,
+) []types.ClobPair {
+	perps := CreateLiquidityTiersAndNPerpetuals(t, ctx, perpKeeper, pricesKeeper, n)
+
+	items := make([]types.ClobPair, n)
+	for i := range items {
+		items[i].Id = uint32(i)
+		items[i].Metadata = &types.ClobPair_PerpetualClobMetadata{
+			PerpetualClobMetadata: &types.PerpetualClobMetadata{
+				PerpetualId: uint32(i),
+			},
+		}
+		items[i].SubticksPerTick = 5
+		items[i].StepBaseQuantums = 5
+		items[i].Status = types.ClobPair_STATUS_ACTIVE
+
+		// PerpetualMarketCreateEvents are emitted when initializing the genesis state, so we need to mock
+		// the indexer event manager to expect these events.
+		mockIndexerEventManager.On("AddTxnEvent",
+			ctx,
+			indexerevents.SubtypePerpetualMarket,
+			indexer_manager.GetB64EncodedEventMessage(
+				indexerevents.NewPerpetualMarketCreateEvent(
+					clobtest.MustPerpetualId(items[i]),
+					items[i].Id,
+					perps[i].Params.Ticker,
+					perps[i].Params.MarketId,
+					items[i].Status,
+					items[i].QuantumConversionExponent,
+					perps[i].Params.AtomicResolution,
+					items[i].SubticksPerTick,
+					items[i].MinOrderBaseQuantums,
+					items[i].StepBaseQuantums,
+					perps[i].Params.LiquidityTier,
+				),
+			),
+		).Return()
+
+		_, err := keeper.CreatePerpetualClobPair(
+			ctx,
+			items[i].Id,
+			clobtest.MustPerpetualId(items[i]),
+			satypes.BaseQuantums(items[i].MinOrderBaseQuantums),
+			satypes.BaseQuantums(items[i].StepBaseQuantums),
+			items[i].QuantumConversionExponent,
+			items[i].SubticksPerTick,
+			items[i].Status,
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return items
 }

--- a/protocol/testutil/keeper/perpetuals.go
+++ b/protocol/testutil/keeper/perpetuals.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	priceskeeper "github.com/dydxprotocol/v4-chain/protocol/x/prices/keeper"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -188,4 +189,43 @@ func GetLiquidityTierUpsertEventsFromIndexerBlock(
 		liquidityTierEvents = append(liquidityTierEvents, &liquidityTierEvent)
 	}
 	return liquidityTierEvents
+}
+
+// CreateTestPricesAndPerpetualMarkets is a test utility function that creates list of given
+// prices and perpetual markets in state.
+func CreateTestPricesAndPerpetualMarkets(
+	t *testing.T,
+	ctx sdk.Context,
+	perpKeeper *keeper.Keeper,
+	pricesKeeper *priceskeeper.Keeper,
+	perpetuals []types.Perpetual,
+	markets []pricestypes.MarketParamPrice,
+) {
+	// Create liquidity tiers.
+	CreateTestLiquidityTiers(t, ctx, perpKeeper)
+
+	// Create a new market param and price.
+	marketId := uint32(0)
+	for _, m := range markets {
+		_, err := pricesKeeper.CreateMarket(
+			ctx,
+			m.Param,
+			m.Price,
+		)
+		require.NoError(t, err)
+		marketId++
+	}
+
+	for _, perp := range perpetuals {
+		_, err := perpKeeper.CreatePerpetual(
+			ctx,
+			perp.Params.Id,
+			perp.Params.Ticker,
+			perp.Params.MarketId,
+			perp.Params.AtomicResolution,
+			perp.Params.DefaultFundingPpm,
+			perp.Params.LiquidityTier,
+		)
+		require.NoError(t, err)
+	}
 }

--- a/protocol/testutil/perpetuals/perpetuals.go
+++ b/protocol/testutil/perpetuals/perpetuals.go
@@ -13,6 +13,12 @@ func WithId(id uint32) PerpetualModifierOption {
 	}
 }
 
+func WithMarketId(id uint32) PerpetualModifierOption {
+	return func(cp *perptypes.Perpetual) {
+		cp.Params.MarketId = id
+	}
+}
+
 func WithPerpetual(perp perptypes.Perpetual) PerpetualModifierOption {
 	return func(cp *perptypes.Perpetual) {
 		cp.Params = perp.Params

--- a/protocol/testutil/prices/market_param_price.go
+++ b/protocol/testutil/prices/market_param_price.go
@@ -1,0 +1,53 @@
+package prices
+
+import (
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+)
+
+type MarketParamPriceModifierOption func(cp *pricestypes.MarketParamPrice)
+
+func WithId(id uint32) MarketParamPriceModifierOption {
+	return func(cp *pricestypes.MarketParamPrice) {
+		cp.Param.Id = id
+		cp.Price.Id = id
+	}
+}
+
+func WithPair(pair string) MarketParamPriceModifierOption {
+	return func(cp *pricestypes.MarketParamPrice) {
+		cp.Param.Pair = pair
+	}
+}
+
+// GenerateMarketParamPrice returns a `MarketParamPrice` object set to default values.
+// Passing in `MarketParamPriceModifierOption` methods alters the value of the `MarketParamPrice` returned.
+// It will start with the default, valid `MarketParamPrice` value defined within the method
+// and make the requested modifications before returning the object.
+//
+// Example usage:
+// `GenerateMarketParamPrice(WithId(10))`
+// This will start with the default `MarketParamPrice` object defined within the method and
+// return the newly-created object after overriding the values of
+// `Id` to 10.
+func GenerateMarketParamPrice(optionalModifications ...MarketParamPriceModifierOption) *pricestypes.MarketParamPrice {
+	marketParamPrice := &pricestypes.MarketParamPrice{
+		Param: pricestypes.MarketParam{
+			Id:                0,
+			Pair:              "BTC-USDC",
+			MinExchanges:      3,
+			MinPriceChangePpm: 100,
+			Exponent:          -8,
+		},
+		Price: pricestypes.MarketPrice{
+			Id:       0,
+			Exponent: -8,
+			Price:    100000,
+		},
+	}
+
+	for _, opt := range optionalModifications {
+		opt(marketParamPrice)
+	}
+
+	return marketParamPrice
+}

--- a/protocol/x/clob/genesis_test.go
+++ b/protocol/x/clob/genesis_test.go
@@ -120,7 +120,7 @@ func TestGenesis(t *testing.T) {
 					{
 						Metadata: &types.ClobPair_PerpetualClobMetadata{
 							PerpetualClobMetadata: &types.PerpetualClobMetadata{
-								PerpetualId: 0,
+								PerpetualId: 1,
 							},
 						},
 						Id:               uint32(1),

--- a/protocol/x/clob/keeper/clob_pair.go
+++ b/protocol/x/clob/keeper/clob_pair.go
@@ -88,25 +88,14 @@ func (k Keeper) CreatePerpetualClobPair(
 
 // validateClobPair validates a CLOB pair's fields are suitable for CLOB pair creation.
 //
-// - Metadata:
+// Stateful Validation:
 //   - Must be a perpetual CLOB pair with a perpetualId matching a perpetual in the store.
 //
-// - Status:
-//   - Must be a supported status.
-//
-// - StepBaseQuantums:
-//   - Must be greater than zero.
-//
-// - SubticksPerTick:
-//   - Must be greater than zero.
+// Stateless Validation
+//   - `clobPair.Validate()` returns no error.
 func (k Keeper) validateClobPair(ctx sdk.Context, clobPair *types.ClobPair) error {
-	if !types.IsSupportedClobPairStatus(clobPair.Status) {
-		return sdkerrors.Wrapf(
-			types.ErrInvalidClobPairParameter,
-			"CLOB pair (%+v) has unsupported status %+v",
-			clobPair,
-			clobPair.Status,
-		)
+	if err := clobPair.Validate(); err != nil {
+		return err
 	}
 
 	// TODO(DEC-1535): update this validation when we implement "spot"/"asset" clob pairs.
@@ -136,25 +125,6 @@ func (k Keeper) validateClobPair(ctx sdk.Context, clobPair *types.ClobPair) erro
 			clobPair,
 		)
 	}
-
-	if clobPair.StepBaseQuantums <= 0 {
-		return sdkerrors.Wrapf(
-			types.ErrInvalidClobPairParameter,
-			"invalid ClobPair parameter: StepBaseQuantums must be > 0. Got %v",
-			clobPair.StepBaseQuantums,
-		)
-	}
-
-	// Since a subtick will be calculated as (1 tick/SubticksPerTick), the denominator cannot be 0
-	// and negative numbers do not make sense.
-	if clobPair.SubticksPerTick <= 0 {
-		return sdkerrors.Wrapf(
-			types.ErrInvalidClobPairParameter,
-			"invalid ClobPair parameter: SubticksPerTick must be > 0. Got %v",
-			clobPair.SubticksPerTick,
-		)
-	}
-
 	return nil
 }
 

--- a/protocol/x/clob/keeper/clob_pair.go
+++ b/protocol/x/clob/keeper/clob_pair.go
@@ -42,6 +42,16 @@ func (k Keeper) CreatePerpetualClobPair(
 		)
 	}
 
+	// Verify the perpetual ID is not already associated with an existing CLOB pair.
+	if clobPairId, found := k.PerpetualIdToClobPairId[perpetualId]; found {
+		return types.ClobPair{}, sdkerrors.Wrapf(
+			types.ErrPerpetualAssociatedWithExistingClobPair,
+			"perpetual id=%v, existing clob pair id=%v",
+			perpetualId,
+			clobPairId,
+		)
+	}
+
 	clobPair := types.ClobPair{
 		Metadata: &types.ClobPair_PerpetualClobMetadata{
 			PerpetualClobMetadata: &types.PerpetualClobMetadata{

--- a/protocol/x/clob/keeper/clob_pair_test.go
+++ b/protocol/x/clob/keeper/clob_pair_test.go
@@ -812,6 +812,7 @@ func TestGetClobPairIdForPerpetual_PanicsMultipleClobPairIds(t *testing.T) {
 		},
 	)
 }
+
 func TestIsPerpetualClobPairActive(t *testing.T) {
 	testCases := map[string]struct {
 		clobPair                *types.ClobPair
@@ -905,7 +906,7 @@ func TestClobPairValidate(t *testing.T) {
 		{
 			desc: "Unsupported Status",
 			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
 				SubticksPerTick:  1,
 				Status:           types.ClobPair_STATUS_PAUSED,
@@ -915,7 +916,7 @@ func TestClobPairValidate(t *testing.T) {
 		{
 			desc: "StepBaseQuantums <= 0",
 			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 0,
 				SubticksPerTick:  1,
 				Status:           types.ClobPair_STATUS_ACTIVE,
@@ -925,7 +926,7 @@ func TestClobPairValidate(t *testing.T) {
 		{
 			desc: "SubticksPerTick <= 0",
 			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
 				SubticksPerTick:  0,
 				Status:           types.ClobPair_STATUS_ACTIVE,
@@ -935,7 +936,7 @@ func TestClobPairValidate(t *testing.T) {
 		{
 			desc: "Valid ClobPair",
 			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
 				SubticksPerTick:  1,
 				Status:           types.ClobPair_STATUS_ACTIVE,

--- a/protocol/x/clob/keeper/grpc_query_clob_pair_test.go
+++ b/protocol/x/clob/keeper/grpc_query_clob_pair_test.go
@@ -11,13 +11,10 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/nullify"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/memclob"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals"
-	"github.com/dydxprotocol/v4-chain/protocol/x/prices"
 )
 
 // Prevent strconv unused error
@@ -28,9 +25,14 @@ func TestClobPairQuerySingle(t *testing.T) {
 	mockIndexerEventManager := &mocks.IndexerEventManager{}
 	ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, mockIndexerEventManager)
 	wctx := sdk.WrapSDKContext(ks.Ctx)
-	prices.InitGenesis(ks.Ctx, *ks.PricesKeeper, constants.Prices_DefaultGenesisState)
-	perpetuals.InitGenesis(ks.Ctx, *ks.PerpetualsKeeper, constants.Perpetuals_DefaultGenesisState)
-	msgs := createNClobPair(ks.ClobKeeper, ks.Ctx, 2, mockIndexerEventManager)
+	msgs := keepertest.CreateNClobPair(t,
+		ks.ClobKeeper,
+		ks.PerpetualsKeeper,
+		ks.PricesKeeper,
+		ks.Ctx,
+		2,
+		mockIndexerEventManager,
+	)
 	for _, tc := range []struct {
 		desc     string
 		request  *types.QueryGetClobPairRequest
@@ -83,9 +85,14 @@ func TestClobPairQueryPaginated(t *testing.T) {
 	mockIndexerEventManager := &mocks.IndexerEventManager{}
 	ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, mockIndexerEventManager)
 	wctx := sdk.WrapSDKContext(ks.Ctx)
-	prices.InitGenesis(ks.Ctx, *ks.PricesKeeper, constants.Prices_DefaultGenesisState)
-	perpetuals.InitGenesis(ks.Ctx, *ks.PerpetualsKeeper, constants.Perpetuals_DefaultGenesisState)
-	msgs := createNClobPair(ks.ClobKeeper, ks.Ctx, 5, mockIndexerEventManager)
+	msgs := keepertest.CreateNClobPair(t,
+		ks.ClobKeeper,
+		ks.PerpetualsKeeper,
+		ks.PricesKeeper,
+		ks.Ctx,
+		10,
+		mockIndexerEventManager,
+	)
 
 	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllClobPairRequest {
 		return &types.QueryAllClobPairRequest{

--- a/protocol/x/clob/keeper/msg_server_create_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_create_clob_pair.go
@@ -2,15 +2,42 @@ package keeper
 
 import (
 	"context"
-	"errors"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
+// CreateClobPair handles `MsgCreateClobPair`.
 func (k msgServer) CreateClobPair(
 	goCtx context.Context,
 	msg *types.MsgCreateClobPair,
 ) (*types.MsgCreateClobPairResponse, error) {
-	// TODO(CORE-502): Implement message handler.
-	return &types.MsgCreateClobPairResponse{}, errors.New("Not implemented")
+	if !k.Keeper.HasAuthority(msg.Authority) {
+		return nil, sdkerrors.Wrapf(
+			govtypes.ErrInvalidSigner,
+			"invalid authority %s",
+			msg.Authority,
+		)
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// TODO(DEC-1535): update this when additional clob pair types are supported.
+	if _, err := k.Keeper.CreatePerpetualClobPair(
+		ctx,
+		msg.ClobPair.Id,
+		// `MsgCreateClobPair.ValidateBasic` ensures that `msg.ClobPair.Metadata` is `PerpetualClobMetadata`.
+		msg.ClobPair.MustGetPerpetualId(),
+		satypes.BaseQuantums(msg.ClobPair.MinOrderBaseQuantums),
+		satypes.BaseQuantums(msg.ClobPair.StepBaseQuantums),
+		msg.ClobPair.QuantumConversionExponent,
+		msg.ClobPair.SubticksPerTick,
+		msg.ClobPair.Status,
+	); err != nil {
+		return nil, err
+	}
+	return &types.MsgCreateClobPairResponse{}, nil
 }

--- a/protocol/x/clob/keeper/msg_server_create_clob_pair_test.go
+++ b/protocol/x/clob/keeper/msg_server_create_clob_pair_test.go
@@ -1,0 +1,166 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
+	"github.com/dydxprotocol/v4-chain/protocol/mocks"
+	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
+	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
+	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/memclob"
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateClobPair(t *testing.T) {
+	testClobPair1 := *clobtest.GenerateClobPair(
+		clobtest.WithId(1),
+		clobtest.WithPerpetualId(1),
+	)
+	testPerp1 := *perptest.GeneratePerpetual(
+		perptest.WithId(1),
+		perptest.WithMarketId(1),
+	)
+	testMarket1 := *pricestest.GenerateMarketParamPrice(pricestest.WithId(1))
+	testCases := map[string]struct {
+		setup             func(t *testing.T, ks keepertest.ClobKeepersTestContext, manager *mocks.IndexerEventManager)
+		msg               *types.MsgCreateClobPair
+		expectedClobPairs []types.ClobPair
+		expectedErr       string
+	}{
+		"Succeeds: create new clob pair": {
+			setup: func(t *testing.T, ks keepertest.ClobKeepersTestContext, mockIndexerEventManager *mocks.IndexerEventManager) {
+				keepertest.CreateTestPricesAndPerpetualMarkets(
+					t,
+					ks.Ctx,
+					ks.PerpetualsKeeper,
+					ks.PricesKeeper,
+					[]perptypes.Perpetual{testPerp1},
+					[]pricestypes.MarketParamPrice{testMarket1},
+				)
+				mockIndexerEventManager.On("AddTxnEvent",
+					ks.Ctx,
+					indexerevents.SubtypePerpetualMarket,
+					indexer_manager.GetB64EncodedEventMessage(
+						indexerevents.NewPerpetualMarketCreateEvent(
+							testClobPair1.MustGetPerpetualId(),
+							testClobPair1.GetId(),
+							testPerp1.Params.Ticker,
+							testPerp1.Params.MarketId,
+							testClobPair1.Status,
+							testClobPair1.QuantumConversionExponent,
+							testPerp1.Params.AtomicResolution,
+							testClobPair1.SubticksPerTick,
+							testClobPair1.MinOrderBaseQuantums,
+							testClobPair1.StepBaseQuantums,
+							testPerp1.Params.LiquidityTier,
+						),
+					),
+				).Return()
+			},
+			msg: &types.MsgCreateClobPair{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				ClobPair:  testClobPair1,
+			},
+			expectedClobPairs: []types.ClobPair{testClobPair1},
+		},
+		"Succeeds: clob pair already exists": {
+			setup: func(t *testing.T, ks keepertest.ClobKeepersTestContext, mockIndexerEventManager *mocks.IndexerEventManager) {
+				keepertest.CreateTestPricesAndPerpetualMarkets(
+					t,
+					ks.Ctx,
+					ks.PerpetualsKeeper,
+					ks.PricesKeeper,
+					[]perptypes.Perpetual{testPerp1},
+					[]pricestypes.MarketParamPrice{testMarket1},
+				)
+				mockIndexerEventManager.On("AddTxnEvent",
+					ks.Ctx,
+					indexerevents.SubtypePerpetualMarket,
+					indexer_manager.GetB64EncodedEventMessage(
+						indexerevents.NewPerpetualMarketCreateEvent(
+							testClobPair1.MustGetPerpetualId(),
+							testClobPair1.GetId(),
+							testPerp1.Params.Ticker,
+							testPerp1.Params.MarketId,
+							testClobPair1.Status,
+							testClobPair1.QuantumConversionExponent,
+							testPerp1.Params.AtomicResolution,
+							testClobPair1.SubticksPerTick,
+							testClobPair1.MinOrderBaseQuantums,
+							testClobPair1.StepBaseQuantums,
+							testPerp1.Params.LiquidityTier,
+						),
+					),
+				).Return()
+				_, err := ks.ClobKeeper.CreatePerpetualClobPair(
+					ks.Ctx,
+					testClobPair1.Id,
+					testClobPair1.MustGetPerpetualId(),
+					satypes.BaseQuantums(testClobPair1.MinOrderBaseQuantums),
+					satypes.BaseQuantums(testClobPair1.StepBaseQuantums),
+					testClobPair1.QuantumConversionExponent,
+					testClobPair1.SubticksPerTick,
+					testClobPair1.Status,
+				)
+				require.NoError(t, err)
+			},
+			msg: &types.MsgCreateClobPair{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				ClobPair:  testClobPair1,
+			},
+			expectedClobPairs: []types.ClobPair{testClobPair1},
+			expectedErr:       "ClobPair with id already exists",
+		},
+		"Failure: refers to non-existing perpetual": {
+			setup: func(t *testing.T, ks keepertest.ClobKeepersTestContext, mockIndexerEventManager *mocks.IndexerEventManager) {
+			},
+			msg: &types.MsgCreateClobPair{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				ClobPair:  testClobPair1,
+			},
+			expectedClobPairs: nil,
+			expectedErr:       "has invalid perpetual.: 1: Perpetual does not exist",
+		},
+		"Failure: invalid authority": {
+			setup: func(t *testing.T, ks keepertest.ClobKeepersTestContext, mockIndexerEventManager *mocks.IndexerEventManager) {
+			},
+			msg: &types.MsgCreateClobPair{
+				Authority: "invalid",
+				ClobPair:  testClobPair1,
+			},
+			expectedClobPairs: nil,
+			expectedErr:       "invalid authority invalid: expected gov account as only signer for proposal message",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memClob := memclob.NewMemClobPriceTimePriority(false)
+			mockIndexerEventManager := &mocks.IndexerEventManager{}
+			ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, mockIndexerEventManager)
+			tc.setup(t, ks, mockIndexerEventManager)
+
+			msgServer := keeper.NewMsgServerImpl(ks.ClobKeeper)
+			wrappedCtx := sdk.WrapSDKContext(ks.Ctx)
+
+			_, err := msgServer.CreateClobPair(wrappedCtx, tc.msg)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectedClobPairs, ks.ClobKeeper.GetAllClobPairs(ks.Ctx))
+		})
+	}
+}

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair.go
@@ -24,6 +24,7 @@ func (k msgServer) UpdateClobPair(
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	if err := k.Keeper.UpdateClobPair(
 		ctx,
+		// TODO(CORE-533): MsgUpdateClobPair.ClobPair should be non-nullable.
 		*msg.GetClobPair(),
 	); err != nil {
 		return nil, err

--- a/protocol/x/clob/types/clob_pair.go
+++ b/protocol/x/clob/types/clob_pair.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -60,4 +61,46 @@ func (c *ClobPair) MustGetPerpetualId() uint32 {
 // GetId returns the `ClobPairId` for the provided `clobPair`.
 func (c *ClobPair) GetClobPairId() ClobPairId {
 	return ClobPairId(c.Id)
+}
+
+// Stateless validation on ClobPair.
+func (c *ClobPair) Validate() error {
+	switch c.Metadata.(type) {
+	// TODO(DEC-1535): update this when additional clob pair types are supported.
+	case *ClobPair_SpotClobMetadata:
+		return sdkerrors.Wrapf(
+			ErrInvalidClobPairParameter,
+			"CLOB pair (%+v) is not a perpetual CLOB.",
+			c,
+		)
+	}
+
+	if !IsSupportedClobPairStatus(c.Status) {
+		return sdkerrors.Wrapf(
+			ErrInvalidClobPairParameter,
+			"CLOB pair (%+v) has unsupported status %+v",
+			c,
+			c.Status,
+		)
+	}
+
+	if c.StepBaseQuantums <= 0 {
+		return sdkerrors.Wrapf(
+			ErrInvalidClobPairParameter,
+			"invalid ClobPair parameter: StepBaseQuantums must be > 0. Got %v",
+			c.StepBaseQuantums,
+		)
+	}
+
+	// Since a subtick will be calculated as (1 tick/SubticksPerTick), the denominator cannot be 0
+	// and negative numbers do not make sense.
+	if c.SubticksPerTick <= 0 {
+		return sdkerrors.Wrapf(
+			ErrInvalidClobPairParameter,
+			"invalid ClobPair parameter: SubticksPerTick must be > 0. Got %v",
+			c.SubticksPerTick,
+		)
+	}
+
+	return nil
 }

--- a/protocol/x/clob/types/errors.go
+++ b/protocol/x/clob/types/errors.go
@@ -178,11 +178,6 @@ var (
 		37,
 		"Perpetual does not exist in state",
 	)
-	ErrInvalidMsgUpdateClobPair = sdkerrors.Register(
-		ModuleName,
-		38,
-		"MsgUpdateClobPair is invalid",
-	)
 	ErrInvalidClobPairUpdate = sdkerrors.Register(
 		ModuleName,
 		39,

--- a/protocol/x/clob/types/errors.go
+++ b/protocol/x/clob/types/errors.go
@@ -188,6 +188,11 @@ var (
 		40,
 		"Authority is invalid",
 	)
+	ErrPerpetualAssociatedWithExistingClobPair = sdkerrors.Register(
+		ModuleName,
+		41,
+		"perpetual ID is already associated with an existing CLOB pair",
+	)
 
 	// Liquidations errors.
 	ErrInvalidLiquidationsConfig = sdkerrors.Register(

--- a/protocol/x/clob/types/message_create_clob_pair.go
+++ b/protocol/x/clob/types/message_create_clob_pair.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -14,6 +12,5 @@ func (msg *MsgCreateClobPair) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgCreateClobPair) ValidateBasic() error {
-	// TODO(CORE-504): Implement message validation.
-	return errors.New("not implemented")
+	return msg.ClobPair.Validate()
 }

--- a/protocol/x/clob/types/message_create_clob_pair.go
+++ b/protocol/x/clob/types/message_create_clob_pair.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var _ sdk.Msg = &MsgCreateClobPair{}
@@ -12,5 +13,9 @@ func (msg *MsgCreateClobPair) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgCreateClobPair) ValidateBasic() error {
+	if msg.Authority == "" {
+		return sdkerrors.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	}
+
 	return msg.ClobPair.Validate()
 }

--- a/protocol/x/clob/types/message_create_clob_pair_test.go
+++ b/protocol/x/clob/types/message_create_clob_pair_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	"github.com/stretchr/testify/require"
@@ -19,66 +21,91 @@ func TestMsgCreateClobPair_GetSigners(t *testing.T) {
 func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 	tests := []struct {
 		desc        string
-		clobPair    types.ClobPair
+		msg         types.MsgCreateClobPair
 		expectedErr string
 	}{
 		{
 			desc: "Invalid Metadata (SpotClobMetadata)",
-			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_SpotClobMetadata{},
-				StepBaseQuantums: 1,
-				SubticksPerTick:  1,
-				Status:           types.ClobPair_STATUS_ACTIVE,
+			msg: types.MsgCreateClobPair{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				ClobPair: types.ClobPair{
+					Metadata:         &types.ClobPair_SpotClobMetadata{},
+					StepBaseQuantums: 1,
+					SubticksPerTick:  1,
+					Status:           types.ClobPair_STATUS_ACTIVE,
+				},
 			},
 			expectedErr: "is not a perpetual CLOB",
 		},
 		{
+			desc: "Empty authority",
+			msg: types.MsgCreateClobPair{
+				Authority: "",
+				ClobPair: types.ClobPair{
+					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
+					StepBaseQuantums: 1,
+					SubticksPerTick:  1,
+					Status:           types.ClobPair_STATUS_ACTIVE,
+				},
+			},
+			expectedErr: "authority cannot be empty: Authority is invalid",
+		},
+		{
 			desc: "Unsupported Status",
-			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
-				StepBaseQuantums: 1,
-				SubticksPerTick:  1,
-				Status:           types.ClobPair_STATUS_PAUSED,
+			msg: types.MsgCreateClobPair{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				ClobPair: types.ClobPair{
+					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
+					StepBaseQuantums: 1,
+					SubticksPerTick:  1,
+					Status:           types.ClobPair_STATUS_PAUSED,
+				},
 			},
 			expectedErr: "has unsupported status",
 		},
 		{
 			desc: "StepBaseQuantums <= 0",
-			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
-				StepBaseQuantums: 0,
-				SubticksPerTick:  1,
-				Status:           types.ClobPair_STATUS_ACTIVE,
+			msg: types.MsgCreateClobPair{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				ClobPair: types.ClobPair{
+					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
+					StepBaseQuantums: 0,
+					SubticksPerTick:  1,
+					Status:           types.ClobPair_STATUS_ACTIVE,
+				},
 			},
 			expectedErr: "StepBaseQuantums must be > 0.",
 		},
 		{
 			desc: "SubticksPerTick <= 0",
-			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
-				StepBaseQuantums: 1,
-				SubticksPerTick:  0,
-				Status:           types.ClobPair_STATUS_ACTIVE,
+			msg: types.MsgCreateClobPair{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				ClobPair: types.ClobPair{
+					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
+					StepBaseQuantums: 1,
+					SubticksPerTick:  0,
+					Status:           types.ClobPair_STATUS_ACTIVE,
+				},
 			},
 			expectedErr: "SubticksPerTick must be > 0",
 		},
 		{
 			desc: "Valid ClobPair",
-			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
-				StepBaseQuantums: 1,
-				SubticksPerTick:  1,
-				Status:           types.ClobPair_STATUS_ACTIVE,
+			msg: types.MsgCreateClobPair{
+				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				ClobPair: types.ClobPair{
+					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
+					StepBaseQuantums: 1,
+					SubticksPerTick:  1,
+					Status:           types.ClobPair_STATUS_ACTIVE,
+				},
 			},
 			expectedErr: "",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			msg := types.MsgCreateClobPair{
-				ClobPair: tc.clobPair,
-			}
-			err := msg.ValidateBasic()
+			err := tc.msg.ValidateBasic()
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/protocol/x/clob/types/message_create_clob_pair_test.go
+++ b/protocol/x/clob/types/message_create_clob_pair_test.go
@@ -35,7 +35,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "Unsupported Status",
 			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
 				SubticksPerTick:  1,
 				Status:           types.ClobPair_STATUS_PAUSED,
@@ -45,7 +45,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "StepBaseQuantums <= 0",
 			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 0,
 				SubticksPerTick:  1,
 				Status:           types.ClobPair_STATUS_ACTIVE,
@@ -55,7 +55,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "SubticksPerTick <= 0",
 			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
 				SubticksPerTick:  0,
 				Status:           types.ClobPair_STATUS_ACTIVE,
@@ -65,7 +65,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "Valid ClobPair",
 			clobPair: types.ClobPair{
-				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
 				SubticksPerTick:  1,
 				Status:           types.ClobPair_STATUS_ACTIVE,

--- a/protocol/x/clob/types/message_create_clob_pair_test.go
+++ b/protocol/x/clob/types/message_create_clob_pair_test.go
@@ -1,0 +1,89 @@
+package types_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgCreateClobPair_GetSigners(t *testing.T) {
+	msg := types.MsgCreateClobPair{
+		Authority: constants.AliceAccAddress.String(),
+	}
+	require.Equal(t, []sdk.AccAddress{constants.AliceAccAddress}, msg.GetSigners())
+}
+
+func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		desc        string
+		clobPair    types.ClobPair
+		expectedErr string
+	}{
+		{
+			desc: "Invalid Metadata (SpotClobMetadata)",
+			clobPair: types.ClobPair{
+				Metadata:         &types.ClobPair_SpotClobMetadata{},
+				StepBaseQuantums: 1,
+				SubticksPerTick:  1,
+				Status:           types.ClobPair_STATUS_ACTIVE,
+			},
+			expectedErr: "is not a perpetual CLOB",
+		},
+		{
+			desc: "Unsupported Status",
+			clobPair: types.ClobPair{
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				StepBaseQuantums: 1,
+				SubticksPerTick:  1,
+				Status:           types.ClobPair_STATUS_PAUSED,
+			},
+			expectedErr: "has unsupported status",
+		},
+		{
+			desc: "StepBaseQuantums <= 0",
+			clobPair: types.ClobPair{
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				StepBaseQuantums: 0,
+				SubticksPerTick:  1,
+				Status:           types.ClobPair_STATUS_ACTIVE,
+			},
+			expectedErr: "StepBaseQuantums must be > 0.",
+		},
+		{
+			desc: "SubticksPerTick <= 0",
+			clobPair: types.ClobPair{
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				StepBaseQuantums: 1,
+				SubticksPerTick:  0,
+				Status:           types.ClobPair_STATUS_ACTIVE,
+			},
+			expectedErr: "SubticksPerTick must be > 0",
+		},
+		{
+			desc: "Valid ClobPair",
+			clobPair: types.ClobPair{
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{}, // Assume it's a supported metadata
+				StepBaseQuantums: 1,
+				SubticksPerTick:  1,
+				Status:           types.ClobPair_STATUS_ACTIVE,
+			},
+			expectedErr: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			msg := types.MsgCreateClobPair{
+				ClobPair: tc.clobPair,
+			}
+			err := msg.ValidateBasic()
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/protocol/x/clob/types/message_update_clob_pair.go
+++ b/protocol/x/clob/types/message_update_clob_pair.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var _ sdk.Msg = &MsgUpdateClobPair{}
@@ -15,15 +14,5 @@ func (msg *MsgUpdateClobPair) GetSigners() []sdk.AccAddress {
 
 // ValidateBasic validates that the message's ClobPair status is a supported status.
 func (msg *MsgUpdateClobPair) ValidateBasic() error {
-	// TODO(CORE-504): Implement message validation, copy from MsgCreateClobPair.
-
-	if !IsSupportedClobPairStatus(msg.ClobPair.Status) {
-		return sdkerrors.Wrapf(
-			ErrInvalidMsgUpdateClobPair,
-			"Cannot set status for ClobPair with id %d to unsupported ClobPair status %s",
-			msg.ClobPair.Id,
-			msg.ClobPair.Status,
-		)
-	}
-	return nil
+	return msg.ClobPair.Validate()
 }

--- a/protocol/x/clob/types/message_update_clob_pair_test.go
+++ b/protocol/x/clob/types/message_update_clob_pair_test.go
@@ -19,23 +19,24 @@ func TestMsgUpdateClobPair_GetSigners(t *testing.T) {
 func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 	tests := map[string]struct {
 		status        types.ClobPair_Status
-		expectedError error
+		expectedError string
 	}{
 		"valid status": {
 			status: types.ClobPair_STATUS_ACTIVE,
 		},
 		"invalid unsupported status": {
 			status:        types.ClobPair_STATUS_UNSPECIFIED,
-			expectedError: types.ErrInvalidMsgUpdateClobPair,
+			expectedError: "has unsupported status",
 		},
 		"invalid negative out of bounds status": {
 			status:        -1,
-			expectedError: types.ErrInvalidMsgUpdateClobPair,
+			expectedError: "has unsupported status",
 		},
 		"invalid positive out of bounds status": {
 			status:        100,
-			expectedError: types.ErrInvalidMsgUpdateClobPair,
+			expectedError: "has unsupported status",
 		},
+		// TODO add more
 	}
 
 	for name, tc := range tests {
@@ -47,8 +48,8 @@ func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 			}
 			err := msg.ValidateBasic()
 
-			if tc.expectedError != nil {
-				require.ErrorContains(t, err, tc.expectedError.Error())
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
 			} else {
 				require.NoError(t, err)
 			}

--- a/protocol/x/perpetuals/keeper/grpc_query_perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_perpetual_test.go
@@ -18,8 +18,7 @@ import (
 func TestPerpetualQuerySingle(t *testing.T) {
 	ctx, keeper, pricesKeeper, _, _ := keepertest.PerpetualsKeepers(t)
 	wctx := sdk.WrapSDKContext(ctx)
-	msgs, err := createLiquidityTiersAndNPerpetuals(t, ctx, keeper, pricesKeeper, 2)
-	require.NoError(t, err)
+	msgs := keepertest.CreateLiquidityTiersAndNPerpetuals(t, ctx, keeper, pricesKeeper, 2)
 	for _, tc := range []struct {
 		desc     string
 		request  *types.QueryPerpetualRequest
@@ -73,8 +72,7 @@ func TestPerpetualQuerySingle(t *testing.T) {
 func TestPerpetualQueryPaginated(t *testing.T) {
 	ctx, keeper, pricesKeeper, _, _ := keepertest.PerpetualsKeepers(t)
 	wctx := sdk.WrapSDKContext(ctx)
-	msgs, err := createLiquidityTiersAndNPerpetuals(t, ctx, keeper, pricesKeeper, 5)
-	require.NoError(t, err)
+	msgs := keepertest.CreateLiquidityTiersAndNPerpetuals(t, ctx, keeper, pricesKeeper, 5)
 
 	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllPerpetualsRequest {
 		return &types.QueryAllPerpetualsRequest{

--- a/protocol/x/perpetuals/keeper/stateful_premium_votes_validation_test.go
+++ b/protocol/x/perpetuals/keeper/stateful_premium_votes_validation_test.go
@@ -176,15 +176,14 @@ func TestPerformStatefulPremiumVotesValidation(t *testing.T) {
 				)
 			}
 
-			_, err := createLiquidityTiersAndNPerpetuals(t, ctx, k, pricesKeeper, tc.numPerpetuals)
-			require.NoError(t, err)
+			_ = keepertest.CreateLiquidityTiersAndNPerpetuals(t, ctx, k, pricesKeeper, tc.numPerpetuals)
 
 			// Run.
 			msg := &types.MsgAddPremiumVotes{
 				Votes: tc.votes,
 			}
 
-			err = k.PerformStatefulPremiumVotesValidation(ctx, msg)
+			err := k.PerformStatefulPremiumVotesValidation(ctx, msg)
 			if tc.expectedErr != nil {
 				require.ErrorIs(t, err, tc.expectedErr)
 				return


### PR DESCRIPTION
Implemented `MsgCreateClobPair` and also refactored `MsgUpdateClobPair` to use the same stateless validation.