### PR TITLE
[CORE-551] - Disallow negative block height queries for delayed message ids

### DIFF
--- a/protocol/x/delaymsg/keeper/block_message_ids.go
+++ b/protocol/x/delaymsg/keeper/block_message_ids.go
@@ -21,6 +21,10 @@ func (k Keeper) GetBlockMessageIds(
 	blockMessageIds types.BlockMessageIds,
 	found bool,
 ) {
+	if blockHeight < 0 {
+		return types.BlockMessageIds{}, false
+	}
+
 	store := k.newBlockMessageIdsStore(ctx)
 	b := store.Get(lib.Int64ToBytesForState(blockHeight))
 

--- a/protocol/x/delaymsg/keeper/block_message_ids_test.go
+++ b/protocol/x/delaymsg/keeper/block_message_ids_test.go
@@ -25,6 +25,12 @@ var (
 	expectedBlock2MessageIds = []uint32{2, 4, 5}
 )
 
+func TestGetBlockMessageIds_NegativeBlockHeight(t *testing.T) {
+	ctx, delaymsg, _, _, _, _ := keeper.DelayMsgKeepers(t)
+	_, found := delaymsg.GetBlockMessageIds(ctx, -1)
+	require.False(t, found)
+}
+
 func TestGetBlockMessageIds_DeleteAllMgs(t *testing.T) {
 	ctx, delaymsg, _, _, _, _ := keeper.DelayMsgKeepers(t)
 

--- a/protocol/x/delaymsg/keeper/grpc_query.go
+++ b/protocol/x/delaymsg/keeper/grpc_query.go
@@ -65,6 +65,11 @@ func (k Keeper) BlockMessageIds(
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
+
+	if req.BlockHeight < 0 {
+		return nil, status.Error(codes.InvalidArgument, "invalid block height")
+	}
+
 	ctx := sdk.UnwrapSDKContext(c)
 
 	blockMessageIds, found := k.GetBlockMessageIds(ctx, req.BlockHeight)

--- a/protocol/x/delaymsg/keeper/grpc_query_test.go
+++ b/protocol/x/delaymsg/keeper/grpc_query_test.go
@@ -118,3 +118,9 @@ func TestBlockMessageIds(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockMessageIds_InvalidHeight(t *testing.T) {
+	ctx, delaymsg, _, _, _, _ := keepertest.DelayMsgKeepers(t)
+	_, err := delaymsg.BlockMessageIds(sdk.WrapSDKContext(ctx), &types.QueryBlockMessageIdsRequest{BlockHeight: -1})
+	require.ErrorContains(t, err, "invalid block height")
+}


### PR DESCRIPTION
This issue came up in conversation with auditors.

Originally, an int64 type was chosen to represent block_height in the delayedmsg module because the context stores block height as an int64, so no type conversions or bound checks were required.

However, the implementation of delaymsg contains a bug: auditors pointed out that we potentially allow queries with negative block height and could even return valid results for another block height if it shares the same uint64 representation as the negative int64. This PR disallows negative numbers from the query and returns "not found" for the keeper method.

 