### PR TITLE
[DEC-1399, CORE-538] Swap from deprecated Cosmos SDK types errors to Cosmos errors module

### DIFF
--- a/protocol/app/ante.go
+++ b/protocol/app/ante.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -27,19 +28,19 @@ type HandlerOptions struct {
 // https://github.com/cosmos/cosmos-sdk/blob/3bb27795742dab2451b232bab02b82566d1a0192/x/auth/ante/ante.go#L25
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	if options.AccountKeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for ante builder")
+		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "account keeper is required for ante builder")
 	}
 
 	if options.BankKeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for ante builder")
+		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "bank keeper is required for ante builder")
 	}
 
 	if options.ClobKeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "clob keeper is required for ante builder")
+		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "clob keeper is required for ante builder")
 	}
 
 	if options.SignModeHandler == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
+		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
 	}
 
 	anteDecorators := newAnteDecoratorChain(options)

--- a/protocol/app/ante/gas_test.go
+++ b/protocol/app/ante/gas_test.go
@@ -7,7 +7,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/app/ante"
 	testante "github.com/dydxprotocol/v4-chain/protocol/testutil/ante"
@@ -66,31 +66,31 @@ func TestValidateMsgType_FreeInfiniteGasDecorator(t *testing.T) {
 			msgOne: constants.Msg_CancelOrder,
 			msgTwo: constants.Msg_Transfer,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no freeInfiniteGasMeter: mult msgs, two MsgCancelOrder": {
 			msgOne: constants.Msg_CancelOrder,
 			msgTwo: constants.Msg_CancelOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no freeInfiniteGasMeter: mult msgs, MsgPlaceOrder with Transfer": {
 			msgOne: constants.Msg_PlaceOrder,
 			msgTwo: constants.Msg_Transfer,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no freeInfiniteGasMeter: mult msgs, two MsgPlaceOrder": {
 			msgOne: constants.Msg_PlaceOrder,
 			msgTwo: constants.Msg_PlaceOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no freeInfiniteGasMeter: mult msgs, MsgPlaceOrder and MsgCancelOrder": {
 			msgOne: constants.Msg_PlaceOrder,
 			msgTwo: constants.Msg_CancelOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 	}
 

--- a/protocol/app/ante/msg_type.go
+++ b/protocol/app/ante/msg_type.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -31,7 +32,7 @@ func (vbd ValidateMsgTypeDecorator) AnteHandle(
 	msgs := tx.GetMsgs()
 	numMsgs := len(msgs)
 	if numMsgs == 0 { // invalid.
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "msgs cannot be empty")
+		return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "msgs cannot be empty")
 	}
 
 	containsAppInjectedMsg := false
@@ -43,30 +44,30 @@ func (vbd ValidateMsgTypeDecorator) AnteHandle(
 
 		// 2. Internal-only message check.
 		if libante.IsInternalMsg(msg) {
-			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "internal msg cannot be submitted externally")
+			return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "internal msg cannot be submitted externally")
 		}
 
 		// 3. Nested message check.
 		if libante.IsNestedMsg(msg) {
 			if err := libante.ValidateNestedMsg(msg); err != nil {
-				return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
+				return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 			}
 		}
 
 		// 4. Unsupported message check.
 		if libante.IsUnsupportedMsg(msg) {
-			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "unsupported msg")
+			return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "unsupported msg")
 		}
 	}
 
 	// "App-injected message" must be the only msg in the tx.
 	if numMsgs > 1 && containsAppInjectedMsg {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "app-injected msg must be the only msg in a tx")
+		return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "app-injected msg must be the only msg in a tx")
 	}
 
 	// "App-injected message" must only be included in DeliverTx.
 	if containsAppInjectedMsg && !lib.IsDeliverTxMode(ctx) {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "app-injected msg must only be included in DeliverTx")
+		return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "app-injected msg must only be included in DeliverTx")
 	}
 
 	return next(ctx, tx, simulate)

--- a/protocol/app/ante/msg_type_test.go
+++ b/protocol/app/ante/msg_type_test.go
@@ -1,6 +1,7 @@
 package ante_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"testing"
 
@@ -37,31 +38,31 @@ var (
 
 	testMsg = &testdata.TestMsg{Signers: []string{"meh"}}
 
-	invalidReqErrCannotBeEmpty = sdkerrors.Wrap(
+	invalidReqErrCannotBeEmpty = errorsmod.Wrap(
 		sdkerrors.ErrInvalidRequest,
 		"msgs cannot be empty",
 	)
-	invalidReqErrAppInjectedMustBeOnlyMsg = sdkerrors.Wrap(
+	invalidReqErrAppInjectedMustBeOnlyMsg = errorsmod.Wrap(
 		sdkerrors.ErrInvalidRequest,
 		"app-injected msg must be the only msg in a tx",
 	)
-	invalidReqErrInternalMsg = sdkerrors.Wrap(
+	invalidReqErrInternalMsg = errorsmod.Wrap(
 		sdkerrors.ErrInvalidRequest,
 		"internal msg cannot be submitted externally",
 	)
-	invalidReqErrNestedUnsupportedMsg = sdkerrors.Wrap(
+	invalidReqErrNestedUnsupportedMsg = errorsmod.Wrap(
 		sdkerrors.ErrInvalidRequest,
 		fmt.Errorf("Invalid nested msg: unsupported msg type").Error(),
 	)
-	invalidReqErrNestedAppInjectedMsg = sdkerrors.Wrap(
+	invalidReqErrNestedAppInjectedMsg = errorsmod.Wrap(
 		sdkerrors.ErrInvalidRequest,
 		fmt.Errorf("Invalid nested msg: app-injected msg type").Error(),
 	)
-	invalidReqErrNestedDoubleNested = sdkerrors.Wrap(
+	invalidReqErrNestedDoubleNested = errorsmod.Wrap(
 		sdkerrors.ErrInvalidRequest,
 		fmt.Errorf("Invalid nested msg: double-nested msg type").Error(),
 	)
-	invalidReqErrUnsupportedMsg = sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "unsupported msg")
+	invalidReqErrUnsupportedMsg = errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "unsupported msg")
 )
 
 func TestValidateMsgType_Empty(t *testing.T) {
@@ -123,7 +124,7 @@ func TestValidateMsgType_AppInjectedMsg(t *testing.T) {
 
 			expectedErr: map[txMode]error{
 				reCheckTx: nil, // ReCheck skips the AnteHandler.
-				checkTx: sdkerrors.Wrap( // Should only be included in DeliverTx
+				checkTx: errorsmod.Wrap( // Should only be included in DeliverTx
 					sdkerrors.ErrInvalidRequest,
 					"app-injected msg must only be included in DeliverTx",
 				),

--- a/protocol/app/ante/sigverify.go
+++ b/protocol/app/ante/sigverify.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 
 	gometrics "github.com/armon/go-metrics"
@@ -62,7 +63,7 @@ func (svd SigVerificationDecorator) AnteHandle(
 ) (newCtx sdk.Context, err error) {
 	sigTx, ok := tx.(authsigning.SigVerifiableTx)
 	if !ok {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+		return ctx, errorsmod.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
 	}
 
 	// stdSigs contains the sequence number, account number, and signatures.
@@ -76,7 +77,7 @@ func (svd SigVerificationDecorator) AnteHandle(
 
 	// check that signer length and signature length are the same
 	if len(sigs) != len(signerAddrs) {
-		err := sdkerrors.Wrapf(
+		err := errorsmod.Wrapf(
 			sdkerrors.ErrUnauthorized,
 			"invalid number of signer;  expected: %d, got %d",
 			len(signerAddrs),
@@ -98,7 +99,7 @@ func (svd SigVerificationDecorator) AnteHandle(
 		// retrieve pubkey
 		pubKey := acc.GetPubKey()
 		if !simulate && pubKey == nil {
-			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
+			return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
 		}
 
 		// Check account sequence number.
@@ -117,7 +118,7 @@ func (svd SigVerificationDecorator) AnteHandle(
 				1,
 				labels,
 			)
-			return ctx, sdkerrors.Wrapf(
+			return ctx, errorsmod.Wrapf(
 				sdkerrors.ErrWrongSequence,
 				"account sequence mismatch, expected %d, got %d", acc.GetSequence(), sig.Sequence,
 			)
@@ -161,7 +162,7 @@ func (svd SigVerificationDecorator) AnteHandle(
 						chainID,
 					)
 				}
-				return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, errMsg)
+				return ctx, errorsmod.Wrap(sdkerrors.ErrUnauthorized, errMsg)
 			}
 		}
 	}

--- a/protocol/app/process/errors.go
+++ b/protocol/app/process/errors.go
@@ -2,9 +2,7 @@ package process
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 const (
 	ModuleName = "process_proposal"
@@ -12,8 +10,8 @@ const (
 
 var (
 	// 1 - 99: Default.
-	ErrDecodingTxBytes   = sdkerrors.Register(ModuleName, 1, "Decoding tx bytes failed")
-	ErrMsgValidateBasic  = sdkerrors.Register(ModuleName, 2, "ValidateBasic failed on msg")
-	ErrUnexpectedNumMsgs = sdkerrors.Register(ModuleName, 3, "Unexpected num of msgs")
-	ErrUnexpectedMsgType = sdkerrors.Register(ModuleName, 4, "Unexpected msg type")
+	ErrDecodingTxBytes   = errorsmod.Register(ModuleName, 1, "Decoding tx bytes failed")
+	ErrMsgValidateBasic  = errorsmod.Register(ModuleName, 2, "ValidateBasic failed on msg")
+	ErrUnexpectedNumMsgs = errorsmod.Register(ModuleName, 3, "Unexpected num of msgs")
+	ErrUnexpectedMsgType = errorsmod.Register(ModuleName, 4, "Unexpected msg type")
 )

--- a/protocol/app/process/market_prices_test.go
+++ b/protocol/app/process/market_prices_test.go
@@ -1,11 +1,11 @@
 package process_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/app/process"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -96,7 +96,7 @@ func TestUpdateMarketPricesTx_Validate(t *testing.T) {
 		"Error: Stateful + Deterministic validation fails": {
 			txBytes:     invalidStatefulMsgTxBytes,
 			indexPrices: constants.AtTimeTSingleExchangePriceUpdate,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidMarketPriceUpdateDeterministic,
 				"market param price (99) does not exist",
 			),
@@ -104,12 +104,12 @@ func TestUpdateMarketPricesTx_Validate(t *testing.T) {
 		"Error: Stateful + NonDeterministic validation fails": {
 			txBytes: validMsgTxBytes, // Msg is valid, but there's no corresponding index price.
 			// Skip index price updates, so the validation fails.
-			expectedErr: sdkerrors.Wrapf(types.ErrIndexPriceNotAvailable, "index price for market (0) is not available"),
+			expectedErr: errorsmod.Wrapf(types.ErrIndexPriceNotAvailable, "index price for market (0) is not available"),
 		},
 		"Error: ValidateBasic fails": {
 			txBytes:     invalidStatelessMsgTxBytes,
 			indexPrices: constants.AtTimeTSingleExchangePriceUpdate,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrMsgValidateBasic,
 				"price cannot be 0 for market id (0): Market price update is invalid: stateless.",
 			),

--- a/protocol/app/process/other_msgs.go
+++ b/protocol/app/process/other_msgs.go
@@ -1,8 +1,8 @@
 package process
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/ante"
 	libprocess "github.com/dydxprotocol/v4-chain/protocol/lib/process"
 )
@@ -22,20 +22,20 @@ func DecodeOtherMsgsTx(decoder sdk.TxDecoder, txBytes []byte) (*OtherMsgsTx, err
 	// Decode.
 	tx, err := decoder(txBytes)
 	if err != nil {
-		return nil, sdkerrors.Wrapf(ErrDecodingTxBytes, "OtherMsgsTx Error: %+v", err)
+		return nil, errorsmod.Wrapf(ErrDecodingTxBytes, "OtherMsgsTx Error: %+v", err)
 	}
 
 	// Check msg length.
 	allMsgs := tx.GetMsgs()
 	if len(allMsgs) == 0 {
-		return nil, sdkerrors.Wrapf(ErrUnexpectedNumMsgs, "OtherMsgs len cannot be zero")
+		return nil, errorsmod.Wrapf(ErrUnexpectedNumMsgs, "OtherMsgs len cannot be zero")
 	}
 
 	// Check msg type.
 	for _, msg := range allMsgs {
 		if ante.IsDisallowExternalSubmitMsg(msg) {
 			return nil,
-				sdkerrors.Wrapf(
+				errorsmod.Wrapf(
 					ErrUnexpectedMsgType,
 					"Invalid msg type or content in OtherTxs %T",
 					msg,
@@ -44,7 +44,7 @@ func DecodeOtherMsgsTx(decoder sdk.TxDecoder, txBytes []byte) (*OtherMsgsTx, err
 
 		if libprocess.IsDisallowTopLevelMsgInOtherTxs(msg) {
 			return nil,
-				sdkerrors.Wrapf(
+				errorsmod.Wrapf(
 					ErrUnexpectedMsgType,
 					"Msg type %T is not allowed in OtherTxs",
 					msg,

--- a/protocol/app/process/other_msgs_test.go
+++ b/protocol/app/process/other_msgs_test.go
@@ -1,10 +1,10 @@
 package process_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/app/process"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/encoding"
@@ -24,65 +24,65 @@ func TestDecodeOtherMsgsTx(t *testing.T) {
 	}{
 		"Error: decode fails": {
 			txBytes:                  []byte{1, 2, 3}, // invalid bytes.
-			expectedErr:              sdkerrors.Wrap(process.ErrDecodingTxBytes, "OtherMsgsTx Error"),
+			expectedErr:              errorsmod.Wrap(process.ErrDecodingTxBytes, "OtherMsgsTx Error"),
 			expectedErrTypeCheckOnly: true,
 		},
 		"Error: empty bytes": {
 			txBytes:     []byte{}, // empty returns 0 msgs.
-			expectedErr: sdkerrors.Wrap(process.ErrUnexpectedNumMsgs, "OtherMsgs len cannot be zero"),
+			expectedErr: errorsmod.Wrap(process.ErrUnexpectedNumMsgs, "OtherMsgs len cannot be zero"),
 		},
 		"Error: app-injected msg type is not allowed": {
 			txBytes: constants.ValidMsgUpdateMarketPricesTxBytes,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrUnexpectedMsgType,
 				"Invalid msg type or content in OtherTxs *types.MsgUpdateMarketPrices",
 			),
 		},
 		"Error: internal msg type is not allowed": {
 			txBytes: testmsgs.MsgSoftwareUpgradeTxBytes,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrUnexpectedMsgType,
 				"Invalid msg type or content in OtherTxs *types.MsgSoftwareUpgrade",
 			),
 		},
 		"Error: unsupported msg type is not allowed": {
 			txBytes: testmsgs.GovBetaMsgSubmitProposalTxBytes,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrUnexpectedMsgType,
 				"Invalid msg type or content in OtherTxs *v1beta1.MsgSubmitProposal",
 			),
 		},
 		"Error: nested msg type with unsupported inner is not allowed": {
 			txBytes: testmsgs.MsgSubmitProposalWithUnsupportedInnerTxBytes,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrUnexpectedMsgType,
 				"Invalid msg type or content in OtherTxs *v1.MsgSubmitProposal",
 			),
 		},
 		"Error: nested msg type with app-injected inner is not allowed": {
 			txBytes: testmsgs.MsgSubmitProposalWithAppInjectedInnerTxBytes,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrUnexpectedMsgType,
 				"Invalid msg type or content in OtherTxs *v1.MsgSubmitProposal",
 			),
 		},
 		"Error: nested msg type with double-nested inner is not allowed": {
 			txBytes: testmsgs.MsgSubmitProposalWithDoubleNestedInnerTxBytes,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrUnexpectedMsgType,
 				"Invalid msg type or content in OtherTxs *v1.MsgSubmitProposal",
 			),
 		},
 		"Error: place order is not allowed": {
 			txBytes: constants.Msg_PlaceOrder_TxBtyes,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrUnexpectedMsgType,
 				"Msg type *types.MsgPlaceOrder is not allowed in OtherTxs",
 			),
 		},
 		"Error: cancel order is not allowed": {
 			txBytes: constants.Msg_CancelOrder_TxBtyes,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrUnexpectedMsgType,
 				"Msg type *types.MsgCancelOrder is not allowed in OtherTxs",
 			),
@@ -131,11 +131,11 @@ func TestOtherMsgsTx_Validate(t *testing.T) {
 	}{
 		"Error Single: ValidateBasic fails": {
 			txBytes:     failingSingleTx,
-			expectedErr: sdkerrors.Wrap(process.ErrMsgValidateBasic, "0foo: invalid coins"),
+			expectedErr: errorsmod.Wrap(process.ErrMsgValidateBasic, "0foo: invalid coins"),
 		},
 		"Error Multi: ValidateBasic fails": {
 			txBytes:     failingMultiTx,
-			expectedErr: sdkerrors.Wrap(process.ErrMsgValidateBasic, "0foo: invalid coins"),
+			expectedErr: errorsmod.Wrap(process.ErrMsgValidateBasic, "0foo: invalid coins"),
 		},
 		"Valid Single: ValidateBasic passes": {
 			txBytes: constants.Msg_Send_TxBytes,

--- a/protocol/app/process/transactions.go
+++ b/protocol/app/process/transactions.go
@@ -1,9 +1,9 @@
 package process
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 type txtype int
@@ -43,7 +43,7 @@ func DecodeProcessProposalTxs(
 	// Check len.
 	numTxs := len(req.Txs)
 	if numTxs < MinTxsCount {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			ErrUnexpectedNumMsgs,
 			"Expected the proposal to contain at least %d txs, but got %d",
 			MinTxsCount,

--- a/protocol/app/process/transactions_test.go
+++ b/protocol/app/process/transactions_test.go
@@ -1,11 +1,11 @@
 package process_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/app/process"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -40,35 +40,35 @@ func TestDecodeProcessProposalTxs_Error(t *testing.T) {
 	}{
 		"Less than min num txs": {
 			txsBytes: [][]byte{validOperationsTx, validAddFundingTx, validUpdatePriceTx}, // need at least 4.
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				process.ErrUnexpectedNumMsgs,
 				"Expected the proposal to contain at least 4 txs, but got 3",
 			),
 		},
 		"Order tx decoding fails": {
 			txsBytes: [][]byte{invalidTxBytes, validAcknowledgeBridgesTx, validAddFundingTx, validUpdatePriceTx},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				process.ErrDecodingTxBytes,
 				"invalid field number: tx parse error",
 			),
 		},
 		"Acknowledge bridges tx decoding fails": {
 			txsBytes: [][]byte{validOperationsTx, invalidTxBytes, validAddFundingTx, validUpdatePriceTx},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				process.ErrDecodingTxBytes,
 				"invalid field number: tx parse error",
 			),
 		},
 		"Add funding tx decoding fails": {
 			txsBytes: [][]byte{validOperationsTx, validAcknowledgeBridgesTx, invalidTxBytes, validUpdatePriceTx},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				process.ErrDecodingTxBytes,
 				"invalid field number: tx parse error",
 			),
 		},
 		"Update prices tx decoding fails": {
 			txsBytes: [][]byte{validOperationsTx, validAcknowledgeBridgesTx, validAddFundingTx, invalidTxBytes},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				process.ErrDecodingTxBytes,
 				"invalid field number: tx parse error",
 			),
@@ -82,7 +82,7 @@ func TestDecodeProcessProposalTxs_Error(t *testing.T) {
 				validAddFundingTx,
 				validUpdatePriceTx,
 			},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				process.ErrDecodingTxBytes,
 				"invalid field number: tx parse error",
 			),
@@ -96,7 +96,7 @@ func TestDecodeProcessProposalTxs_Error(t *testing.T) {
 				validAddFundingTx,
 				validUpdatePriceTx,
 			},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				process.ErrUnexpectedMsgType,
 				"Invalid msg type or content in OtherTxs *types.MsgUpdateMarketPrices",
 			),
@@ -267,14 +267,14 @@ func TestProcessProposalTxs_Validate_Error(t *testing.T) {
 		},
 		"AddFunding tx validation fails": {
 			txsBytes: [][]byte{validOperationsTx, validAcknowledgeBridgesTx, invalidAddFundingTx, validUpdatePriceTx},
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrMsgValidateBasic,
 				"premium votes must be sorted by perpetual id in ascending order and "+
 					"cannot contain duplicates: MsgAddPremiumVotes is invalid"),
 		},
 		"UpdatePrices tx validation fails": {
 			txsBytes: [][]byte{validOperationsTx, validAcknowledgeBridgesTx, validAddFundingTx, invalidUpdatePriceTx},
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				process.ErrMsgValidateBasic,
 				"price cannot be 0 for market id (0): Market price update is invalid: stateless.",
 			),
@@ -288,7 +288,7 @@ func TestProcessProposalTxs_Validate_Error(t *testing.T) {
 				validAddFundingTx,
 				validUpdatePriceTx,
 			},
-			expectedErr: sdkerrors.Wrap(process.ErrMsgValidateBasic, "0foo: invalid coins"),
+			expectedErr: errorsmod.Wrap(process.ErrMsgValidateBasic, "0foo: invalid coins"),
 		},
 		"Other txs validation fails: multi txs": {
 			txsBytes: [][]byte{
@@ -299,7 +299,7 @@ func TestProcessProposalTxs_Validate_Error(t *testing.T) {
 				validAddFundingTx,
 				validUpdatePriceTx,
 			},
-			expectedErr: sdkerrors.Wrap(process.ErrMsgValidateBasic, "0foo: invalid coins"),
+			expectedErr: errorsmod.Wrap(process.ErrMsgValidateBasic, "0foo: invalid coins"),
 		},
 	}
 

--- a/protocol/app/process/utils.go
+++ b/protocol/app/process/utils.go
@@ -1,26 +1,26 @@
 package process
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"reflect"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // getValidateBasicError returns a sdk error for `Msg.ValidateBasic` failure.
 func getValidateBasicError(msg sdk.Msg, err error) error {
-	return sdkerrors.Wrapf(ErrMsgValidateBasic, "Msg Type: %T, Error: %+v", msg, err)
+	return errorsmod.Wrapf(ErrMsgValidateBasic, "Msg Type: %T, Error: %+v", msg, err)
 }
 
 // getDecodingError returns a sdk error for tx decoding failure.
 func getDecodingError(msgType reflect.Type, err error) error {
-	return sdkerrors.Wrapf(ErrDecodingTxBytes, "Msg Type: %s, Error: %+v", msgType, err)
+	return errorsmod.Wrapf(ErrDecodingTxBytes, "Msg Type: %s, Error: %+v", msgType, err)
 }
 
 // getUnexpectedNumMsgsError returns a sdk error for having unexpected num of msgs in the tx.
 func getUnexpectedNumMsgsError(msgType reflect.Type, expectedNum int, actualNum int) error {
-	return sdkerrors.Wrapf(
+	return errorsmod.Wrapf(
 		ErrUnexpectedNumMsgs,
 		"Msg Type: %s, Expected %d num of msgs, but got %d",
 		msgType,
@@ -31,7 +31,7 @@ func getUnexpectedNumMsgsError(msgType reflect.Type, expectedNum int, actualNum 
 
 // getUnexpectedMsgTypeError returns a sdk error for having unexpected msg type in the tx.
 func getUnexpectedMsgTypeError(expectedMsgType reflect.Type, actualMsg sdk.Msg) error {
-	return sdkerrors.Wrapf(
+	return errorsmod.Wrapf(
 		ErrUnexpectedMsgType, "Expected MsgType %s, but got %T", expectedMsgType, actualMsg,
 	)
 }

--- a/protocol/daemons/server/pricefeed.go
+++ b/protocol/daemons/server/pricefeed.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 	"time"
 
 	gometrics "github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
 	pricefeedmetrics "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
@@ -45,7 +45,7 @@ func (s *Server) UpdateMarketPrices(
 
 	if s.marketToExchange == nil {
 		panic(
-			sdkerrors.Wrapf(
+			errorsmod.Wrapf(
 				types.ErrServerNotInitializedCorrectly,
 				"MarketToExchange not initialized",
 			),
@@ -112,5 +112,5 @@ func validateMarketPriceUpdate(mpu *api.MarketPriceUpdate) error {
 
 // generateSdkErrorForExchangePrice generates an error for an invalid `ExchangePrice`.
 func generateSdkErrorForExchangePrice(err error, ep *api.ExchangePrice, marketId uint32) error {
-	return sdkerrors.Wrapf(err, "ExchangePrice: %v and MarketId: %d", ep, marketId)
+	return errorsmod.Wrapf(err, "ExchangePrice: %v and MarketId: %d", ep, marketId)
 }

--- a/protocol/daemons/server/pricefeed_test.go
+++ b/protocol/daemons/server/pricefeed_test.go
@@ -2,12 +2,12 @@ package server_test
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"fmt"
 	pricefeed_types "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/types"
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	pricefeedconstants "github.com/dydxprotocol/v4-chain/protocol/daemons/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/server"
@@ -50,7 +50,7 @@ func TestUpdateMarketPrices_NotInitialized(t *testing.T) {
 	req := &api.UpdateMarketPricesRequest{MarketPriceUpdates: constants.AtTimeTPriceUpdate}
 	require.PanicsWithError(
 		t,
-		sdkerrors.Wrapf(
+		errorsmod.Wrapf(
 			types.ErrServerNotInitializedCorrectly,
 			"MarketToExchange not initialized",
 		).Error(),
@@ -150,7 +150,7 @@ func TestUpdateMarketPrices_InvalidExchangePrices(t *testing.T) {
 			).WithPriceFeedMarketToExchangePrices(
 				pricefeedserver_types.NewMarketToExchangePrices(pricefeed_types.MaxPriceAge),
 			)
-			expectedErr := sdkerrors.Wrapf(
+			expectedErr := errorsmod.Wrapf(
 				tc.expectedError,
 				"ExchangePrice: %v and MarketId: %d",
 				// Assumes first ExchangePrice is the one with a validation error.

--- a/protocol/daemons/types/errors.go
+++ b/protocol/daemons/types/errors.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/constants"
 )
 
@@ -12,15 +12,15 @@ const Name = "daemons"
 // daemon errors
 var (
 	// Generic daemon server errors.
-	ErrDaemonMethodNotImplemented    = sdkerrors.Register(Name, 1, "Daemon method not implemented")
-	ErrServerNotInitializedCorrectly = sdkerrors.Register(Name, 2, "Daemon server not initialized correctly")
+	ErrDaemonMethodNotImplemented    = errorsmod.Register(Name, 1, "Daemon method not implemented")
+	ErrServerNotInitializedCorrectly = errorsmod.Register(Name, 2, "Daemon server not initialized correctly")
 
 	// PriceFeed daemon service errors will have code 1xxx.
-	ErrPriceFeedInvalidPrice = sdkerrors.Register(
+	ErrPriceFeedInvalidPrice = errorsmod.Register(
 		Name,
 		1000,
 		fmt.Sprintf("Price is set to %d which is not a valid price", constants.DefaultPrice),
 	)
-	ErrPriceFeedLastUpdateTimeNotSet   = sdkerrors.Register(Name, 1001, "LastUpdateTime is not set")
-	ErrPriceFeedMarketPriceUpdateEmpty = sdkerrors.Register(Name, 1002, "Market price update has length of 0")
+	ErrPriceFeedLastUpdateTimeNotSet   = errorsmod.Register(Name, 1001, "LastUpdateTime is not set")
+	ErrPriceFeedMarketPriceUpdateEmpty = errorsmod.Register(Name, 1002, "Market price update has length of 0")
 )

--- a/protocol/indexer/off_chain_updates/off_chain_updates_test.go
+++ b/protocol/indexer/off_chain_updates/off_chain_updates_test.go
@@ -1,11 +1,11 @@
 package off_chain_updates
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"testing"
 
 	"github.com/cometbft/cometbft/libs/log"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/msgsender"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/protocol/v1"
@@ -336,31 +336,31 @@ func TestShouldSendOrderRemovalOnReplay(t *testing.T) {
 			expected:   false,
 		},
 		"Returns false for wrapped ErrOrderReprocessed": {
-			orderError: sdkerrors.Wrapf(clobtypes.ErrOrderReprocessed, "wrapped error"),
+			orderError: errorsmod.Wrapf(clobtypes.ErrOrderReprocessed, "wrapped error"),
 			expected:   false,
 		},
 		"Returns false for wrapped ErrInvalidReplacement": {
-			orderError: sdkerrors.Wrapf(clobtypes.ErrInvalidReplacement, "wrapped error"),
+			orderError: errorsmod.Wrapf(clobtypes.ErrInvalidReplacement, "wrapped error"),
 			expected:   false,
 		},
 		"Returns false for wrapped ErrOrderFullyFilled": {
-			orderError: sdkerrors.Wrapf(clobtypes.ErrOrderFullyFilled, "wrapped error"),
+			orderError: errorsmod.Wrapf(clobtypes.ErrOrderFullyFilled, "wrapped error"),
 			expected:   false,
 		},
 		"Returns false for wrapped ErrOrderIsCanceled": {
-			orderError: sdkerrors.Wrapf(clobtypes.ErrOrderIsCanceled, "wrapped error"),
+			orderError: errorsmod.Wrapf(clobtypes.ErrOrderIsCanceled, "wrapped error"),
 			expected:   false,
 		},
 		"Returns false for wrapped ErrStatefulOrderAlreadyExists": {
-			orderError: sdkerrors.Wrapf(clobtypes.ErrStatefulOrderAlreadyExists, "wrapped error"),
+			orderError: errorsmod.Wrapf(clobtypes.ErrStatefulOrderAlreadyExists, "wrapped error"),
 			expected:   false,
 		},
 		"Returns false for wrapped ErrHeightExceedsGoodTilBlock": {
-			orderError: sdkerrors.Wrapf(clobtypes.ErrHeightExceedsGoodTilBlock, "wrapped error"),
+			orderError: errorsmod.Wrapf(clobtypes.ErrHeightExceedsGoodTilBlock, "wrapped error"),
 			expected:   false,
 		},
 		"Returns false for wrapped ErrTimeExceedsGoodTilBlockTime": {
-			orderError: sdkerrors.Wrapf(clobtypes.ErrTimeExceedsGoodTilBlockTime, "wrapped error"),
+			orderError: errorsmod.Wrapf(clobtypes.ErrTimeExceedsGoodTilBlockTime, "wrapped error"),
 			expected:   false,
 		},
 		"Returns false for other error": {

--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -1,13 +1,13 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 )
@@ -26,7 +26,7 @@ func (k Keeper) CreateAsset(
 
 	_, found := k.internalGetIdByDenom(ctx, denom)
 	if found {
-		return types.Asset{}, sdkerrors.Wrap(types.ErrAssetDenomAlreadyExists, denom)
+		return types.Asset{}, errorsmod.Wrap(types.ErrAssetDenomAlreadyExists, denom)
 	}
 
 	// Create the asset
@@ -47,7 +47,7 @@ func (k Keeper) CreateAsset(
 			return asset, err
 		}
 	} else if marketId > 0 {
-		return asset, sdkerrors.Wrapf(
+		return asset, errorsmod.Wrapf(
 			types.ErrInvalidMarketId,
 			"Market ID: %v",
 			marketId,
@@ -121,7 +121,7 @@ func (k Keeper) ModifyLongInterest(
 
 	// Validate delta
 	if !isIncrease && delta > asset.LongInterest {
-		return asset, sdkerrors.Wrap(types.ErrNegativeLongInterest, lib.Uint32ToString(id))
+		return asset, errorsmod.Wrap(types.ErrNegativeLongInterest, lib.Uint32ToString(id))
 	}
 
 	// Modify asset
@@ -202,7 +202,7 @@ func (k Keeper) GetIdByDenom(
 	id, found := k.internalGetIdByDenom(ctx, denom)
 
 	if !found {
-		return 0, sdkerrors.Wrap(types.ErrNoAssetWithDenom, denom)
+		return 0, errorsmod.Wrap(types.ErrNoAssetWithDenom, denom)
 	}
 
 	return id, nil
@@ -233,7 +233,7 @@ func (k Keeper) GetAsset(
 
 	b := store.Get(types.AssetKey(id))
 	if b == nil {
-		return val, sdkerrors.Wrap(types.ErrAssetDoesNotExist, lib.Uint32ToString(id))
+		return val, errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.Uint32ToString(id))
 	}
 
 	k.cdc.MustUnmarshal(b, &val)
@@ -358,7 +358,7 @@ func (k Keeper) ConvertAssetToCoin(
 	}
 
 	if lib.AbsInt32(asset.AtomicResolution) > types.MaxAssetUnitExponentAbs {
-		return nil, sdk.Coin{}, sdkerrors.Wrapf(
+		return nil, sdk.Coin{}, errorsmod.Wrapf(
 			types.ErrInvalidAssetAtomicResolution,
 			"asset: %+v",
 			asset,
@@ -366,7 +366,7 @@ func (k Keeper) ConvertAssetToCoin(
 	}
 
 	if lib.AbsInt32(asset.DenomExponent) > types.MaxAssetUnitExponentAbs {
-		return nil, sdk.Coin{}, sdkerrors.Wrapf(
+		return nil, sdk.Coin{}, errorsmod.Wrapf(
 			types.ErrInvalidDenomExponent,
 			"asset: %+v",
 			asset,

--- a/protocol/x/assets/keeper/asset_test.go
+++ b/protocol/x/assets/keeper/asset_test.go
@@ -1,13 +1,13 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"math/big"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/nullify"
@@ -67,7 +67,7 @@ func TestCreateAsset_MarketNotFound(t *testing.T) {
 		uint32(999),
 		int32(-1),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(pricestypes.ErrMarketPriceDoesNotExist, "999").Error())
+	require.EqualError(t, err, errorsmod.Wrap(pricestypes.ErrMarketPriceDoesNotExist, "999").Error())
 
 	// Does not create an asset.
 	numAssets := keeper.GetNumAssets(ctx)
@@ -87,7 +87,7 @@ func TestCreateAsset_MarketIdInvalid(t *testing.T) {
 		uint32(1),
 		int32(-1),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrInvalidMarketId, "Market ID: 1").Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrInvalidMarketId, "Market ID: 1").Error())
 
 	// Does not create an asset.
 	numAssets := keeper.GetNumAssets(ctx)
@@ -120,7 +120,7 @@ func TestCreateAsset_AssetAlreadyExists(t *testing.T) {
 		0,           // marketId
 		10,          // atomicResolution
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrAssetDenomAlreadyExists, "btc-denom").Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrAssetDenomAlreadyExists, "btc-denom").Error())
 }
 
 func TestModifyAsset_Success(t *testing.T) {
@@ -176,7 +176,7 @@ func TestModifyAsset_NotFound(t *testing.T) {
 		true,
 		uint32(1),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrAssetDoesNotExist, "0").Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrAssetDoesNotExist, "0").Error())
 	require.ErrorIs(t, err, types.ErrAssetDoesNotExist)
 
 	// Actually create the asset
@@ -204,7 +204,7 @@ func TestModifyAsset_MarketNotFound(t *testing.T) {
 		true,
 		uint32(999),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(pricestypes.ErrMarketPriceDoesNotExist, "999").Error())
+	require.EqualError(t, err, errorsmod.Wrap(pricestypes.ErrMarketPriceDoesNotExist, "999").Error())
 }
 
 func TestGetDenomById_Success(t *testing.T) {
@@ -232,7 +232,7 @@ func TestGetDenomById_NotFound(t *testing.T) {
 		ctx,
 		0,
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrAssetDoesNotExist, "0").Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrAssetDoesNotExist, "0").Error())
 }
 
 func TestGetIdByDenom_Success(t *testing.T) {
@@ -262,7 +262,7 @@ func TestGetIdByDenom_NotFound(t *testing.T) {
 	_, err = keeper.GetIdByDenom(ctx,
 		nonExistingDenom,
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrNoAssetWithDenom, nonExistingDenom).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrNoAssetWithDenom, nonExistingDenom).Error())
 }
 
 func TestGetAsset_Success(t *testing.T) {
@@ -287,7 +287,7 @@ func TestGetAsset_NotFound(t *testing.T) {
 	_, err := keeper.GetAsset(ctx,
 		uint32(0),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrAssetDoesNotExist, "0").Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrAssetDoesNotExist, "0").Error())
 }
 
 func TestGetAllAssets_Success(t *testing.T) {
@@ -383,7 +383,7 @@ func TestModifyLongInterest_CannotNegative(t *testing.T) {
 		false,
 		uint64(12),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrNegativeLongInterest, "0").Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrNegativeLongInterest, "0").Error())
 	getAsset, err = keeper.GetAsset(ctx, assetId)
 	require.NoError(t, err)
 	require.Equal(t, asset, getAsset)

--- a/protocol/x/assets/types/errors.go
+++ b/protocol/x/assets/types/errors.go
@@ -2,25 +2,23 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/assets module sentinel errors
 var (
-	ErrAssetDoesNotExist            = sdkerrors.Register(ModuleName, 1, "Asset does not exist")
-	ErrNegativeLongInterest         = sdkerrors.Register(ModuleName, 2, "LongInterest cannot be negative")
-	ErrNoAssetWithDenom             = sdkerrors.Register(ModuleName, 3, "No asset found associated with given denom")
-	ErrAssetDenomAlreadyExists      = sdkerrors.Register(ModuleName, 4, "Existing asset found with the same denom")
-	ErrAssetIdAlreadyExists         = sdkerrors.Register(ModuleName, 5, "Existing asset found with the same asset id")
-	ErrGapFoundInAssetId            = sdkerrors.Register(ModuleName, 6, "Found gap in asset Id")
-	ErrAssetZeroNotUsdc             = sdkerrors.Register(ModuleName, 7, "First asset is not USDC")
-	ErrNoAssetInGenesis             = sdkerrors.Register(ModuleName, 8, "No asset found in genesis state")
-	ErrInvalidMarketId              = sdkerrors.Register(ModuleName, 9, "Found market id for asset without market")
-	ErrInvalidAssetAtomicResolution = sdkerrors.Register(ModuleName, 10, "Invalid asset atomic resolution")
-	ErrInvalidDenomExponent         = sdkerrors.Register(ModuleName, 11, "Invalid denom exponent")
+	ErrAssetDoesNotExist            = errorsmod.Register(ModuleName, 1, "Asset does not exist")
+	ErrNegativeLongInterest         = errorsmod.Register(ModuleName, 2, "LongInterest cannot be negative")
+	ErrNoAssetWithDenom             = errorsmod.Register(ModuleName, 3, "No asset found associated with given denom")
+	ErrAssetDenomAlreadyExists      = errorsmod.Register(ModuleName, 4, "Existing asset found with the same denom")
+	ErrAssetIdAlreadyExists         = errorsmod.Register(ModuleName, 5, "Existing asset found with the same asset id")
+	ErrGapFoundInAssetId            = errorsmod.Register(ModuleName, 6, "Found gap in asset Id")
+	ErrAssetZeroNotUsdc             = errorsmod.Register(ModuleName, 7, "First asset is not USDC")
+	ErrNoAssetInGenesis             = errorsmod.Register(ModuleName, 8, "No asset found in genesis state")
+	ErrInvalidMarketId              = errorsmod.Register(ModuleName, 9, "Found market id for asset without market")
+	ErrInvalidAssetAtomicResolution = errorsmod.Register(ModuleName, 10, "Invalid asset atomic resolution")
+	ErrInvalidDenomExponent         = errorsmod.Register(ModuleName, 11, "Invalid denom exponent")
 
 	// Errors for Not Implemented
-	ErrNotImplementedMulticollateral = sdkerrors.Register(ModuleName, 401, "Not Implemented: Multi-Collateral")
-	ErrNotImplementedMargin          = sdkerrors.Register(ModuleName, 402, "Not Implemented: Margin-Trading of Assets")
+	ErrNotImplementedMulticollateral = errorsmod.Register(ModuleName, 401, "Not Implemented: Multi-Collateral")
+	ErrNotImplementedMargin          = errorsmod.Register(ModuleName, 402, "Not Implemented: Margin-Trading of Assets")
 )

--- a/protocol/x/blocktime/keeper/msg_server.go
+++ b/protocol/x/blocktime/keeper/msg_server.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -29,7 +29,7 @@ func (k msgServer) UpdateDowntimeParams(
 	msg *types.MsgUpdateDowntimeParams,
 ) (*types.MsgUpdateDowntimeParamsResponse, error) {
 	if !k.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/blocktime/types/errors.go
+++ b/protocol/x/blocktime/types/errors.go
@@ -2,17 +2,15 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 var (
-	ErrNonpositiveDuration = sdkerrors.Register(
+	ErrNonpositiveDuration = errorsmod.Register(
 		ModuleName,
 		400,
 		"Durations must be positive",
 	)
-	ErrUnorderedDurations = sdkerrors.Register(
+	ErrUnorderedDurations = errorsmod.Register(
 		ModuleName,
 		401,
 		"Durations must be in ascending order by length",

--- a/protocol/x/bridge/types/errors.go
+++ b/protocol/x/bridge/types/errors.go
@@ -2,49 +2,47 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/bridge module sentinel errors
 var (
-	ErrBridgeIdNotRecognized = sdkerrors.Register(
+	ErrBridgeIdNotRecognized = errorsmod.Register(
 		ModuleName,
 		1,
 		"Bridge event ID is not recognized",
 	)
-	ErrBridgeIdNotNextToAcknowledge = sdkerrors.Register(
+	ErrBridgeIdNotNextToAcknowledge = errorsmod.Register(
 		ModuleName,
 		2,
 		"Bridge event ID is not the ID to be next acknowledged",
 	)
-	ErrBridgeIdsNotConsecutive = sdkerrors.Register(
+	ErrBridgeIdsNotConsecutive = errorsmod.Register(
 		ModuleName,
 		3,
 		"Bridge event IDs are not consecutive",
 	)
-	ErrInvalidAuthority = sdkerrors.Register(
+	ErrInvalidAuthority = errorsmod.Register(
 		ModuleName,
 		4,
 		"Authority is invalid",
 	)
-	ErrBridgeEventNotFound = sdkerrors.Register(
+	ErrBridgeEventNotFound = errorsmod.Register(
 		ModuleName,
 		5,
 		"Bridge event not found",
 	)
-	ErrBridgeEventContentMismatch = sdkerrors.Register(
+	ErrBridgeEventContentMismatch = errorsmod.Register(
 		ModuleName,
 		6,
 		"Bridge event content mismatch",
 	)
 
-	ErrNegativeDuration = sdkerrors.Register(
+	ErrNegativeDuration = errorsmod.Register(
 		ModuleName,
 		400,
 		"Duration is negative",
 	)
-	ErrRateOutOfBounds = sdkerrors.Register(
+	ErrRateOutOfBounds = errorsmod.Register(
 		ModuleName,
 		401,
 		"Rate is out of bounds",

--- a/protocol/x/clob/ante/ante_wrapper_test.go
+++ b/protocol/x/clob/ante/ante_wrapper_test.go
@@ -6,7 +6,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	testante "github.com/dydxprotocol/v4-chain/protocol/testutil/ante"
@@ -68,31 +68,31 @@ func TestValidateMsgType_NewSingleMsgClobTx(t *testing.T) {
 			msgOne: constants.Msg_CancelOrder,
 			msgTwo: constants.Msg_Transfer,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no skip: mult msgs, two MsgCancelOrder": {
 			msgOne: constants.Msg_CancelOrder,
 			msgTwo: constants.Msg_CancelOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no skip: mult msgs, MsgPlaceOrder with Transfer": {
 			msgOne: constants.Msg_PlaceOrder,
 			msgTwo: constants.Msg_Transfer,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no skip: mult msgs, two MsgPlaceOrder": {
 			msgOne: constants.Msg_PlaceOrder,
 			msgTwo: constants.Msg_PlaceOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no skip: mult msgs, MsgCancelOrder and MsgPlaceOrder": {
 			msgOne: constants.Msg_CancelOrder,
 			msgTwo: constants.Msg_PlaceOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 	}
 
@@ -203,31 +203,31 @@ func TestValidateMsgType_NewShortTermSingleMsgClobTx(t *testing.T) {
 			msgOne: constants.Msg_CancelOrder,
 			msgTwo: constants.Msg_Transfer,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no skip: mult msgs, two MsgCancelOrder": {
 			msgOne: constants.Msg_CancelOrder,
 			msgTwo: constants.Msg_CancelOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no skip: mult msgs, MsgPlaceOrder with Transfer": {
 			msgOne: constants.Msg_PlaceOrder,
 			msgTwo: constants.Msg_Transfer,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no skip: mult msgs, two MsgPlaceOrder": {
 			msgOne: constants.Msg_PlaceOrder,
 			msgTwo: constants.Msg_PlaceOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 		"no skip: mult msgs, MsgCancelOrder and MsgPlaceOrder": {
 			msgOne: constants.Msg_CancelOrder,
 			msgTwo: constants.Msg_PlaceOrder,
 
-			expectedErr: errors.ErrInvalidRequest,
+			expectedErr: sdkerrors.ErrInvalidRequest,
 		},
 	}
 

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/libs/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -170,7 +171,7 @@ func IsSingleClobMsgTx(ctx sdk.Context, tx sdk.Tx) (bool, error) {
 
 	numMsgs := len(msgs)
 	if numMsgs > 1 {
-		return false, sdkerrors.Wrap(
+		return false, errorsmod.Wrap(
 			sdkerrors.ErrInvalidRequest,
 			"a transaction containing MsgCancelOrder or MsgPlaceOrder may not contain more than one message",
 		)
@@ -214,7 +215,7 @@ func IsShortTermClobMsgTx(ctx sdk.Context, tx sdk.Tx) (bool, error) {
 
 	numMsgs := len(msgs)
 	if numMsgs > 1 {
-		return false, sdkerrors.Wrap(
+		return false, errorsmod.Wrap(
 			sdkerrors.ErrInvalidRequest,
 			"a transaction containing MsgCancelOrder or MsgPlaceOrder may not contain more than one message",
 		)

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -9,7 +9,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -193,22 +193,22 @@ func TestClobDecorator_MsgPlaceOrder(t *testing.T) {
 		"Fails if there are multiple off-chain places": {
 			msgs:                    []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_PlaceOrder},
 			useWithIsCheckTxContext: true,
-			expectedErr:             errors.ErrInvalidRequest,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
 		"Fails if there is a mix of long term and short term orders": {
 			msgs:                    []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_PlaceOrder_LongTerm},
 			useWithIsCheckTxContext: true,
-			expectedErr:             errors.ErrInvalidRequest,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
 		"Fails if there is a mix of conditional and short term orders": {
 			msgs:                    []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_PlaceOrder_Conditional},
 			useWithIsCheckTxContext: true,
-			expectedErr:             errors.ErrInvalidRequest,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
 		"Fails if there are a mix of off-chain and on-chain messages": {
 			msgs:                    []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_Send},
 			useWithIsCheckTxContext: true,
-			expectedErr:             errors.ErrInvalidRequest,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
 	}
 
@@ -244,22 +244,22 @@ func TestIsClobTransaction(t *testing.T) {
 		"Returns false and error for multiple `PlaceOrder` message": {
 			msgs:           []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_PlaceOrder},
 			expectedResult: false,
-			expectedErr:    errors.ErrInvalidRequest,
+			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns false and error for multiple `CancelOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_CancelOrder, constants.Msg_CancelOrder},
 			expectedResult: false,
-			expectedErr:    errors.ErrInvalidRequest,
+			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns false and error for mix of `PlaceOrder` and `CancelOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_CancelOrder},
 			expectedResult: false,
-			expectedErr:    errors.ErrInvalidRequest,
+			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns false and error for mix of `MsgSend` and `PlaceOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_Send, constants.Msg_PlaceOrder},
 			expectedResult: false,
-			expectedErr:    errors.ErrInvalidRequest,
+			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns true for a `CancelOrder` message": {
 			msgs:           []sdk.Msg{constants.Msg_CancelOrder},
@@ -319,22 +319,22 @@ func TestIsShortTermClobTransaction(t *testing.T) {
 		"Returns false and error for multiple `PlaceOrder` message": {
 			msgs:           []sdk.Msg{constants.Msg_PlaceOrder_LongTerm, constants.Msg_PlaceOrder},
 			expectedResult: false,
-			expectedErr:    errors.ErrInvalidRequest,
+			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns false and error for multiple `CancelOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_CancelOrder_LongTerm, constants.Msg_CancelOrder},
 			expectedResult: false,
-			expectedErr:    errors.ErrInvalidRequest,
+			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns false and error for mix of `PlaceOrder` and `CancelOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_CancelOrder},
 			expectedResult: false,
-			expectedErr:    errors.ErrInvalidRequest,
+			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns false and error for mix of `MsgSend` and `PlaceOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_Send, constants.Msg_PlaceOrder},
 			expectedResult: false,
-			expectedErr:    errors.ErrInvalidRequest,
+			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns true for a Short-Term `CancelOrder` message": {
 			msgs:           []sdk.Msg{constants.Msg_CancelOrder},
@@ -515,17 +515,17 @@ func TestClobDecorator_MsgCancelOrder(t *testing.T) {
 		"Fails if there are multiple off-chain cancels": {
 			msgs:                    []sdk.Msg{constants.Msg_CancelOrder, constants.Msg_CancelOrder},
 			useWithIsCheckTxContext: true,
-			expectedErr:             errors.ErrInvalidRequest,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
 		"Fails if there are multiple off-chain messages": {
 			msgs:                    []sdk.Msg{constants.Msg_CancelOrder, constants.Msg_PlaceOrder},
 			useWithIsCheckTxContext: true,
-			expectedErr:             errors.ErrInvalidRequest,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
 		"Fails if there are a mix of off-chain and on-chain messages": {
 			msgs:                    []sdk.Msg{constants.Msg_CancelOrder, constants.Msg_Send},
 			useWithIsCheckTxContext: true,
-			expectedErr:             errors.ErrInvalidRequest,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
 	}
 

--- a/protocol/x/clob/genesis.go
+++ b/protocol/x/clob/genesis.go
@@ -1,8 +1,8 @@
 package clob
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -17,7 +17,7 @@ func InitGenesis(ctx sdk.Context, k *keeper.Keeper, genState types.GenesisState)
 	for _, elem := range genState.ClobPairs {
 		perpetualId, err := elem.GetPerpetualId()
 		if err != nil {
-			panic(sdkerrors.Wrap(types.ErrInvalidClobPairParameter, err.Error()))
+			panic(errorsmod.Wrap(types.ErrInvalidClobPairParameter, err.Error()))
 		}
 		_, err = k.CreatePerpetualClobPair(
 			ctx,

--- a/protocol/x/clob/genesis_test.go
+++ b/protocol/x/clob/genesis_test.go
@@ -1,6 +1,7 @@
 package clob_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"testing"
 
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -459,7 +459,7 @@ func TestGenesis(t *testing.T) {
 			if tc.expectedErr != "" {
 				require.PanicsWithError(
 					t,
-					sdkerrors.Wrap(
+					errorsmod.Wrap(
 						tc.expectedErrType,
 						tc.expectedErr,
 					).Error(),

--- a/protocol/x/clob/keeper/clob_pair.go
+++ b/protocol/x/clob/keeper/clob_pair.go
@@ -1,12 +1,12 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"sort"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -33,7 +33,7 @@ func (k Keeper) CreatePerpetualClobPair(
 ) (types.ClobPair, error) {
 	// If the desired CLOB pair ID is already in use, return an error.
 	if clobPair, exists := k.GetClobPair(ctx, types.ClobPairId(clobPairId)); exists {
-		return types.ClobPair{}, sdkerrors.Wrapf(
+		return types.ClobPair{}, errorsmod.Wrapf(
 			types.ErrClobPairAlreadyExists,
 			"id=%v, existing clob pair=%v",
 			clobPairId,
@@ -43,7 +43,7 @@ func (k Keeper) CreatePerpetualClobPair(
 
 	// Verify the perpetual ID is not already associated with an existing CLOB pair.
 	if clobPairId, found := k.PerpetualIdToClobPairId[perpetualId]; found {
-		return types.ClobPair{}, sdkerrors.Wrapf(
+		return types.ClobPair{}, errorsmod.Wrapf(
 			types.ErrPerpetualAssociatedWithExistingClobPair,
 			"perpetual id=%v, existing clob pair id=%v",
 			perpetualId,
@@ -111,7 +111,7 @@ func (k Keeper) validateClobPair(ctx sdk.Context, clobPair *types.ClobPair) erro
 	case *types.ClobPair_PerpetualClobMetadata:
 		perpetualId, err := clobPair.GetPerpetualId()
 		if err != nil {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				err,
 				"CLOB pair (%+v) has invalid perpetual.",
 				clobPair,
@@ -119,14 +119,14 @@ func (k Keeper) validateClobPair(ctx sdk.Context, clobPair *types.ClobPair) erro
 		}
 		// Validate the perpetual referenced by the CLOB pair exists.
 		if _, err := k.perpetualsKeeper.GetPerpetual(ctx, perpetualId); err != nil {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				err,
 				"CLOB pair (%+v) has invalid perpetual.",
 				clobPair,
 			)
 		}
 	default:
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidClobPairParameter,
 			// TODO(DEC-1535): update this error message when we implement "spot"/"asset" clob pairs.
 			"CLOB pair (%+v) is not a perpetual CLOB.",
@@ -209,7 +209,7 @@ func (k Keeper) GetClobPairIdForPerpetual(
 ) {
 	clobPairIds, exists := k.PerpetualIdToClobPairId[perpetualId]
 	if !exists {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrNoClobPairForPerpetual,
 			"Perpetual ID %d has no associated CLOB pairs",
 			perpetualId,
@@ -303,7 +303,7 @@ func (k Keeper) validateOrderAgainstClobPairStatus(
 		// from controlling the price at which new orders can be placed. This is necessary when all orders
 		// are post-only.
 		if order.IsStatefulOrder() {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrOrderConflictsWithClobPairStatus,
 				"Order %+v must not be stateful for clob pair with status %+v",
 				order,
@@ -314,7 +314,7 @@ func (k Keeper) validateOrderAgainstClobPairStatus(
 		// Reject non-post-only orders. During the initializing phase we only allow post-only orders.
 		// This allows liquidity to build around the oracle price without any real trading happening.
 		if order.TimeInForce != types.Order_TIME_IN_FORCE_POST_ONLY {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrOrderConflictsWithClobPairStatus,
 				"Order %+v must be post-only for clob pair with status %+v",
 				order,
@@ -329,7 +329,7 @@ func (k Keeper) validateOrderAgainstClobPairStatus(
 		currentOraclePriceSubticks := lib.BigRatRound(currentOraclePriceSubticksRat, false).Uint64()
 		// Throw error if order is a buy and order subticks is greater than oracle price subticks
 		if order.IsBuy() && order.Subticks > currentOraclePriceSubticks {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrOrderConflictsWithClobPairStatus,
 				"Order subticks %+v must be less than or equal to oracle price subticks %+v for clob pair with status %+v",
 				order.Subticks,
@@ -339,7 +339,7 @@ func (k Keeper) validateOrderAgainstClobPairStatus(
 		}
 		// Throw error if order is a sell and order subticks is less than oracle price subticks
 		if !order.IsBuy() && order.Subticks < currentOraclePriceSubticks {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrOrderConflictsWithClobPairStatus,
 				"Order subticks %+v must be greater than or equal to oracle price subticks %+v for clob pair with status %+v",
 				order.Subticks,
@@ -395,25 +395,25 @@ func (k Keeper) UpdateClobPair(
 	// Note, only perpetual clob pairs are currently supported. Neither the old nor the
 	// new clob pair should be spot.
 	if clobPair.MustGetPerpetualId() != oldClobPair.MustGetPerpetualId() {
-		return sdkerrors.Wrap(
+		return errorsmod.Wrap(
 			types.ErrInvalidClobPairUpdate,
 			"UpdateClobPair: cannot update ClobPair perpetual id",
 		)
 	}
 	if clobPair.StepBaseQuantums != oldClobPair.StepBaseQuantums {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidClobPairUpdate,
 			"UpdateClobPair: cannot update ClobPair step base quantums",
 		)
 	}
 	if clobPair.SubticksPerTick != oldClobPair.SubticksPerTick {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidClobPairUpdate,
 			"UpdateClobPair: cannot update ClobPair subticks per tick",
 		)
 	}
 	if clobPair.QuantumConversionExponent != oldClobPair.QuantumConversionExponent {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidClobPairUpdate,
 			"UpdateClobPair: cannot update ClobPair quantum conversion exponent",
 		)
@@ -422,7 +422,7 @@ func (k Keeper) UpdateClobPair(
 	oldStatus := oldClobPair.Status
 	newStatus := clobPair.Status
 	if oldStatus != newStatus && !types.IsSupportedClobPairStatusTransition(oldStatus, newStatus) {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidClobPairStatusTransition,
 			"Cannot transition from status %+v to status %+v",
 			oldStatus,
@@ -501,7 +501,7 @@ func (k Keeper) validateInternalOperationAgainstClobPairStatus(
 	// Fail if the ClobPair cannot be found.
 	clobPair, found := k.GetClobPair(ctx, clobPairId)
 	if !found {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidClob,
 			"CLOB pair ID %d not found in state",
 			clobPairId,
@@ -519,7 +519,7 @@ func (k Keeper) validateInternalOperationAgainstClobPairStatus(
 	switch clobPair.Status {
 	case types.ClobPair_STATUS_INITIALIZING:
 		// All operations are invalid for initializing clob pairs.
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrOperationConflictsWithClobPairStatus,
 			"Operation %s invalid for ClobPair with id %d with status %s",
 			internalOperation.GetInternalOperationTextString(),
@@ -544,7 +544,7 @@ func (k Keeper) IsPerpetualClobPairActive(
 
 	clobPair, found := k.GetClobPair(ctx, clobPairId)
 	if !found {
-		return false, sdkerrors.Wrapf(
+		return false, errorsmod.Wrapf(
 			types.ErrInvalidClob,
 			"GetPerpetualClobPairStatus: did not find clob pair with id = %d",
 			clobPairId,

--- a/protocol/x/clob/keeper/equity_tier_limit.go
+++ b/protocol/x/clob/keeper/equity_tier_limit.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -117,7 +117,7 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForNewOrder(ctx sdk.Context, or
 	}
 	// Return immediately if the amount the subaccount can open is 0.
 	if equityTierLimit.Limit == 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrOrderWouldExceedMaxOpenOrdersEquityTierLimit,
 			"Opening order would exceed equity tier limit of %d. Order id: %+v",
 			equityTierLimit.Limit,
@@ -168,7 +168,7 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForNewOrder(ctx sdk.Context, or
 	// stateful orders on the memclob we should always have a negative number since we only count order
 	// cancellations/removals for orders that exist.
 	if lib.MustConvertIntegerToUint32(equityTierCount) >= equityTierLimit.Limit {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrOrderWouldExceedMaxOpenOrdersEquityTierLimit,
 			"Opening order would exceed equity tier limit of %d. Order id: %+v",
 			equityTierLimit.Limit,

--- a/protocol/x/clob/keeper/get_price_premium.go
+++ b/protocol/x/clob/keeper/get_price_premium.go
@@ -1,8 +1,8 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 )
@@ -24,7 +24,7 @@ func (k Keeper) GetPricePremiumForPerpetual(
 
 	clobPair, found := k.GetClobPair(ctx, clobPairId)
 	if !found {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrInvalidClob,
 			"GetPricePremiumForPerpetual: did not find clob pair with clobPairId = %d",
 			clobPairId,

--- a/protocol/x/clob/keeper/get_price_premium_test.go
+++ b/protocol/x/clob/keeper/get_price_premium_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"math/big"
 	"testing"
@@ -8,7 +9,6 @@ import (
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -132,7 +132,7 @@ func TestGetPricePremiumForPerpetual(t *testing.T) {
 			perpetualIdToClobPairId: map[uint32][]types.ClobPairId{
 				0: {1},
 			},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				types.ErrInvalidClob,
 				"GetPricePremiumForPerpetual: did not find clob pair with clobPairId = %d",
 				1,

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -1,13 +1,13 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math"
 	"math/big"
 
 	gometrics "github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -195,7 +195,7 @@ func (k Keeper) GetBankruptcyPriceInQuoteQuantums(
 	// Validate that the provided deltaQuantums is valid with respect to
 	// the current position size.
 	if psBig.Sign()*deltaQuantums.Sign() != -1 || psBig.CmpAbs(deltaQuantums) == -1 {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			types.ErrInvalidPerpetualPositionSizeDelta,
 			"Position size delta %v is invalid for %v and perpetual %v, outstanding position size is %v",
 			deltaQuantums,
@@ -305,7 +305,7 @@ func (k Keeper) GetFillablePrice(
 	// Validate that the provided deltaQuantums is valid with respect to
 	// the current position size.
 	if psBig.Sign()*deltaQuantums.Sign() != -1 || psBig.CmpAbs(deltaQuantums) == -1 {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			types.ErrInvalidPerpetualPositionSizeDelta,
 			"Position size delta %v is invalid for %v and perpetual %v, outstanding position size is %v",
 			deltaQuantums,
@@ -400,7 +400,7 @@ func (k Keeper) GetLiquidationInsuranceFundDelta(
 ) {
 	// Verify that fill amount is not zero.
 	if fillAmount == 0 {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			types.ErrInvalidQuantumsForInsuranceFundDeltaCalculation,
 			"FillAmount is zero for subaccount %v and perpetual %v.",
 			subaccountId,
@@ -502,7 +502,7 @@ func (k Keeper) GetPerpetualPositionToLiquidate(
 	if perpetualPosition == nil {
 		return types.ClobPair{},
 			nil,
-			sdkerrors.Wrapf(
+			errorsmod.Wrapf(
 				types.ErrNoPerpetualPositionsToLiquidate,
 				"Subaccount ID: %v",
 				subaccount.Id,
@@ -602,7 +602,7 @@ func (k Keeper) GetSubaccountMaxNotionalLiquidatable(
 
 	// Make sure that this subaccount <> perpetual has not previously been liquidated in the same block.
 	if subaccountLiquidationInfo.HasPerpetualBeenLiquidatedForSubaccount(perpetualId) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			types.ErrSubaccountHasLiquidatedPerpetual,
 			"Subaccount %v and perpetual %v have already been liquidated within the last block",
 			subaccountId,
@@ -619,7 +619,7 @@ func (k Keeper) GetSubaccountMaxNotionalLiquidatable(
 	)
 	if bigTotalNotionalLiquidated.Cmp(bigNotionalLiquidatedBlockLimit) > 0 {
 		panic(
-			sdkerrors.Wrapf(
+			errorsmod.Wrapf(
 				types.ErrLiquidationExceedsSubaccountMaxNotionalLiquidated,
 				"Subaccount %+v notional liquidated exceeds block limit. Current notional liquidated: %v, block limit: %v",
 				subaccountId,
@@ -653,7 +653,7 @@ func (k Keeper) GetSubaccountMaxInsuranceLost(
 
 	// Make sure that the subaccount has not previously liquidated this perpetual in the same block.
 	if subaccountLiquidationInfo.HasPerpetualBeenLiquidatedForSubaccount(perpetualId) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			types.ErrSubaccountHasLiquidatedPerpetual,
 			"Subaccount %v and perpetual %v have already been liquidated within the last block",
 			subaccountId,
@@ -670,7 +670,7 @@ func (k Keeper) GetSubaccountMaxInsuranceLost(
 	)
 	if bigCurrentInsuranceFundLost.Cmp(bigInsuranceFundLostBlockLimit) > 0 {
 		panic(
-			sdkerrors.Wrapf(
+			errorsmod.Wrapf(
 				types.ErrLiquidationExceedsSubaccountMaxInsuranceLost,
 				"Subaccount %+v insurance lost exceeds block limit. Current insurance lost: %v, block limit: %v",
 				subaccountId,

--- a/protocol/x/clob/keeper/liquidations_deleveraging.go
+++ b/protocol/x/clob/keeper/liquidations_deleveraging.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"fmt"
 	"math/big"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
@@ -274,7 +274,7 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 			types.ModuleName, metrics.CheckTx, metrics.Deleveraging, metrics.NotEnoughPositionToFullyOffset, metrics.Count,
 		)
 		k.Logger(ctx).Error(
-			sdkerrors.Wrapf(
+			errorsmod.Wrapf(
 				types.ErrPositionCannotBeFullyOffset,
 				"OffsetSubaccountPerpetualPosition: Not enough position to fully offset position, "+
 					"subaccount = (%+v), perpetual = (%d), quantums remaining = (%+v)",
@@ -326,7 +326,7 @@ func (k Keeper) ProcessDeleveraging(
 		liquidatedPositionQuantums.CmpAbs(deltaQuantums) == -1 ||
 		offsettingPositionQuantums.Sign()*deltaQuantums.Sign() != 1 ||
 		offsettingPositionQuantums.CmpAbs(deltaQuantums) == -1 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidPerpetualPositionSizeDelta,
 			"ProcessDeleveraging: liquidated = (%+v), offsetting = (%+v), perpetual id = (%d), deltaQuantums = (%+v)",
 			liquidatedSubaccount,

--- a/protocol/x/clob/keeper/liquidations_state.go
+++ b/protocol/x/clob/keeper/liquidations_state.go
@@ -1,12 +1,12 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
@@ -86,7 +86,7 @@ func (k Keeper) UpdateSubaccountLiquidationInfo(
 		// This should never happen, since the total notional liquidated for any subaccount should
 		// never exceed the value of maximum notional liquidated (uint64) in the liquidation config.
 		panic(
-			sdkerrors.Wrapf(
+			errorsmod.Wrapf(
 				satypes.ErrIntegerOverflow,
 				"Notional liquidated update for subaccount %v overflows uint64",
 				subaccountId,
@@ -108,7 +108,7 @@ func (k Keeper) UpdateSubaccountLiquidationInfo(
 			// exceed the value of maximum insurance lost (uint64) in the liquidation config.
 			// This should also never exceed the maximum possible insurance fund balance.
 			panic(
-				sdkerrors.Wrapf(
+				errorsmod.Wrapf(
 					satypes.ErrIntegerOverflow,
 					"Quantums insurance lost update for subaccount %v overflows uint64",
 					subaccountId,

--- a/protocol/x/clob/keeper/liquidations_test.go
+++ b/protocol/x/clob/keeper/liquidations_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math"
 	"math/big"
 	"testing"
@@ -979,7 +980,7 @@ func TestPlacePerpetualLiquidation_PreexistingLiquidation(t *testing.T) {
 			},
 			order: constants.LiquidationOrder_Carl_Num0_Clob1_Buy1ETH_Price3000,
 
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrSubaccountHasLiquidatedPerpetual,
 				"Subaccount %v and perpetual %v have already been liquidated within the last block",
 				constants.Carl_Num0,
@@ -4719,7 +4720,7 @@ func TestGetMaxLiquidatableNotionalAndInsuranceLost(t *testing.T) {
 
 			expectedMaxInsuranceLost:             big.NewInt(50),
 			expectedMaxNotionalLiquidatablePanic: true,
-			expectedMaxNotionalLiquidatableErr: sdkerrors.Wrapf(
+			expectedMaxNotionalLiquidatableErr: errorsmod.Wrapf(
 				types.ErrLiquidationExceedsSubaccountMaxNotionalLiquidated,
 				"Subaccount %+v notional liquidated exceeds block limit. Current notional liquidated: %v, block limit: %v",
 				constants.Alice_Num0,
@@ -4743,7 +4744,7 @@ func TestGetMaxLiquidatableNotionalAndInsuranceLost(t *testing.T) {
 
 			expectedMaxNotionalLiquidatable: big.NewInt(50),
 			expectedMaxInsuranceLostPanic:   true,
-			expectedMaxInsuranceLostErr: sdkerrors.Wrapf(
+			expectedMaxInsuranceLostErr: errorsmod.Wrapf(
 				types.ErrLiquidationExceedsSubaccountMaxInsuranceLost,
 				"Subaccount %+v insurance lost exceeds block limit. Current insurance lost: %v, block limit: %v",
 				constants.Alice_Num0,

--- a/protocol/x/clob/keeper/msg_server_create_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_create_clob_pair.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -16,7 +16,7 @@ func (k msgServer) CreateClobPair(
 	msg *types.MsgCreateClobPair,
 ) (*types.MsgCreateClobPairResponse, error) {
 	if !k.Keeper.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -2,10 +2,10 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -27,7 +27,7 @@ func (k msgServer) PlaceOrder(goCtx context.Context, msg *types.MsgPlaceOrder) (
 	processProposerMatchesEvents := k.Keeper.GetProcessProposerMatchesEvents(ctx)
 	cancelledOrderIds := lib.SliceToSet(processProposerMatchesEvents.PlacedStatefulCancellationOrderIds)
 	if _, found := cancelledOrderIds[order.GetOrderId()]; found {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			types.ErrStatefulOrderPreviouslyCancelled,
 			"PlaceOrder: order (%+v)",
 			order,
@@ -35,7 +35,7 @@ func (k msgServer) PlaceOrder(goCtx context.Context, msg *types.MsgPlaceOrder) (
 	}
 	removedOrderIds := lib.SliceToSet(processProposerMatchesEvents.RemovedStatefulOrderIds)
 	if _, found := removedOrderIds[order.GetOrderId()]; found {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			types.ErrStatefulOrderPreviouslyRemoved,
 			"PlaceOrder: order (%+v)",
 			order,

--- a/protocol/x/clob/keeper/msg_server_proposed_operations.go
+++ b/protocol/x/clob/keeper/msg_server_proposed_operations.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -19,7 +19,7 @@ func (k msgServer) ProposedOperations(
 		msg.GetOperationsQueue(),
 	); err != nil {
 		panic(
-			sdkerrors.Wrapf(
+			errorsmod.Wrapf(
 				err,
 				"Block height: %d",
 				ctx.BlockHeight(),

--- a/protocol/x/clob/keeper/msg_server_proposed_operations_test.go
+++ b/protocol/x/clob/keeper/msg_server_proposed_operations_test.go
@@ -1,11 +1,11 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	keeper "github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper"
@@ -63,7 +63,7 @@ func TestProposedOperations(t *testing.T) {
 			if tc.shouldPanic {
 				require.PanicsWithError(
 					t,
-					sdkerrors.Wrapf(
+					errorsmod.Wrapf(
 						tc.expectedErr,
 						"Block height: %d",
 						blockHeight,

--- a/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
@@ -2,8 +2,8 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
@@ -15,7 +15,7 @@ func (k msgServer) UpdateBlockRateLimitConfiguration(
 	msg *types.MsgUpdateBlockRateLimitConfiguration,
 ) (*types.MsgUpdateBlockRateLimitConfigurationResponse, error) {
 	if !k.Keeper.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
@@ -14,7 +14,7 @@ func (k msgServer) UpdateClobPair(
 	msg *types.MsgUpdateClobPair,
 ) (*types.MsgUpdateClobPairResponse, error) {
 	if !k.Keeper.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
@@ -2,8 +2,8 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
@@ -15,7 +15,7 @@ func (k msgServer) UpdateEquityTierLimitConfiguration(
 	msg *types.MsgUpdateEquityTierLimitConfiguration,
 ) (*types.MsgUpdateEquityTierLimitConfigurationResponse, error) {
 	if !k.Keeper.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
@@ -15,7 +15,7 @@ func (k msgServer) UpdateLiquidationsConfig(
 	msg *types.MsgUpdateLiquidationsConfig,
 ) (*types.MsgUpdateLiquidationsConfigResponse, error) {
 	if !k.Keeper.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -1888,7 +1888,7 @@ func TestGetStatePosition_PanicsOnInvalidClob(t *testing.T) {
 // 	// Run the test and verify expectations.
 // 	require.PanicsWithError(
 // 		t,
-// 		sdkerrors.Wrap(
+// 		errorsmod.Wrap(
 // 			types.ErrAssetOrdersNotImplemented,
 // 			"GetStatePosition: Reduce-only orders for assets not implemented",
 // 		).Error(),

--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -8,7 +9,6 @@ import (
 	gometrics "github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	indexershared "github.com/dydxprotocol/v4-chain/protocol/indexer/shared"
@@ -34,7 +34,7 @@ func (k Keeper) ProcessProposerOperations(
 	// Stateless validation of RawOperations and transforms them into InternalOperations to be used internally by memclob.
 	operations, err := types.ValidateAndTransformRawOperations(ctx, rawOperations, k.txDecoder, k.antehandler)
 	if err != nil {
-		return sdkerrors.Wrapf(types.ErrInvalidMsgProposedOperations, "Error: %+v", err)
+		return errorsmod.Wrapf(types.ErrInvalidMsgProposedOperations, "Error: %+v", err)
 	}
 
 	k.Logger(ctx).Debug(
@@ -131,7 +131,7 @@ func (k Keeper) ProcessInternalOperations(
 		case *types.InternalOperation_Match:
 			clobMatch := castedOperation.Match
 			if err := k.PersistMatchToState(ctx, clobMatch, placedShortTermOrders); err != nil {
-				return sdkerrors.Wrapf(
+				return errorsmod.Wrapf(
 					err,
 					"ProcessInternalOperations: Failed to process clobMatch: %+v",
 					clobMatch,
@@ -157,7 +157,7 @@ func (k Keeper) ProcessInternalOperations(
 			orderIdToRemove := orderRemoval.GetOrderId()
 			_, found := k.GetLongTermOrderPlacement(ctx, orderIdToRemove)
 			if !found {
-				return sdkerrors.Wrapf(
+				return errorsmod.Wrapf(
 					types.ErrStatefulOrderDoesNotExist,
 					"Stateful order id %+v does not exist in state.",
 					orderIdToRemove,
@@ -263,7 +263,7 @@ func (k Keeper) PersistMatchOrdersToState(
 
 	// Taker order cannot be post only.
 	if takerOrder.GetTimeInForce() == types.Order_TIME_IN_FORCE_POST_ONLY {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidMatchOrder,
 			"Taker order %+v cannot be post only.",
 			takerOrder.GetOrderTextString(),
@@ -341,9 +341,9 @@ func (k Keeper) PersistMatchLiquidationToState(
 		return err
 	}
 	if !isLiquidatable {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrSubaccountNotLiquidatable,
-			"PersistMatchLiquidationToState: Subaccount %s is not liquidatable",
+			"PersistMatchLiquidationToState: Subaccount %+v is not liquidatable",
 			matchLiquidation.Liquidated,
 		)
 	}
@@ -351,7 +351,7 @@ func (k Keeper) PersistMatchLiquidationToState(
 	perpId := matchLiquidation.GetPerpetualId()
 	_, err = k.perpetualsKeeper.GetPerpetual(ctx, perpId)
 	if err != nil {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrPerpetualDoesNotExist,
 			"Perpetual id %+v does not exist in state.",
 			perpId,
@@ -359,7 +359,7 @@ func (k Keeper) PersistMatchLiquidationToState(
 	}
 	clobPair := matchLiquidation.ClobPairId
 	if _, found := k.GetClobPair(ctx, types.ClobPairId(clobPair)); !found {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidClob,
 			"Clob Pair id %+v does not exist in state.",
 			clobPair,
@@ -461,7 +461,7 @@ func (k Keeper) PersistMatchDeleveragingToState(
 		)
 	} else if !canDeleverageSubaccount {
 		// TODO(CLOB-853): Add more verbose error logging about why deleveraging failed validation.
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidDeleveragedSubaccount,
 			"Subaccount %+v failed deleveraging validation",
 			liquidatedSubaccountId,
@@ -473,7 +473,7 @@ func (k Keeper) PersistMatchDeleveragingToState(
 	liquidatedSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, liquidatedSubaccountId)
 	position, exists := liquidatedSubaccount.GetPerpetualPositionForId(perpetualId)
 	if !exists {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrNoOpenPositionForPerpetual,
 			"Subaccount %+v does not have an open position for perpetual %+v",
 			liquidatedSubaccountId,
@@ -503,7 +503,7 @@ func (k Keeper) PersistMatchDeleveragingToState(
 			perpetualId,
 			deltaQuantums,
 		); err != nil {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrInvalidDeleveragingFill,
 				"Failed to process deleveraging fill: %+v. liquidatedSubaccountId: %+v, "+
 					"perpetualId: %v, deltaQuantums: %v, error: %v",

--- a/protocol/x/clob/keeper/process_operations_liquidations.go
+++ b/protocol/x/clob/keeper/process_operations_liquidations.go
@@ -1,11 +1,11 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -24,7 +24,7 @@ func (k Keeper) ValidateLiquidationOrderAgainstProposedLiquidation(
 	proposedMatch *types.MatchPerpetualLiquidation,
 ) error {
 	if order.GetClobPairId() != types.ClobPairId(proposedMatch.GetClobPairId()) {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrClobPairAndPerpetualDoNotMatch,
 			"Order CLOB Pair ID: %v, Match CLOB Pair ID: %v",
 			order.GetClobPairId(),
@@ -33,7 +33,7 @@ func (k Keeper) ValidateLiquidationOrderAgainstProposedLiquidation(
 	}
 
 	if order.MustGetLiquidatedPerpetualId() != proposedMatch.GetPerpetualId() {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrClobPairAndPerpetualDoNotMatch,
 			"Order Perpetual ID: %v, Match Perpetual ID: %v",
 			order.MustGetLiquidatedPerpetualId(),
@@ -42,7 +42,7 @@ func (k Keeper) ValidateLiquidationOrderAgainstProposedLiquidation(
 	}
 
 	if order.GetBaseQuantums() != satypes.BaseQuantums(proposedMatch.TotalSize) {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidLiquidationOrderTotalSize,
 			"Order Size: %v, Match Size: %v",
 			order.GetBaseQuantums(),
@@ -51,7 +51,7 @@ func (k Keeper) ValidateLiquidationOrderAgainstProposedLiquidation(
 	}
 
 	if order.IsBuy() != proposedMatch.GetIsBuy() {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidLiquidationOrderSide,
 			"Order Side: %v, Match Side: %v",
 			order.IsBuy(),
@@ -103,7 +103,7 @@ func (k Keeper) validateMatchedLiquidation(
 	// in the insurance fund (such that the liquidation couldn't have possibly continued).
 	if !k.IsValidInsuranceFundDelta(ctx, insuranceFundDelta) {
 		k.Logger(ctx).Info("ProcessMatches: insurance fund has insufficient balance to process the liquidation.")
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			types.ErrInsuranceFundHasInsufficientFunds,
 			"Liquidation order %v, insurance fund delta %v",
 			order,
@@ -160,7 +160,7 @@ func (k Keeper) validateLiquidationAgainstSubaccountBlockLimits(
 	}
 
 	if bigNotionalLiquidated.CmpAbs(bigMaxNotionalLiquidatable) > 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrLiquidationExceedsSubaccountMaxNotionalLiquidated,
 			"Subaccount ID: %v, Perpetual ID: %v, Max Notional Liquidatable: %v, Notional Liquidated: %v",
 			subaccountId,
@@ -183,7 +183,7 @@ func (k Keeper) validateLiquidationAgainstSubaccountBlockLimits(
 		}
 
 		if insuranceFundDeltaQuoteQuantums.CmpAbs(bigMaxQuantumsInsuranceLost) > 0 {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrLiquidationExceedsSubaccountMaxInsuranceLost,
 				"Subaccount ID: %v, Perpetual ID: %v, Max Insurance Lost: %v, Insurance Lost: %v",
 				subaccountId,

--- a/protocol/x/clob/keeper/process_operations_stateful_validation.go
+++ b/protocol/x/clob/keeper/process_operations_stateful_validation.go
@@ -1,10 +1,10 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -23,7 +23,7 @@ func (k Keeper) FetchOrderFromOrderId(
 	if orderId.IsShortTermOrder() {
 		order, exists := shortTermOrdersMap[orderId]
 		if !exists {
-			return order, sdkerrors.Wrapf(
+			return order, errorsmod.Wrapf(
 				types.ErrInvalidMatchOrder,
 				"Failed fetching short term order id %+v from previous operations in operations queue",
 				orderId,
@@ -36,7 +36,7 @@ func (k Keeper) FetchOrderFromOrderId(
 	if orderId.IsLongTermOrder() {
 		statefulOrderPlacement, found := k.GetLongTermOrderPlacement(ctx, orderId)
 		if !found {
-			return order, sdkerrors.Wrapf(
+			return order, errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful long term order id %+v does not exist in state.",
 				orderId,
@@ -46,7 +46,7 @@ func (k Keeper) FetchOrderFromOrderId(
 	} else if orderId.IsConditionalOrder() {
 		conditionalOrderPlacement, found := k.GetTriggeredConditionalOrderPlacement(ctx, orderId)
 		if !found {
-			return order, sdkerrors.Wrapf(
+			return order, errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful conditional order id %+v does not exist in triggered conditional state.",
 				orderId,
@@ -100,7 +100,7 @@ func (k Keeper) StatefulValidateMakerFill(
 	// Orders must be on different sides of the book.
 	if takerOrder != nil {
 		if takerOrder.IsBuy() == makerOrder.IsBuy() {
-			return makerOrder, sdkerrors.Wrapf(
+			return makerOrder, errorsmod.Wrapf(
 				types.ErrInvalidMatchOrder,
 				"Taker Order %+v and Maker order %+v are not on opposing sides of the book",
 				takerOrder.GetOrderTextString(),
@@ -112,7 +112,7 @@ func (k Keeper) StatefulValidateMakerFill(
 	// Maker order cannot be FOK or IOC.
 	if makerOrder.GetTimeInForce() == types.Order_TIME_IN_FORCE_FILL_OR_KILL ||
 		makerOrder.GetTimeInForce() == types.Order_TIME_IN_FORCE_IOC {
-		return makerOrder, sdkerrors.Wrapf(
+		return makerOrder, errorsmod.Wrapf(
 			types.ErrInvalidMatchOrder,
 			"Maker order %+v cannot be FOK or IOC.",
 			makerOrder.GetOrderTextString(),

--- a/protocol/x/clob/keeper/process_operations_stateful_validation_test.go
+++ b/protocol/x/clob/keeper/process_operations_stateful_validation_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"fmt"
 	"math"
@@ -8,7 +9,6 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	testutil_bank "github.com/dydxprotocol/v4-chain/protocol/testutil/bank"
@@ -50,7 +50,7 @@ func TestProcessProposerMatches_LongTerm_StatefulValidation_Failure(t *testing.T
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful long term order id %+v does not exist in state.",
 				constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10.OrderId,
@@ -82,7 +82,7 @@ func TestProcessProposerMatches_LongTerm_StatefulValidation_Failure(t *testing.T
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful long term order id %+v does not exist in state.",
 				constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10.OrderId,
@@ -118,7 +118,7 @@ func TestProcessProposerMatches_LongTerm_StatefulValidation_Failure(t *testing.T
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful long term order id %+v does not exist in state.",
 				constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10.OrderId,
@@ -158,7 +158,7 @@ func TestProcessProposerMatches_LongTerm_StatefulValidation_Failure(t *testing.T
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrInvalidMatchOrder,
 				"Taker Order %+v and Maker order %+v are not on opposing sides of the book",
 				constants.Order_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTB10.GetOrderTextString(),
@@ -197,7 +197,7 @@ func TestProcessProposerMatches_LongTerm_StatefulValidation_Failure(t *testing.T
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrInvalidMatchOrder,
 				"Taker order %+v cannot be post only.",
 				constants.LongTermOrder_Dave_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_PO.GetOrderTextString(),
@@ -235,7 +235,7 @@ func TestProcessProposerMatches_LongTerm_StatefulValidation_Failure(t *testing.T
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrInvalidMatchOrder,
 				"Maker order %+v cannot be FOK or IOC.",
 				constants.LongTermOrder_Carl_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_FOK.GetOrderTextString(),
@@ -273,7 +273,7 @@ func TestProcessProposerMatches_LongTerm_StatefulValidation_Failure(t *testing.T
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrInvalidMatchOrder,
 				"Maker order %+v cannot be FOK or IOC.",
 				constants.LongTermOrder_Carl_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_IOC.GetOrderTextString(),
@@ -430,7 +430,7 @@ func TestProcessProposerMatches_Conditional_Validation_Failure(t *testing.T) {
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful conditional order id %+v does not exist in triggered conditional state.",
 				constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10.OrderId,
@@ -462,7 +462,7 @@ func TestProcessProposerMatches_Conditional_Validation_Failure(t *testing.T) {
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful conditional order id %+v does not exist in triggered conditional state.",
 				constants.ConditionalOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10.OrderId,
@@ -498,7 +498,7 @@ func TestProcessProposerMatches_Conditional_Validation_Failure(t *testing.T) {
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful conditional order id %+v does not exist in triggered conditional state.",
 				constants.ConditionalOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10.OrderId,
@@ -533,7 +533,7 @@ func TestProcessProposerMatches_Conditional_Validation_Failure(t *testing.T) {
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful conditional order id %+v does not exist in triggered conditional state.",
 				constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10.OrderId,
@@ -573,7 +573,7 @@ func TestProcessProposerMatches_Conditional_Validation_Failure(t *testing.T) {
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrInvalidMatchOrder,
 				"Taker Order %+v and Maker order %+v are not on opposing sides of the book",
 				constants.Order_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTB10.GetOrderTextString(),

--- a/protocol/x/clob/keeper/process_operations_test.go
+++ b/protocol/x/clob/keeper/process_operations_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"testing"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
@@ -1217,7 +1217,7 @@ func TestProcessProposerOperations(t *testing.T) {
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful conditional order id %+v does not exist in triggered conditional state.",
 				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20.OrderId,
@@ -1272,7 +1272,7 @@ func TestProcessProposerOperations(t *testing.T) {
 					},
 				),
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrStatefulOrderDoesNotExist,
 				"stateful conditional order id %+v does not exist in triggered conditional state.",
 				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20.OrderId,

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -1,13 +1,13 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"fmt"
 	"math"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -69,7 +69,7 @@ func (k Keeper) ProcessSingleMatch(
 
 	// Perform stateless validation on the match.
 	if err := matchWithOrders.Validate(); err != nil {
-		return false, takerUpdateResult, makerUpdateResult, nil, sdkerrors.Wrapf(
+		return false, takerUpdateResult, makerUpdateResult, nil, errorsmod.Wrapf(
 			err,
 			"ProcessSingleMatch: Invalid MatchWithOrders: %+v",
 			matchWithOrders,
@@ -410,7 +410,7 @@ func (k Keeper) persistMatchedOrders(
 		lib.UsdcAssetId,
 		bigTotalFeeQuoteQuantums,
 	); err != nil {
-		return takerUpdateResult, makerUpdateResult, sdkerrors.Wrapf(
+		return takerUpdateResult, makerUpdateResult, errorsmod.Wrapf(
 			types.ErrSubaccountFeeTransferFailed,
 			"persistMatchedOrders: subaccounts (%v, %v) updated, but fee transfer (bigFeeQuoteQuantums: %v)"+
 				" to fee-collector failed. Err: %v",
@@ -531,7 +531,7 @@ func getUpdatedOrderFillAmount(
 	bigCurrentFillAmount := currentFillAmount.ToBigInt()
 	bigNewFillAmount := bigCurrentFillAmount.Add(bigCurrentFillAmount, fillQuantums.ToBigInt())
 	if bigNewFillAmount.Cmp(orderBaseQuantums.ToBigInt()) == 1 {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrInvalidMsgProposedOperations,
 			"Match with Quantums %v would exceed total Quantums %v of OrderId %v. New total filled quantums would be %v.",
 			fillQuantums,

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -1,6 +1,7 @@
 package memclob
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"fmt"
 	"math/big"
@@ -12,7 +13,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates"
 	indexershared "github.com/dydxprotocol/v4-chain/protocol/indexer/shared"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -1259,7 +1259,7 @@ func (m *MemClobPriceTimePriority) validateNewOrder(
 		// If the cancelation has an equal-to-or-greater `GoodTilBlock` than the new order, return an error.
 		// If the cancelation has a lesser `GoodTilBlock` than the new order, we do not remove the cancelation.
 		if cancelTilBlock, cancelExists := m.cancels.get(orderId); cancelExists && cancelTilBlock >= order.GetGoodTilBlock() {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrOrderIsCanceled,
 				"Order: %+v, Cancellation GoodTilBlock: %d",
 				order,
@@ -1314,7 +1314,7 @@ func (m *MemClobPriceTimePriority) validateNewOrder(
 	orderbook := m.openOrders.mustGetOrderbook(ctx, order.GetClobPairId())
 	remainingAmount, hasRemainingAmount := m.getOrderRemainingAmount(ctx, order)
 	if !hasRemainingAmount || remainingAmount < orderbook.MinOrderBaseQuantums {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrOrderFullyFilled,
 			"Order remaining amount is less than `MinOrderBaseQuantums`. Remaining amount: %d. Order: %+v",
 			remainingAmount,
@@ -2136,7 +2136,7 @@ func (m *MemClobPriceTimePriority) GetPricePremium(
 
 	// Check the `ClobPair` is a perpetual.
 	if clobPair.GetPerpetualClobMetadata() == nil {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrPremiumWithNonPerpetualClobPair,
 			"ClobPair ID: %d",
 			clobPair.Id,
@@ -2154,7 +2154,7 @@ func (m *MemClobPriceTimePriority) GetPricePremium(
 
 	// Check `indexPriceSubticks` is non-zero.
 	if indexPriceSubticks.Sign() == 0 {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrZeroIndexPriceForPremiumCalculation,
 			"market = %+v, clobPair = %+v, baseAtomicResolution = %d, quoteAtomicResolution = %d",
 			params.MarketPrice,

--- a/protocol/x/clob/memclob/memclob_get_premium_price_test.go
+++ b/protocol/x/clob/memclob/memclob_get_premium_price_test.go
@@ -1,11 +1,11 @@
 package memclob
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math"
 	"math/big"
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	sdktest "github.com/dydxprotocol/v4-chain/protocol/testutil/sdk"
@@ -590,7 +590,7 @@ func TestGetPremiumPrice(t *testing.T) {
 			clobPair:                    constants.ClobPair_Spot_Btc,
 			maxAbsPremiumVotePpm:        big.NewInt(100_000), // 10%
 			impactNotionalQuoteQuantums: big.NewInt(1000),
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				types.ErrPremiumWithNonPerpetualClobPair,
 				"ClobPair ID: %d",
 				constants.ClobPair_Spot_Btc.Id,

--- a/protocol/x/clob/memclob/memclob_open_orders.go
+++ b/protocol/x/clob/memclob/memclob_open_orders.go
@@ -1,11 +1,11 @@
 package memclob
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/pkg/errors"
@@ -227,7 +227,7 @@ func (m *memclobOpenOrders) getSubaccountOrders(
 	orderbook, exists := m.orderbooksMap[clobPairId]
 	// If the CLOB doesn't exist, then `clobPairId` is invalid.
 	if !exists {
-		return openOrders, sdkerrors.Wrapf(
+		return openOrders, errorsmod.Wrapf(
 			types.ErrInvalidClob,
 			"Invalid ClobPair ID: %d",
 			clobPairId,

--- a/protocol/x/clob/rate_limit/multi_block_rate_limiter.go
+++ b/protocol/x/clob/rate_limit/multi_block_rate_limiter.go
@@ -1,11 +1,11 @@
 package rate_limit
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"sort"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
@@ -99,7 +99,7 @@ func (r *multiBlockRateLimiter[K]) RateLimit(ctx sdk.Context, key K) error {
 	// Check the accumulated rate limit count to see if any rate limit has been exceeded.
 	for i, rl := range r.config {
 		if perRateLimitCounts[i] > rl.Limit {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrBlockRateLimitExceeded,
 				"Rate of %d exceeds configured block rate limit of %+v for %s and %+v",
 				perRateLimitCounts[i],

--- a/protocol/x/clob/rate_limit/single_block_rate_limiter.go
+++ b/protocol/x/clob/rate_limit/single_block_rate_limiter.go
@@ -1,10 +1,10 @@
 package rate_limit
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -36,7 +36,7 @@ func (r *singleBlockRateLimiter[K]) RateLimit(ctx sdk.Context, key K) error {
 	count := r.perKeyCounts[key] + 1
 	r.perKeyCounts[key] = count
 	if count > r.config.Limit {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrBlockRateLimitExceeded,
 			"Rate of %d exceeds configured block rate limit of %+v for %s and key %+v",
 			count,

--- a/protocol/x/clob/types/block_rate_limit_config.go
+++ b/protocol/x/clob/types/block_rate_limit_config.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	errorsmod "cosmossdk.io/errors"
 )
 
 const (
@@ -63,7 +63,7 @@ func (rl maxPerNBlocksRateLimits) validate(field string, maxBlocks uint32, maxOr
 			return err
 		}
 		if existing, found := duplicates[rateLimit.NumBlocks]; found {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				ErrInvalidBlockRateLimitConfig,
 				"Multiple rate limits %+v and %+v for the same block height found for %s",
 				existing,
@@ -77,7 +77,7 @@ func (rl maxPerNBlocksRateLimits) validate(field string, maxBlocks uint32, maxOr
 
 func (rl MaxPerNBlocksRateLimit) validate(field string, maxBlocks uint32, maxOrders uint32) error {
 	if rl.Limit == 0 || rl.Limit > maxOrders {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidBlockRateLimitConfig,
 			"%d is not a valid Limit for %s rate limit %+v",
 			rl.Limit,
@@ -85,7 +85,7 @@ func (rl MaxPerNBlocksRateLimit) validate(field string, maxBlocks uint32, maxOrd
 			rl)
 	}
 	if rl.NumBlocks == 0 || rl.NumBlocks > maxBlocks {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidBlockRateLimitConfig,
 			"%d is not a valid NumBlocks for %s rate limit %+v",
 			rl.NumBlocks,

--- a/protocol/x/clob/types/clob_pair.go
+++ b/protocol/x/clob/types/clob_pair.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	errorsmod "cosmossdk.io/errors"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -68,7 +68,7 @@ func (c *ClobPair) Validate() error {
 	switch c.Metadata.(type) {
 	// TODO(DEC-1535): update this when additional clob pair types are supported.
 	case *ClobPair_SpotClobMetadata:
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidClobPairParameter,
 			"CLOB pair (%+v) is not a perpetual CLOB.",
 			c,
@@ -76,7 +76,7 @@ func (c *ClobPair) Validate() error {
 	}
 
 	if !IsSupportedClobPairStatus(c.Status) {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidClobPairParameter,
 			"CLOB pair (%+v) has unsupported status %+v",
 			c,
@@ -85,7 +85,7 @@ func (c *ClobPair) Validate() error {
 	}
 
 	if c.StepBaseQuantums <= 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidClobPairParameter,
 			"invalid ClobPair parameter: StepBaseQuantums must be > 0. Got %v",
 			c.StepBaseQuantums,
@@ -95,7 +95,7 @@ func (c *ClobPair) Validate() error {
 	// Since a subtick will be calculated as (1 tick/SubticksPerTick), the denominator cannot be 0
 	// and negative numbers do not make sense.
 	if c.SubticksPerTick <= 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidClobPairParameter,
 			"invalid ClobPair parameter: SubticksPerTick must be > 0. Got %v",
 			c.SubticksPerTick,

--- a/protocol/x/clob/types/equity_tier_limit_config.go
+++ b/protocol/x/clob/types/equity_tier_limit_config.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	errorsmod "cosmossdk.io/errors"
 	"sort"
 )
 
@@ -63,7 +63,7 @@ func (l equityTierLimits) validate(field string, maxOrders uint32) error {
 		}
 
 		if i > 0 && l[i-1].UsdTncRequired.Cmp(l[i].UsdTncRequired) >= 0 {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				ErrInvalidEquityTierLimitConfig,
 				"Expected %s equity tier UsdTncRequired to be strictly ascending. "+
 					"Found %+v and %+v out of order",
@@ -78,7 +78,7 @@ func (l equityTierLimits) validate(field string, maxOrders uint32) error {
 
 func (l EquityTierLimit) validate(field string, maxOrders uint32) error {
 	if l.Limit > maxOrders {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidEquityTierLimitConfig,
 			"%d is not a valid Limit for %s equity tier limit %+v",
 			l.Limit,
@@ -87,7 +87,7 @@ func (l EquityTierLimit) validate(field string, maxOrders uint32) error {
 		)
 	}
 	if l.UsdTncRequired.IsNil() || l.UsdTncRequired.BigInt().Sign() < 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidEquityTierLimitConfig,
 			"%d is not a valid UsdTncRequired for %s equity tier limit %+v",
 			l.UsdTncRequired.BigInt(),

--- a/protocol/x/clob/types/errors.go
+++ b/protocol/x/clob/types/errors.go
@@ -2,464 +2,462 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/clob module sentinel errors
 // TODO(CLOB-553) Clean up sentinel errors not in use.
 var (
-	ErrMemClobOrderDoesNotExist = sdkerrors.Register(
+	ErrMemClobOrderDoesNotExist = errorsmod.Register(
 		ModuleName,
 		2,
 		"Order does not exist in memclob",
 	)
-	ErrInvalidOrderSide = sdkerrors.Register(
+	ErrInvalidOrderSide = errorsmod.Register(
 		ModuleName,
 		3,
 		"Invalid order side",
 	)
-	ErrInvalidOrderQuantums     = sdkerrors.Register(ModuleName, 4, "Invalid order quantums")
-	ErrInvalidOrderGoodTilBlock = sdkerrors.Register(ModuleName, 5, "Invalid order goodTilBlock")
-	ErrInvalidOrderSubticks     = sdkerrors.Register(ModuleName, 6, "Invalid order subticks")
-	ErrOrderIsCanceled          = sdkerrors.Register(
+	ErrInvalidOrderQuantums     = errorsmod.Register(ModuleName, 4, "Invalid order quantums")
+	ErrInvalidOrderGoodTilBlock = errorsmod.Register(ModuleName, 5, "Invalid order goodTilBlock")
+	ErrInvalidOrderSubticks     = errorsmod.Register(ModuleName, 6, "Invalid order subticks")
+	ErrOrderIsCanceled          = errorsmod.Register(
 		ModuleName,
 		7,
 		"Attempt to place an order that is already canceled",
 	)
-	ErrInvalidClob = sdkerrors.Register(
+	ErrInvalidClob = errorsmod.Register(
 		ModuleName,
 		8,
 		"ClobPair ID does not reference a valid CLOB",
 	)
-	ErrMemClobCancelAlreadyExists = sdkerrors.Register(
+	ErrMemClobCancelAlreadyExists = errorsmod.Register(
 		ModuleName,
 		9,
 		"A cancel already exists in the memclob for this order with a greater than or equal GoodTilBlock",
 	)
-	ErrHeightExceedsGoodTilBlock = sdkerrors.Register(
+	ErrHeightExceedsGoodTilBlock = errorsmod.Register(
 		ModuleName,
 		10,
 		"The next block height is greater than the GoodTilBlock of the message",
 	)
-	ErrGoodTilBlockExceedsShortBlockWindow = sdkerrors.Register(
+	ErrGoodTilBlockExceedsShortBlockWindow = errorsmod.Register(
 		ModuleName,
 		11,
 		"The GoodTilBlock of the message is further than ShortBlockWindow blocks into the future",
 	)
-	ErrInvalidPlaceOrder = sdkerrors.Register(
+	ErrInvalidPlaceOrder = errorsmod.Register(
 		ModuleName,
 		12,
 		"MsgPlaceOrder is invalid",
 	)
-	ErrInvalidMsgProposedMatchOrders = sdkerrors.Register(
+	ErrInvalidMsgProposedMatchOrders = errorsmod.Register(
 		ModuleName,
 		13,
 		"MsgProposedMatchOrders is invalid",
 	)
-	ErrStateFilledAmountNoChange = sdkerrors.Register(
+	ErrStateFilledAmountNoChange = errorsmod.Register(
 		ModuleName,
 		14,
 		"State filled amount cannot be unchanged",
 	)
-	ErrStateFilledAmountDecreasing = sdkerrors.Register(
+	ErrStateFilledAmountDecreasing = errorsmod.Register(
 		ModuleName,
 		15,
 		"State filled amount cannot decrease",
 	)
-	ErrInvalidPruneStateFilledAmount = sdkerrors.Register(
+	ErrInvalidPruneStateFilledAmount = errorsmod.Register(
 		ModuleName,
 		16,
 		"Cannot prune state fill amount that does not exist",
 	)
-	ErrOrderWouldExceedMaxOpenOrdersPerClobAndSide = sdkerrors.Register(
+	ErrOrderWouldExceedMaxOpenOrdersPerClobAndSide = errorsmod.Register(
 		ModuleName,
 		17,
 		"Subaccount cannot open more than 20 orders on a given CLOB and side",
 	)
-	ErrFillAmountNotDivisibleByStepSize = sdkerrors.Register(
+	ErrFillAmountNotDivisibleByStepSize = errorsmod.Register(
 		ModuleName,
 		18,
 		"`FillAmount` is not divisible by `StepBaseQuantums` of the specified `ClobPairId`",
 	)
-	ErrNoClobPairForPerpetual = sdkerrors.Register(
+	ErrNoClobPairForPerpetual = errorsmod.Register(
 		ModuleName,
 		19,
 		"The provided perpetual ID does not have any associated CLOB pairs",
 	)
-	ErrInvalidReplacement = sdkerrors.Register(
+	ErrInvalidReplacement = errorsmod.Register(
 		ModuleName,
 		20,
 		"An order with the same `OrderId` already exists for this CLOB with a greater-than-or-equal `GoodTilBlock` "+
 			"or Order Hash",
 	)
-	ErrClobPairAndPerpetualDoNotMatch = sdkerrors.Register(
+	ErrClobPairAndPerpetualDoNotMatch = errorsmod.Register(
 		ModuleName,
 		21,
 		"Clob pair and perpetual ids do not match",
 	)
-	ErrMatchedOrderNegativeFee = sdkerrors.Register(
+	ErrMatchedOrderNegativeFee = errorsmod.Register(
 		ModuleName,
 		22,
 		"Matched order has negative fee",
 	)
-	ErrSubaccountFeeTransferFailed = sdkerrors.Register(
+	ErrSubaccountFeeTransferFailed = errorsmod.Register(
 		ModuleName,
 		23,
 		"Subaccounts updated for a matched order, but fee transfer to fee-collector failed",
 	)
-	ErrOrderFullyFilled = sdkerrors.Register(
+	ErrOrderFullyFilled = errorsmod.Register(
 		ModuleName,
 		24,
 		"Order is fully filled",
 	)
-	ErrPremiumWithNonPerpetualClobPair = sdkerrors.Register(
+	ErrPremiumWithNonPerpetualClobPair = errorsmod.Register(
 		ModuleName,
 		25,
 		"Attempting to get price premium with a non-perpetual CLOB pair",
 	)
-	ErrZeroIndexPriceForPremiumCalculation = sdkerrors.Register(
+	ErrZeroIndexPriceForPremiumCalculation = errorsmod.Register(
 		ModuleName,
 		26,
 		"Index price is zero when calculating price premium",
 	)
-	ErrInvalidClobPairParameter = sdkerrors.Register(
+	ErrInvalidClobPairParameter = errorsmod.Register(
 		ModuleName,
 		27,
 		"Invalid ClobPair parameter",
 	)
-	ErrZeroPriceForOracle = sdkerrors.Register(
+	ErrZeroPriceForOracle = errorsmod.Register(
 		ModuleName,
 		28,
 		"Oracle price must be > 0.",
 	)
-	ErrInvalidStatefulOrderCancellation = sdkerrors.Register(
+	ErrInvalidStatefulOrderCancellation = errorsmod.Register(
 		ModuleName,
 		29,
 		"Invalid stateful order cancellation",
 	)
-	ErrOrderReprocessed = sdkerrors.Register(
+	ErrOrderReprocessed = errorsmod.Register(
 		ModuleName,
 		30,
 		"An order with the same `OrderId` and `OrderHash` has already been processed for this CLOB",
 	)
-	ErrMissingMidPrice = sdkerrors.Register(
+	ErrMissingMidPrice = errorsmod.Register(
 		ModuleName,
 		31,
 		"Missing mid price for ClobPair",
 	)
-	ErrStatefulOrderCancellationAlreadyExists = sdkerrors.Register(
+	ErrStatefulOrderCancellationAlreadyExists = errorsmod.Register(
 		ModuleName,
 		32,
 		"Existing stateful order cancellation has higher-or-equal priority than the new one",
 	)
-	ErrClobPairAlreadyExists = sdkerrors.Register(
+	ErrClobPairAlreadyExists = errorsmod.Register(
 		ModuleName,
 		33,
 		"ClobPair with id already exists",
 	)
-	ErrOrderConflictsWithClobPairStatus = sdkerrors.Register(
+	ErrOrderConflictsWithClobPairStatus = errorsmod.Register(
 		ModuleName,
 		34,
 		"Order conflicts with ClobPair status",
 	)
-	ErrInvalidClobPairStatusTransition = sdkerrors.Register(
+	ErrInvalidClobPairStatusTransition = errorsmod.Register(
 		ModuleName,
 		35,
 		"Invalid ClobPair status transition",
 	)
-	ErrOperationConflictsWithClobPairStatus = sdkerrors.Register(
+	ErrOperationConflictsWithClobPairStatus = errorsmod.Register(
 		ModuleName,
 		36,
 		"Operation conflicts with ClobPair status",
 	)
-	ErrPerpetualDoesNotExist = sdkerrors.Register(
+	ErrPerpetualDoesNotExist = errorsmod.Register(
 		ModuleName,
 		37,
 		"Perpetual does not exist in state",
 	)
-	ErrInvalidClobPairUpdate = sdkerrors.Register(
+	ErrInvalidClobPairUpdate = errorsmod.Register(
 		ModuleName,
 		39,
 		"ClobPair update is invalid",
 	)
-	ErrInvalidAuthority = sdkerrors.Register(
+	ErrInvalidAuthority = errorsmod.Register(
 		ModuleName,
 		40,
 		"Authority is invalid",
 	)
-	ErrPerpetualAssociatedWithExistingClobPair = sdkerrors.Register(
+	ErrPerpetualAssociatedWithExistingClobPair = errorsmod.Register(
 		ModuleName,
 		41,
 		"perpetual ID is already associated with an existing CLOB pair",
 	)
 
 	// Liquidations errors.
-	ErrInvalidLiquidationsConfig = sdkerrors.Register(
+	ErrInvalidLiquidationsConfig = errorsmod.Register(
 		ModuleName,
 		1000,
 		"Proposed LiquidationsConfig is invalid",
 	)
-	ErrNoPerpetualPositionsToLiquidate = sdkerrors.Register(
+	ErrNoPerpetualPositionsToLiquidate = errorsmod.Register(
 		ModuleName,
 		1001,
 		"Subaccount has no perpetual positions to liquidate",
 	)
-	ErrSubaccountNotLiquidatable = sdkerrors.Register(
+	ErrSubaccountNotLiquidatable = errorsmod.Register(
 		ModuleName,
 		1002,
 		"Subaccount is not liquidatable",
 	)
-	ErrNoOpenPositionForPerpetual = sdkerrors.Register(
+	ErrNoOpenPositionForPerpetual = errorsmod.Register(
 		ModuleName,
 		1003,
 		"Subaccount does not have an open position for perpetual",
 	)
-	ErrInvalidLiquidationOrderTotalSize = sdkerrors.Register(
+	ErrInvalidLiquidationOrderTotalSize = errorsmod.Register(
 		ModuleName,
 		1004,
 		"Liquidation order has invalid size",
 	)
-	ErrInvalidLiquidationOrderSide = sdkerrors.Register(
+	ErrInvalidLiquidationOrderSide = errorsmod.Register(
 		ModuleName,
 		1005,
 		"Liquidation order is on the wrong side",
 	)
-	ErrTotalFillAmountExceedsOrderSize = sdkerrors.Register(
+	ErrTotalFillAmountExceedsOrderSize = errorsmod.Register(
 		ModuleName,
 		1006,
 		"Total fills amount exceeds size of liquidation order",
 	)
-	ErrLiquidationContainsNoFills = sdkerrors.Register(
+	ErrLiquidationContainsNoFills = errorsmod.Register(
 		ModuleName,
 		1007,
 		"Liquidation order does not contain any fills",
 	)
-	ErrSubaccountHasLiquidatedPerpetual = sdkerrors.Register(
+	ErrSubaccountHasLiquidatedPerpetual = errorsmod.Register(
 		ModuleName,
 		1008,
 		"Subaccount has previously liquidated this perpetual in the current block",
 	)
-	ErrLiquidationOrderSizeSmallerThanMin = sdkerrors.Register(
+	ErrLiquidationOrderSizeSmallerThanMin = errorsmod.Register(
 		ModuleName,
 		1009,
 		"Liquidation order has size smaller than min position notional specified in the liquidation config",
 	)
-	ErrLiquidationOrderSizeGreaterThanMax = sdkerrors.Register(
+	ErrLiquidationOrderSizeGreaterThanMax = errorsmod.Register(
 		ModuleName,
 		1010,
 		"Liquidation order has size greater than max position notional specified in the liquidation config",
 	)
-	ErrLiquidationExceedsSubaccountMaxNotionalLiquidated = sdkerrors.Register(
+	ErrLiquidationExceedsSubaccountMaxNotionalLiquidated = errorsmod.Register(
 		ModuleName,
 		1011,
 		"Liquidation exceeds the maximum notional amount that a single subaccount can have liquidated per block",
 	)
-	ErrLiquidationExceedsSubaccountMaxInsuranceLost = sdkerrors.Register(
+	ErrLiquidationExceedsSubaccountMaxInsuranceLost = errorsmod.Register(
 		ModuleName,
 		1012,
 		"Liquidation exceeds the maximum insurance fund payout amount for a given subaccount per block",
 	)
-	ErrInsuranceFundHasInsufficientFunds = sdkerrors.Register(
+	ErrInsuranceFundHasInsufficientFunds = errorsmod.Register(
 		ModuleName,
 		1013,
 		"Insurance fund does not have sufficient funds to cover liquidation losses",
 	)
-	ErrInvalidPerpetualPositionSizeDelta = sdkerrors.Register(
+	ErrInvalidPerpetualPositionSizeDelta = errorsmod.Register(
 		ModuleName,
 		1014,
 		"Invalid perpetual position size delta",
 	)
-	ErrInvalidQuantumsForInsuranceFundDeltaCalculation = sdkerrors.Register(
+	ErrInvalidQuantumsForInsuranceFundDeltaCalculation = errorsmod.Register(
 		ModuleName,
 		1015,
 		"Invalid delta base and/or quote quantums for insurance fund delta calculation",
 	)
-	ErrEmptyDeleveragingFills = sdkerrors.Register(
+	ErrEmptyDeleveragingFills = errorsmod.Register(
 		ModuleName,
 		1016,
 		"Deleveraging fills length must be greater than 0",
 	)
-	ErrDeleveragingAgainstSelf = sdkerrors.Register(
+	ErrDeleveragingAgainstSelf = errorsmod.Register(
 		ModuleName,
 		1017,
 		"Cannot deleverage subaccount against itself",
 	)
-	ErrDuplicateDeleveragingFillSubaccounts = sdkerrors.Register(
+	ErrDuplicateDeleveragingFillSubaccounts = errorsmod.Register(
 		ModuleName,
 		1018,
 		"Deleveraging match cannot have fills with same id",
 	)
-	ErrZeroDeleveragingFillAmount = sdkerrors.Register(
+	ErrZeroDeleveragingFillAmount = errorsmod.Register(
 		ModuleName,
 		1019,
 		"Deleveraging match cannot have fills with zero amount",
 	)
-	ErrPositionCannotBeFullyOffset = sdkerrors.Register(
+	ErrPositionCannotBeFullyOffset = errorsmod.Register(
 		ModuleName,
 		1020,
 		"Position cannot be fully offset",
 	)
 
 	// Advanced order type errors.
-	ErrFokOrderCouldNotBeFullyFilled = sdkerrors.Register(
+	ErrFokOrderCouldNotBeFullyFilled = errorsmod.Register(
 		ModuleName,
 		2000,
 		"FillOrKill order could not be fully filled",
 	)
-	ErrReduceOnlyWouldIncreasePositionSize = sdkerrors.Register(
+	ErrReduceOnlyWouldIncreasePositionSize = errorsmod.Register(
 		ModuleName,
 		2001,
 		"Reduce-only orders cannot increase the position size",
 	)
-	ErrReduceOnlyWouldChangePositionSide = sdkerrors.Register(
+	ErrReduceOnlyWouldChangePositionSide = errorsmod.Register(
 		ModuleName,
 		2002,
 		"Reduce-only orders cannot change the position side",
 	)
-	ErrPostOnlyWouldCrossMakerOrder = sdkerrors.Register(
+	ErrPostOnlyWouldCrossMakerOrder = errorsmod.Register(
 		ModuleName,
 		2003,
 		"Post-only order would cross one or more maker orders",
 	)
 
 	// Stateful order errors.
-	ErrInvalidOrderFlag = sdkerrors.Register(
+	ErrInvalidOrderFlag = errorsmod.Register(
 		ModuleName,
 		3000,
 		"Invalid order flags",
 	)
-	ErrInvalidStatefulOrderGoodTilBlockTime = sdkerrors.Register(
+	ErrInvalidStatefulOrderGoodTilBlockTime = errorsmod.Register(
 		ModuleName,
 		3001,
 		"Invalid order goodTilBlockTime",
 	)
-	ErrStatefulOrdersCannotRequireImmediateExecution = sdkerrors.Register(
+	ErrStatefulOrdersCannotRequireImmediateExecution = errorsmod.Register(
 		ModuleName,
 		3002,
 		"Stateful orders cannot require immediate execution",
 	)
-	ErrTimeExceedsGoodTilBlockTime = sdkerrors.Register(
+	ErrTimeExceedsGoodTilBlockTime = errorsmod.Register(
 		ModuleName,
 		3003,
 		"The block time is greater than the GoodTilBlockTime of the message",
 	)
-	ErrGoodTilBlockTimeExceedsStatefulOrderTimeWindow = sdkerrors.Register(
+	ErrGoodTilBlockTimeExceedsStatefulOrderTimeWindow = errorsmod.Register(
 		ModuleName,
 		3004,
 		"The GoodTilBlockTime of the message is further than StatefulOrderTimeWindow into the future",
 	)
-	ErrStatefulOrderAlreadyExists = sdkerrors.Register(
+	ErrStatefulOrderAlreadyExists = errorsmod.Register(
 		ModuleName,
 		3005,
 		"Existing stateful order has higher-or-equal priority than the new one",
 	)
-	ErrStatefulOrderDoesNotExist = sdkerrors.Register(
+	ErrStatefulOrderDoesNotExist = errorsmod.Register(
 		ModuleName,
 		3006,
 		"Stateful order does not exist",
 	)
-	ErrStatefulOrderCollateralizationCheckFailed = sdkerrors.Register(
+	ErrStatefulOrderCollateralizationCheckFailed = errorsmod.Register(
 		ModuleName,
 		3007,
 		"Stateful order collateralization check failed",
 	)
-	ErrStatefulOrderPreviouslyCancelled = sdkerrors.Register(
+	ErrStatefulOrderPreviouslyCancelled = errorsmod.Register(
 		ModuleName,
 		3008,
 		"Stateful order was previously cancelled and therefore cannot be placed",
 	)
-	ErrStatefulOrderPreviouslyRemoved = sdkerrors.Register(
+	ErrStatefulOrderPreviouslyRemoved = errorsmod.Register(
 		ModuleName,
 		3009,
 		"Stateful order was previously removed and therefore cannot be placed",
 	)
 
 	// Operations Queue validation errors
-	ErrInvalidMsgProposedOperations = sdkerrors.Register(
+	ErrInvalidMsgProposedOperations = errorsmod.Register(
 		ModuleName,
 		4000,
 		"MsgProposedOperations is invalid",
 	)
-	ErrInvalidMatchOrder = sdkerrors.Register(
+	ErrInvalidMatchOrder = errorsmod.Register(
 		ModuleName,
 		4001,
 		"Match Order is invalid",
 	)
-	ErrOrderPlacementNotInOperationsQueue = sdkerrors.Register(
+	ErrOrderPlacementNotInOperationsQueue = errorsmod.Register(
 		ModuleName,
 		4002,
 		"Order was not previously placed in operations queue",
 	)
-	ErrFillAmountIsZero = sdkerrors.Register(
+	ErrFillAmountIsZero = errorsmod.Register(
 		ModuleName,
 		4003,
 		"Fill amount cannot be zero",
 	)
-	ErrInvalidDeleveragingFill = sdkerrors.Register(
+	ErrInvalidDeleveragingFill = errorsmod.Register(
 		ModuleName,
 		4004,
 		"Deleveraging fill is invalid",
 	)
-	ErrInvalidDeleveragedSubaccount = sdkerrors.Register(
+	ErrInvalidDeleveragedSubaccount = errorsmod.Register(
 		ModuleName,
 		4005,
 		"Deleveraged subaccount in proposed deleveraged operation failed deleveraging validation",
 	)
 
 	// Block rate limit errors.
-	ErrInvalidBlockRateLimitConfig = sdkerrors.Register(
+	ErrInvalidBlockRateLimitConfig = errorsmod.Register(
 		ModuleName,
 		5000,
 		"Proposed BlockRateLimitConfig is invalid",
 	)
-	ErrBlockRateLimitExceeded = sdkerrors.Register(
+	ErrBlockRateLimitExceeded = errorsmod.Register(
 		ModuleName,
 		5001,
 		"Block rate limit exceeded",
 	)
 
 	// Conditional order errors.
-	ErrInvalidConditionType = sdkerrors.Register(
+	ErrInvalidConditionType = errorsmod.Register(
 		ModuleName,
 		6000,
 		"Conditional type is invalid",
 	)
-	ErrInvalidConditionalOrderTriggerSubticks = sdkerrors.Register(
+	ErrInvalidConditionalOrderTriggerSubticks = errorsmod.Register(
 		ModuleName,
 		6001,
 		"Conditional order trigger subticks is invalid",
 	)
 
 	// Errors for unimplemented and disabled functionality.
-	ErrAssetOrdersNotImplemented = sdkerrors.Register(
+	ErrAssetOrdersNotImplemented = errorsmod.Register(
 		ModuleName,
 		9000,
 		"Asset orders are not implemented",
 	)
-	ErrAssetUpdateNotImplemented = sdkerrors.Register(
+	ErrAssetUpdateNotImplemented = errorsmod.Register(
 		ModuleName,
 		9001,
 		"Updates for assets other than USDC are not implemented",
 	)
-	ErrNotImplemented = sdkerrors.Register(
+	ErrNotImplemented = errorsmod.Register(
 		ModuleName,
 		9002,
 		"This function is not implemented",
 	)
-	ErrReduceOnlyDisabled = sdkerrors.Register(
+	ErrReduceOnlyDisabled = errorsmod.Register(
 		ModuleName,
 		9003,
 		"Reduce-only is currently disabled",
 	)
 
 	// Equity tier limit errors.
-	ErrInvalidEquityTierLimitConfig = sdkerrors.Register(
+	ErrInvalidEquityTierLimitConfig = errorsmod.Register(
 		ModuleName,
 		10000,
 		"Proposed EquityTierLimitConfig is invalid",
 	)
-	ErrOrderWouldExceedMaxOpenOrdersEquityTierLimit = sdkerrors.Register(
+	ErrOrderWouldExceedMaxOpenOrdersEquityTierLimit = errorsmod.Register(
 		ModuleName,
 		10001,
 		"Subaccount cannot open more orders due to equity tier limit.",

--- a/protocol/x/clob/types/liquidations_config.go
+++ b/protocol/x/clob/types/liquidations_config.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	errorsmod "cosmossdk.io/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
 
@@ -20,7 +20,7 @@ func (lc *LiquidationsConfig) Validate() error {
 	// Validate the BankruptcyAdjustmentPpm.
 	bankruptcyAdjustmentPpm := lc.FillablePriceConfig.BankruptcyAdjustmentPpm
 	if bankruptcyAdjustmentPpm < lib.OneMillion {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidLiquidationsConfig,
 			"%v is not a valid BankruptcyAdjustmentPpm",
 			bankruptcyAdjustmentPpm,
@@ -30,7 +30,7 @@ func (lc *LiquidationsConfig) Validate() error {
 	// Validate the SpreadToMaintenanceMarginRatioPpm.
 	spreadToMaintenanceMarginRatioPpm := lc.FillablePriceConfig.SpreadToMaintenanceMarginRatioPpm
 	if spreadToMaintenanceMarginRatioPpm == 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidLiquidationsConfig,
 			"%v is not a valid SpreadToMaintenanceMarginRatioPpm",
 			spreadToMaintenanceMarginRatioPpm,
@@ -39,7 +39,7 @@ func (lc *LiquidationsConfig) Validate() error {
 
 	// Validate the MaxLiquidationFeePpm.
 	if lc.MaxLiquidationFeePpm == 0 || lc.MaxLiquidationFeePpm > lib.OneMillion {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidLiquidationsConfig,
 			"%v is not a valid MaxLiquidationFeePpm",
 			lc.MaxLiquidationFeePpm,
@@ -49,7 +49,7 @@ func (lc *LiquidationsConfig) Validate() error {
 	// Validate the MaxPositionPortionLiquidatedPpm.
 	maxPositionPortionLiquidatedPpm := lc.PositionBlockLimits.MaxPositionPortionLiquidatedPpm
 	if maxPositionPortionLiquidatedPpm == 0 || maxPositionPortionLiquidatedPpm > lib.OneMillion {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidLiquidationsConfig,
 			"%v is not a valid MaxPositionPortionLiquidatedPpm",
 			maxPositionPortionLiquidatedPpm,
@@ -59,7 +59,7 @@ func (lc *LiquidationsConfig) Validate() error {
 	// Validate the MaxNotionalLiquidated.
 	maxNotionalLiquidated := lc.SubaccountBlockLimits.MaxNotionalLiquidated
 	if maxNotionalLiquidated == 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidLiquidationsConfig,
 			"%v is not a valid MaxNotionalLiquidated",
 			maxNotionalLiquidated,
@@ -69,7 +69,7 @@ func (lc *LiquidationsConfig) Validate() error {
 	// Validate the MaxQuantumsInsuranceLost.
 	maxQuantumsInsuranceLost := lc.SubaccountBlockLimits.MaxQuantumsInsuranceLost
 	if maxQuantumsInsuranceLost == 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidLiquidationsConfig,
 			"%v is not a valid MaxQuantumsInsuranceLost",
 			maxQuantumsInsuranceLost,

--- a/protocol/x/clob/types/message_cancel_order.go
+++ b/protocol/x/clob/types/message_cancel_order.go
@@ -1,12 +1,12 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 )
 
@@ -61,7 +61,7 @@ func (msg *MsgCancelOrder) ValidateBasic() (err error) {
 
 	if orderId.IsStatefulOrder() {
 		if msg.GetGoodTilBlockTime() == 0 {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				ErrInvalidStatefulOrderGoodTilBlockTime,
 				"stateful cancellation goodTilBlockTime cannot be 0, %+v",
 				orderId,
@@ -69,7 +69,7 @@ func (msg *MsgCancelOrder) ValidateBasic() (err error) {
 		}
 	} else {
 		if msg.GetGoodTilBlock() == 0 {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				ErrInvalidOrderGoodTilBlock,
 				"cancellation goodTilBlock cannot be 0, orderId %+v",
 				orderId,

--- a/protocol/x/clob/types/message_create_clob_pair.go
+++ b/protocol/x/clob/types/message_create_clob_pair.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var _ sdk.Msg = &MsgCreateClobPair{}
@@ -14,7 +14,7 @@ func (msg *MsgCreateClobPair) GetSigners() []sdk.AccAddress {
 
 func (msg *MsgCreateClobPair) ValidateBasic() error {
 	if msg.Authority == "" {
-		return sdkerrors.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
 	}
 
 	return msg.ClobPair.Validate()

--- a/protocol/x/clob/types/message_place_order.go
+++ b/protocol/x/clob/types/message_place_order.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 )
 
@@ -42,32 +42,32 @@ func (msg *MsgPlaceOrder) ValidateBasic() (err error) {
 	}
 
 	if _, exists := Order_Side_name[int32(msg.Order.Side)]; !exists {
-		return sdkerrors.Wrapf(ErrInvalidOrderSide, "invalid order side (%s)", msg.Order.Side)
+		return errorsmod.Wrapf(ErrInvalidOrderSide, "invalid order side (%s)", msg.Order.Side)
 	}
 
 	if msg.Order.Side == Order_SIDE_UNSPECIFIED {
-		return sdkerrors.Wrapf(ErrInvalidOrderSide, "UNSPECIFIED is not a valid order side")
+		return errorsmod.Wrapf(ErrInvalidOrderSide, "UNSPECIFIED is not a valid order side")
 	}
 
 	if msg.Order.Quantums == uint64(0) {
-		return sdkerrors.Wrapf(ErrInvalidOrderQuantums, "order size quantums cannot be 0")
+		return errorsmod.Wrapf(ErrInvalidOrderQuantums, "order size quantums cannot be 0")
 	}
 
 	orderId := msg.Order.GetOrderId()
 	if orderId.IsShortTermOrder() {
 		// This also implicitly verifies that GoodTilBlockTime is not set / is zero for short-term orders.
 		if msg.Order.GetGoodTilBlock() == uint32(0) {
-			return sdkerrors.Wrapf(ErrInvalidOrderGoodTilBlock, "order goodTilBlock cannot be 0")
+			return errorsmod.Wrapf(ErrInvalidOrderGoodTilBlock, "order goodTilBlock cannot be 0")
 		}
 	} else if orderId.IsStatefulOrder() {
 		if msg.Order.GetGoodTilBlockTime() == uint32(0) {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				ErrInvalidStatefulOrderGoodTilBlockTime,
 				"stateful order goodTilBlockTime cannot be 0",
 			)
 		}
 	} else {
-		return sdkerrors.Wrapf(ErrInvalidOrderFlag, "invalid order flag %v", orderId.OrderFlags)
+		return errorsmod.Wrapf(ErrInvalidOrderFlag, "invalid order flag %v", orderId.OrderFlags)
 	}
 
 	if orderId.IsLongTermOrder() && msg.Order.RequiresImmediateExecution() {
@@ -75,28 +75,28 @@ func (msg *MsgPlaceOrder) ValidateBasic() (err error) {
 	}
 
 	if msg.Order.ReduceOnly {
-		return sdkerrors.Wrapf(ErrReduceOnlyDisabled, "reduce-only is temporarily disabled")
+		return errorsmod.Wrapf(ErrReduceOnlyDisabled, "reduce-only is temporarily disabled")
 	}
 
 	if msg.Order.Subticks == uint64(0) {
-		return sdkerrors.Wrapf(ErrInvalidOrderSubticks, "order subticks cannot be 0")
+		return errorsmod.Wrapf(ErrInvalidOrderSubticks, "order subticks cannot be 0")
 	}
 
 	if orderId.IsConditionalOrder() {
 		if msg.Order.ConditionType == Order_CONDITION_TYPE_UNSPECIFIED {
-			return sdkerrors.Wrapf(ErrInvalidConditionType, "condition type cannot be unspecified")
+			return errorsmod.Wrapf(ErrInvalidConditionType, "condition type cannot be unspecified")
 		}
 
 		if msg.Order.ConditionalOrderTriggerSubticks == uint64(0) {
-			return sdkerrors.Wrapf(ErrInvalidConditionalOrderTriggerSubticks, "conditional order trigger subticks cannot be 0")
+			return errorsmod.Wrapf(ErrInvalidConditionalOrderTriggerSubticks, "conditional order trigger subticks cannot be 0")
 		}
 	} else {
 		if msg.Order.ConditionType != Order_CONDITION_TYPE_UNSPECIFIED {
-			return sdkerrors.Wrapf(ErrInvalidConditionType, "condition type specified for non-conditional order")
+			return errorsmod.Wrapf(ErrInvalidConditionType, "condition type specified for non-conditional order")
 		}
 
 		if msg.Order.ConditionalOrderTriggerSubticks != uint64(0) {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				ErrInvalidConditionalOrderTriggerSubticks,
 				"conditional order trigger subticks greater than 0 for non-conditional order",
 			)

--- a/protocol/x/clob/types/message_update_liquidations_config.go
+++ b/protocol/x/clob/types/message_update_liquidations_config.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var _ sdk.Msg = &MsgUpdateLiquidationsConfig{}
@@ -17,7 +17,7 @@ func (msg *MsgUpdateLiquidationsConfig) GetSigners() []sdk.AccAddress {
 // is empty or if the LiquidationsConfig is invalid.
 func (msg *MsgUpdateLiquidationsConfig) ValidateBasic() error {
 	if msg.Authority == "" {
-		return sdkerrors.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
 	}
 
 	return msg.LiquidationsConfig.Validate()

--- a/protocol/x/clob/types/order_id.go
+++ b/protocol/x/clob/types/order_id.go
@@ -1,13 +1,12 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"sort"
 
 	gometrics "github.com/armon/go-metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
-
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const (
@@ -92,7 +91,7 @@ func (o *OrderId) Validate() error {
 		return err
 	}
 	if !o.IsShortTermOrder() && !o.IsStatefulOrder() {
-		return sdkerrors.Wrapf(ErrInvalidOrderFlag, "orderId: %v", o)
+		return errorsmod.Wrapf(ErrInvalidOrderFlag, "orderId: %v", o)
 	}
 	return nil
 }

--- a/protocol/x/delaymsg/keeper/block_message_ids.go
+++ b/protocol/x/delaymsg/keeper/block_message_ids.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 )
@@ -68,7 +68,7 @@ func (k Keeper) deleteMessageIdFromBlock(
 ) {
 	blockMessageIds, found := k.GetBlockMessageIds(ctx, blockHeight)
 	if !found {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidInput,
 			"block %v not found",
 			blockHeight,
@@ -99,7 +99,7 @@ func (k Keeper) deleteMessageIdFromBlock(
 	}
 
 	// If we make it here, the message id was not found in the block.
-	return sdkerrors.Wrapf(
+	return errorsmod.Wrapf(
 		types.ErrInvalidInput,
 		"message id %v not found in block %v",
 		id,

--- a/protocol/x/delaymsg/keeper/delayed_message.go
+++ b/protocol/x/delaymsg/keeper/delayed_message.go
@@ -2,10 +2,10 @@ package keeper
 
 import (
 	"bytes"
+	errorsmod "cosmossdk.io/errors"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
@@ -86,7 +86,7 @@ func (k Keeper) DeleteMessage(
 ) {
 	delayedMsg, found := k.GetMessage(ctx, id)
 	if !found {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidInput,
 			"failed to delete message: message with id %d not found",
 			id,
@@ -97,7 +97,7 @@ func (k Keeper) DeleteMessage(
 
 	// Remove message id from block message ids.
 	if err := k.deleteMessageIdFromBlock(ctx, id, delayedMsg.BlockHeight); err != nil {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidInput,
 			"failed to delete message: %v",
 			err,
@@ -115,7 +115,7 @@ func (k Keeper) SetDelayedMessage(
 	err error,
 ) {
 	if msg.BlockHeight < ctx.BlockHeight() {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidInput,
 			"failed to delay message: block height %d is in the past",
 			msg.BlockHeight,
@@ -136,14 +136,14 @@ func (k Keeper) SetDelayedMessage(
 func validateSigners(msg sdk.Msg) error {
 	signers := msg.GetSigners()
 	if len(signers) != 1 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidSigner,
 			"message must have exactly one signer",
 		)
 	}
 	moduleAddress := authtypes.NewModuleAddress(types.ModuleName)
 	if !bytes.Equal(signers[0], moduleAddress) {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidSigner,
 			"message signer must be delaymsg module address",
 		)
@@ -163,14 +163,14 @@ func (k Keeper) DelayMessageByBlocks(
 	handler := k.router.Handler(msg)
 	// If the message type is not routable, return an error.
 	if handler == nil {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrMsgIsUnroutable,
 			sdk.MsgTypeURL(msg),
 		)
 	}
 
 	if err := msg.ValidateBasic(); err != nil {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrInvalidInput,
 			"message failed basic validation: %v",
 			err,
@@ -184,7 +184,7 @@ func (k Keeper) DelayMessageByBlocks(
 	nextId := k.GetNumMessages(ctx)
 	blockHeight, err := lib.AddUint32(ctx.BlockHeight(), blockDelay)
 	if err != nil {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrInvalidInput,
 			"failed to add block delay to current block height: %v",
 			err,
@@ -193,7 +193,7 @@ func (k Keeper) DelayMessageByBlocks(
 
 	anyMsg, err := codectypes.NewAnyWithValue(msg)
 	if err != nil {
-		return 0, sdkerrors.Wrapf(
+		return 0, errorsmod.Wrapf(
 			types.ErrInvalidInput,
 			"failed to convert message to Any: %v",
 			err,

--- a/protocol/x/delaymsg/types/errors.go
+++ b/protocol/x/delaymsg/types/errors.go
@@ -1,13 +1,13 @@
 package types
 
-import sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+import errorsmod "cosmossdk.io/errors"
 
 // x/delaymsg module sentinel errors
 var (
-	ErrInvalidInput    = sdkerrors.Register(ModuleName, 1, "Invalid input")
-	ErrMsgIsNil        = sdkerrors.Register(ModuleName, 2, "Delayed msg is nil")
-	ErrMsgIsUnroutable = sdkerrors.Register(ModuleName, 3, "Message not recognized by router")
-	ErrInvalidSigner   = sdkerrors.Register(ModuleName, 4, "Invalid signer")
+	ErrInvalidInput    = errorsmod.Register(ModuleName, 1, "Invalid input")
+	ErrMsgIsNil        = errorsmod.Register(ModuleName, 2, "Delayed msg is nil")
+	ErrMsgIsUnroutable = errorsmod.Register(ModuleName, 3, "Message not recognized by router")
+	ErrInvalidSigner   = errorsmod.Register(ModuleName, 4, "Invalid signer")
 
-	ErrInvalidGenesisState = sdkerrors.Register(ModuleName, 10, "Invalid genesis state")
+	ErrInvalidGenesisState = errorsmod.Register(ModuleName, 10, "Invalid genesis state")
 )

--- a/protocol/x/delaymsg/types/genesis.go
+++ b/protocol/x/delaymsg/types/genesis.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // DefaultGenesis returns the default genesis state
@@ -20,20 +20,20 @@ func (gs GenesisState) Validate() error {
 
 	for i, msg := range gs.DelayedMessages {
 		if err := msg.Validate(); err != nil {
-			return sdkerrors.Wrap(
+			return errorsmod.Wrap(
 				ErrInvalidGenesisState,
 				fmt.Sprintf("invalid delayed message at index %v with id %v: %v", i, msg.Id, err),
 			)
 		}
 
 		if msg.Id >= gs.NumMessages {
-			return sdkerrors.Wrap(
+			return errorsmod.Wrap(
 				ErrInvalidGenesisState,
 				"delayed message id exceeds total number of messages",
 			)
 		}
 		if _, ok := ids[msg.Id]; ok {
-			return sdkerrors.Wrap(
+			return errorsmod.Wrap(
 				ErrInvalidGenesisState,
 				"duplicate delayed message id",
 			)

--- a/protocol/x/epochs/keeper/epoch_info.go
+++ b/protocol/x/epochs/keeper/epoch_info.go
@@ -1,13 +1,13 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 
 	gometrics "github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/epochs/types"
@@ -32,7 +32,7 @@ func (k Keeper) setEpochInfo(ctx sdk.Context, epochInfo types.EpochInfo) {
 func (k Keeper) MaybeStartNextEpoch(ctx sdk.Context, id types.EpochInfoName) (nextEpochStarted bool, err error) {
 	epoch, found := k.GetEpochInfo(ctx, id)
 	if !found {
-		return false, sdkerrors.Wrapf(types.ErrEpochInfoNotFound, "EpochInfo Id not found (%s)", id)
+		return false, errorsmod.Wrapf(types.ErrEpochInfoNotFound, "EpochInfo Id not found (%s)", id)
 	}
 
 	blockTime := uint32(ctx.BlockTime().Unix())
@@ -111,7 +111,7 @@ func (k Keeper) CreateEpochInfo(ctx sdk.Context, epochInfo types.EpochInfo) erro
 
 	// Check if identifier already exists
 	if _, found := k.GetEpochInfo(ctx, epochInfo.GetEpochInfoName()); found {
-		return sdkerrors.Wrapf(types.ErrEpochInfoAlreadyExists, "epochInfo.Name already exists (%s)", epochInfo.Name)
+		return errorsmod.Wrapf(types.ErrEpochInfoAlreadyExists, "epochInfo.Name already exists (%s)", epochInfo.Name)
 	}
 
 	k.setEpochInfo(ctx, epochInfo)
@@ -169,7 +169,7 @@ func (k Keeper) NumBlocksSinceEpochStart(
 ) {
 	epoch, found := k.GetEpochInfo(ctx, id)
 	if !found {
-		return 0, sdkerrors.Wrapf(types.ErrEpochInfoNotFound, "EpochInfo Id not found (%s)", id)
+		return 0, errorsmod.Wrapf(types.ErrEpochInfoNotFound, "EpochInfo Id not found (%s)", id)
 	}
 
 	return lib.MustConvertIntegerToUint32(ctx.BlockHeight() - int64(epoch.CurrentEpochStartBlock)), nil
@@ -202,7 +202,7 @@ func (k Keeper) mustGetEpochInfo(
 		epochInfoName,
 	)
 	if !found {
-		panic(sdkerrors.Wrapf(
+		panic(errorsmod.Wrapf(
 			types.ErrEpochInfoNotFound,
 			"name: %s",
 			epochInfoName,

--- a/protocol/x/epochs/keeper/epoch_info_test.go
+++ b/protocol/x/epochs/keeper/epoch_info_test.go
@@ -1,13 +1,13 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"sort"
 	"strconv"
 	"testing"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/nullify"
 	"github.com/dydxprotocol/v4-chain/protocol/x/epochs/keeper"
@@ -371,7 +371,7 @@ func TestMustGetFundingEpochInfo(t *testing.T) {
 			ctx, keeper, _ := keepertest.EpochsKeeper(t)
 
 			// No epoch info created, should panic
-			require.PanicsWithError(t, sdkerrors.Wrapf(
+			require.PanicsWithError(t, errorsmod.Wrapf(
 				types.ErrEpochInfoNotFound,
 				"name: %s",
 				tc.epochInfoName,

--- a/protocol/x/epochs/types/epoch_info.go
+++ b/protocol/x/epochs/types/epoch_info.go
@@ -1,22 +1,21 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
-
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // Validate does basic validation for epoch info.
 func (epoch EpochInfo) Validate() error {
 	if epoch.Name == "" {
-		return sdkerrors.Wrap(ErrEmptyEpochInfoName, "EpochInfo Name is empty")
+		return errorsmod.Wrap(ErrEmptyEpochInfoName, "EpochInfo Name is empty")
 	}
 	if epoch.Duration == 0 {
-		return sdkerrors.Wrap(ErrDurationIsZero, "Duration is zero")
+		return errorsmod.Wrap(ErrDurationIsZero, "Duration is zero")
 	}
 	// `CurrentEpoch` should be zero if and only if `CurrentEpochStartBlock` is zero.
 	if (epoch.CurrentEpoch == 0) != (epoch.CurrentEpochStartBlock == 0) {
-		return sdkerrors.Wrap(
+		return errorsmod.Wrap(
 			ErrInvalidCurrentEpochAndCurrentEpochStartBlockTuple,
 			fmt.Sprintf(
 				"CurrentEpoch: %d, CurrentEpochStartBlock: %v",

--- a/protocol/x/epochs/types/errors.go
+++ b/protocol/x/epochs/types/errors.go
@@ -2,33 +2,31 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/epochs module sentinel errors
 var (
-	ErrEmptyEpochInfoName = sdkerrors.Register(
+	ErrEmptyEpochInfoName = errorsmod.Register(
 		ModuleName,
 		2,
 		"EpochInfo name is empty",
 	)
-	ErrDurationIsZero = sdkerrors.Register(
+	ErrDurationIsZero = errorsmod.Register(
 		ModuleName,
 		3,
 		"Duration is zero",
 	)
-	ErrEpochInfoAlreadyExists = sdkerrors.Register(
+	ErrEpochInfoAlreadyExists = errorsmod.Register(
 		ModuleName,
 		4,
 		"EpochInfo name already exists",
 	)
-	ErrEpochInfoNotFound = sdkerrors.Register(
+	ErrEpochInfoNotFound = errorsmod.Register(
 		ModuleName,
 		5,
 		"EpochInfo name not found",
 	)
-	ErrInvalidCurrentEpochAndCurrentEpochStartBlockTuple = sdkerrors.Register(
+	ErrInvalidCurrentEpochAndCurrentEpochStartBlockTuple = errorsmod.Register(
 		ModuleName,
 		6,
 		"Invalid CurrentEpoch and CurrentEpochStartBlock tuple: CurrentEpoch should"+

--- a/protocol/x/feetiers/keeper/msg_server.go
+++ b/protocol/x/feetiers/keeper/msg_server.go
@@ -2,10 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
 )
@@ -27,7 +26,7 @@ func (k msgServer) UpdatePerpetualFeeParams(
 	msg *types.MsgUpdatePerpetualFeeParams,
 ) (*types.MsgUpdatePerpetualFeeParamsResponse, error) {
 	if !k.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/feetiers/types/errors.go
+++ b/protocol/x/feetiers/types/errors.go
@@ -2,27 +2,25 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 var (
-	ErrNoTiersExist = sdkerrors.Register(
+	ErrNoTiersExist = errorsmod.Register(
 		ModuleName,
 		400,
 		"Must have at least one fee tier",
 	)
-	ErrInvalidFirstTierRequirements = sdkerrors.Register(
+	ErrInvalidFirstTierRequirements = errorsmod.Register(
 		ModuleName,
 		401,
 		"First fee tier must not have volume requirements",
 	)
-	ErrTiersOutOfOrder = sdkerrors.Register(
+	ErrTiersOutOfOrder = errorsmod.Register(
 		ModuleName,
 		402,
 		"Fee tiers must have ascending requirements",
 	)
-	ErrInvalidFee = sdkerrors.Register(
+	ErrInvalidFee = errorsmod.Register(
 		ModuleName,
 		403,
 		"No maker and taker fee combination should result in a net rebate",

--- a/protocol/x/perpetuals/keeper/msg_server_create_perpetual.go
+++ b/protocol/x/perpetuals/keeper/msg_server_create_perpetual.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 )
@@ -14,7 +14,7 @@ func (k msgServer) CreatePerpetual(
 	msg *types.MsgCreatePerpetual,
 ) (*types.MsgCreatePerpetualResponse, error) {
 	if !k.Keeper.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -12,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -36,7 +36,7 @@ func (k Keeper) CreatePerpetual(
 ) (types.Perpetual, error) {
 	// Check if perpetual exists.
 	if k.HasPerpetual(ctx, id) {
-		return types.Perpetual{}, sdkerrors.Wrap(
+		return types.Perpetual{}, errorsmod.Wrap(
 			types.ErrPerpetualAlreadyExists,
 			lib.Uint32ToString(id),
 		)
@@ -139,7 +139,7 @@ func (k Keeper) GetPerpetual(
 
 	b := store.Get(types.PerpetualKey(id))
 	if b == nil {
-		return val, sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, lib.Uint32ToString(id))
+		return val, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, lib.Uint32ToString(id))
 	}
 
 	k.cdc.MustUnmarshal(b, &val)
@@ -619,7 +619,7 @@ func (k Keeper) MaybeProcessNewFundingTickEpoch(ctx sdk.Context) {
 
 		// Panic if maintenance fraction ppm is larger than its maximum value.
 		if liquidityTier.MaintenanceFractionPpm > types.MaxMaintenanceFractionPpm {
-			panic(sdkerrors.Wrapf(
+			panic(errorsmod.Wrapf(
 				types.ErrMaintenanceFractionPpmExceedsMax,
 				"perpetual Id = (%d), liquidity tier Id = (%d), maintenance fraction ppm = (%v)",
 				perp.Params.Id, perp.Params.LiquidityTier, liquidityTier.MaintenanceFractionPpm,
@@ -652,7 +652,7 @@ func (k Keeper) MaybeProcessNewFundingTickEpoch(ctx sdk.Context) {
 		)
 
 		if bigFundingRatePpm.Cmp(lib.BigMaxInt32()) > 0 {
-			panic(sdkerrors.Wrapf(
+			panic(errorsmod.Wrapf(
 				types.ErrFundingRateInt32Overflow,
 				"perpetual Id = (%d), funding rate = (%v)",
 				perp.Params.Id, bigFundingRatePpm,
@@ -979,7 +979,7 @@ func (k Keeper) addToPremiumStore(
 
 	for _, sample := range newSamples {
 		if !k.HasPerpetual(ctx, sample.PerpetualId) {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrPerpetualDoesNotExist,
 				"perpetual ID = %d",
 				sample.PerpetualId,
@@ -1104,8 +1104,8 @@ func (k Keeper) GetPerpetualAndMarketPrice(
 	// Get market price.
 	marketPrice, err := k.pricesKeeper.GetMarketPrice(ctx, perpetual.Params.MarketId)
 	if err != nil {
-		if sdkerrors.IsOf(err, pricestypes.ErrMarketPriceDoesNotExist) {
-			return perpetual, marketPrice, sdkerrors.Wrap(
+		if errorsmod.IsOf(err, pricestypes.ErrMarketPriceDoesNotExist) {
+			return perpetual, marketPrice, errorsmod.Wrap(
 				types.ErrMarketDoesNotExist,
 				fmt.Sprintf(
 					"Market ID %d does not exist on perpetual ID %d",
@@ -1141,7 +1141,7 @@ func (k Keeper) validatePerpetual(
 
 	// Validate `liquidityTier` exists.
 	if perpetual.Params.LiquidityTier >= k.GetNumLiquidityTiers(ctx) {
-		return sdkerrors.Wrap(types.ErrLiquidityTierDoesNotExist, lib.Uint32ToString(perpetual.Params.LiquidityTier))
+		return errorsmod.Wrap(types.ErrLiquidityTierDoesNotExist, lib.Uint32ToString(perpetual.Params.LiquidityTier))
 	}
 
 	return nil
@@ -1190,7 +1190,7 @@ func (k Keeper) PerformStatefulPremiumVotesValidation(
 	for _, vote := range msg.Votes {
 		// Check that the perpetual Id is valid.
 		if _, err := k.GetPerpetual(ctx, vote.PerpetualId); err != nil {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrPerpetualDoesNotExist,
 				"perpetualId = %d",
 				vote.PerpetualId,
@@ -1208,13 +1208,13 @@ func (k Keeper) PerformStatefulPremiumVotesValidation(
 		if isActive, err := k.clobKeeper.IsPerpetualClobPairActive(
 			ctx, vote.PerpetualId,
 		); err != nil {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				err,
 				"PerformStatefulPremiumVotesValidation: failed to determine ClobPair status for perpetual with id %d",
 				vote.PerpetualId,
 			)
 		} else if !isActive { // reject premium votes for non active markets
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrPremiumVoteForNonActiveMarket,
 				"PerformStatefulPremiumVotesValidation: no premium vote should be included for inactive perpetual with id %d",
 				vote.PerpetualId,
@@ -1228,7 +1228,7 @@ func (k Keeper) PerformStatefulPremiumVotesValidation(
 			lib.AbsInt32(vote.PremiumPpm),
 		))
 		if bigAbsPremiumPpm.Cmp(maxAbsPremiumVotePpm) > 0 {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrPremiumVoteNotClamped,
 				"perpetualId = %d, premium vote = %d, maxAbsPremiumVotePpm = %d",
 				vote.PerpetualId,
@@ -1372,7 +1372,7 @@ func (k Keeper) GetLiquidityTier(ctx sdk.Context, id uint32) (
 
 	b := store.Get(types.LiquidityTierKey(id))
 	if b == nil {
-		return liquidityTier, sdkerrors.Wrap(types.ErrLiquidityTierDoesNotExist, lib.Uint32ToString(id))
+		return liquidityTier, errorsmod.Wrap(types.ErrLiquidityTierDoesNotExist, lib.Uint32ToString(id))
 	}
 
 	k.cdc.MustUnmarshal(b, &liquidityTier)

--- a/protocol/x/perpetuals/keeper/perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/perpetual_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -21,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	big_testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/big"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -108,7 +108,7 @@ func TestCreatePerpetual_Failure(t *testing.T) {
 			atomicResolution:  -10,
 			defaultFundingPpm: 0,
 			liquidityTier:     0,
-			expectedError:     sdkerrors.Wrap(pricestypes.ErrMarketPriceDoesNotExist, fmt.Sprint(999)),
+			expectedError:     errorsmod.Wrap(pricestypes.ErrMarketPriceDoesNotExist, fmt.Sprint(999)),
 		},
 		"Positive default funding magnitude exceeds maximum": {
 			id:                0,
@@ -117,7 +117,7 @@ func TestCreatePerpetual_Failure(t *testing.T) {
 			atomicResolution:  -10,
 			defaultFundingPpm: int32(lib.OneMillion + 1),
 			liquidityTier:     0,
-			expectedError: sdkerrors.Wrap(
+			expectedError: errorsmod.Wrap(
 				types.ErrDefaultFundingPpmMagnitudeExceedsMax,
 				fmt.Sprint(int32(lib.OneMillion+1)),
 			),
@@ -129,7 +129,7 @@ func TestCreatePerpetual_Failure(t *testing.T) {
 			atomicResolution:  -10,
 			defaultFundingPpm: 0 - int32(lib.OneMillion) - 1,
 			liquidityTier:     0,
-			expectedError: sdkerrors.Wrap(
+			expectedError: errorsmod.Wrap(
 				types.ErrDefaultFundingPpmMagnitudeExceedsMax,
 				fmt.Sprint(0-int32(lib.OneMillion)-1),
 			),
@@ -141,7 +141,7 @@ func TestCreatePerpetual_Failure(t *testing.T) {
 			atomicResolution:  -10,
 			defaultFundingPpm: math.MinInt32,
 			liquidityTier:     0,
-			expectedError:     sdkerrors.Wrap(types.ErrDefaultFundingPpmMagnitudeExceedsMax, fmt.Sprint(math.MinInt32)),
+			expectedError:     errorsmod.Wrap(types.ErrDefaultFundingPpmMagnitudeExceedsMax, fmt.Sprint(math.MinInt32)),
 		},
 		"Ticker is an empty string": {
 			id:                0,
@@ -194,7 +194,7 @@ func TestModifyPerpetual_Failure(t *testing.T) {
 			marketId:          0,
 			defaultFundingPpm: 0,
 			liquidityTier:     0,
-			expectedError:     sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(999)),
+			expectedError:     errorsmod.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(999)),
 		},
 		"Price doesn't exist": {
 			id:                0,
@@ -202,7 +202,7 @@ func TestModifyPerpetual_Failure(t *testing.T) {
 			marketId:          999,
 			defaultFundingPpm: 0,
 			liquidityTier:     0,
-			expectedError:     sdkerrors.Wrap(pricestypes.ErrMarketPriceDoesNotExist, fmt.Sprint(999)),
+			expectedError:     errorsmod.Wrap(pricestypes.ErrMarketPriceDoesNotExist, fmt.Sprint(999)),
 		},
 		"Ticker is an empty string": {
 			id:                0,
@@ -316,7 +316,7 @@ func TestGetPerpetual_NotFound(t *testing.T) {
 		ctx,
 		nonExistentPerpetualId,
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
 	require.ErrorIs(t, err, types.ErrPerpetualDoesNotExist)
 }
 
@@ -705,7 +705,7 @@ func TestGetMarginRequirements_PerpetualNotFound(t *testing.T) {
 		nonExistentPerpetualId,
 		big.NewInt(-1),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
 	require.ErrorIs(t, err, types.ErrPerpetualDoesNotExist)
 }
 
@@ -739,7 +739,7 @@ func TestGetMarginRequirements_MarketNotFound(t *testing.T) {
 		perpetual.Params.MarketId,
 		perpetual.Params.Id,
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrMarketDoesNotExist, expectedErrorStr).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrMarketDoesNotExist, expectedErrorStr).Error())
 	require.ErrorIs(t, err, types.ErrMarketDoesNotExist)
 }
 
@@ -771,7 +771,7 @@ func TestGetMarginRequirements_LiquidityTierNotFound(t *testing.T) {
 	require.EqualError(
 		t,
 		err,
-		sdkerrors.Wrap(types.ErrLiquidityTierDoesNotExist, fmt.Sprint(nonExistentLiquidityTier)).Error(),
+		errorsmod.Wrap(types.ErrLiquidityTierDoesNotExist, fmt.Sprint(nonExistentLiquidityTier)).Error(),
 	)
 	require.ErrorIs(t, err, types.ErrLiquidityTierDoesNotExist)
 }
@@ -904,7 +904,7 @@ func TestGetNetNotional_PerpetualNotFound(t *testing.T) {
 		nonExistentPerpetualId,
 		big.NewInt(-1),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
 	require.ErrorIs(t, err, types.ErrPerpetualDoesNotExist)
 }
 
@@ -937,7 +937,7 @@ func TestGetNetNotional_MarketNotFound(t *testing.T) {
 		perpetual.Params.MarketId,
 		perpetual.Params.Id,
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrMarketDoesNotExist, expectedErrorStr).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrMarketDoesNotExist, expectedErrorStr).Error())
 	require.ErrorIs(t, err, types.ErrMarketDoesNotExist)
 }
 
@@ -1068,7 +1068,7 @@ func TestGetNotionalInBaseQuantums_PerpetualNotFound(t *testing.T) {
 		nonExistentPerpetualId,
 		big.NewInt(-1),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
 	require.ErrorIs(t, err, types.ErrPerpetualDoesNotExist)
 }
 
@@ -1101,7 +1101,7 @@ func TestGetNotionalInBaseQuantums_MarketNotFound(t *testing.T) {
 		perpetual.Params.MarketId,
 		perpetual.Params.Id,
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrMarketDoesNotExist, expectedErrorStr).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrMarketDoesNotExist, expectedErrorStr).Error())
 	require.ErrorIs(t, err, types.ErrMarketDoesNotExist)
 }
 
@@ -1233,7 +1233,7 @@ func TestGetNetCollateral_PerpetualNotFound(t *testing.T) {
 		nonExistentPerpetualId,
 		big.NewInt(-1),
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
 	require.ErrorIs(t, err, types.ErrPerpetualDoesNotExist)
 }
 
@@ -1266,7 +1266,7 @@ func TestGetNetCollateral_MarketNotFound(t *testing.T) {
 		perpetual.Params.MarketId,
 		perpetual.Params.Id,
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrMarketDoesNotExist, expectedErrorStr).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrMarketDoesNotExist, expectedErrorStr).Error())
 	require.ErrorIs(t, err, types.ErrMarketDoesNotExist)
 }
 
@@ -1399,7 +1399,7 @@ func TestGetSettlement_PerpetualNotFound(t *testing.T) {
 		big.NewInt(-100),       // quantum
 		big.NewInt(0),          // index
 	)
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
 	require.ErrorIs(t, err, types.ErrPerpetualDoesNotExist)
 }
 
@@ -1439,7 +1439,7 @@ func TestModifyFundingIndex_PerpetualDoesNotExist(t *testing.T) {
 		big.NewInt(1),
 	)
 
-	require.EqualError(t, err, sdkerrors.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
+	require.EqualError(t, err, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, fmt.Sprint(nonExistentPerpetualId)).Error())
 	require.ErrorIs(t, err, types.ErrPerpetualDoesNotExist)
 }
 
@@ -2038,7 +2038,7 @@ func TestMaybeProcessNewFundingTickEpoch_Failure(t *testing.T) {
 					Duration:               3600,
 				},
 			},
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				epochstypes.ErrEpochInfoNotFound,
 				"name: %s",
 				epochstypes.FundingSampleEpochInfoName,
@@ -2486,7 +2486,7 @@ func TestAddPremiums_NonExistingPerpetuals(t *testing.T) {
 		require.ErrorIs(t, err, types.ErrPerpetualDoesNotExist)
 		require.Error(t,
 			err,
-			sdkerrors.Wrapf(
+			errorsmod.Wrapf(
 				types.ErrPerpetualDoesNotExist,
 				"perpetual ID = %d",
 				1000,
@@ -2839,7 +2839,7 @@ func TestCreateLiquidityTier_Failure(t *testing.T) {
 			maintenanceFractionPpm: 500_000,
 			basePositionNotional:   uint64(lib.OneMillion),
 			impactNotional:         uint64(lib.OneMillion),
-			expectedError:          sdkerrors.Wrap(types.ErrInitialMarginPpmExceedsMax, fmt.Sprint(lib.OneMillion+1)),
+			expectedError:          errorsmod.Wrap(types.ErrInitialMarginPpmExceedsMax, fmt.Sprint(lib.OneMillion+1)),
 		},
 		"Maintenance Fraction Ppm exceeds maximum": {
 			id:                     1,
@@ -2848,7 +2848,7 @@ func TestCreateLiquidityTier_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion + 1,
 			basePositionNotional:   uint64(lib.OneMillion),
 			impactNotional:         uint64(lib.OneMillion),
-			expectedError:          sdkerrors.Wrap(types.ErrMaintenanceFractionPpmExceedsMax, fmt.Sprint(lib.OneMillion+1)),
+			expectedError:          errorsmod.Wrap(types.ErrMaintenanceFractionPpmExceedsMax, fmt.Sprint(lib.OneMillion+1)),
 		},
 		"Base Position Notional is zero": {
 			id:                     1,
@@ -2857,7 +2857,7 @@ func TestCreateLiquidityTier_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion,
 			basePositionNotional:   uint64(0),
 			impactNotional:         uint64(lib.OneMillion),
-			expectedError:          sdkerrors.Wrap(types.ErrBasePositionNotionalIsZero, fmt.Sprint(0)),
+			expectedError:          errorsmod.Wrap(types.ErrBasePositionNotionalIsZero, fmt.Sprint(0)),
 		},
 		"Impact Notional is zero": {
 			id:                     1,
@@ -2866,7 +2866,7 @@ func TestCreateLiquidityTier_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion,
 			basePositionNotional:   uint64(lib.OneMillion),
 			impactNotional:         uint64(0),
-			expectedError:          sdkerrors.Wrap(types.ErrImpactNotionalIsZero, fmt.Sprint(0)),
+			expectedError:          errorsmod.Wrap(types.ErrImpactNotionalIsZero, fmt.Sprint(0)),
 		},
 	}
 
@@ -2977,7 +2977,7 @@ func TestModifyLiquidityTier_Failure(t *testing.T) {
 			maintenanceFractionPpm: 500_000,
 			basePositionNotional:   uint64(lib.OneMillion),
 			impactNotional:         uint64(lib.OneMillion),
-			expectedError:          sdkerrors.Wrap(types.ErrInitialMarginPpmExceedsMax, fmt.Sprint(lib.OneMillion+1)),
+			expectedError:          errorsmod.Wrap(types.ErrInitialMarginPpmExceedsMax, fmt.Sprint(lib.OneMillion+1)),
 		},
 		"Maintenance Fraction Ppm exceeds maximum": {
 			id:                     1,
@@ -2986,7 +2986,7 @@ func TestModifyLiquidityTier_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion + 1,
 			basePositionNotional:   uint64(lib.OneMillion),
 			impactNotional:         uint64(lib.OneMillion),
-			expectedError:          sdkerrors.Wrap(types.ErrMaintenanceFractionPpmExceedsMax, fmt.Sprint(lib.OneMillion+1)),
+			expectedError:          errorsmod.Wrap(types.ErrMaintenanceFractionPpmExceedsMax, fmt.Sprint(lib.OneMillion+1)),
 		},
 		"Base Position Notional is zero": {
 			id:                     1,
@@ -2995,7 +2995,7 @@ func TestModifyLiquidityTier_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion,
 			basePositionNotional:   uint64(0),
 			impactNotional:         uint64(lib.OneMillion),
-			expectedError:          sdkerrors.Wrap(types.ErrBasePositionNotionalIsZero, fmt.Sprint(0)),
+			expectedError:          errorsmod.Wrap(types.ErrBasePositionNotionalIsZero, fmt.Sprint(0)),
 		},
 		"Impact Notional is zero": {
 			id:                     1,
@@ -3004,7 +3004,7 @@ func TestModifyLiquidityTier_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion,
 			basePositionNotional:   uint64(lib.OneMillion),
 			impactNotional:         uint64(0),
-			expectedError:          sdkerrors.Wrap(types.ErrImpactNotionalIsZero, fmt.Sprint(0)),
+			expectedError:          errorsmod.Wrap(types.ErrImpactNotionalIsZero, fmt.Sprint(0)),
 		},
 	}
 

--- a/protocol/x/perpetuals/types/errors.go
+++ b/protocol/x/perpetuals/types/errors.go
@@ -2,105 +2,103 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/perpetuals module sentinel errors
 var (
-	ErrPerpetualDoesNotExist = sdkerrors.Register(
+	ErrPerpetualDoesNotExist = errorsmod.Register(
 		ModuleName,
 		1,
 		"Perpetual does not exist",
 	)
-	ErrMarketDoesNotExist = sdkerrors.Register(
+	ErrMarketDoesNotExist = errorsmod.Register(
 		ModuleName,
 		2,
 		"MarketId on perpetual does not exist",
 	)
-	ErrInitialMarginPpmExceedsMax = sdkerrors.Register(
+	ErrInitialMarginPpmExceedsMax = errorsmod.Register(
 		ModuleName,
 		3,
 		"InitialMarginPpm exceeds maximum value of 1e6",
 	)
-	ErrMaintenanceFractionPpmExceedsMax = sdkerrors.Register(
+	ErrMaintenanceFractionPpmExceedsMax = errorsmod.Register(
 		ModuleName,
 		4,
 		"MaintenanceFractionPpm exceeds maximum value of 1e6",
 	)
-	ErrDefaultFundingPpmMagnitudeExceedsMax = sdkerrors.Register(
+	ErrDefaultFundingPpmMagnitudeExceedsMax = errorsmod.Register(
 		ModuleName,
 		5,
 		"DefaultFundingPpm magnitude exceeds maximum value of 1e6",
 	)
-	ErrTickerEmptyString = sdkerrors.Register(
+	ErrTickerEmptyString = errorsmod.Register(
 		ModuleName,
 		6,
 		"Ticker must be non-empty string",
 	)
-	ErrNoNewPremiumVotes = sdkerrors.Register(
+	ErrNoNewPremiumVotes = errorsmod.Register(
 		ModuleName,
 		7,
 		"No new premium votes were collected",
 	)
-	ErrMoreFundingSamplesThanExpected = sdkerrors.Register(
+	ErrMoreFundingSamplesThanExpected = errorsmod.Register(
 		ModuleName,
 		8,
 		"Recorded more than expected funding samples in the past funding-tick epoch",
 	)
-	ErrInvalidAddPremiumVotes = sdkerrors.Register(ModuleName, 9, "MsgAddPremiumVotes is invalid")
-	ErrPremiumVoteNotClamped  = sdkerrors.Register(
+	ErrInvalidAddPremiumVotes = errorsmod.Register(ModuleName, 9, "MsgAddPremiumVotes is invalid")
+	ErrPremiumVoteNotClamped  = errorsmod.Register(
 		ModuleName,
 		10,
 		"Premium vote value is not clamped by MaxAbsPremiumVotePpm",
 	)
-	ErrFundingRateInt32Overflow = sdkerrors.Register(
+	ErrFundingRateInt32Overflow = errorsmod.Register(
 		ModuleName,
 		11,
 		"Funding rate int32 overflow",
 	)
-	ErrLiquidityTierDoesNotExist = sdkerrors.Register(
+	ErrLiquidityTierDoesNotExist = errorsmod.Register(
 		ModuleName,
 		12,
 		"Liquidity Tier does not exist",
 	)
-	ErrBasePositionNotionalIsZero = sdkerrors.Register(
+	ErrBasePositionNotionalIsZero = errorsmod.Register(
 		ModuleName,
 		13,
 		"Base position notional is zero",
 	)
-	ErrFundingRateClampFactorPpmIsZero = sdkerrors.Register(
+	ErrFundingRateClampFactorPpmIsZero = errorsmod.Register(
 		ModuleName,
 		14,
 		"Funding rate clamp factor ppm is zero",
 	)
-	ErrPremiumVoteClampFactorPpmIsZero = sdkerrors.Register(
+	ErrPremiumVoteClampFactorPpmIsZero = errorsmod.Register(
 		ModuleName,
 		15,
 		"Premium vote clamp factor ppm is zero",
 	)
-	ErrImpactNotionalIsZero = sdkerrors.Register(
+	ErrImpactNotionalIsZero = errorsmod.Register(
 		ModuleName,
 		16,
 		"Impact notional is zero",
 	)
-	ErrPerpetualAlreadyExists = sdkerrors.Register(
+	ErrPerpetualAlreadyExists = errorsmod.Register(
 		ModuleName,
 		17,
 		"Perpetual already exists",
 	)
-	ErrPremiumVoteForNonActiveMarket = sdkerrors.Register(
+	ErrPremiumVoteForNonActiveMarket = errorsmod.Register(
 		ModuleName,
 		18,
 		"Premium votes are disallowed for non active markets",
 	)
-	ErrInvalidAuthority = sdkerrors.Register(
+	ErrInvalidAuthority = errorsmod.Register(
 		ModuleName,
 		19,
 		"Authority is invalid",
 	)
 
 	// Errors for Not Implemented
-	ErrNotImplementedFunding      = sdkerrors.Register(ModuleName, 1001, "Not Implemented: Perpetuals Funding")
-	ErrNotImplementedOpenInterest = sdkerrors.Register(ModuleName, 1002, "Not Implemented: Perpetuals Open Interest")
+	ErrNotImplementedFunding      = errorsmod.Register(ModuleName, 1001, "Not Implemented: Perpetuals Funding")
+	ErrNotImplementedOpenInterest = errorsmod.Register(ModuleName, 1002, "Not Implemented: Perpetuals Open Interest")
 )

--- a/protocol/x/perpetuals/types/liquidity_tier.go
+++ b/protocol/x/perpetuals/types/liquidity_tier.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math/big"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
 
@@ -12,20 +12,20 @@ import (
 // - Base position notional is not 0.
 func (liquidityTier LiquidityTier) Validate() error {
 	if liquidityTier.InitialMarginPpm > MaxInitialMarginPpm {
-		return sdkerrors.Wrap(ErrInitialMarginPpmExceedsMax, lib.Uint32ToString(liquidityTier.InitialMarginPpm))
+		return errorsmod.Wrap(ErrInitialMarginPpmExceedsMax, lib.Uint32ToString(liquidityTier.InitialMarginPpm))
 	}
 
 	if liquidityTier.MaintenanceFractionPpm > MaxMaintenanceFractionPpm {
-		return sdkerrors.Wrap(ErrMaintenanceFractionPpmExceedsMax,
+		return errorsmod.Wrap(ErrMaintenanceFractionPpmExceedsMax,
 			lib.Uint32ToString(liquidityTier.MaintenanceFractionPpm))
 	}
 
 	if liquidityTier.BasePositionNotional == 0 {
-		return sdkerrors.Wrap(ErrBasePositionNotionalIsZero, lib.Uint32ToString(0))
+		return errorsmod.Wrap(ErrBasePositionNotionalIsZero, lib.Uint32ToString(0))
 	}
 
 	if liquidityTier.ImpactNotional == 0 {
-		return sdkerrors.Wrap(ErrImpactNotionalIsZero, lib.Uint32ToString(0))
+		return errorsmod.Wrap(ErrImpactNotionalIsZero, lib.Uint32ToString(0))
 	}
 
 	return nil
@@ -35,7 +35,7 @@ func (liquidityTier LiquidityTier) Validate() error {
 // and maintenance fraction ppm.
 func (liquidityTier LiquidityTier) GetMaintenanceMarginPpm() uint32 {
 	if liquidityTier.MaintenanceFractionPpm > MaxMaintenanceFractionPpm {
-		panic(sdkerrors.Wrapf(ErrMaintenanceFractionPpmExceedsMax, "maintenance fraction ppm: %d",
+		panic(errorsmod.Wrapf(ErrMaintenanceFractionPpmExceedsMax, "maintenance fraction ppm: %d",
 			liquidityTier.MaintenanceFractionPpm))
 	}
 	// maintenance margin = initial margin * maintenance fraction

--- a/protocol/x/perpetuals/types/message_add_premium_votes.go
+++ b/protocol/x/perpetuals/types/message_add_premium_votes.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var _ sdk.Msg = &MsgAddPremiumVotes{}
@@ -26,7 +26,7 @@ func (msg *MsgAddPremiumVotes) GetSigners() []sdk.AccAddress {
 func (msg *MsgAddPremiumVotes) ValidateBasic() error {
 	for i, sample := range msg.Votes {
 		if i > 0 && msg.Votes[i-1].PerpetualId >= sample.PerpetualId {
-			return sdkerrors.Wrap(
+			return errorsmod.Wrap(
 				ErrInvalidAddPremiumVotes,
 				"premium votes must be sorted by perpetual id in ascending order and cannot contain duplicates",
 			)

--- a/protocol/x/perpetuals/types/message_create_perpetual.go
+++ b/protocol/x/perpetuals/types/message_create_perpetual.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var _ sdk.Msg = &MsgCreatePerpetual{}
@@ -14,7 +14,7 @@ func (msg *MsgCreatePerpetual) GetSigners() []sdk.AccAddress {
 
 func (msg *MsgCreatePerpetual) ValidateBasic() error {
 	if msg.Authority == "" {
-		return sdkerrors.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
 	}
 	return msg.Params.Validate()
 }

--- a/protocol/x/perpetuals/types/perpetual.go
+++ b/protocol/x/perpetuals/types/perpetual.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	errorsmod "cosmossdk.io/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/pkg/errors"
 )
@@ -20,7 +20,7 @@ func (p *PerpetualParams) Validate() error {
 	// Validate `defaultFundingPpm`
 	defaultFundingPpm := lib.AbsInt32(p.DefaultFundingPpm)
 	if defaultFundingPpm > MaxDefaultFundingPpmAbs {
-		return sdkerrors.Wrap(
+		return errorsmod.Wrap(
 			ErrDefaultFundingPpmMagnitudeExceedsMax,
 			lib.Int32ToString(p.DefaultFundingPpm))
 	}

--- a/protocol/x/prices/keeper/grpc_query_market.go
+++ b/protocol/x/prices/keeper/grpc_query_market.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"google.golang.org/grpc/codes"
@@ -58,7 +58,7 @@ func (k Keeper) MarketPrice(
 		req.Id,
 	)
 	if err != nil {
-		if sdkerrors.IsOf(err, types.ErrMarketPriceDoesNotExist) {
+		if errorsmod.IsOf(err, types.ErrMarketPriceDoesNotExist) {
 			return nil, status.Error(codes.NotFound, "not found")
 		} else {
 			return nil, status.Error(codes.Internal, "unknown error getting market price")
@@ -115,7 +115,7 @@ func (k Keeper) MarketParam(
 		req.Id,
 	)
 	if err != nil {
-		if sdkerrors.IsOf(err, types.ErrMarketParamDoesNotExist) {
+		if errorsmod.IsOf(err, types.ErrMarketParamDoesNotExist) {
 			return nil, status.Error(codes.NotFound, "not found")
 		} else {
 			return nil, status.Error(codes.Internal, "unknown error getting market param")

--- a/protocol/x/prices/keeper/market.go
+++ b/protocol/x/prices/keeper/market.go
@@ -1,10 +1,10 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -58,7 +58,7 @@ func (k Keeper) GetAllMarketParamPrices(ctx sdk.Context) ([]types.MarketParamPri
 	marketPrices := k.GetAllMarketPrices(ctx)
 
 	if len(marketParams) != len(marketPrices) {
-		return nil, sdkerrors.Wrap(types.ErrMarketPricesAndParamsDontMatch, "market param and price lengths do not match")
+		return nil, errorsmod.Wrap(types.ErrMarketPricesAndParamsDontMatch, "market param and price lengths do not match")
 	}
 
 	marketParamPrices := make([]types.MarketParamPrice, len(marketParams))
@@ -66,7 +66,7 @@ func (k Keeper) GetAllMarketParamPrices(ctx sdk.Context) ([]types.MarketParamPri
 		marketParamPrices[i].Param = param
 		price := marketPrices[i]
 		if param.Id != price.Id {
-			return nil, sdkerrors.Wrap(types.ErrMarketPricesAndParamsDontMatch,
+			return nil, errorsmod.Wrap(types.ErrMarketPricesAndParamsDontMatch,
 				fmt.Sprintf("market param and price ids do not match: %d != %d", param.Id, price.Id))
 		}
 		marketParamPrices[i].Price = price
@@ -83,7 +83,7 @@ func (k Keeper) GetNumMarkets(
 	marketPrices := k.GetAllMarketPrices(ctx)
 
 	if len(marketParams) != len(marketPrices) {
-		panic(sdkerrors.Wrap(types.ErrMarketPricesAndParamsDontMatch, "market param and price lengths do not match"))
+		panic(errorsmod.Wrap(types.ErrMarketPricesAndParamsDontMatch, "market param and price lengths do not match"))
 	}
 
 	return lib.MustConvertIntegerToUint32(len(marketParams))

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -1,11 +1,11 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"sort"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -36,7 +36,7 @@ func (k Keeper) ModifyMarketParam(
 	// Validate update is permitted.
 	if marketParam.Exponent != existingParam.Exponent {
 		return types.MarketParam{},
-			sdkerrors.Wrapf(types.ErrMarketExponentCannotBeUpdated, lib.Uint32ToString(marketParam.Id))
+			errorsmod.Wrapf(types.ErrMarketExponentCannotBeUpdated, lib.Uint32ToString(marketParam.Id))
 	}
 
 	// Store the modified market param.
@@ -67,7 +67,7 @@ func (k Keeper) GetMarketParam(
 	marketParamStore := k.newMarketParamStore(ctx)
 	b := marketParamStore.Get(types.MarketKey(id))
 	if b == nil {
-		return types.MarketParam{}, sdkerrors.Wrap(types.ErrMarketParamDoesNotExist, lib.Uint32ToString(id))
+		return types.MarketParam{}, errorsmod.Wrap(types.ErrMarketParamDoesNotExist, lib.Uint32ToString(id))
 	}
 
 	var market = types.MarketParam{}

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -1,10 +1,10 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
@@ -56,28 +56,28 @@ func TestModifyMarketParam_Errors(t *testing.T) {
 			pair:              constants.BtcUsdPair,
 			minExchanges:      uint32(2),
 			minPriceChangePpm: uint32(50),
-			expectedErr:       sdkerrors.Wrap(types.ErrMarketParamDoesNotExist, "99").Error(),
+			expectedErr:       errorsmod.Wrap(types.ErrMarketParamDoesNotExist, "99").Error(),
 		},
 		"Empty pair": {
 			targetId:          0,
 			pair:              "", // pair cannot be empty
 			minExchanges:      uint32(2),
 			minPriceChangePpm: uint32(50),
-			expectedErr:       sdkerrors.Wrap(types.ErrInvalidInput, constants.ErrorMsgMarketPairCannotBeEmpty).Error(),
+			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgMarketPairCannotBeEmpty).Error(),
 		},
 		"Invalid min price change: zero": {
 			targetId:          0,
 			pair:              constants.BtcUsdPair,
 			minExchanges:      uint32(2),
 			minPriceChangePpm: uint32(0), // must be > 0
-			expectedErr:       sdkerrors.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
+			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
 		},
 		"Invalid min price change: ten thousand": {
 			targetId:          0,
 			pair:              constants.BtcUsdPair,
 			minExchanges:      uint32(2),
 			minPriceChangePpm: uint32(10_000), // must be < 10,000
-			expectedErr:       sdkerrors.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
+			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
 		},
 		"Min exchanges cannot be zero": {
 			pair:              constants.BtcUsdPair,

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math/big"
 	"sort"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	pricefeedmetrics "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
@@ -115,7 +115,7 @@ func (k Keeper) GetMarketPrice(
 	store := k.newMarketPriceStore(ctx)
 	b := store.Get(types.MarketKey(id))
 	if b == nil {
-		return types.MarketPrice{}, sdkerrors.Wrap(types.ErrMarketPriceDoesNotExist, lib.Uint32ToString(id))
+		return types.MarketPrice{}, errorsmod.Wrap(types.ErrMarketPriceDoesNotExist, lib.Uint32ToString(id))
 	}
 
 	var marketPrice = types.MarketPrice{}

--- a/protocol/x/prices/keeper/market_test.go
+++ b/protocol/x/prices/keeper/market_test.go
@@ -1,9 +1,9 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
@@ -70,21 +70,21 @@ func TestCreateMarket_Errors(t *testing.T) {
 			minExchanges:      uint32(2),
 			minPriceChangePpm: uint32(50),
 			price:             constants.FiveBillion,
-			expectedErr:       sdkerrors.Wrap(types.ErrInvalidInput, constants.ErrorMsgMarketPairCannotBeEmpty).Error(),
+			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgMarketPairCannotBeEmpty).Error(),
 		},
 		"Invalid min price change: zero": {
 			pair:              constants.BtcUsdPair,
 			minExchanges:      uint32(2),
 			minPriceChangePpm: uint32(0), // must be > 0
 			price:             constants.FiveBillion,
-			expectedErr:       sdkerrors.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
+			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
 		},
 		"Invalid min price change: ten thousand": {
 			pair:              constants.BtcUsdPair,
 			minExchanges:      uint32(2),
 			minPriceChangePpm: uint32(10_000), // must be < 10,000
 			price:             constants.FiveBillion,
-			expectedErr:       sdkerrors.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
+			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
 		},
 		"Min exchanges cannot be zero": {
 			pair:              constants.BtcUsdPair,
@@ -99,7 +99,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 			minPriceChangePpm:                     uint32(50),
 			price:                                 constants.FiveBillion,
 			marketPriceIdDoesntMatchMarketParamId: true,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidInput,
 				"market param id 0 does not match market price id 1",
 			).Error(),
@@ -110,7 +110,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 			minPriceChangePpm: uint32(50),
 			price:             constants.FiveBillion,
 			marketPriceExponentDoesntMatchMarketParamExponent: true,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidInput,
 				"market param 0 exponent -6 does not match market price 0 exponent -5",
 			).Error(),
@@ -120,7 +120,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 			minExchanges:      uint32(2),
 			minPriceChangePpm: uint32(50),
 			price:             uint64(0),
-			expectedErr:       sdkerrors.Wrap(types.ErrInvalidInput, "market 0 price cannot be zero").Error(),
+			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, "market 0 price cannot be zero").Error(),
 		},
 	}
 	for name, tc := range tests {
@@ -160,7 +160,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 			require.EqualError(
 				t,
 				err,
-				sdkerrors.Wrap(types.ErrMarketPriceDoesNotExist, lib.Uint32ToString(0)).Error(),
+				errorsmod.Wrap(types.ErrMarketPriceDoesNotExist, lib.Uint32ToString(0)).Error(),
 			)
 
 			// Verify no new market event.

--- a/protocol/x/prices/keeper/msg_server_update_market_prices_test.go
+++ b/protocol/x/prices/keeper/msg_server_update_market_prices_test.go
@@ -1,12 +1,12 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"testing"
 
 	"github.com/cometbft/cometbft/libs/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
@@ -330,7 +330,7 @@ func TestUpdateMarketPrices_Error(t *testing.T) {
 			msgUpdateMarketPrices: []*types.MsgUpdateMarketPrices_MarketPrice{
 				types.NewMarketPriceUpdate(99, 11), // Market with id 99 does not exist.
 			},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				types.ErrInvalidMarketPriceUpdateDeterministic,
 				"market param price (99) does not exist",
 			),
@@ -343,7 +343,7 @@ func TestUpdateMarketPrices_Error(t *testing.T) {
 					constants.FiveBillion+(constants.FiveBillion*50/uint64(lib.OneMillion))-1,
 				),
 			},
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				types.ErrInvalidMarketPriceUpdateDeterministic,
 				"update price (5000249999) for market (0) does not meet min price change requirement"+
 					" (50 ppm) based on the current market price (5000000000)",

--- a/protocol/x/prices/keeper/validate_market_price_updates.go
+++ b/protocol/x/prices/keeper/validate_market_price_updates.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"math/big"
@@ -9,7 +10,6 @@ import (
 	gometrics "github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	pricefeedmetrics "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
@@ -50,7 +50,7 @@ func (k Keeper) PerformStatefulPriceUpdateValidation(
 			metrics.Error,
 		)
 		return errorlib.WrapErrorWithSourceModuleContext(
-			sdkerrors.Wrap(err, "failed to get all market param prices"),
+			errorsmod.Wrap(err, "failed to get all market param prices"),
 			types.ModuleName,
 		)
 	}
@@ -121,7 +121,7 @@ func (k Keeper) performNonDeterministicStatefulValidation(
 					pricefeedmetrics.GetLabelForMarketId(marketParamPrice.Param.Id),
 				},
 			)
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrIndexPriceNotAvailable,
 				"index price for market (%d) is not available",
 				priceUpdate.MarketId,
@@ -177,7 +177,7 @@ func (k Keeper) performDeterministicStatefulValidation(
 
 		// Check price respects min price change.
 		if !isAboveRequiredMinPriceChange(marketParamPrice, priceUpdate.Price) {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrInvalidMarketPriceUpdateDeterministic,
 				"update price (%d) for market (%d) does not meet min price change requirement"+
 					" (%d ppm) based on the current market price (%d)",
@@ -223,7 +223,7 @@ func (k Keeper) validatePriceAccuracy(
 		IndexPrice: indexPrice,
 		NewPrice:   priceUpdate.Price,
 	}) {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidMarketPriceUpdateNonDeterministic,
 			"update price (%d) for market (%d) trends in the opposite direction of the index price (%d) compared "+
 				"to the current price (%d)",
@@ -243,7 +243,7 @@ func (k Keeper) validatePriceAccuracy(
 	// and new_delta to determine if the price change is valid.
 	if priceDeltaIsWithinOneTick(oldDelta, tickSizePpm) {
 		if newDelta.Cmp(oldDelta) > 0 {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				types.ErrInvalidMarketPriceUpdateNonDeterministic,
 				"update price (%d) for market (%d) crosses the index price (%d) with current price (%d) "+
 					"and deviates from index price (%d) more than minimum allowed (%d)",
@@ -260,7 +260,7 @@ func (k Keeper) validatePriceAccuracy(
 
 	// Update price crosses index price and old_ticks > 1: check new_ticks <= sqrt(old_ticks)
 	if !newPriceMeetsSqrtCondition(oldDelta, newDelta, tickSizePpm) {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			types.ErrInvalidMarketPriceUpdateNonDeterministic,
 			"update price (%d) for market (%d) crosses the index price (%d) with current price (%d) "+
 				"and deviates from index price (%d) more than minimum allowed (%d)",
@@ -324,7 +324,7 @@ func getMarketParamPrice(
 ) {
 	marketParamPrice, marketParamPriceExists := idToMarketParamPrice[marketId]
 	if !marketParamPriceExists {
-		return marketParamPrice, sdkerrors.Wrapf(
+		return marketParamPrice, errorsmod.Wrapf(
 			types.ErrInvalidMarketPriceUpdateDeterministic,
 			"market param price (%d) does not exist",
 			marketId,

--- a/protocol/x/prices/keeper/validate_market_price_updates_test.go
+++ b/protocol/x/prices/keeper/validate_market_price_updates_test.go
@@ -1,9 +1,9 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -238,7 +238,7 @@ func TestPerformStatefulPriceUpdateValidation_Error(t *testing.T) {
 				types.NewMarketPriceUpdate(99, 11), // Market with id 99 does not exist.
 			},
 			indexPrices: constants.AtTimeTSingleExchangePriceUpdate,
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				types.ErrInvalidMarketPriceUpdateDeterministic,
 				"market param price (99) does not exist",
 			).Error(),
@@ -252,7 +252,7 @@ func TestPerformStatefulPriceUpdateValidation_Error(t *testing.T) {
 				),
 			},
 			indexPrices: constants.AtTimeTSingleExchangePriceUpdate,
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				types.ErrInvalidMarketPriceUpdateDeterministic,
 				"update price (5000249999) for market (0) does not meet min price change requirement"+
 					" (50 ppm) based on the current market price (5000000000)",
@@ -263,7 +263,7 @@ func TestPerformStatefulPriceUpdateValidation_Error(t *testing.T) {
 				types.NewMarketPriceUpdate(constants.MarketId0, 11),
 			},
 			// Skipping price cache update, so the index price does not exist.
-			expectedErr: sdkerrors.Wrapf(
+			expectedErr: errorsmod.Wrapf(
 				types.ErrIndexPriceNotAvailable,
 				"index price for market (0) is not available",
 			).Error(),
@@ -284,7 +284,7 @@ func TestPerformStatefulPriceUpdateValidation_Error(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidMarketPriceUpdateNonDeterministic,
 				"update price (5015000000) for market (0) crosses the index price (5010000000) with "+
 					"current price (5000000000) and deviates from index price (5000000) more than minimum allowed "+
@@ -307,7 +307,7 @@ func TestPerformStatefulPriceUpdateValidation_Error(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidMarketPriceUpdateNonDeterministic,
 				"update price (5015000000) for market (0) crosses the index price (5000250000) with current "+
 					"price (5000000000) and deviates from index price (14750000) more than minimum allowed (250000)",
@@ -329,7 +329,7 @@ func TestPerformStatefulPriceUpdateValidation_Error(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidMarketPriceUpdateNonDeterministic,
 				"update price (5005000000) for market (0) trends in the opposite direction of the index "+
 					"price (4999999999) compared to the current price (5000000000)",

--- a/protocol/x/prices/module_test.go
+++ b/protocol/x/prices/module_test.go
@@ -2,13 +2,12 @@ package prices_test
 
 import (
 	"bytes"
+	errorsmod "cosmossdk.io/errors"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -146,7 +145,7 @@ func TestAppModuleBasic_ValidateGenesisErr(t *testing.T) {
 		},
 		"Bad state: Invalid param": {
 			genesisJson: `{"market_params": [{ "pair": "" }]}`,
-			expectedErr: sdkerrors.Wrap(pricestypes.ErrInvalidInput, "Pair cannot be empty").Error(),
+			expectedErr: errorsmod.Wrap(pricestypes.ErrInvalidInput, "Pair cannot be empty").Error(),
 		},
 		"Bad state: Mismatch between params and prices": {
 			genesisJson: `{"market_params": [{"pair": "DENT-USD","minExchanges":1,"minPriceChangePpm":1}]}`,
@@ -155,7 +154,7 @@ func TestAppModuleBasic_ValidateGenesisErr(t *testing.T) {
 		"Bad state: Invalid price": {
 			genesisJson: `{"market_params":[{"pair": "DENT-USD","minExchanges":1,"minPriceChangePpm":1}],` +
 				`"market_prices": [{"exponent":1,"price": "0"}]}`,
-			expectedErr: sdkerrors.Wrap(
+			expectedErr: errorsmod.Wrap(
 				pricestypes.ErrInvalidInput,
 				"market param 0 exponent 0 does not match market price 0 exponent 1",
 			).Error(),

--- a/protocol/x/prices/types/errors.go
+++ b/protocol/x/prices/types/errors.go
@@ -2,38 +2,36 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 var (
 	// 1 - 99: Default.
-	ErrInvalidInput = sdkerrors.Register(ModuleName, 1, "Invalid input")
+	ErrInvalidInput = errorsmod.Register(ModuleName, 1, "Invalid input")
 
 	// 100 - 199: Exchange related errors.
-	ErrExchangeDoesNotExist = sdkerrors.Register(ModuleName, 100, "Exchange does not exist")
-	ErrZeroMinExchanges     = sdkerrors.Register(ModuleName, 101, "Min exchanges must be greater than zero")
-	ErrTooFewExchanges      = sdkerrors.Register(ModuleName, 102, "Exchanges is fewer than minExchanges")
-	ErrDuplicateExchanges   = sdkerrors.Register(
+	ErrExchangeDoesNotExist = errorsmod.Register(ModuleName, 100, "Exchange does not exist")
+	ErrZeroMinExchanges     = errorsmod.Register(ModuleName, 101, "Min exchanges must be greater than zero")
+	ErrTooFewExchanges      = errorsmod.Register(ModuleName, 102, "Exchanges is fewer than minExchanges")
+	ErrDuplicateExchanges   = errorsmod.Register(
 		ModuleName,
 		103,
 		"Exchanges must not contain duplicates and must be provided in ascending order",
 	)
 
 	// 200 - 299: Market related errors.
-	ErrMarketParamDoesNotExist        = sdkerrors.Register(ModuleName, 200, "Market param does not exist")
-	ErrMarketPriceDoesNotExist        = sdkerrors.Register(ModuleName, 201, "Market price does not exist")
-	ErrMarketExponentCannotBeUpdated  = sdkerrors.Register(ModuleName, 202, "Market exponent cannot be updated")
-	ErrMarketPricesAndParamsDontMatch = sdkerrors.Register(ModuleName, 203, "Market prices and params don't match")
+	ErrMarketParamDoesNotExist        = errorsmod.Register(ModuleName, 200, "Market param does not exist")
+	ErrMarketPriceDoesNotExist        = errorsmod.Register(ModuleName, 201, "Market price does not exist")
+	ErrMarketExponentCannotBeUpdated  = errorsmod.Register(ModuleName, 202, "Market exponent cannot be updated")
+	ErrMarketPricesAndParamsDontMatch = errorsmod.Register(ModuleName, 203, "Market prices and params don't match")
 
 	// 300 - 399: Price related errors.
-	ErrIndexPriceNotAvailable = sdkerrors.Register(ModuleName, 300, "Index price is not available")
+	ErrIndexPriceNotAvailable = errorsmod.Register(ModuleName, 300, "Index price is not available")
 
 	// 400 - 499: Market price update related errors.
-	ErrInvalidMarketPriceUpdateStateless = sdkerrors.Register(
+	ErrInvalidMarketPriceUpdateStateless = errorsmod.Register(
 		ModuleName, 400, "Market price update is invalid: stateless.")
-	ErrInvalidMarketPriceUpdateDeterministic = sdkerrors.Register(
+	ErrInvalidMarketPriceUpdateDeterministic = errorsmod.Register(
 		ModuleName, 401, "Market price update is invalid: deterministic.")
-	ErrInvalidMarketPriceUpdateNonDeterministic = sdkerrors.Register(
+	ErrInvalidMarketPriceUpdateNonDeterministic = errorsmod.Register(
 		ModuleName, 402, "Market price update is invalid: non-deterministic.")
 )

--- a/protocol/x/prices/types/genesis_test.go
+++ b/protocol/x/prices/types/genesis_test.go
@@ -1,10 +1,9 @@
 package types_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"testing"
-
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
@@ -77,7 +76,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: sdkerrors.Wrap(types.ErrInvalidInput, "Pair cannot be empty"),
+			expectedError: errorsmod.Wrap(types.ErrInvalidInput, "Pair cannot be empty"),
 		},
 		"invalid: mismatched number of market params and prices": {
 			genState: &types.GenesisState{
@@ -131,7 +130,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: sdkerrors.Wrap(types.ErrInvalidInput, "market param id 1 does not match market price id 2"),
+			expectedError: errorsmod.Wrap(types.ErrInvalidInput, "market param id 1 does not match market price id 2"),
 		},
 		"invalid: invalid market price": {
 			genState: &types.GenesisState{
@@ -160,7 +159,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: sdkerrors.Wrap(types.ErrInvalidInput, "market 1 price cannot be zero"),
+			expectedError: errorsmod.Wrap(types.ErrInvalidInput, "market 1 price cannot be zero"),
 		},
 	}
 	for name, tc := range tests {

--- a/protocol/x/prices/types/market_param.go
+++ b/protocol/x/prices/types/market_param.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	errorsmod "cosmossdk.io/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
 
@@ -9,7 +9,7 @@ import (
 func (mp *MarketParam) Validate() error {
 	// Validate pair.
 	if mp.Pair == "" {
-		return sdkerrors.Wrap(ErrInvalidInput, "Pair cannot be empty")
+		return errorsmod.Wrap(ErrInvalidInput, "Pair cannot be empty")
 	}
 
 	if mp.MinExchanges == 0 {
@@ -18,7 +18,7 @@ func (mp *MarketParam) Validate() error {
 
 	// Validate min price change.
 	if mp.MinPriceChangePpm == 0 || mp.MinPriceChangePpm >= lib.MaxPriceChangePpm {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidInput,
 			"Min price change in parts-per-million must be greater than 0 and less than %d",
 			lib.MaxPriceChangePpm)

--- a/protocol/x/prices/types/market_price.go
+++ b/protocol/x/prices/types/market_price.go
@@ -1,13 +1,13 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	errorsmod "cosmossdk.io/errors"
 )
 
 // ValidateFromParam checks that the MarketPrice is valid and that it corresponds to the given MarketParam.
 func (mp *MarketPrice) ValidateFromParam(marketParam MarketParam) error {
 	if marketParam.Id != mp.Id {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidInput,
 			"market param id %d does not match market price id %d",
 			marketParam.Id,
@@ -15,7 +15,7 @@ func (mp *MarketPrice) ValidateFromParam(marketParam MarketParam) error {
 		)
 	}
 	if marketParam.Exponent != mp.Exponent {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidInput,
 			"market param %d exponent %d does not match market price %d exponent %d",
 			marketParam.Id,
@@ -25,7 +25,7 @@ func (mp *MarketPrice) ValidateFromParam(marketParam MarketParam) error {
 		)
 	}
 	if mp.Price == 0 {
-		return sdkerrors.Wrapf(
+		return errorsmod.Wrapf(
 			ErrInvalidInput,
 			"market %d price cannot be zero",
 			mp.Id,

--- a/protocol/x/prices/types/message_update_market_prices.go
+++ b/protocol/x/prices/types/message_update_market_prices.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var _ sdk.Msg = &MsgUpdateMarketPrices{}
@@ -33,7 +33,7 @@ func (msg *MsgUpdateMarketPrices) ValidateBasic() error {
 	for i, marketPriceUpdate := range msg.MarketPriceUpdates {
 		// Check price is not 0.
 		if marketPriceUpdate.Price == uint64(0) {
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				ErrInvalidMarketPriceUpdateStateless,
 				"price cannot be 0 for market id (%d)",
 				marketPriceUpdate.MarketId,
@@ -42,7 +42,7 @@ func (msg *MsgUpdateMarketPrices) ValidateBasic() error {
 
 		// Check updates are sorted by market id and there are no duplicates.
 		if i > 0 && msg.MarketPriceUpdates[i-1].MarketId >= marketPriceUpdate.MarketId {
-			return sdkerrors.Wrap(
+			return errorsmod.Wrap(
 				ErrInvalidMarketPriceUpdateStateless,
 				"market price updates must be sorted by market id in ascending order and cannot contain duplicates",
 			)

--- a/protocol/x/rewards/keeper/msg_server.go
+++ b/protocol/x/rewards/keeper/msg_server.go
@@ -2,10 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 )
@@ -27,7 +26,7 @@ func (k msgServer) UpdateParams(
 	msg *types.MsgUpdateParams,
 ) (*types.MsgUpdateParamsResponse, error) {
 	if !k.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/rewards/types/errors.go
+++ b/protocol/x/rewards/types/errors.go
@@ -2,12 +2,10 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/rewards module sentinel errors
 var (
-	ErrInvalidTreasuryAccount  = sdkerrors.Register(ModuleName, 1001, "invalid treasury account")
-	ErrInvalidFeeMultiplierPpm = sdkerrors.Register(ModuleName, 1002, "invalid FeeMultiplierPpm")
+	ErrInvalidTreasuryAccount  = errorsmod.Register(ModuleName, 1001, "invalid treasury account")
+	ErrInvalidFeeMultiplierPpm = errorsmod.Register(ModuleName, 1002, "invalid FeeMultiplierPpm")
 )

--- a/protocol/x/rewards/types/params.go
+++ b/protocol/x/rewards/types/params.go
@@ -1,8 +1,7 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
@@ -22,11 +21,11 @@ func DefaultParams() Params {
 // Validate validates the set of params
 func (p Params) Validate() error {
 	if p.TreasuryAccount == "" {
-		return sdkerrors.Wrap(ErrInvalidTreasuryAccount, "treasury account cannot have empty name")
+		return errorsmod.Wrap(ErrInvalidTreasuryAccount, "treasury account cannot have empty name")
 	}
 
 	if p.FeeMultiplierPpm > lib.OneMillion {
-		return sdkerrors.Wrap(ErrInvalidFeeMultiplierPpm, "FeeMultiplierPpm cannot be greater than 1_000_000 (100%)")
+		return errorsmod.Wrap(ErrInvalidFeeMultiplierPpm, "FeeMultiplierPpm cannot be greater than 1_000_000 (100%)")
 	}
 
 	if err := sdk.ValidateDenom(p.Denom); err != nil {

--- a/protocol/x/sending/types/errors.go
+++ b/protocol/x/sending/types/errors.go
@@ -2,24 +2,22 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/sending module sentinel errors
 var (
-	ErrSenderSameAsRecipient       = sdkerrors.Register(ModuleName, 1, "Sender is the same as recipient")
-	ErrInvalidTransferAmount       = sdkerrors.Register(ModuleName, 2, "Invalid transfer amount")
-	ErrDuplicatedTransfer          = sdkerrors.Register(ModuleName, 3, "Duplicated transfer")
-	ErrTransferNotFound            = sdkerrors.Register(ModuleName, 4, "Transfer not found")
-	ErrMissingFields               = sdkerrors.Register(ModuleName, 5, "Transfer does not contain all required fields")
-	ErrInvalidAccountAddress       = sdkerrors.Register(ModuleName, 6, "Account address is invalid")
-	ErrKeeperMethodsNotImplemented = sdkerrors.Register(
+	ErrSenderSameAsRecipient       = errorsmod.Register(ModuleName, 1, "Sender is the same as recipient")
+	ErrInvalidTransferAmount       = errorsmod.Register(ModuleName, 2, "Invalid transfer amount")
+	ErrDuplicatedTransfer          = errorsmod.Register(ModuleName, 3, "Duplicated transfer")
+	ErrTransferNotFound            = errorsmod.Register(ModuleName, 4, "Transfer not found")
+	ErrMissingFields               = errorsmod.Register(ModuleName, 5, "Transfer does not contain all required fields")
+	ErrInvalidAccountAddress       = errorsmod.Register(ModuleName, 6, "Account address is invalid")
+	ErrKeeperMethodsNotImplemented = errorsmod.Register(
 		ModuleName,
 		1100,
 		"Sending module keeper method not implemented",
 	)
-	ErrNonUsdcAssetTransferNotImplemented = sdkerrors.Register(
+	ErrNonUsdcAssetTransferNotImplemented = errorsmod.Register(
 		ModuleName,
 		1101,
 		"Non-USDC asset transfer not implemented",

--- a/protocol/x/sending/types/message_create_transfer.go
+++ b/protocol/x/sending/types/message_create_transfer.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
 
@@ -34,7 +34,7 @@ func (msg *MsgCreateTransfer) ValidateBasic() error {
 	}
 
 	if msg.Transfer.Sender == msg.Transfer.Recipient {
-		return sdkerrors.Wrapf(ErrSenderSameAsRecipient, "Sender is the same as recipient (%s)", &msg.Transfer.Sender)
+		return errorsmod.Wrapf(ErrSenderSameAsRecipient, "Sender is the same as recipient (%s)", &msg.Transfer.Sender)
 	}
 
 	if msg.Transfer.AssetId != lib.UsdcAssetId {

--- a/protocol/x/stats/keeper/msg_server.go
+++ b/protocol/x/stats/keeper/msg_server.go
@@ -2,10 +2,9 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/stats/types"
 )
@@ -27,7 +26,7 @@ func (k msgServer) UpdateParams(
 	msg *types.MsgUpdateParams,
 ) (*types.MsgUpdateParamsResponse, error) {
 	if !k.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/stats/types/errors.go
+++ b/protocol/x/stats/types/errors.go
@@ -2,12 +2,10 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 var (
-	ErrNonpositiveDuration = sdkerrors.Register(
+	ErrNonpositiveDuration = errorsmod.Register(
 		ModuleName,
 		400,
 		"Duration is nonpositive",

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"fmt"
 	"math/big"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
@@ -719,7 +719,7 @@ func applyUpdatesToPositions[
 		_, exists := updateMap[id]
 		if exists {
 			errMsg := fmt.Sprintf("Multiple updates exist for position %v", update.GetId())
-			return nil, sdkerrors.Wrap(types.ErrNonUniqueUpdatesPosition, errMsg)
+			return nil, errorsmod.Wrap(types.ErrNonUniqueUpdatesPosition, errMsg)
 		}
 
 		updateMap[id] = update

--- a/protocol/x/subaccounts/keeper/transfer.go
+++ b/protocol/x/subaccounts/keeper/transfer.go
@@ -1,11 +1,11 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -97,7 +97,7 @@ func (k Keeper) TransferFundsFromSubaccountToModule(
 	}
 
 	if quantums.Sign() <= 0 {
-		return sdkerrors.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
+		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
 	}
 
 	convertedQuantums, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
@@ -158,7 +158,7 @@ func (k Keeper) TransferFundsFromModuleToSubaccount(
 	}
 
 	if quantums.Sign() <= 0 {
-		return sdkerrors.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
+		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
 	}
 
 	convertedQuantums, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
@@ -217,7 +217,7 @@ func (k Keeper) DepositFundsFromAccountToSubaccount(
 	}
 
 	if quantums.Sign() <= 0 {
-		return sdkerrors.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
+		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
 	}
 
 	convertedQuantums, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
@@ -274,7 +274,7 @@ func (k Keeper) WithdrawFundsFromSubaccountToAccount(
 	}
 
 	if quantums.Sign() <= 0 {
-		return sdkerrors.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
+		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
 	}
 
 	convertedQuantums, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math"
 	"math/big"
 	"testing"
@@ -1053,7 +1054,7 @@ func TestTransferInsuranceFundPayments(t *testing.T) {
 			skipSetUpUsdc:                       true,
 			subaccountModuleAccBalance:          500,
 			quantums:                            big.NewInt(500),
-			expectedErr:                         sdkerrors.Wrap(asstypes.ErrAssetDoesNotExist, lib.Uint32ToString(0)),
+			expectedErr:                         errorsmod.Wrap(asstypes.ErrAssetDoesNotExist, lib.Uint32ToString(0)),
 			expectedSubaccountsModuleAccBalance: 500,
 			expectedInsuranceFundBalance:        1500,
 			panics:                              true,

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -2,41 +2,39 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/subaccounts module sentinel errors
 var (
 	// 0 - 99: generic.
-	ErrIntegerOverflow = sdkerrors.Register(ModuleName, 0, "integer overflow")
+	ErrIntegerOverflow = errorsmod.Register(ModuleName, 0, "integer overflow")
 
 	// 100 - 199: update related.
-	ErrNonUniqueUpdatesPosition = sdkerrors.Register(
+	ErrNonUniqueUpdatesPosition = errorsmod.Register(
 		ModuleName, 100, "multiple updates were specified for the same position id")
-	ErrNonUniqueUpdatesSubaccount = sdkerrors.Register(
+	ErrNonUniqueUpdatesSubaccount = errorsmod.Register(
 		ModuleName, 101, "multiple updates were specified for the same subaccountId")
-	ErrFailedToUpdateSubaccounts = sdkerrors.Register(ModuleName, 102, "failed to apply subaccount updates")
+	ErrFailedToUpdateSubaccounts = errorsmod.Register(ModuleName, 102, "failed to apply subaccount updates")
 
 	// 200 - 299: subaccount id related.
-	ErrInvalidSubaccountIdNumber = sdkerrors.Register(ModuleName, 200, "subaccount id number cannot exceed 127")
-	ErrInvalidSubaccountIdOwner  = sdkerrors.Register(ModuleName, 201, "subaccount id owner is an invalid address")
-	ErrDuplicateSubaccountIds    = sdkerrors.Register(ModuleName, 202, "duplicate subaccount id found in genesis")
+	ErrInvalidSubaccountIdNumber = errorsmod.Register(ModuleName, 200, "subaccount id number cannot exceed 127")
+	ErrInvalidSubaccountIdOwner  = errorsmod.Register(ModuleName, 201, "subaccount id owner is an invalid address")
+	ErrDuplicateSubaccountIds    = errorsmod.Register(ModuleName, 202, "duplicate subaccount id found in genesis")
 
 	// 300 - 399: asset position related.
-	ErrAssetPositionsOutOfOrder       = sdkerrors.Register(ModuleName, 300, "asset positions are out of order")
-	ErrAssetPositionZeroQuantum       = sdkerrors.Register(ModuleName, 301, "asset position's quantum cannot be zero")
-	ErrAssetPositionNotSupported      = sdkerrors.Register(ModuleName, 302, "asset position is not supported")
-	ErrMultAssetPositionsNotSupported = sdkerrors.Register(
+	ErrAssetPositionsOutOfOrder       = errorsmod.Register(ModuleName, 300, "asset positions are out of order")
+	ErrAssetPositionZeroQuantum       = errorsmod.Register(ModuleName, 301, "asset position's quantum cannot be zero")
+	ErrAssetPositionNotSupported      = errorsmod.Register(ModuleName, 302, "asset position is not supported")
+	ErrMultAssetPositionsNotSupported = errorsmod.Register(
 		ModuleName, 303, "having multiple asset positions is not supported")
 
 	// 400 - 499: perpetual position related.
-	ErrPerpPositionsOutOfOrder = sdkerrors.Register(ModuleName, 400, "perpetual positions are out of order")
-	ErrPerpPositionZeroQuantum = sdkerrors.Register(ModuleName, 401, "perpetual position's quantum cannot be zero")
+	ErrPerpPositionsOutOfOrder = errorsmod.Register(ModuleName, 400, "perpetual positions are out of order")
+	ErrPerpPositionZeroQuantum = errorsmod.Register(ModuleName, 401, "perpetual position's quantum cannot be zero")
 
 	// 500 - 599: transfer related.
-	ErrAssetTransferQuantumsNotPositive = sdkerrors.Register(
+	ErrAssetTransferQuantumsNotPositive = errorsmod.Register(
 		ModuleName, 500, "asset transfer quantums is not positive")
-	ErrAssetTransferThroughBankNotImplemented = sdkerrors.Register(
+	ErrAssetTransferThroughBankNotImplemented = errorsmod.Register(
 		ModuleName, 501, "asset transfer (other than USDC) through the bank module is not implemented")
 )

--- a/protocol/x/subaccounts/types/genesis.go
+++ b/protocol/x/subaccounts/types/genesis.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	errorsmod "cosmossdk.io/errors"
 )
 
 // DefaultGenesis returns the default Capability genesis state
@@ -21,7 +21,7 @@ func (gs GenesisState) Validate() error {
 			return err
 		}
 		if includedAccounts[*subaccountId] {
-			return sdkerrors.Wrapf(ErrDuplicateSubaccountIds,
+			return errorsmod.Wrapf(ErrDuplicateSubaccountIds,
 				"duplicate subaccount id %+v found within genesis state", subaccountId)
 		}
 		includedAccounts[*subaccountId] = true

--- a/protocol/x/subaccounts/types/genesis_test.go
+++ b/protocol/x/subaccounts/types/genesis_test.go
@@ -1,9 +1,9 @@
 package types_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sample"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -176,7 +176,7 @@ func TestGenesisState_Validate(t *testing.T) {
 				},
 			},
 			shouldPanic: true,
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrAssetPositionZeroQuantum,
 				"asset position (asset Id: 0) has zero quantum",
 			),
@@ -222,7 +222,7 @@ func TestGenesisState_Validate(t *testing.T) {
 				},
 			},
 			shouldPanic: true,
-			expectedError: sdkerrors.Wrapf(
+			expectedError: errorsmod.Wrapf(
 				types.ErrPerpPositionZeroQuantum,
 				"perpetual position (perpetual Id: 0) has zero quantum",
 			),

--- a/protocol/x/subaccounts/types/position_size.go
+++ b/protocol/x/subaccounts/types/position_size.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math/big"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 )
 
@@ -49,7 +49,7 @@ func (m *AssetPosition) GetBigQuantums() *big.Int {
 	}
 
 	if m.Quantums.BigInt().Sign() == 0 {
-		panic(sdkerrors.Wrapf(
+		panic(errorsmod.Wrapf(
 			ErrAssetPositionZeroQuantum,
 			"asset position (asset Id: %v) has zero quantum",
 			m.AssetId,
@@ -81,7 +81,7 @@ func (m *PerpetualPosition) GetBigQuantums() *big.Int {
 	}
 
 	if m.Quantums.BigInt().Sign() == 0 {
-		panic(sdkerrors.Wrapf(
+		panic(errorsmod.Wrapf(
 			ErrPerpPositionZeroQuantum,
 			"perpetual position (perpetual Id: %v) has zero quantum",
 			m.PerpetualId,

--- a/protocol/x/subaccounts/types/position_size_test.go
+++ b/protocol/x/subaccounts/types/position_size_test.go
@@ -1,10 +1,10 @@
 package types_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math/big"
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 
@@ -44,7 +44,7 @@ func TestPerpetualPosition_GetIsLong(t *testing.T) {
 		longPosition.GetIsLong(),
 	)
 	require.PanicsWithError(t,
-		sdkerrors.Wrapf(
+		errorsmod.Wrapf(
 			types.ErrPerpPositionZeroQuantum,
 			"perpetual position (perpetual Id: 0) has zero quantum",
 		).Error(),
@@ -76,7 +76,7 @@ func TestAssetPosition_GetIsLong(t *testing.T) {
 		longPosition.GetIsLong(),
 	)
 	require.PanicsWithError(t,
-		sdkerrors.Wrapf(
+		errorsmod.Wrapf(
 			types.ErrAssetPositionZeroQuantum,
 			"asset position (asset Id: 0) has zero quantum",
 		).Error(),

--- a/protocol/x/subaccounts/types/subaccount.go
+++ b/protocol/x/subaccounts/types/subaccount.go
@@ -1,10 +1,10 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
@@ -28,7 +28,7 @@ func (bq BaseQuantums) ToUint64() uint64 {
 
 func (m *SubaccountId) Validate() error {
 	if _, err := sdk.AccAddressFromBech32(m.Owner); err != nil {
-		return sdkerrors.Wrapf(ErrInvalidSubaccountIdOwner,
+		return errorsmod.Wrapf(ErrInvalidSubaccountIdOwner,
 			"invalid SubaccountId Owner address (%s). Error: (%s)", m.Owner, err)
 	}
 

--- a/protocol/x/subaccounts/types/update.go
+++ b/protocol/x/subaccounts/types/update.go
@@ -1,9 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"math/big"
-
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 type UpdateResult uint
@@ -36,7 +35,7 @@ func GetErrorFromUpdateResults(
 	for index, result := range successPerUpdate {
 		if !result.IsSuccess() {
 			subaccountId := updates[index].SubaccountId
-			return sdkerrors.Wrapf(
+			return errorsmod.Wrapf(
 				ErrFailedToUpdateSubaccounts,
 				"Subaccount with id %v failed with UpdateResult: %v",
 				subaccountId,

--- a/protocol/x/vest/keeper/keeper.go
+++ b/protocol/x/vest/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -14,7 +15,6 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -170,7 +170,7 @@ func (k Keeper) GetVestEntry(ctx sdk.Context, vesterAccount string) (
 
 	// If VestEntry does not exist in state, return error
 	if b == nil {
-		return types.VestEntry{}, sdkerrors.Wrapf(types.ErrVestEntryNotFound, "vesterAccount: %s", vesterAccount)
+		return types.VestEntry{}, errorsmod.Wrapf(types.ErrVestEntryNotFound, "vesterAccount: %s", vesterAccount)
 	}
 
 	k.cdc.MustUnmarshal(b, &val)
@@ -202,7 +202,7 @@ func (k Keeper) DeleteVestEntry(
 	err error,
 ) {
 	if _, err := k.GetVestEntry(ctx, vesterAccount); err != nil {
-		return sdkerrors.Wrap(err, "failed to delete vest entry")
+		return errorsmod.Wrap(err, "failed to delete vest entry")
 	}
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.VestEntryKeyPrefix))
 	store.Delete(types.VestEntryKey(vesterAccount))

--- a/protocol/x/vest/keeper/msg_server.go
+++ b/protocol/x/vest/keeper/msg_server.go
@@ -2,11 +2,11 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
@@ -27,7 +27,7 @@ func (k msgServer) SetVestEntry(
 	msg *types.MsgSetVestEntry,
 ) (*types.MsgSetVestEntryResponse, error) {
 	if !k.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,
@@ -47,7 +47,7 @@ func (k msgServer) DeleteVestEntry(
 	msg *types.MsgDeleteVestEntry,
 ) (*types.MsgDeleteVestEntryResponse, error) {
 	if !k.HasAuthority(msg.Authority) {
-		return nil, sdkerrors.Wrapf(
+		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
 			msg.Authority,

--- a/protocol/x/vest/types/errors.go
+++ b/protocol/x/vest/types/errors.go
@@ -2,16 +2,14 @@ package types
 
 // DONTCOVER
 
-import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-)
+import errorsmod "cosmossdk.io/errors"
 
 // x/vest module sentinel errors
 var (
-	ErrInvalidVesterAccount    = sdkerrors.Register(ModuleName, 1001, "invalid vester account")
-	ErrInvalidTreasuryAccount  = sdkerrors.Register(ModuleName, 1002, "invalid treasury account")
-	ErrInvalidDenom            = sdkerrors.Register(ModuleName, 1003, "invalid denom")
-	ErrVestEntryNotFound       = sdkerrors.Register(ModuleName, 1004, "account is not associated with a vest entry")
-	ErrInvalidStartAndEndTimes = sdkerrors.Register(ModuleName, 1005, "start_time must be before end_time")
-	ErrInvalidTimeZone         = sdkerrors.Register(ModuleName, 1006, "timestamp must be in UTC")
+	ErrInvalidVesterAccount    = errorsmod.Register(ModuleName, 1001, "invalid vester account")
+	ErrInvalidTreasuryAccount  = errorsmod.Register(ModuleName, 1002, "invalid treasury account")
+	ErrInvalidDenom            = errorsmod.Register(ModuleName, 1003, "invalid denom")
+	ErrVestEntryNotFound       = errorsmod.Register(ModuleName, 1004, "account is not associated with a vest entry")
+	ErrInvalidStartAndEndTimes = errorsmod.Register(ModuleName, 1005, "start_time must be before end_time")
+	ErrInvalidTimeZone         = errorsmod.Register(ModuleName, 1006, "timestamp must be in UTC")
 )

--- a/protocol/x/vest/types/vest_entry.go
+++ b/protocol/x/vest/types/vest_entry.go
@@ -1,33 +1,33 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 func (entry VestEntry) Validate() error {
 	if entry.VesterAccount == "" {
-		return sdkerrors.Wrapf(ErrInvalidVesterAccount, "vester account cannot be empty")
+		return errorsmod.Wrapf(ErrInvalidVesterAccount, "vester account cannot be empty")
 	}
 
 	if entry.TreasuryAccount == "" {
-		return sdkerrors.Wrapf(ErrInvalidTreasuryAccount, "treasury account cannot be empty")
+		return errorsmod.Wrapf(ErrInvalidTreasuryAccount, "treasury account cannot be empty")
 	}
 
 	if err := sdk.ValidateDenom(entry.Denom); err != nil {
-		return sdkerrors.Wrapf(ErrInvalidDenom, err.Error())
+		return errorsmod.Wrapf(ErrInvalidDenom, err.Error())
 	}
 
 	if !entry.StartTime.Before(entry.EndTime) {
-		return sdkerrors.Wrapf(ErrInvalidStartAndEndTimes, "start_time = %v, end_time = %v", entry.StartTime, entry.EndTime)
+		return errorsmod.Wrapf(ErrInvalidStartAndEndTimes, "start_time = %v, end_time = %v", entry.StartTime, entry.EndTime)
 	}
 
 	if entry.StartTime.Location().String() != "UTC" {
-		return sdkerrors.Wrapf(ErrInvalidTimeZone, "start_time must be in UTC")
+		return errorsmod.Wrapf(ErrInvalidTimeZone, "start_time must be in UTC")
 	}
 
 	if entry.EndTime.Location().String() != "UTC" {
-		return sdkerrors.Wrapf(ErrInvalidTimeZone, "start_time must be in UTC")
+		return errorsmod.Wrapf(ErrInvalidTimeZone, "start_time must be in UTC")
 	}
 	return nil
 }


### PR DESCRIPTION
See https://github.com/cosmos/cosmos-sdk/blob/3b509c187e1643757f5ef8a0b5ae3decca0c7719/types/errors/errors.go#L33 This makes upgrading to Cosmos 0.50.0 easier as the deprecated version was removed.

Note this change had the compiler pick up an error in `clob/keeper/process_operations.go` which is now fixed.