### PR TITLE
Fix v4-proto-py package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 .proto-export-deps
 v4-proto-py/build
 v4-proto-py/dist
-v4-proto-py/v4-proto-py.egg-info/
-v4-proto-py/v4-proto-py
+v4-proto-py/v4_proto.egg-info/
+v4-proto-py/v4_proto
 v4-proto-js/build
 v4-proto-js/node_modules
 v4-proto-js/src

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,16 @@ proto-export-deps:
 PROTO_DIRS=$(shell find .proto-export-deps -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 
 v4-proto-py-gen: proto-export-deps
-	@rm -rf ./v4-proto-py/v4-proto-py
-	@mkdir -p ./v4-proto-py/v4-proto-py
+	@rm -rf ./v4-proto-py/v4_proto
+	@mkdir -p ./v4-proto-py/v4_proto
 	@for dir in $(PROTO_DIRS); do \
 		python3 -m grpc_tools.protoc \
 		-I .proto-export-deps \
-		--python_out=./v4-proto-py/v4-proto-py \
-		--pyi_out=./v4-proto-py/v4-proto-py \
-		--grpc_python_out=./v4-proto-py/v4-proto-py \
+		--python_out=./v4-proto-py/v4_proto \
+		--pyi_out=./v4-proto-py/v4_proto \
+		--grpc_python_out=./v4-proto-py/v4_proto \
 		$$(find ./$${dir} -type f -name '*.proto'); \
 	done; \
-	touch v4-proto-py/v4-proto-py/__init__.py
+	echo "import os\nimport sys\n\nsys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))" > v4-proto-py/v4_proto/__init__.py
 
 .PHONY: proto-format proto-lint proto-check-bc-breaking proto-export proto-export-deps v4-proto-py-gen


### PR DESCRIPTION
Fix the build of v4-proto-py, as I was trying to import it into the `v4-client-py` with no luck. The following changes worked for me:

* Build everything under `v4_proto` (when importing the package, it gets put under `v4-proto`, which has incompatible naming with python)
* Add a boilerplate `__init__.py`. This was in the original `dydxpy`, i'm not completely familiar with what it does but it helped to set the subdirectories correctly