### PR TITLE
[CORE-385] - Remove quotes from binance/binanceUS tickers

### DIFF
--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config.go
@@ -107,7 +107,7 @@ var (
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_COMP_USD: {
-					Ticker:         `"COMPUSDT"`,
+					Ticker:         "COMPUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_APE_USD: {

--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config.go
@@ -27,83 +27,83 @@ var (
 			// example `symbols` parameter: ["BTCUSDT","BNBUSDT"]
 			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
 				exchange_common.MARKET_BTC_USD: {
-					Ticker:         `"BTCUSDT"`,
+					Ticker:         "BTCUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_ETH_USD: {
-					Ticker:         `"ETHUSDT"`,
+					Ticker:         "ETHUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_LINK_USD: {
-					Ticker:         `"LINKUSDT"`,
+					Ticker:         "LINKUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_MATIC_USD: {
-					Ticker:         `"MATICUSDT"`,
+					Ticker:         "MATICUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_CRV_USD: {
-					Ticker:         `"CRVUSDT"`,
+					Ticker:         "CRVUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_SOL_USD: {
-					Ticker:         `"SOLUSDT"`,
+					Ticker:         "SOLUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_ADA_USD: {
-					Ticker:         `"ADAUSDT"`,
+					Ticker:         "ADAUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_AVAX_USD: {
-					Ticker:         `"AVAXUSDT"`,
+					Ticker:         "AVAXUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_FIL_USD: {
-					Ticker:         `"FILUSDT"`,
+					Ticker:         "FILUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_LTC_USD: {
-					Ticker:         `"LTCUSDT"`,
+					Ticker:         "LTCUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_DOGE_USD: {
-					Ticker:         `"DOGEUSDT"`,
+					Ticker:         "DOGEUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_ATOM_USD: {
-					Ticker:         `"ATOMUSDT"`,
+					Ticker:         "ATOMUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_DOT_USD: {
-					Ticker:         `"DOTUSDT"`,
+					Ticker:         "DOTUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_UNI_USD: {
-					Ticker:         `"UNIUSDT"`,
+					Ticker:         "UNIUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_BCH_USD: {
-					Ticker:         `"BCHUSDT"`,
+					Ticker:         "BCHUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_TRX_USD: {
-					Ticker:         `"TRXUSDT"`,
+					Ticker:         "TRXUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_NEAR_USD: {
-					Ticker:         `"NEARUSDT"`,
+					Ticker:         "NEARUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_MKR_USD: {
-					Ticker:         `"MKRUSDT"`,
+					Ticker:         "MKRUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_XLM_USD: {
-					Ticker:         `"XLMUSDT"`,
+					Ticker:         "XLMUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_ETC_USD: {
-					Ticker:         `"ETCUSDT"`,
+					Ticker:         "ETCUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_COMP_USD: {
@@ -111,51 +111,51 @@ var (
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_APE_USD: {
-					Ticker:         `"APEUSDT"`,
+					Ticker:         "APEUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_APT_USD: {
-					Ticker:         `"APTUSDT"`,
+					Ticker:         "APTUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_ARB_USD: {
-					Ticker:         `"ARBUSDT"`,
+					Ticker:         "ARBUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_LDO_USD: {
-					Ticker:         `"LDOUSDT"`,
+					Ticker:         "LDOUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_OP_USD: {
-					Ticker:         `"OPUSDT"`,
+					Ticker:         "OPUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_PEPE_USD: {
-					Ticker:         `"PEPEUSDT"`,
+					Ticker:         "PEPEUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_SEI_USD: {
-					Ticker:         `"SEIUSDT"`,
+					Ticker:         "SEIUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_SHIB_USD: {
-					Ticker:         `"SHIBUSDT"`,
+					Ticker:         "SHIBUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_SUI_USD: {
-					Ticker:         `"SUIUSDT"`,
+					Ticker:         "SUIUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_WLD_USD: {
-					Ticker:         `"WLDUSDT"`,
+					Ticker:         "WLDUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_XRP_USD: {
-					Ticker:         `"XRPUSDT"`,
+					Ticker:         "XRPUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_USDT_USD: {
-					Ticker:         `"BTCUSDT"`, // Adjusted with BTC index price.
+					Ticker:         "BTCUSDT", // Adjusted with BTC index price.
 					Invert:         true,
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_BTC_USD),
 				},
@@ -166,19 +166,19 @@ var (
 			// example `symbols` parameter: ["BTCUSD","BNBUSD"]
 			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
 				exchange_common.MARKET_BTC_USD: {
-					Ticker:         `"BTCUSDT"`,
+					Ticker:         "BTCUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_ETH_USD: {
-					Ticker:         `"ETHUSDT"`,
+					Ticker:         "ETHUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_DOGE_USD: {
-					Ticker:         `"DOGEUSDT"`,
+					Ticker:         "DOGEUSDT",
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_USDT_USD: {
-					Ticker: `"USDTUSD"`,
+					Ticker: "USDTUSD",
 				},
 			},
 		},

--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"os"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
@@ -181,11 +182,11 @@ func TestGenerateExchangeConfigJson(t *testing.T) {
 			configs := GenerateExchangeConfigJson(StaticExchangeMarketConfig)
 
 			// Uncomment to update test data
-			//f, err := os.OpenFile("testdata/"+tc.expectedExchangeConfigJsonFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-			//require.NoError(t, err)
-			//defer f.Close()
-			//_, err = f.WriteString(configs[tc.id] + "\n") // Final newline added manually.
-			//require.NoError(t, err)
+			f, err := os.OpenFile("testdata/"+tc.expectedExchangeConfigJsonFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+			require.NoError(t, err)
+			defer f.Close()
+			_, err = f.WriteString(configs[tc.id] + "\n") // Final newline added manually.
+			require.NoError(t, err)
 
 			actualExchangeConfigJson := json.CompactJsonString(t, configs[tc.id])
 			expectedExchangeConfigJson := pricefeed.ReadJsonTestFile(t, tc.expectedExchangeConfigJsonFile)

--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
@@ -1,7 +1,6 @@
 package constants
 
 import (
-	"os"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
@@ -182,11 +181,11 @@ func TestGenerateExchangeConfigJson(t *testing.T) {
 			configs := GenerateExchangeConfigJson(StaticExchangeMarketConfig)
 
 			// Uncomment to update test data
-			f, err := os.OpenFile("testdata/"+tc.expectedExchangeConfigJsonFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-			require.NoError(t, err)
-			defer f.Close()
-			_, err = f.WriteString(configs[tc.id] + "\n") // Final newline added manually.
-			require.NoError(t, err)
+			//f, err := os.OpenFile("testdata/"+tc.expectedExchangeConfigJsonFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+			//require.NoError(t, err)
+			//defer f.Close()
+			//_, err = f.WriteString(configs[tc.id] + "\n") // Final newline added manually.
+			//require.NoError(t, err)
 
 			actualExchangeConfigJson := json.CompactJsonString(t, configs[tc.id])
 			expectedExchangeConfigJson := pricefeed.ReadJsonTestFile(t, tc.expectedExchangeConfigJsonFile)

--- a/protocol/daemons/pricefeed/client/constants/testdata/ada_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/ada_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"ADAUSDT\"",
+      "ticker": "ADAUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/ape_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/ape_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"APEUSDT\"",
+      "ticker": "APEUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/apt_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/apt_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"APTUSDT\"",
+      "ticker": "APTUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/arb_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/arb_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"ARBUSDT\"",
+      "ticker": "ARBUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/atom_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/atom_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"ATOMUSDT\"",
+      "ticker": "ATOMUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/avax_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/avax_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"AVAXUSDT\"",
+      "ticker": "AVAXUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/bch_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/bch_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"BCHUSDT\"",
+      "ticker": "BCHUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/btc_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/btc_exchange_config.json
@@ -2,12 +2,12 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"BTCUSDT\"",
+      "ticker": "BTCUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "BinanceUS",
-      "ticker": "\"BTCUSDT\"",
+      "ticker": "BTCUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/comp_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/comp_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"COMPUSDT\"",
+      "ticker": "COMPUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/crv_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/crv_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"CRVUSDT\"",
+      "ticker": "CRVUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/doge_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/doge_exchange_config.json
@@ -2,12 +2,12 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"DOGEUSDT\"",
+      "ticker": "DOGEUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "BinanceUS",
-      "ticker": "\"DOGEUSDT\"",
+      "ticker": "DOGEUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/dot_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/dot_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"DOTUSDT\"",
+      "ticker": "DOTUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/etc_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/etc_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"ETCUSDT\"",
+      "ticker": "ETCUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/eth_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/eth_exchange_config.json
@@ -2,12 +2,12 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"ETHUSDT\"",
+      "ticker": "ETHUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "BinanceUS",
-      "ticker": "\"ETHUSDT\"",
+      "ticker": "ETHUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/fil_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/fil_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"FILUSDT\"",
+      "ticker": "FILUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/ldo_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/ldo_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"LDOUSDT\"",
+      "ticker": "LDOUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/link_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/link_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"LINKUSDT\"",
+      "ticker": "LINKUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/ltc_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/ltc_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"LTCUSDT\"",
+      "ticker": "LTCUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/matic_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/matic_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"MATICUSDT\"",
+      "ticker": "MATICUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/mkr_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/mkr_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"MKRUSDT\"",
+      "ticker": "MKRUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/near_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/near_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"NEARUSDT\"",
+      "ticker": "NEARUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/op_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/op_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"OPUSDT\"",
+      "ticker": "OPUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/pepe_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/pepe_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"PEPEUSDT\"",
+      "ticker": "PEPEUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/sei_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/sei_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"SEIUSDT\"",
+      "ticker": "SEIUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/shib_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/shib_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"SHIBUSDT\"",
+      "ticker": "SHIBUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/sol_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/sol_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"SOLUSDT\"",
+      "ticker": "SOLUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/sui_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/sui_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"SUIUSDT\"",
+      "ticker": "SUIUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/trx_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/trx_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"TRXUSDT\"",
+      "ticker": "TRXUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/uni_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/uni_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"UNIUSDT\"",
+      "ticker": "UNIUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/usdt_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/usdt_exchange_config.json
@@ -2,13 +2,13 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"BTCUSDT\"",
+      "ticker": "BTCUSDT",
       "adjustByMarket": "BTC-USD",
       "invert": true
     },
     {
       "exchangeName": "BinanceUS",
-      "ticker": "\"USDTUSD\""
+      "ticker": "USDTUSD"
     },
     {
       "exchangeName": "Bitfinex",

--- a/protocol/daemons/pricefeed/client/constants/testdata/wld_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/wld_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"WLDUSDT\"",
+      "ticker": "WLDUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/xlm_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/xlm_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"XLMUSDT\"",
+      "ticker": "XLMUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/xrp_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/xrp_exchange_config.json
@@ -2,7 +2,7 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "\"XRPUSDT\"",
+      "ticker": "XRPUSDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/price_function/binance/binance.go
+++ b/protocol/daemons/pricefeed/client/price_function/binance/binance.go
@@ -2,7 +2,6 @@ package binance
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/price_function"
@@ -20,7 +19,7 @@ type BinanceTicker struct {
 
 func (t BinanceTicker) GetPair() string {
 	// needs to be wrapped in quotes to be consistent with the API request format.
-	return fmt.Sprintf(`"%s"`, t.Pair)
+	return t.Pair
 }
 
 func (t BinanceTicker) GetAskPrice() string {

--- a/protocol/daemons/pricefeed/client/price_function/binance/binance_test.go
+++ b/protocol/daemons/pricefeed/client/price_function/binance/binance_test.go
@@ -109,7 +109,7 @@ func TestBinancePriceFunction_Mixed(t *testing.T) {
 			exponentMap:        BtcExponentMap,
 			expectedPriceMap:   make(map[string]uint64),
 			expectedUnavailableMap: map[string]error{
-				BTCUSDC_TICKER: errors.New(`no listing found for ticker BTCUSDT`),
+				BTCUSDC_TICKER: errors.New("no listing found for ticker BTCUSDT"),
 			},
 		},
 		"Unavailable - empty list response": {
@@ -117,7 +117,7 @@ func TestBinancePriceFunction_Mixed(t *testing.T) {
 			exponentMap:        BtcExponentMap,
 			expectedPriceMap:   make(map[string]uint64),
 			expectedUnavailableMap: map[string]error{
-				BTCUSDC_TICKER: errors.New(`no listing found for ticker BTCUSDT`),
+				BTCUSDC_TICKER: errors.New("no listing found for ticker BTCUSDT"),
 			},
 		},
 		"Unavailable - incomplete response": {
@@ -155,7 +155,7 @@ func TestBinancePriceFunction_Mixed(t *testing.T) {
 				ETHUSDC_TICKER: uint64(1_780_250_000),
 			},
 			expectedUnavailableMap: map[string]error{
-				BTCUSDC_TICKER: errors.New(`no listing found for ticker BTCUSDT`),
+				BTCUSDC_TICKER: errors.New("no listing found for ticker BTCUSDT"),
 			},
 		},
 		"Success - integers": {

--- a/protocol/daemons/pricefeed/client/price_function/binance/binance_test.go
+++ b/protocol/daemons/pricefeed/client/price_function/binance/binance_test.go
@@ -18,8 +18,8 @@ import (
 
 // Test tickers for Binance.
 const (
-	BTCUSDC_TICKER = `"BTCUSDT"`
-	ETHUSDC_TICKER = `"ETHUSDT"`
+	BTCUSDC_TICKER = "BTCUSDT"
+	ETHUSDC_TICKER = "ETHUSDT"
 )
 
 // Test exponent maps.
@@ -109,7 +109,7 @@ func TestBinancePriceFunction_Mixed(t *testing.T) {
 			exponentMap:        BtcExponentMap,
 			expectedPriceMap:   make(map[string]uint64),
 			expectedUnavailableMap: map[string]error{
-				BTCUSDC_TICKER: errors.New(`no listing found for ticker "BTCUSDT"`),
+				BTCUSDC_TICKER: errors.New(`no listing found for ticker BTCUSDT`),
 			},
 		},
 		"Unavailable - empty list response": {
@@ -117,7 +117,7 @@ func TestBinancePriceFunction_Mixed(t *testing.T) {
 			exponentMap:        BtcExponentMap,
 			expectedPriceMap:   make(map[string]uint64),
 			expectedUnavailableMap: map[string]error{
-				BTCUSDC_TICKER: errors.New(`no listing found for ticker "BTCUSDT"`),
+				BTCUSDC_TICKER: errors.New(`no listing found for ticker BTCUSDT`),
 			},
 		},
 		"Unavailable - incomplete response": {
@@ -155,7 +155,7 @@ func TestBinancePriceFunction_Mixed(t *testing.T) {
 				ETHUSDC_TICKER: uint64(1_780_250_000),
 			},
 			expectedUnavailableMap: map[string]error{
-				BTCUSDC_TICKER: errors.New(`no listing found for ticker "BTCUSDT"`),
+				BTCUSDC_TICKER: errors.New(`no listing found for ticker BTCUSDT`),
 			},
 		},
 		"Success - integers": {


### PR DESCRIPTION
Most of these diffs are config files, which are auto-generated and can be ignored.

Pushing to `dev3` to double check prices look good from binance.