### PR TITLE
[CORE-538] Swap to cosmossdk.io/math module since the package we are using has deprecated these functions and is removed on 0.50.

### DIFF
--- a/protocol/app/module/slashing.go
+++ b/protocol/app/module/slashing.go
@@ -1,13 +1,13 @@
 package module
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"encoding/json"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
@@ -23,8 +23,8 @@ func (SlashingModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	genState := slashingtypes.DefaultGenesisState()
 
 	// No slashing for downtime and double-signing.
-	genState.Params.SlashFractionDowntime = sdk.ZeroDec()
-	genState.Params.SlashFractionDoubleSign = sdk.ZeroDec()
+	genState.Params.SlashFractionDowntime = sdkmath.LegacyZeroDec()
+	genState.Params.SlashFractionDoubleSign = sdkmath.LegacyZeroDec()
 
 	// 1 minute jail duration for downtime.
 	genState.Params.DowntimeJailDuration = 1 * time.Minute
@@ -33,7 +33,7 @@ func (SlashingModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	genState.Params.SignedBlocksWindow = 3000
 
 	// Require 5% minimum liveness per signed block window.
-	genState.Params.MinSignedPerWindow = sdk.MustNewDecFromStr("0.05")
+	genState.Params.MinSignedPerWindow = sdkmath.LegacyMustNewDecFromStr("0.05")
 
 	return cdc.MustMarshalJSON(genState)
 }

--- a/protocol/app/msgs/app_injected_msgs.go
+++ b/protocol/app/msgs/app_injected_msgs.go
@@ -1,6 +1,7 @@
 package msgs
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -30,7 +31,7 @@ var (
 					Id: 0,
 					Coin: sdk.NewCoin(
 						"bridge-token",
-						sdk.NewIntFromUint64(1234),
+						sdkmath.NewIntFromUint64(1234),
 					),
 					Address: constants.Alice_Num0.Owner,
 				},

--- a/protocol/app/process/acknowledge_bridges_test.go
+++ b/protocol/app/process/acknowledge_bridges_test.go
@@ -1,6 +1,7 @@
 package process_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"errors"
 	"testing"
 
@@ -154,7 +155,7 @@ func TestAcknowledgeBridgesTx_Validate(t *testing.T) {
 						Id: event.Id,
 						Coin: sdk.NewCoin(
 							event.Coin.Denom,
-							sdk.NewInt(1000000000000000000), // incorrect amount.
+							sdkmath.NewInt(1000000000000000000), // incorrect amount.
 						),
 						Address:        event.Address,
 						EthBlockHeight: event.EthBlockHeight,

--- a/protocol/app/process/process_proposal_test.go
+++ b/protocol/app/process/process_proposal_test.go
@@ -1,6 +1,7 @@
 package process_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -115,7 +116,7 @@ func TestProcessProposalHandler_Error(t *testing.T) {
 						Id: event.Id,
 						Coin: sdk.NewCoin(
 							event.Coin.Denom,
-							event.Coin.Amount.Add(sdk.NewInt(10_000)), // second event has different amount.
+							event.Coin.Amount.Add(sdkmath.NewInt(10_000)), // second event has different amount.
 						),
 						Address:        event.Address,
 						EthBlockHeight: event.EthBlockHeight,

--- a/protocol/lib/eth/util.go
+++ b/protocol/lib/eth/util.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"math/big"
 	"strings"
 
@@ -72,7 +73,7 @@ func BridgeLogToEvent(
 
 	return bridgetypes.BridgeEvent{
 		Id:             id,
-		Coin:           sdk.NewCoin(denom, sdk.NewIntFromBigInt(amount)),
+		Coin:           sdk.NewCoin(denom, sdkmath.NewIntFromBigInt(amount)),
 		Address:        sdk.MustBech32ifyAddressBytes(config.Bech32PrefixAccAddr, address),
 		EthBlockHeight: log.BlockNumber,
 	}

--- a/protocol/lib/eth/util_test.go
+++ b/protocol/lib/eth/util_test.go
@@ -1,6 +1,7 @@
 package eth_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -25,7 +26,7 @@ func TestBridgeLogToEvent(t *testing.T) {
 				Id: 0,
 				Coin: sdk.NewCoin(
 					"dv4tnt",
-					sdk.NewInt(12345),
+					sdkmath.NewInt(12345),
 				),
 				Address:        "dydx1qqgzqvzq2ps8pqys5zcvp58q7rluextx92xhln",
 				EthBlockHeight: 3872013,
@@ -38,7 +39,7 @@ func TestBridgeLogToEvent(t *testing.T) {
 				Id: 1,
 				Coin: sdk.NewCoin(
 					"test-token",
-					sdk.NewInt(55),
+					sdkmath.NewInt(55),
 				),
 				// address shorter than 20 bytes is padded with zeros.
 				Address:        "dydx1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq66wm82",
@@ -52,7 +53,7 @@ func TestBridgeLogToEvent(t *testing.T) {
 				Id: 2,
 				Coin: sdk.NewCoin(
 					"test-token",
-					sdk.NewInt(777),
+					sdkmath.NewInt(777),
 				),
 				// 32 bytes * 8 bits / 5 bits = 51.2 characters ~ 52 bech32 characters
 				Address:        "dydx1qqgzqvzq2ps8pqys5zcvp58q7rluextxzy3rx3z4vemc3xgq42as94fpcv",
@@ -66,7 +67,7 @@ func TestBridgeLogToEvent(t *testing.T) {
 				Id: 3,
 				Coin: sdk.NewCoin(
 					"test-token-2",
-					sdk.NewInt(888),
+					sdkmath.NewInt(888),
 				),
 				// address data is 62 bytes but we take the first 32 bytes only.
 				// 32 bytes * 8 bits / 5 bits ~ 52 bech32 characters
@@ -81,7 +82,7 @@ func TestBridgeLogToEvent(t *testing.T) {
 				Id: 4,
 				Coin: sdk.NewCoin(
 					"dv4tnt",
-					sdk.NewInt(1234123443214321),
+					sdkmath.NewInt(1234123443214321),
 				),
 				// address shorter than 20 bytes is padded with zeros.
 				Address:        "dydx1zg6pydqqqqqqqqqqqqqqqqqqqqqqqqqqm0r5ra",

--- a/protocol/testutil/bank/bank_helpers.go
+++ b/protocol/testutil/bank/bank_helpers.go
@@ -1,6 +1,7 @@
 package bank
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	testutilcli "github.com/cosmos/cosmos-sdk/testutil/cli"
@@ -48,7 +49,7 @@ func GetModuleAccUsdcBalance(
 // *big.Int type when setting up mocks.
 func MatchUsdcOfAmount(amount int64) func(coins sdk.Coins) bool {
 	return func(coins sdk.Coins) bool {
-		return coins[0].Amount.Equal(sdk.NewInt(amount))
+		return coins[0].Amount.Equal(sdkmath.NewInt(amount))
 	}
 }
 

--- a/protocol/testutil/constants/bridge.go
+++ b/protocol/testutil/constants/bridge.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -34,7 +35,7 @@ var (
 	// Private
 	coin = sdk.Coin{
 		Denom:  "dv4tnt",
-		Amount: sdk.NewIntFromUint64(888),
+		Amount: sdkmath.NewIntFromUint64(888),
 	}
 
 	// Public

--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 
@@ -390,7 +391,7 @@ func (k Keeper) ConvertAssetToCoin(
 
 	bigConvertedQuantums := bigRatConvertedQuantums.Num()
 
-	return bigConvertedQuantums, sdk.NewCoin(asset.Denom, sdk.NewIntFromBigInt(bigConvertedDenomAmount)), nil
+	return bigConvertedQuantums, sdk.NewCoin(asset.Denom, sdkmath.NewIntFromBigInt(bigConvertedDenomAmount)), nil
 }
 
 // IsPositionUpdatable returns whether position of an asset is updatable.

--- a/protocol/x/assets/keeper/asset_test.go
+++ b/protocol/x/assets/keeper/asset_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	errorsmod "cosmossdk.io/errors"
-	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
-
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/nullify"
@@ -464,63 +464,63 @@ func TestConvertAssetToCoin_Success(t *testing.T) {
 			denomExponent:             -6,
 			atomicResolution:          -8,
 			quantumsToConvert:         big.NewInt(1100),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(11)),
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(11)),
 			expectedConvertedQuantums: big.NewInt(1100),
 		},
 		"atomicResolution < denomExponent, divisble, DenomExponent=-6, AtomicResolution=-7": {
 			denomExponent:             -6,
 			atomicResolution:          -7,
 			quantumsToConvert:         big.NewInt(1120),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(112)),
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(112)),
 			expectedConvertedQuantums: big.NewInt(1120),
 		},
 		"atomicResolution < denomExponent, not divisble, DenomExponent=-6,AtomicResolution=-8": {
 			denomExponent:             -6,
 			atomicResolution:          -8,
 			quantumsToConvert:         big.NewInt(1125),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(11)), // 11.25 rounded down
-			expectedConvertedQuantums: big.NewInt(1100),                       // 11 * 100
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(11)), // 11.25 rounded down
+			expectedConvertedQuantums: big.NewInt(1100),                           // 11 * 100
 		},
 		"atomicResolution < denomExponent, not, divisble, DenomExponent=-6, AtomicResolution=-7": {
 			denomExponent:             -6,
 			atomicResolution:          -7,
 			quantumsToConvert:         big.NewInt(1125),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(112)), // 112.5 rounded down
-			expectedConvertedQuantums: big.NewInt(1120),                        // 112 * 10
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(112)), // 112.5 rounded down
+			expectedConvertedQuantums: big.NewInt(1120),                            // 112 * 10
 		},
 		"atomicResolution < denomExponent, not, divisble, DenomExponent=1, AtomicResolution=-3": {
 			denomExponent:             1,
 			atomicResolution:          -3,
 			quantumsToConvert:         big.NewInt(123456),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(12)), // 12.3456 rounded down
-			expectedConvertedQuantums: big.NewInt(120000),                     // 12*10000
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(12)), // 12.3456 rounded down
+			expectedConvertedQuantums: big.NewInt(120000),                         // 12*10000
 		},
 		"atomicResolution = denomExponent, DenomExponent=-6, AtomicResolution=-6": {
 			denomExponent:             -6,
 			atomicResolution:          -6,
 			quantumsToConvert:         big.NewInt(1500),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(1500)),
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(1500)),
 			expectedConvertedQuantums: big.NewInt(1500),
 		},
 		"atomicResolution = denomExponent, DenomExponent=-6, AtomicResolution=-6, large input": {
 			denomExponent:             -6,
 			atomicResolution:          -6,
 			quantumsToConvert:         big.NewInt(12345678),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(12345678)),
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(12345678)),
 			expectedConvertedQuantums: big.NewInt(12345678),
 		},
 		"atomicResolution > denomExponent": {
 			denomExponent:             -6,
 			atomicResolution:          -4,
 			quantumsToConvert:         big.NewInt(275),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(27500)),
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(27500)),
 			expectedConvertedQuantums: big.NewInt(275),
 		},
 		"atomicResolution > denomExponent, positive AtomicResoluton": {
 			denomExponent:             -2,
 			atomicResolution:          1,
 			quantumsToConvert:         big.NewInt(275),
-			expectedCoin:              sdk.NewCoin(testDenom, sdk.NewInt(275000)),
+			expectedCoin:              sdk.NewCoin(testDenom, sdkmath.NewInt(275000)),
 			expectedConvertedQuantums: big.NewInt(275),
 		},
 	}

--- a/protocol/x/bridge/app_test.go
+++ b/protocol/x/bridge/app_test.go
@@ -1,6 +1,7 @@
 package bridge_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"testing"
 	"time"
 
@@ -203,7 +204,7 @@ func TestBridge_REJECT(t *testing.T) {
 					Id: e1.Id,
 					Coin: sdk.NewCoin(
 						e1.Coin.Denom,
-						e1.Coin.Amount.Add(sdk.NewInt(1)), // bad amount.
+						e1.Coin.Amount.Add(sdkmath.NewInt(1)), // bad amount.
 					),
 					Address:        e1.Address,
 					EthBlockHeight: e1.EthBlockHeight,

--- a/protocol/x/bridge/keeper/complete_bridge_test.go
+++ b/protocol/x/bridge/keeper/complete_bridge_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -24,37 +25,37 @@ func TestCompleteBridge(t *testing.T) {
 		expectedBalance sdk.Coin
 	}{
 		"Success": {
-			initialBalance:  sdk.NewCoin("dv4tnt", sdk.NewInt(1_000)),
-			bridgeEvent:     constants.BridgeEvent_Id0_Height0,      // bridges 888 tokens.
-			expectedBalance: sdk.NewCoin("dv4tnt", sdk.NewInt(112)), // 1000 - 888.
+			initialBalance:  sdk.NewCoin("dv4tnt", sdkmath.NewInt(1_000)),
+			bridgeEvent:     constants.BridgeEvent_Id0_Height0,          // bridges 888 tokens.
+			expectedBalance: sdk.NewCoin("dv4tnt", sdkmath.NewInt(112)), // 1000 - 888.
 		},
 		"Failure: coin amount is 0": {
-			initialBalance: sdk.NewCoin("dv4tnt", sdk.NewInt(1_000)),
+			initialBalance: sdk.NewCoin("dv4tnt", sdkmath.NewInt(1_000)),
 			bridgeEvent: types.BridgeEvent{
 				Id:             7,
 				Address:        constants.BobAccAddress.String(),
-				Coin:           sdk.NewCoin("dv4tnt", sdk.ZeroInt()),
+				Coin:           sdk.NewCoin("dv4tnt", sdkmath.ZeroInt()),
 				EthBlockHeight: 3,
 			},
 			expectedError:   "invalid coin",
-			expectedBalance: sdk.NewCoin("dv4tnt", sdk.NewInt(1_000)),
+			expectedBalance: sdk.NewCoin("dv4tnt", sdkmath.NewInt(1_000)),
 		},
 		"Failure: invalid address string": {
-			initialBalance: sdk.NewCoin("dv4tnt", sdk.NewInt(1_000)),
+			initialBalance: sdk.NewCoin("dv4tnt", sdkmath.NewInt(1_000)),
 			bridgeEvent: types.BridgeEvent{
 				Id:             4,
 				Address:        "not an address string",
-				Coin:           sdk.NewCoin("dv4tnt", sdk.NewInt(1)),
+				Coin:           sdk.NewCoin("dv4tnt", sdkmath.NewInt(1)),
 				EthBlockHeight: 2,
 			},
 			expectedError:   "decoding bech32 failed",
-			expectedBalance: sdk.NewCoin("dv4tnt", sdk.NewInt(1_000)),
+			expectedBalance: sdk.NewCoin("dv4tnt", sdkmath.NewInt(1_000)),
 		},
 		"Failure: bridge module account has insufficient balance": {
-			initialBalance:  sdk.NewCoin("dv4tnt", sdk.NewInt(500)),
+			initialBalance:  sdk.NewCoin("dv4tnt", sdkmath.NewInt(500)),
 			bridgeEvent:     constants.BridgeEvent_Id0_Height0, // bridges 888 tokens.
 			expectedError:   "insufficient funds",
-			expectedBalance: sdk.NewCoin("dv4tnt", sdk.NewInt(500)),
+			expectedBalance: sdk.NewCoin("dv4tnt", sdkmath.NewInt(500)),
 		},
 	}
 

--- a/protocol/x/bridge/keeper/msg_server_complete_bridge_test.go
+++ b/protocol/x/bridge/keeper/msg_server_complete_bridge_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"fmt"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestMsgServerCompleteBridge(t *testing.T) {
 				Authority: constants.DelayMsgModuleAccAddressString,
 				Event: types.BridgeEvent{
 					Id:             0,
-					Coin:           sdk.NewCoin("dv4tnt", sdk.NewInt(1)),
+					Coin:           sdk.NewCoin("dv4tnt", sdkmath.NewInt(1)),
 					Address:        "invalid",
 					EthBlockHeight: 1,
 				},

--- a/protocol/x/bridge/types/bridge_event_test.go
+++ b/protocol/x/bridge/types/bridge_event_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,13 +18,13 @@ func TestBridgeEvent_Equal(t *testing.T) {
 		"Equal": {
 			a: types.BridgeEvent{
 				Id:             1,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(17)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(17)),
 				Address:        "address",
 				EthBlockHeight: 128,
 			},
 			b: types.BridgeEvent{
 				Id:             1,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(17)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(17)),
 				Address:        "address",
 				EthBlockHeight: 128,
 			},
@@ -32,13 +33,13 @@ func TestBridgeEvent_Equal(t *testing.T) {
 		"Id not equal": {
 			a: types.BridgeEvent{
 				Id:             1,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(17)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(17)),
 				Address:        "address",
 				EthBlockHeight: 128,
 			},
 			b: types.BridgeEvent{
 				Id:             2,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(17)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(17)),
 				Address:        "address",
 				EthBlockHeight: 128,
 			},
@@ -47,13 +48,13 @@ func TestBridgeEvent_Equal(t *testing.T) {
 		"Coin denom not equal": {
 			a: types.BridgeEvent{
 				Id:             10,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(171)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(171)),
 				Address:        "address",
 				EthBlockHeight: 1280,
 			},
 			b: types.BridgeEvent{
 				Id:             10,
-				Coin:           sdk.NewCoin("test2", sdk.NewInt(171)),
+				Coin:           sdk.NewCoin("test2", sdkmath.NewInt(171)),
 				Address:        "address",
 				EthBlockHeight: 1280,
 			},
@@ -62,13 +63,13 @@ func TestBridgeEvent_Equal(t *testing.T) {
 		"Coin amount not equal": {
 			a: types.BridgeEvent{
 				Id:             10,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(171)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(171)),
 				Address:        "address",
 				EthBlockHeight: 1280,
 			},
 			b: types.BridgeEvent{
 				Id:             10,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(1711)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(1711)),
 				Address:        "address",
 				EthBlockHeight: 1280,
 			},
@@ -77,13 +78,13 @@ func TestBridgeEvent_Equal(t *testing.T) {
 		"Address not equal": {
 			a: types.BridgeEvent{
 				Id:             10,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(171)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(171)),
 				Address:        "address",
 				EthBlockHeight: 1280,
 			},
 			b: types.BridgeEvent{
 				Id:             10,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(1711)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(1711)),
 				Address:        "address1",
 				EthBlockHeight: 1280,
 			},
@@ -92,13 +93,13 @@ func TestBridgeEvent_Equal(t *testing.T) {
 		"Eth block height not equal": {
 			a: types.BridgeEvent{
 				Id:             10,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(171)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(171)),
 				Address:        "address",
 				EthBlockHeight: 1280,
 			},
 			b: types.BridgeEvent{
 				Id:             10,
-				Coin:           sdk.NewCoin("test", sdk.NewInt(1711)),
+				Coin:           sdk.NewCoin("test", sdkmath.NewInt(1711)),
 				Address:        "address",
 				EthBlockHeight: 1281,
 			},

--- a/protocol/x/clob/abci_test.go
+++ b/protocol/x/clob/abci_test.go
@@ -1,6 +1,7 @@
 package clob_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"errors"
 	"fmt"
 	"math/big"
@@ -1324,7 +1325,7 @@ func TestPrepareCheckState(t *testing.T) {
 				mock.Anything,
 				authtypes.NewModuleAddress(types.InsuranceFundName),
 				constants.Usdc.Denom,
-			).Return(sdk.NewCoin(constants.Usdc.Denom, sdk.NewIntFromBigInt(new(big.Int))))
+			).Return(sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))))
 			mockBankKeeper.On(
 				"SendCoinsFromModuleToModule",
 				mock.Anything,

--- a/protocol/x/clob/keeper/deleveraging_test.go
+++ b/protocol/x/clob/keeper/deleveraging_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"errors"
 	"math"
 	"math/big"
@@ -94,7 +95,7 @@ func TestGetInsuranceFundBalance(t *testing.T) {
 					authtypes.NewModuleAddress(types.InsuranceFundName),
 					constants.Usdc.Denom,
 				).Return(
-					sdk.NewCoin(constants.Usdc.Denom, sdk.NewIntFromBigInt(tc.insuranceFundBalance)),
+					sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),
 				)
 			}
 
@@ -200,7 +201,7 @@ func TestIsValidInsuranceFundDelta(t *testing.T) {
 				authtypes.NewModuleAddress(types.InsuranceFundName),
 				constants.Usdc.Denom,
 			).Return(
-				sdk.NewCoin(constants.Usdc.Denom, sdk.NewIntFromBigInt(tc.insuranceFundBalance)),
+				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),
 			)
 			require.Equal(
 				t,
@@ -332,7 +333,7 @@ func TestCanDeleverageSubaccount(t *testing.T) {
 				authtypes.NewModuleAddress(types.InsuranceFundName),
 				constants.Usdc.Denom,
 			).Return(
-				sdk.NewCoin(constants.Usdc.Denom, sdk.NewIntFromBigInt(tc.insuranceFundBalance)),
+				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),
 			)
 
 			// Create test markets.

--- a/protocol/x/clob/keeper/liquidations_test.go
+++ b/protocol/x/clob/keeper/liquidations_test.go
@@ -7,13 +7,12 @@ import (
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
-
-	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
-
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
@@ -266,7 +265,7 @@ func TestPlacePerpetualLiquidation(t *testing.T) {
 			).Return(
 				sdk.NewCoin(
 					constants.Usdc.Denom,
-					sdk.NewIntFromBigInt(big.NewInt(1_000_000_000_000)),
+					sdkmath.NewIntFromBigInt(big.NewInt(1_000_000_000_000)),
 				),
 			)
 
@@ -721,7 +720,7 @@ func TestPlacePerpetualLiquidation_PreexistingLiquidation(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
-				).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(0))) // Insurance fund is empty.
+				).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(0))) // Insurance fund is empty.
 			},
 
 			liquidationConfig: constants.LiquidationsConfig_No_Limit, // `MaxInsuranceFundQuantumsForDeleveraging` is zero.
@@ -761,7 +760,7 @@ func TestPlacePerpetualLiquidation_PreexistingLiquidation(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
-				).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(0))) // Insurance fund is empty.
+				).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(0))) // Insurance fund is empty.
 			},
 
 			liquidationConfig: constants.LiquidationsConfig_No_Limit, // `MaxInsuranceFundQuantumsForDeleveraging` is zero.
@@ -803,7 +802,7 @@ func TestPlacePerpetualLiquidation_PreexistingLiquidation(t *testing.T) {
 					mock.Anything,
 				).Return(
 					// Insurance fund has $0.99 initially.
-					sdk.NewCoin("USDC", sdk.NewIntFromUint64(990_000)),
+					sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(990_000)),
 				).Once()
 				bk.On(
 					"GetBalance",
@@ -812,7 +811,7 @@ func TestPlacePerpetualLiquidation_PreexistingLiquidation(t *testing.T) {
 					mock.Anything,
 				).Return(
 					// Insurance fund has $0.74 after covering the loss of the first match.
-					sdk.NewCoin("USDC", sdk.NewIntFromUint64(740_000)),
+					sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(740_000)),
 				).Twice()
 			},
 
@@ -886,7 +885,7 @@ func TestPlacePerpetualLiquidation_PreexistingLiquidation(t *testing.T) {
 					mock.Anything,
 				).Return(
 					// Insurance fund has $0.99 initially.
-					sdk.NewCoin("USDC", sdk.NewIntFromUint64(990_000)),
+					sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(990_000)),
 				).Once()
 				bk.On(
 					"GetBalance",
@@ -895,7 +894,7 @@ func TestPlacePerpetualLiquidation_PreexistingLiquidation(t *testing.T) {
 					mock.Anything,
 				).Return(
 					// Insurance fund has $0.74 after covering the loss of the first match.
-					sdk.NewCoin("USDC", sdk.NewIntFromUint64(740_000)),
+					sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(740_000)),
 				).Once()
 			},
 
@@ -1011,7 +1010,7 @@ func TestPlacePerpetualLiquidation_PreexistingLiquidation(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
-				).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(math.MaxUint64)))
+				).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(math.MaxUint64)))
 			}
 
 			mockIndexerEventManager := &mocks.IndexerEventManager{}
@@ -1893,7 +1892,7 @@ func TestPlacePerpetualLiquidation_Deleveraging(t *testing.T) {
 				mock.Anything,
 				mock.Anything,
 				mock.Anything,
-			).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(tc.insuranceFundBalance))).Twice()
+			).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(tc.insuranceFundBalance))).Twice()
 
 			mockIndexerEventManager := &mocks.IndexerEventManager{}
 			mockIndexerEventManager.On("Enabled").Return(false)
@@ -4600,7 +4599,7 @@ func TestMaybeGetLiquidationOrder(t *testing.T) {
 			).Return(
 				sdk.NewCoin(
 					constants.Usdc.Denom,
-					sdk.NewIntFromBigInt(big.NewInt(1_000_000_000_000)),
+					sdkmath.NewIntFromBigInt(big.NewInt(1_000_000_000_000)),
 				),
 			)
 			ks := keepertest.NewClobKeepersTestContext(t, memClob, mockBankKeeper, indexer_manager.NewIndexerEventManagerNoop())

--- a/protocol/x/clob/keeper/mev_test.go
+++ b/protocol/x/clob/keeper/mev_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"math/big"
 	"testing"
 
@@ -839,7 +840,7 @@ func TestRecordMevMetrics(t *testing.T) {
 				authtypes.NewModuleAddress(types.InsuranceFundName),
 				constants.Usdc.Denom,
 			).Return(
-				sdk.NewCoin(constants.Usdc.Denom, sdk.NewIntFromBigInt(new(big.Int))),
+				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))),
 			)
 
 			ks := keepertest.NewClobKeepersTestContext(t, memClob, mockBankKeeper, indexer_manager.NewIndexerEventManagerNoop())

--- a/protocol/x/clob/keeper/process_operations_liquidations_test.go
+++ b/protocol/x/clob/keeper/process_operations_liquidations_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"errors"
 	"fmt"
 	"math"
@@ -278,7 +279,7 @@ func TestProcessProposerMatches_Liquidation_Success(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
-				).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(math.MaxUint64)))
+				).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(math.MaxUint64)))
 				bk.On(
 					"SendCoinsFromModuleToModule",
 					mock.Anything,
@@ -462,7 +463,7 @@ func TestProcessProposerMatches_Liquidation_Success(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
-				).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(math.MaxUint64)))
+				).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(math.MaxUint64)))
 				bk.On(
 					"SendCoinsFromModuleToModule",
 					mock.Anything,
@@ -567,7 +568,7 @@ func TestProcessProposerMatches_Liquidation_Success(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
-				).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(math.MaxUint64)))
+				).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(math.MaxUint64)))
 				bk.On(
 					"SendCoinsFromModuleToModule",
 					mock.Anything,
@@ -671,7 +672,7 @@ func TestProcessProposerMatches_Liquidation_Success(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
-				).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(math.MaxUint64)))
+				).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(math.MaxUint64)))
 				bk.On(
 					"SendCoinsFromModuleToModule",
 					mock.Anything,

--- a/protocol/x/clob/keeper/process_operations_test.go
+++ b/protocol/x/clob/keeper/process_operations_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
-
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
@@ -21,14 +21,13 @@ import (
 	blocktimetypes "github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/memclob"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
-	sakeeper "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-
 	feetierstypes "github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	sakeeper "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MatchWithOrdersForTesting represents a match which occurred between two orders and the amount that was matched.
@@ -1586,7 +1585,7 @@ func setupProcessProposerOperationsTestCase(
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,
-		).Return(sdk.NewCoin("USDC", sdk.NewIntFromUint64(tc.insuranceFundBalance)))
+		).Return(sdk.NewCoin("USDC", sdkmath.NewIntFromUint64(tc.insuranceFundBalance)))
 	}
 
 	mockIndexerEventManager = &mocks.IndexerEventManager{}

--- a/protocol/x/delaymsg/keeper/dispatch_test.go
+++ b/protocol/x/delaymsg/keeper/dispatch_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"fmt"
 	"github.com/cometbft/cometbft/libs/log"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -28,12 +29,12 @@ var (
 
 	DelayMsgAuthority = authtypes.NewModuleAddress(types.ModuleName).String()
 
-	BridgeGenesisAccountBalance = sdk.NewCoin("dv4tnt", sdk.NewInt(1000000000))
-	AliceInitialAccountBalance  = sdk.NewCoin("dv4tnt", sdk.NewInt(99500000000))
+	BridgeGenesisAccountBalance = sdk.NewCoin("dv4tnt", sdkmath.NewInt(1000000000))
+	AliceInitialAccountBalance  = sdk.NewCoin("dv4tnt", sdkmath.NewInt(99500000000))
 
 	delta                        = constants.BridgeEvent_Id0_Height0.Coin.Amount.Int64()
-	BridgeExpectedAccountBalance = sdk.NewCoin("dv4tnt", sdk.NewInt(1000000000-delta))
-	AliceExpectedAccountBalance  = sdk.NewCoin("dv4tnt", sdk.NewInt(99500000000+delta))
+	BridgeExpectedAccountBalance = sdk.NewCoin("dv4tnt", sdkmath.NewInt(1000000000-delta))
+	AliceExpectedAccountBalance  = sdk.NewCoin("dv4tnt", sdkmath.NewInt(99500000000+delta))
 )
 
 func TestDispatchMessagesForBlock(t *testing.T) {

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"fmt"
 	"math/big"
 	"time"
@@ -307,7 +308,7 @@ func (k Keeper) ProcessRewardsForBlock(
 			[]sdk.Coin{
 				{
 					Denom:  params.Denom,
-					Amount: sdk.NewIntFromBigInt(rewardAmountForAddress),
+					Amount: sdkmath.NewIntFromBigInt(rewardAmountForAddress),
 				},
 			},
 		); err != nil {

--- a/protocol/x/rewards/keeper/keeper_test.go
+++ b/protocol/x/rewards/keeper/keeper_test.go
@@ -29,7 +29,7 @@ var (
 		Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
 		Coins: []sdk.Coin{{
 			Denom:  TestRewardTokenDenom,
-			Amount: sdk.NewInt(0),
+			Amount: sdkmath.NewInt(0),
 		}},
 	}
 )
@@ -296,15 +296,15 @@ func TestProcessRewardsForBlock(t *testing.T) {
 		"zero reward share, no change in treasury balance": {
 			rewardShares:           []types.RewardShare{},
 			tokenPrice:             tokenPrice2Usdc,
-			treasuryAccountBalance: sdk.NewInt(1_000_000_000), // 1000 full coins
-			feeMultiplierPpm:       1_000_000,                 // 100%
+			treasuryAccountBalance: sdkmath.NewInt(1_000_000_000), // 1000 full coins
+			feeMultiplierPpm:       1_000_000,                     // 100%
 			// 1$ / 2$ * 100% = 0.5 full coin, all paid to TestAddress1
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(1_000_000_000),
+						Amount: sdkmath.NewInt(1_000_000_000),
 					}},
 				},
 			},
@@ -317,22 +317,22 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				},
 			},
 			tokenPrice:             tokenPrice2Usdc,
-			treasuryAccountBalance: sdk.NewInt(1_000_000_000), // 1000 full coins
-			feeMultiplierPpm:       1_000_000,                 // 100%
+			treasuryAccountBalance: sdkmath.NewInt(1_000_000_000), // 1000 full coins
+			feeMultiplierPpm:       1_000_000,                     // 100%
 			// 1$ / 2$ * 100% = 0.5 full coin, all paid to TestAddress1
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: TestAddress1,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(500_000),
+						Amount: sdkmath.NewInt(500_000),
 					}},
 				},
 				{
 					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(999_500_000), // 999.5 full coins
+						Amount: sdkmath.NewInt(999_500_000), // 999.5 full coins
 					}},
 				},
 			},
@@ -345,22 +345,22 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				},
 			},
 			tokenPrice:             tokenPrice2Usdc,
-			treasuryAccountBalance: sdk.NewInt(1_000_000_000), // 1000 full coins
-			feeMultiplierPpm:       950_000,                   // 95%
+			treasuryAccountBalance: sdkmath.NewInt(1_000_000_000), // 1000 full coins
+			feeMultiplierPpm:       950_000,                       // 95%
 			// 1$ / 2$ * 95% = 0.475 full coin, all paid to TestAddress1
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: TestAddress1,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(475_000),
+						Amount: sdkmath.NewInt(475_000),
 					}},
 				},
 				{
 					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(999_525_000), // 999.525 full coins
+						Amount: sdkmath.NewInt(999_525_000), // 999.525 full coins
 					}},
 				},
 			},
@@ -373,15 +373,15 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				},
 			},
 			tokenPrice:             tokenPrice2Usdc,
-			treasuryAccountBalance: sdk.NewInt(200_000), // 0.2 full coin
-			feeMultiplierPpm:       1_000_000,           // 100%
+			treasuryAccountBalance: sdkmath.NewInt(200_000), // 0.2 full coin
+			feeMultiplierPpm:       1_000_000,               // 100%
 			// 1$ / 2$ * 100% = 0.5 full coin > 0.2 full coin. Pay 0.2 full coin to TestAddress1.
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: TestAddress1,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(200_000),
+						Amount: sdkmath.NewInt(200_000),
 					}},
 				},
 				ZeroTreasuryAccountBalance, // No balance left in treasury.
@@ -395,14 +395,14 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				},
 			},
 			tokenPrice:             tokenPrice2Usdc,
-			treasuryAccountBalance: sdk.NewInt(0),
+			treasuryAccountBalance: sdkmath.NewInt(0),
 			feeMultiplierPpm:       1_000_000, // 100%
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: TestAddress1,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(0),
+						Amount: sdkmath.NewInt(0),
 					}}, // No balance to pay out to TestAddress1.
 				},
 				ZeroTreasuryAccountBalance,
@@ -424,35 +424,35 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				},
 			},
 			tokenPrice:             tokenPrice2Usdc,
-			treasuryAccountBalance: sdk.NewInt(1_000_000_000), // 1000 full coins
-			feeMultiplierPpm:       990_000,                   // 99%
+			treasuryAccountBalance: sdkmath.NewInt(1_000_000_000), // 1000 full coins
+			feeMultiplierPpm:       990_000,                       // 99%
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: TestAddress1,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(495_000), // $1 weight / $2 price * 99% = 0.495 full coin
+						Amount: sdkmath.NewInt(495_000), // $1 weight / $2 price * 99% = 0.495 full coin
 					}},
 				},
 				{
 					Address: TestAddress2,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(990_000), // $2 weight / $2 price * 99% = 0.99 full coin
+						Amount: sdkmath.NewInt(990_000), // $2 weight / $2 price * 99% = 0.99 full coin
 					}},
 				},
 				{
 					Address: TestAddress3,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(1_485_000), // $3 weight / $2 price * 99% = 1.485 full coin
+						Amount: sdkmath.NewInt(1_485_000), // $3 weight / $2 price * 99% = 1.485 full coin
 					}},
 				},
 				{
 					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(997_030_000), // 997.03 full coins
+						Amount: sdkmath.NewInt(997_030_000), // 997.03 full coins
 					}},
 				},
 			},
@@ -473,35 +473,35 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				},
 			},
 			tokenPrice:             tokenPrice2Usdc,
-			treasuryAccountBalance: sdk.NewInt(10_000_000), // 10 full coins
-			feeMultiplierPpm:       1_000_000,              // 100%
+			treasuryAccountBalance: sdkmath.NewInt(10_000_000), // 10 full coins
+			feeMultiplierPpm:       1_000_000,                  // 100%
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: TestAddress1,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(1_666_666), // 1/6 of 10 = 1.666666 full coins
+						Amount: sdkmath.NewInt(1_666_666), // 1/6 of 10 = 1.666666 full coins
 					}},
 				},
 				{
 					Address: TestAddress2,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(3_333_333), // 1/3 of 10 = 3.333333 full coins
+						Amount: sdkmath.NewInt(3_333_333), // 1/3 of 10 = 3.333333 full coins
 					}},
 				},
 				{
 					Address: TestAddress3,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(5_000_000), // 1/2 of 10 = 5 full coins
+						Amount: sdkmath.NewInt(5_000_000), // 1/2 of 10 = 5 full coins
 					}},
 				},
 				{
 					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(1), // 0.000001 full coins left due to rounding
+						Amount: sdkmath.NewInt(1), // 0.000001 full coins left due to rounding
 					}},
 				},
 			},
@@ -522,35 +522,35 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				},
 			},
 			tokenPrice:             tokenPrice1_18Usdc,
-			treasuryAccountBalance: sdk.NewInt(100_000_000), // 100 full coins
-			feeMultiplierPpm:       990_000,                 // 99%
+			treasuryAccountBalance: sdkmath.NewInt(100_000_000), // 100 full coins
+			feeMultiplierPpm:       990_000,                     // 99%
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: TestAddress1,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(56_722081), // 56.722081 full coins
+						Amount: sdkmath.NewInt(56_722081), // 56.722081 full coins
 					}},
 				},
 				{
 					Address: TestAddress2,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(225_876), // 0.225876 full coin
+						Amount: sdkmath.NewInt(225_876), // 0.225876 full coin
 					}},
 				},
 				{
 					Address: TestAddress3,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(43_052_041), // 43.052041 full coins
+						Amount: sdkmath.NewInt(43_052_041), // 43.052041 full coins
 					}},
 				},
 				{
 					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(2), // 0.000002 full coins left due to rounding
+						Amount: sdkmath.NewInt(2), // 0.000002 full coins left due to rounding
 					}},
 				},
 			},
@@ -567,28 +567,28 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				},
 			},
 			tokenPrice:             tokenPrice2Usdc,
-			treasuryAccountBalance: sdk.NewInt(1_000), // 0.001 full coins
-			feeMultiplierPpm:       990_000,           // 0.99
+			treasuryAccountBalance: sdkmath.NewInt(1_000), // 0.001 full coins
+			feeMultiplierPpm:       990_000,               // 0.99
 			expectedBalances: []banktypes.Balance{
 				{
 					Address: TestAddress1,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(999),
+						Amount: sdkmath.NewInt(999),
 					}},
 				},
 				{
 					Address: TestAddress2,
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(0), // rounded to 0
+						Amount: sdkmath.NewInt(0), // rounded to 0
 					}},
 				},
 				{
 					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
-						Amount: sdk.NewInt(1),
+						Amount: sdkmath.NewInt(1),
 					}},
 				},
 			},

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	errorsmod "cosmossdk.io/errors"
-
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -155,7 +155,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 					ctx,
 					testAccAddress,
 					sdk.Coins{
-						sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.accAddressBalance)),
+						sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.accAddressBalance)),
 					},
 					*bankKeeper,
 				)
@@ -167,7 +167,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 					ctx,
 					types.ModuleName,
 					sdk.Coins{
-						sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
+						sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
 					},
 					*bankKeeper,
 				)
@@ -230,7 +230,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 				tc.asset.Denom,
 			)
 			require.Equal(t,
-				sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
+				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
 				subaccountsModuleAccBalance,
 			)
 
@@ -240,7 +240,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 				tc.asset.Denom,
 			)
 			require.Equal(t,
-				sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.expectedAccAddressBalance)),
+				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedAccAddressBalance)),
 				testAccountBalance,
 			)
 		})
@@ -384,7 +384,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 					ctx,
 					testAccAddress,
 					sdk.Coins{
-						sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.accAddressBalance)),
+						sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.accAddressBalance)),
 					},
 					*bankKeeper,
 				)
@@ -396,7 +396,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 					ctx,
 					types.ModuleName,
 					sdk.Coins{
-						sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
+						sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
 					},
 					*bankKeeper,
 				)
@@ -473,7 +473,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 				tc.asset.Denom,
 			)
 			require.Equal(t,
-				sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
+				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
 				subaccountsModuleAccBalance,
 			)
 
@@ -483,7 +483,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 				tc.asset.Denom,
 			)
 			require.Equal(t,
-				sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.accAddressBalance)),
+				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.accAddressBalance)),
 				testAccountBalance,
 			)
 		})
@@ -693,7 +693,7 @@ func TestTransferFundsFromSubaccountToModule_TransferFundsFromModuleToSubaccount
 					ctx,
 					tc.otherModuleName,
 					sdk.Coins{
-						sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.otherModuleAccBalance)),
+						sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.otherModuleAccBalance)),
 					},
 					*bankKeeper,
 				)
@@ -705,7 +705,7 @@ func TestTransferFundsFromSubaccountToModule_TransferFundsFromModuleToSubaccount
 					ctx,
 					types.ModuleName,
 					sdk.Coins{
-						sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
+						sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
 					},
 					*bankKeeper,
 				)
@@ -792,7 +792,7 @@ func TestTransferFundsFromSubaccountToModule_TransferFundsFromModuleToSubaccount
 				tc.asset.Denom,
 			)
 			require.Equal(t,
-				sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
+				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
 				subaccountsModuleAccBalance,
 			)
 
@@ -802,7 +802,7 @@ func TestTransferFundsFromSubaccountToModule_TransferFundsFromModuleToSubaccount
 				tc.asset.Denom,
 			)
 			require.Equal(t,
-				sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.expectedOtherModuleAccBalance)),
+				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedOtherModuleAccBalance)),
 				toModuleBalance,
 			)
 		})
@@ -912,7 +912,7 @@ func TestTransferFeesToFeeCollectorModule(t *testing.T) {
 					ctx,
 					authtypes.FeeCollectorName,
 					sdk.Coins{
-						sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.feeModuleAccBalance)),
+						sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.feeModuleAccBalance)),
 					},
 					*bankKeeper,
 				)
@@ -924,7 +924,7 @@ func TestTransferFeesToFeeCollectorModule(t *testing.T) {
 					ctx,
 					types.ModuleName,
 					sdk.Coins{
-						sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
+						sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
 					},
 					*bankKeeper,
 				)
@@ -979,7 +979,7 @@ func TestTransferFeesToFeeCollectorModule(t *testing.T) {
 				tc.asset.Denom,
 			)
 			require.Equal(t,
-				sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
+				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
 				subaccountsModuleAccBalance,
 			)
 
@@ -989,7 +989,7 @@ func TestTransferFeesToFeeCollectorModule(t *testing.T) {
 				tc.asset.Denom,
 			)
 			require.Equal(t,
-				sdk.NewCoin(tc.asset.Denom, sdk.NewIntFromBigInt(tc.expectedFeeModuleAccBalance)),
+				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedFeeModuleAccBalance)),
 				toModuleBalance,
 			)
 		})

--- a/protocol/x/subaccounts/simulation/genesis.go
+++ b/protocol/x/subaccounts/simulation/genesis.go
@@ -36,7 +36,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 	allSubaccounts := make([]types.Subaccount, 0)
 
 	// Define the total USDC supply as the sum of all USDC quantums in all subaccounts.
-	totalUsdcSupply := sdk.NewInt(0)
+	totalUsdcSupply := sdkmath.NewInt(0)
 
 	for _, acc := range simState.Accounts {
 		saIdNumbers := genSubaccountIdNumbers(r)
@@ -60,7 +60,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 					},
 				}
 
-				bigQuantums := sdk.NewIntFromUint64(quantums)
+				bigQuantums := sdkmath.NewIntFromUint64(quantums)
 				totalUsdcSupply = totalUsdcSupply.Add(bigQuantums)
 			}
 

--- a/protocol/x/subaccounts/simulation/genesis_test.go
+++ b/protocol/x/subaccounts/simulation/genesis_test.go
@@ -7,7 +7,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -45,7 +44,7 @@ func TestRandomizedGenState(t *testing.T) {
 		banksim.RandomizedGenState(&simState)
 		simulation.RandomizedGenState(&simState)
 
-		totalUsdcSupply := sdk.NewInt(0)
+		totalUsdcSupply := sdkmath.NewInt(0)
 
 		var saGenesis types.GenesisState
 		simState.Cdc.MustUnmarshalJSON(simState.GenState[types.ModuleName], &saGenesis)
@@ -65,7 +64,7 @@ func TestRandomizedGenState(t *testing.T) {
 				onlyAssetPosition := sa.GetAssetPositions()[0]
 				require.True(t, onlyAssetPosition.AssetId == lib.UsdcAssetId)
 
-				bigQuantums := sdk.NewIntFromBigInt(onlyAssetPosition.GetBigQuantums())
+				bigQuantums := sdkmath.NewIntFromBigInt(onlyAssetPosition.GetBigQuantums())
 				totalUsdcSupply = totalUsdcSupply.Add(bigQuantums)
 			}
 

--- a/protocol/x/vest/keeper/keeper_test.go
+++ b/protocol/x/vest/keeper/keeper_test.go
@@ -107,7 +107,7 @@ func TestProcessVesting(t *testing.T) {
 		expectedTreasuryBalance sdkmath.Int
 	}{
 		"vesting has not started": {
-			vesterBalance: sdk.NewInt(1_000_000),
+			vesterBalance: sdkmath.NewInt(1_000_000),
 			vestEntry: types.VestEntry{
 				VesterAccount:   testVesterAccount,
 				TreasuryAccount: testTreasuryAccount,
@@ -117,11 +117,11 @@ func TestProcessVesting(t *testing.T) {
 			},
 			prevBlockTime:           time.Unix(1000, 0).In(time.UTC),
 			blockTime:               time.Unix(1001, 0).In(time.UTC),
-			expectedVesterBalance:   sdk.NewInt(1_000_000),
-			expectedTreasuryBalance: sdk.NewInt(0),
+			expectedVesterBalance:   sdkmath.NewInt(1_000_000),
+			expectedTreasuryBalance: sdkmath.NewInt(0),
 		},
 		"vesting has ended": {
-			vesterBalance: sdk.NewInt(0),
+			vesterBalance: sdkmath.NewInt(0),
 			vestEntry: types.VestEntry{
 				VesterAccount:   testVesterAccount,
 				TreasuryAccount: testTreasuryAccount,
@@ -131,11 +131,11 @@ func TestProcessVesting(t *testing.T) {
 			},
 			prevBlockTime:           time.Unix(1000, 0).In(time.UTC),
 			blockTime:               time.Unix(1001, 0).In(time.UTC),
-			expectedVesterBalance:   sdk.NewInt(0),
-			expectedTreasuryBalance: sdk.NewInt(0),
+			expectedVesterBalance:   sdkmath.NewInt(0),
+			expectedTreasuryBalance: sdkmath.NewInt(0),
 		},
 		"vesting in progress, start_time < prev_block_time < block_time < end_time": {
-			vesterBalance: sdk.NewInt(2_000_000),
+			vesterBalance: sdkmath.NewInt(2_000_000),
 			vestEntry: types.VestEntry{
 				VesterAccount:   testVesterAccount,
 				TreasuryAccount: testTreasuryAccount,
@@ -146,11 +146,11 @@ func TestProcessVesting(t *testing.T) {
 			prevBlockTime: time.Unix(1000, 0),
 			blockTime:     time.Unix(1001, 0),
 			// (1001 - 1000) / (2000 - 1000) * 1_000_000 = 1_000
-			expectedTreasuryBalance: sdk.NewInt(2_000),
-			expectedVesterBalance:   sdk.NewInt(1_998_000),
+			expectedTreasuryBalance: sdkmath.NewInt(2_000),
+			expectedVesterBalance:   sdkmath.NewInt(1_998_000),
 		},
 		"vesting in progress, start_time < prev_block_time < block_time < end_time, rounds down": {
-			vesterBalance: sdk.NewInt(2_005_000),
+			vesterBalance: sdkmath.NewInt(2_005_000),
 			vestEntry: types.VestEntry{
 				VesterAccount:   testVesterAccount,
 				TreasuryAccount: testTreasuryAccount,
@@ -161,11 +161,11 @@ func TestProcessVesting(t *testing.T) {
 			prevBlockTime: time.Unix(1000, 0),
 			blockTime:     time.Unix(1001, 500_000_000),
 			// (1001.5 - 1000) / (2000 - 1000) * 2_005_000 = 3007
-			expectedTreasuryBalance: sdk.NewInt(3_007),
-			expectedVesterBalance:   sdk.NewInt(2_001_993),
+			expectedTreasuryBalance: sdkmath.NewInt(3_007),
+			expectedVesterBalance:   sdkmath.NewInt(2_001_993),
 		},
 		"vesting in progress,  start_time < prev_block_time < block_time < end_time, vester has empty balance": {
-			vesterBalance: sdk.NewInt(0),
+			vesterBalance: sdkmath.NewInt(0),
 			vestEntry: types.VestEntry{
 				VesterAccount:   testVesterAccount,
 				TreasuryAccount: testTreasuryAccount,
@@ -175,11 +175,11 @@ func TestProcessVesting(t *testing.T) {
 			},
 			prevBlockTime:           time.Unix(1000, 0),
 			blockTime:               time.Unix(1001, 500_000_000),
-			expectedTreasuryBalance: sdk.NewInt(0),
-			expectedVesterBalance:   sdk.NewInt(0),
+			expectedTreasuryBalance: sdkmath.NewInt(0),
+			expectedVesterBalance:   sdkmath.NewInt(0),
 		},
 		"vesting about to end, start_time < prev_block_time < end_time < block_time, vest all balance": {
-			vesterBalance: sdk.NewInt(2_005_000),
+			vesterBalance: sdkmath.NewInt(2_005_000),
 			vestEntry: types.VestEntry{
 				VesterAccount:   testVesterAccount,
 				TreasuryAccount: testTreasuryAccount,
@@ -189,11 +189,11 @@ func TestProcessVesting(t *testing.T) {
 			},
 			prevBlockTime:           time.Unix(1999, 0).In(time.UTC),
 			blockTime:               time.Unix(2001, 0).In(time.UTC),
-			expectedTreasuryBalance: sdk.NewInt(2_005_000),
-			expectedVesterBalance:   sdk.NewInt(0),
+			expectedTreasuryBalance: sdkmath.NewInt(2_005_000),
+			expectedVesterBalance:   sdkmath.NewInt(0),
 		},
 		"vesting just started, prev_block_time < start_time < block_time < end_time": {
-			vesterBalance: sdk.NewInt(2_005_000),
+			vesterBalance: sdkmath.NewInt(2_005_000),
 			vestEntry: types.VestEntry{
 				VesterAccount:   testVesterAccount,
 				TreasuryAccount: testTreasuryAccount,
@@ -204,11 +204,11 @@ func TestProcessVesting(t *testing.T) {
 			prevBlockTime: time.Unix(499, 0),
 			blockTime:     time.Unix(500, 500_000_000),
 			// 0.5 / (2000 - 500) * 2_005_000 = 668
-			expectedTreasuryBalance: sdk.NewInt(668),
-			expectedVesterBalance:   sdk.NewInt(2_004_332),
+			expectedTreasuryBalance: sdkmath.NewInt(668),
+			expectedVesterBalance:   sdkmath.NewInt(2_004_332),
 		},
 		"vesting just started, prev_block_time < start_time < block_time < end_time, vester has empty balance": {
-			vesterBalance: sdk.NewInt(0),
+			vesterBalance: sdkmath.NewInt(0),
 			vestEntry: types.VestEntry{
 				VesterAccount:   testVesterAccount,
 				TreasuryAccount: testTreasuryAccount,
@@ -218,8 +218,8 @@ func TestProcessVesting(t *testing.T) {
 			},
 			prevBlockTime:           time.Unix(499, 0),
 			blockTime:               time.Unix(500, 500_000_000),
-			expectedTreasuryBalance: sdk.NewInt(0),
-			expectedVesterBalance:   sdk.NewInt(0),
+			expectedTreasuryBalance: sdkmath.NewInt(0),
+			expectedVesterBalance:   sdkmath.NewInt(0),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
This simplifies the upgrade to Cosmos 0.50.0.

See https://github.com/cosmos/cosmos-sdk/blob/3b509c187e1643757f5ef8a0b5ae3decca0c7719/types/math.go#L9 for the deprecation.