### PR TITLE
[CORE-538] Upgrade proto builder to a version which is compatible for Cosmos 0.50.0

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -28,7 +28,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cosmos/proto-builder:0.13.3
+      image: ghcr.io/cosmos/proto-builder:0.14.0
       options: --user root
     timeout-minutes: 5
     steps:
@@ -41,7 +41,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cosmos/proto-builder:0.13.3
+      image: ghcr.io/cosmos/proto-builder:0.14.0
       options: --user root
     timeout-minutes: 5
     steps:
@@ -51,7 +51,7 @@ jobs:
   check-bc-breaking:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cosmos/proto-builder:0.13.3
+      image: ghcr.io/cosmos/proto-builder:0.14.0
       options: --user root
     timeout-minutes: 5
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER := $(shell which docker)
-protoVer=0.13.3
+protoVer=0.14.0
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(protoImageName)
 


### PR DESCRIPTION
Regenerating the protos produced no changes.