### PR TITLE
Implement `message_create_oracle_market` msg type

### DIFF
--- a/protocol/daemons/pricefeed/client/types/price_feed_mutable_market_configs_test.go
+++ b/protocol/daemons/pricefeed/client/types/price_feed_mutable_market_configs_test.go
@@ -3,13 +3,14 @@ package types_test
 import (
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/types"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	prices_types "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 const (
@@ -168,30 +169,30 @@ func TestValidateAndTransformParams_Mixed(t *testing.T) {
 		},
 		"Invalid: invalid params (missing pair)": {
 			marketParams: []prices_types.MarketParam{{
-				Id:                1,
-				Exponent:          -2,
-				MinExchanges:      1,
-				MinPriceChangePpm: 1,
+				Id:                 1,
+				Exponent:           -2,
+				MinExchanges:       1,
+				MinPriceChangePpm:  1,
+				ExchangeConfigJson: "{}",
 			}},
 			expectedError: errors.New("invalid market param 0: Pair cannot be empty: Invalid input"),
 		},
-		"Invalid: invalid exchangeConfigJson (empty)": {
+		"Invalid: invalid exchangeConfigJson (empty, fails marketParams.Validate)": {
 			marketParams: []prices_types.MarketParam{{
-				Id:                1,
-				Exponent:          -2,
-				Pair:              "BTC-USD",
-				MinExchanges:      1,
-				MinPriceChangePpm: 1,
+				Id:                 1,
+				Exponent:           -2,
+				Pair:               "BTC-USD",
+				MinExchanges:       1,
+				MinPriceChangePpm:  1,
+				ExchangeConfigJson: "",
 			}},
-			expectedError: errors.New("invalid exchange config json for market param 0: unexpected end of JSON input"),
+			expectedError: errors.New("ExchangeConfigJson string is not valid"),
 		},
-		"Invalid: invalid exchangeConfigJson (not json)": {
+		"Invalid: invalid exchangeConfigJson (not json, fails marketParams.Validate)": {
 			marketParams: []prices_types.MarketParam{
 				validMarketParamWithExchangeConfig("invalid"),
 			},
-			expectedError: errors.New(
-				"invalid exchange config json for market param 0: invalid character 'i' looking for beginning " +
-					"of value"),
+			expectedError: errors.New("ExchangeConfigJson string is not valid"),
 		},
 		"Invalid: invalid exchangeConfigJson (does not conform to schema)": {
 			marketParams: []prices_types.MarketParam{

--- a/protocol/lib/json/json.go
+++ b/protocol/lib/json/json.go
@@ -1,0 +1,15 @@
+package json
+
+import (
+	"encoding/json"
+)
+
+// IsValidJSON checks if a JSON string is well-formed.
+func IsValidJSON(str string) error {
+	var js map[string]interface{}
+	err := json.Unmarshal([]byte(str), &js)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/protocol/lib/json/json_test.go
+++ b/protocol/lib/json/json_test.go
@@ -40,7 +40,7 @@ func TestIsValidJSON(t *testing.T) {
 				"exchanges": [
 				  {
 					"exchangeName": "Binance",
-					"ticker": "\"LINKUSDT\"",
+					"ticker": "LINKUSDT",
 					"adjustByMarket": "USDT-USD"
 				  },
 				  {
@@ -62,7 +62,7 @@ func TestIsValidJSON(t *testing.T) {
 				"exchanges": [
 				  {
 					"exchangeName": "Binance",
-					"ticker": "\"LINKUSDT\"",
+					"ticker": "LINKUSDT",
 					"adjustByMarket": "USDT-USD"
 				  },
 				  {

--- a/protocol/lib/json/json_test.go
+++ b/protocol/lib/json/json_test.go
@@ -1,0 +1,91 @@
+package json_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/lib/json"
+)
+
+func TestIsValidJSON(t *testing.T) {
+	type testCase struct {
+		name    string
+		input   string
+		wantErr bool
+	}
+
+	testCases := []testCase{
+		{
+			name:    "Basic JSON string",
+			input:   `{"key": "value"}`,
+			wantErr: false,
+		},
+		{
+			name:    "Invalid string",
+			input:   `{"key": "value`,
+			wantErr: true,
+		},
+		{
+			name:    "Nested well formed JSON object",
+			input:   `{"key": {"nestedKey": "nestedValue"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Typo in nested JSON object",
+			input:   `{"key": {"nestedKey": "nestedValue}`,
+			wantErr: true,
+		},
+		{
+			name: "Nested well formed JSON object with array",
+			input: `{
+				"exchanges": [
+				  {
+					"exchangeName": "Binance",
+					"ticker": "\"LINKUSDT\"",
+					"adjustByMarket": "USDT-USD"
+				  },
+				  {
+					"exchangeName": "Bitstamp",
+					"ticker": "LINK/USD"
+				  },
+				  {
+					"exchangeName": "Bybit",
+					"ticker": "LINKUSDT",
+					"adjustByMarket": "USDT-USD"
+				  }
+				]
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "Typo in JSON object with array",
+			input: `{
+				"exchanges": [
+				  {
+					"exchangeName": "Binance",
+					"ticker": "\"LINKUSDT\"",
+					"adjustByMarket": "USDT-USD"
+				  },
+				  {
+					"exchangeName": "Bitstamp",
+					"ticker": "LINK/USD"
+				  },
+				  {
+					"exchangeName": "Bybit",
+					"ticker": "LINKUSDT",
+					"adjustByMarket": "USDT-USD"
+				  },
+				]
+			}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := json.IsValidJSON(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("IsValidJSON() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/protocol/testutil/constants/prices.go
+++ b/protocol/testutil/constants/prices.go
@@ -137,7 +137,7 @@ var (
 	}
 	InvalidMsgUpdateMarketPricesStatefulTxBytes []byte
 
-	marketExchangeConfigs = constants.GenerateExchangeConfigJson(constants.StaticExchangeMarketConfig)
+	TestMarketExchangeConfigs = constants.GenerateExchangeConfigJson(constants.StaticExchangeMarketConfig)
 
 	Prices_DefaultGenesisState = types.GenesisState{
 		// `ExchangeConfigJson` is left unset as it is not used by the server.
@@ -147,7 +147,7 @@ var (
 				Pair:               BtcUsdPair,
 				Exponent:           BtcUsdExponent,
 				MinExchanges:       uint32(2),
-				ExchangeConfigJson: marketExchangeConfigs[exchange_common.MARKET_BTC_USD],
+				ExchangeConfigJson: TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 				MinPriceChangePpm:  uint32(50),
 			},
 			{
@@ -155,7 +155,7 @@ var (
 				Pair:               EthUsdPair,
 				Exponent:           EthUsdExponent,
 				MinExchanges:       uint32(1),
-				ExchangeConfigJson: marketExchangeConfigs[exchange_common.MARKET_ETH_USD],
+				ExchangeConfigJson: TestMarketExchangeConfigs[exchange_common.MARKET_ETH_USD],
 				MinPriceChangePpm:  uint32(50),
 			},
 		},
@@ -180,7 +180,7 @@ var (
 				Id:                 uint32(0),
 				Pair:               BtcUsdPair,
 				Exponent:           BtcUsdExponent,
-				ExchangeConfigJson: marketExchangeConfigs[exchange_common.MARKET_BTC_USD],
+				ExchangeConfigJson: TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 				MinExchanges:       uint32(2),
 				MinPriceChangePpm:  uint32(50),
 			},
@@ -188,7 +188,7 @@ var (
 				Id:                 uint32(1),
 				Pair:               EthUsdPair,
 				Exponent:           EthUsdExponent,
-				ExchangeConfigJson: marketExchangeConfigs[exchange_common.MARKET_ETH_USD],
+				ExchangeConfigJson: TestMarketExchangeConfigs[exchange_common.MARKET_ETH_USD],
 				MinExchanges:       uint32(2),
 				MinPriceChangePpm:  uint32(50),
 			},

--- a/protocol/testutil/constants/prices.go
+++ b/protocol/testutil/constants/prices.go
@@ -1,8 +1,8 @@
 package constants
 
 import (
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
+	pricefeedclient "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
@@ -51,7 +51,157 @@ const (
 	ErrorMsgInvalidMinPriceChange   = "Min price change in parts-per-million must be greater than 0 and less than 10000"
 )
 
-var TestMarketExchangeConfigs = constants.GenerateExchangeConfigJson(constants.StaticExchangeMarketConfig)
+var TestMarketExchangeConfigs = map[pricefeedclient.MarketId]string{
+	exchange_common.MARKET_BTC_USD: `{
+		"exchanges": [
+		  {
+			"exchangeName": "Binance",
+			"ticker": "BTCUSDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "BinanceUS",
+			"ticker": "BTCUSDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Bitfinex",
+			"ticker": "tBTCUSD"
+		  },
+		  {
+			"exchangeName": "Bitstamp",
+			"ticker": "BTC/USD"
+		  },
+		  {
+			"exchangeName": "Bybit",
+			"ticker": "BTCUSDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "CoinbasePro",
+			"ticker": "BTC-USD"
+		  },
+		  {
+			"exchangeName": "CryptoCom",
+			"ticker": "BTC_USD"
+		  },
+		  {
+			"exchangeName": "Kraken",
+			"ticker": "XXBTZUSD"
+		  },
+		  {
+			"exchangeName": "Mexc",
+			"ticker": "BTC_USDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Okx",
+			"ticker": "BTC-USDT",
+			"adjustByMarket": "USDT-USD"
+		  }
+		]
+	  }`,
+	exchange_common.MARKET_ETH_USD: `{
+		"exchanges": [
+		  {
+			"exchangeName": "Binance",
+			"ticker": "ETHUSDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "BinanceUS",
+			"ticker": "ETHUSDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Bitfinex",
+			"ticker": "tETHUSD"
+		  },
+		  {
+			"exchangeName": "Bitstamp",
+			"ticker": "ETH/USD"
+		  },
+		  {
+			"exchangeName": "Bybit",
+			"ticker": "ETHUSDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "CoinbasePro",
+			"ticker": "ETH-USD"
+		  },
+		  {
+			"exchangeName": "CryptoCom",
+			"ticker": "ETH_USD"
+		  },
+		  {
+			"exchangeName": "Kraken",
+			"ticker": "XETHZUSD"
+		  },
+		  {
+			"exchangeName": "Mexc",
+			"ticker": "ETH_USDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Okx",
+			"ticker": "ETH-USDT",
+			"adjustByMarket": "USDT-USD"
+		  }
+		]
+	  }`,
+	exchange_common.MARKET_SOL_USD: `{
+		"exchanges": [
+		  {
+			"exchangeName": "Binance",
+			"ticker": "SOLUSDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Bitfinex",
+			"ticker": "tSOLUSD",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Bybit",
+			"ticker": "SOLUSDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "CoinbasePro",
+			"ticker": "SOL-USD"
+		  },
+		  {
+			"exchangeName": "CryptoCom",
+			"ticker": "SOL_USD"
+		  },
+		  {
+			"exchangeName": "Huobi",
+			"ticker": "solusdt",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Kraken",
+			"ticker": "SOLUSD"
+		  },
+		  {
+			"exchangeName": "Kucoin",
+			"ticker": "SOL-USDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Mexc",
+			"ticker": "SOL_USDT",
+			"adjustByMarket": "USDT-USD"
+		  },
+		  {
+			"exchangeName": "Okx",
+			"ticker": "SOL-USDT",
+			"adjustByMarket": "USDT-USD"
+		  }
+		]
+	  }`,
+}
 
 // The `MarketParam.ExchangeConfigJson` field is left unset as it is not used by the server.
 var TestMarketParams = []types.MarketParam{

--- a/protocol/testutil/constants/prices.go
+++ b/protocol/testutil/constants/prices.go
@@ -51,28 +51,33 @@ const (
 	ErrorMsgInvalidMinPriceChange   = "Min price change in parts-per-million must be greater than 0 and less than 10000"
 )
 
+var TestMarketExchangeConfigs = constants.GenerateExchangeConfigJson(constants.StaticExchangeMarketConfig)
+
 // The `MarketParam.ExchangeConfigJson` field is left unset as it is not used by the server.
 var TestMarketParams = []types.MarketParam{
 	{
-		Id:                0,
-		Pair:              BtcUsdPair,
-		Exponent:          BtcUsdExponent,
-		MinExchanges:      1,
-		MinPriceChangePpm: 50,
+		Id:                 0,
+		Pair:               BtcUsdPair,
+		Exponent:           BtcUsdExponent,
+		MinExchanges:       1,
+		MinPriceChangePpm:  50,
+		ExchangeConfigJson: TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 	},
 	{
-		Id:                1,
-		Pair:              EthUsdPair,
-		Exponent:          EthUsdExponent,
-		MinExchanges:      1,
-		MinPriceChangePpm: 50,
+		Id:                 1,
+		Pair:               EthUsdPair,
+		Exponent:           EthUsdExponent,
+		MinExchanges:       1,
+		MinPriceChangePpm:  50,
+		ExchangeConfigJson: TestMarketExchangeConfigs[exchange_common.MARKET_ETH_USD],
 	},
 	{
-		Id:                2,
-		Pair:              SolUsdPair,
-		Exponent:          SolUsdExponent,
-		MinExchanges:      1,
-		MinPriceChangePpm: 50,
+		Id:                 2,
+		Pair:               SolUsdPair,
+		Exponent:           SolUsdExponent,
+		MinExchanges:       1,
+		MinPriceChangePpm:  50,
+		ExchangeConfigJson: TestMarketExchangeConfigs[exchange_common.MARKET_SOL_USD],
 	},
 }
 
@@ -136,8 +141,6 @@ var (
 		},
 	}
 	InvalidMsgUpdateMarketPricesStatefulTxBytes []byte
-
-	TestMarketExchangeConfigs = constants.GenerateExchangeConfigJson(constants.StaticExchangeMarketConfig)
 
 	Prices_DefaultGenesisState = types.GenesisState{
 		// `ExchangeConfigJson` is left unset as it is not used by the server.

--- a/protocol/testutil/constants/prices.go
+++ b/protocol/testutil/constants/prices.go
@@ -203,7 +203,6 @@ var TestMarketExchangeConfigs = map[pricefeedclient.MarketId]string{
 	  }`,
 }
 
-// The `MarketParam.ExchangeConfigJson` field is left unset as it is not used by the server.
 var TestMarketParams = []types.MarketParam{
 	{
 		Id:                 0,
@@ -293,7 +292,6 @@ var (
 	InvalidMsgUpdateMarketPricesStatefulTxBytes []byte
 
 	Prices_DefaultGenesisState = types.GenesisState{
-		// `ExchangeConfigJson` is left unset as it is not used by the server.
 		MarketParams: []types.MarketParam{
 			{
 				Id:                 uint32(0),
@@ -327,7 +325,6 @@ var (
 	}
 
 	Prices_MultiExchangeMarketGenesisState = types.GenesisState{
-		// `ExchangeConfigJson` is left unset as it is unused by the server.
 		MarketParams: []types.MarketParam{
 			{ // BTC-USD
 				Id:                 uint32(0),

--- a/protocol/testutil/keeper/prices.go
+++ b/protocol/testutil/keeper/prices.go
@@ -126,6 +126,7 @@ func CreateNMarkets(t *testing.T, ctx sdk.Context, keeper *keeper.Keeper, n int)
 		items[i].Price.Id = uint32(i) + numExistingMarkets
 		items[i].Price.Exponent = int32(i)
 		items[i].Price.Price = uint64(1_000 + i)
+		items[i].Param.ExchangeConfigJson = "{}" // Use empty, valid JSON for testing.
 
 		_, err := keeper.CreateMarket(
 			ctx,

--- a/protocol/testutil/prices/cli/util.go
+++ b/protocol/testutil/prices/cli/util.go
@@ -23,10 +23,11 @@ func NetworkWithMarketObjects(t *testing.T, n int) (*network.Network, []types.Ma
 	// Market params
 	for i := 0; i < n; i++ {
 		marketParam := types.MarketParam{
-			Id:                uint32(i),
-			Pair:              fmt.Sprint(constants.BtcUsdPair, i),
-			MinExchanges:      uint32(1),
-			MinPriceChangePpm: uint32((i + 1) * 2),
+			Id:                 uint32(i),
+			Pair:               fmt.Sprint(constants.BtcUsdPair, i),
+			MinExchanges:       uint32(1),
+			MinPriceChangePpm:  uint32((i + 1) * 2),
+			ExchangeConfigJson: "{}",
 		}
 		state.MarketParams = append(state.MarketParams, marketParam)
 	}

--- a/protocol/testutil/prices/market_param_price.go
+++ b/protocol/testutil/prices/market_param_price.go
@@ -32,11 +32,12 @@ func WithPair(pair string) MarketParamPriceModifierOption {
 func GenerateMarketParamPrice(optionalModifications ...MarketParamPriceModifierOption) *pricestypes.MarketParamPrice {
 	marketParamPrice := &pricestypes.MarketParamPrice{
 		Param: pricestypes.MarketParam{
-			Id:                0,
-			Pair:              "BTC-USDC",
-			MinExchanges:      3,
-			MinPriceChangePpm: 100,
-			Exponent:          -8,
+			Id:                 0,
+			Pair:               "BTC-USDC",
+			MinExchanges:       3,
+			MinPriceChangePpm:  100,
+			Exponent:           -8,
+			ExchangeConfigJson: "{}",
 		},
 		Price: pricestypes.MarketPrice{
 			Id:       0,

--- a/protocol/x/perpetuals/keeper/perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/perpetual_test.go
@@ -1,12 +1,13 @@
 package keeper_test
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math"
 	"math/big"
 	"sort"
 	"testing"
+
+	errorsmod "cosmossdk.io/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/common"
@@ -270,13 +271,13 @@ func TestHasPerpetual(t *testing.T) {
 
 	_, err := pricesKeeper.CreateMarket(
 		ctx,
-		// `ExchangeConfigJson` is left unset as it is not used by the server.
 		pricestypes.MarketParam{
-			Id:                0,
-			Pair:              "marketName",
-			Exponent:          -10,
-			MinExchanges:      uint32(1),
-			MinPriceChangePpm: uint32(50),
+			Id:                 0,
+			Pair:               "marketName",
+			Exponent:           -10,
+			MinExchanges:       uint32(1),
+			MinPriceChangePpm:  uint32(50),
+			ExchangeConfigJson: "{}",
 		},
 		pricestypes.MarketPrice{
 			Id:       0,
@@ -348,13 +349,13 @@ func TestGetAllPerpetuals_Sorted(t *testing.T) {
 
 	_, err := pricesKeeper.CreateMarket(
 		ctx,
-		// `ExchangeConfigJson` is left unset as it is not used by the server.
 		pricestypes.MarketParam{
-			Id:                0,
-			Pair:              "marketName",
-			Exponent:          -10,
-			MinExchanges:      uint32(1),
-			MinPriceChangePpm: uint32(50),
+			Id:                 0,
+			Pair:               "marketName",
+			Exponent:           -10,
+			MinExchanges:       uint32(1),
+			MinPriceChangePpm:  uint32(50),
+			ExchangeConfigJson: "{}",
 		},
 		pricestypes.MarketPrice{
 			Id:       0,
@@ -620,13 +621,13 @@ func TestGetMarginRequirements_Success(t *testing.T) {
 			marketId := pricesKeeper.GetNumMarkets(ctx)
 			_, err := pricesKeeper.CreateMarket(
 				ctx,
-				// `ExchangeConfigJson` is left unset as it is not used by the server.
 				pricestypes.MarketParam{
-					Id:                marketId,
-					Pair:              "marketName",
-					Exponent:          tc.exponent,
-					MinExchanges:      uint32(1),
-					MinPriceChangePpm: uint32(50),
+					Id:                 marketId,
+					Pair:               "marketName",
+					Exponent:           tc.exponent,
+					MinExchanges:       uint32(1),
+					MinPriceChangePpm:  uint32(50),
+					ExchangeConfigJson: "{}",
 				},
 				pricestypes.MarketPrice{
 					Id:       marketId,
@@ -850,11 +851,12 @@ func TestGetNetNotional_Success(t *testing.T) {
 			_, err := pricesKeeper.CreateMarket(
 				ctx,
 				pricestypes.MarketParam{
-					Id:                marketId,
-					Pair:              "marketName",
-					Exponent:          tc.exponent,
-					MinExchanges:      uint32(1),
-					MinPriceChangePpm: uint32(50),
+					Id:                 marketId,
+					Pair:               "marketName",
+					Exponent:           tc.exponent,
+					MinExchanges:       uint32(1),
+					MinPriceChangePpm:  uint32(50),
+					ExchangeConfigJson: "{}",
 				},
 				pricestypes.MarketPrice{
 					Id:       marketId,
@@ -1014,11 +1016,12 @@ func TestGetNotionalInBaseQuantums_Success(t *testing.T) {
 			_, err := pricesKeeper.CreateMarket(
 				ctx,
 				pricestypes.MarketParam{
-					Id:                marketId,
-					Pair:              "marketName",
-					Exponent:          tc.exponent,
-					MinExchanges:      uint32(1),
-					MinPriceChangePpm: uint32(50),
+					Id:                 marketId,
+					Pair:               "marketName",
+					Exponent:           tc.exponent,
+					MinExchanges:       uint32(1),
+					MinPriceChangePpm:  uint32(50),
+					ExchangeConfigJson: "{}",
 				},
 				pricestypes.MarketPrice{
 					Id:       marketId,
@@ -1179,11 +1182,12 @@ func TestGetNetCollateral_Success(t *testing.T) {
 			_, err := pricesKeeper.CreateMarket(
 				ctx,
 				pricestypes.MarketParam{
-					Id:                marketId,
-					Pair:              "marketName",
-					Exponent:          tc.exponent,
-					MinExchanges:      uint32(1),
-					MinPriceChangePpm: uint32(50),
+					Id:                 marketId,
+					Pair:               "marketName",
+					Exponent:           tc.exponent,
+					MinExchanges:       uint32(1),
+					MinPriceChangePpm:  uint32(50),
+					ExchangeConfigJson: "{}",
 				},
 				pricestypes.MarketPrice{
 					Id:       marketId,

--- a/protocol/x/perpetuals/module_test.go
+++ b/protocol/x/perpetuals/module_test.go
@@ -290,11 +290,12 @@ func TestAppModule_InitExportGenesis(t *testing.T) {
 	if _, err := pricesKeeper.CreateMarket(
 		ctx,
 		pricetypes.MarketParam{
-			Id:                0,
-			Pair:              constants.EthUsdPair,
-			Exponent:          -2,
-			MinExchanges:      1,
-			MinPriceChangePpm: 1_000,
+			Id:                 0,
+			Pair:               constants.EthUsdPair,
+			Exponent:           -2,
+			MinExchanges:       1,
+			MinPriceChangePpm:  1_000,
+			ExchangeConfigJson: "{}",
 		},
 		pricetypes.MarketPrice{
 			Id:       0,

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -38,12 +38,8 @@ func TestModifyMarketParam(t *testing.T) {
 		require.Equal(t, item.Param.Exponent, newItem.Exponent)
 		require.Equal(t, uint32(2), newItem.MinExchanges)
 		require.Equal(t, uint32(9999-i), newItem.MinPriceChangePpm)
-<<<<<<< HEAD
 		require.Equal(t, fmt.Sprintf("foo_%v", i), metrics.GetMarketPairForTelemetry(item.Param.Id))
-		require.Equal(t, fmt.Sprintf("{\"id\":\"%v\"}", i), newItem.ExchangeConfigJson)
-=======
 		require.Equal(t, fmt.Sprintf(`{"id":"%v"}`, i), newItem.ExchangeConfigJson)
->>>>>>> dea84f7 (comments)
 		keepertest.AssertMarketModifyEventInIndexerBlock(t, keeper, ctx, newItem)
 	}
 }

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -1,10 +1,12 @@
 package keeper_test
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
 	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
+
+	errorsmod "cosmossdk.io/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
@@ -27,7 +29,7 @@ func TestModifyMarketParam(t *testing.T) {
 				MinExchanges:       uint32(2),
 				Exponent:           item.Param.Exponent,
 				MinPriceChangePpm:  uint32(9_999 - i),
-				ExchangeConfigJson: fmt.Sprintf("config_%v", i),
+				ExchangeConfigJson: fmt.Sprintf("{\"id\":\"%v\"}", i),
 			},
 		)
 		require.NoError(t, err)
@@ -36,58 +38,75 @@ func TestModifyMarketParam(t *testing.T) {
 		require.Equal(t, item.Param.Exponent, newItem.Exponent)
 		require.Equal(t, uint32(2), newItem.MinExchanges)
 		require.Equal(t, uint32(9999-i), newItem.MinPriceChangePpm)
-		require.Equal(t, fmt.Sprintf("config_%v", i), newItem.ExchangeConfigJson)
-
 		require.Equal(t, fmt.Sprintf("foo_%v", i), metrics.GetMarketPairForTelemetry(item.Param.Id))
-
+		require.Equal(t, fmt.Sprintf("{\"id\":\"%v\"}", i), newItem.ExchangeConfigJson)
 		keepertest.AssertMarketModifyEventInIndexerBlock(t, keeper, ctx, newItem)
 	}
 }
 
 func TestModifyMarketParam_Errors(t *testing.T) {
+	validExchangeConfigJson := "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]}"
 	tests := map[string]struct {
 		// Setup
-		targetId          uint32
-		pair              string
-		minExchanges      uint32
-		minPriceChangePpm uint32
+		targetId           uint32
+		pair               string
+		minExchanges       uint32
+		minPriceChangePpm  uint32
+		exchangeConfigJson string
 
 		// Expected
 		expectedErr string
 	}{
 		"Market not found": {
-			targetId:          99, // this market id does not exist
-			pair:              constants.BtcUsdPair,
-			minExchanges:      uint32(2),
-			minPriceChangePpm: uint32(50),
-			expectedErr:       errorsmod.Wrap(types.ErrMarketParamDoesNotExist, "99").Error(),
+			targetId:           99, // this market id does not exist
+			pair:               constants.BtcUsdPair,
+			minExchanges:       uint32(2),
+			minPriceChangePpm:  uint32(50),
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        errorsmod.Wrap(types.ErrMarketParamDoesNotExist, "99").Error(),
 		},
 		"Empty pair": {
-			targetId:          0,
-			pair:              "", // pair cannot be empty
-			minExchanges:      uint32(2),
-			minPriceChangePpm: uint32(50),
-			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgMarketPairCannotBeEmpty).Error(),
+			targetId:           0,
+			pair:               "", // pair cannot be empty
+			minExchanges:       uint32(2),
+			minPriceChangePpm:  uint32(50),
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgMarketPairCannotBeEmpty).Error(),
 		},
 		"Invalid min price change: zero": {
-			targetId:          0,
-			pair:              constants.BtcUsdPair,
-			minExchanges:      uint32(2),
-			minPriceChangePpm: uint32(0), // must be > 0
-			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
+			targetId:           0,
+			pair:               constants.BtcUsdPair,
+			minExchanges:       uint32(2),
+			minPriceChangePpm:  uint32(0), // must be > 0
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
 		},
 		"Invalid min price change: ten thousand": {
-			targetId:          0,
-			pair:              constants.BtcUsdPair,
-			minExchanges:      uint32(2),
-			minPriceChangePpm: uint32(10_000), // must be < 10,000
-			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
+			targetId:           0,
+			pair:               constants.BtcUsdPair,
+			minExchanges:       uint32(2),
+			minPriceChangePpm:  uint32(10_000), // must be < 10,000
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
 		},
 		"Min exchanges cannot be zero": {
-			pair:              constants.BtcUsdPair,
-			minExchanges:      uint32(0), // cannot be zero
-			minPriceChangePpm: uint32(50),
-			expectedErr:       types.ErrZeroMinExchanges.Error(),
+			pair:               constants.BtcUsdPair,
+			minExchanges:       uint32(0), // cannot be zero
+			minPriceChangePpm:  uint32(50),
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        types.ErrZeroMinExchanges.Error(),
+		},
+		"Empty exchange config json string": {
+			pair:               constants.BtcUsdPair,
+			minExchanges:       uint32(1),
+			minPriceChangePpm:  uint32(50),
+			exchangeConfigJson: "",
+			expectedErr: errorsmod.Wrapf(
+				types.ErrInvalidInput,
+				"ExchangeConfigJson string is not valid: err=%v, input=%v",
+				"unexpected end of JSON input",
+				"",
+			).Error(),
 		},
 	}
 	for name, tc := range tests {
@@ -98,10 +117,11 @@ func TestModifyMarketParam_Errors(t *testing.T) {
 			_, err := keeper.ModifyMarketParam(
 				ctx,
 				types.MarketParam{
-					Id:                tc.targetId,
-					Pair:              tc.pair,
-					MinExchanges:      tc.minExchanges,
-					MinPriceChangePpm: tc.minPriceChangePpm,
+					Id:                 tc.targetId,
+					Pair:               tc.pair,
+					MinExchanges:       tc.minExchanges,
+					MinPriceChangePpm:  tc.minPriceChangePpm,
+					ExchangeConfigJson: tc.exchangeConfigJson,
 				},
 			)
 			require.EqualError(t, err, tc.expectedErr)

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -29,7 +29,7 @@ func TestModifyMarketParam(t *testing.T) {
 				MinExchanges:       uint32(2),
 				Exponent:           item.Param.Exponent,
 				MinPriceChangePpm:  uint32(9_999 - i),
-				ExchangeConfigJson: fmt.Sprintf("{\"id\":\"%v\"}", i),
+				ExchangeConfigJson: fmt.Sprintf(`{"id":"%v"}`, i),
 			},
 		)
 		require.NoError(t, err)
@@ -38,8 +38,12 @@ func TestModifyMarketParam(t *testing.T) {
 		require.Equal(t, item.Param.Exponent, newItem.Exponent)
 		require.Equal(t, uint32(2), newItem.MinExchanges)
 		require.Equal(t, uint32(9999-i), newItem.MinPriceChangePpm)
+<<<<<<< HEAD
 		require.Equal(t, fmt.Sprintf("foo_%v", i), metrics.GetMarketPairForTelemetry(item.Param.Id))
 		require.Equal(t, fmt.Sprintf("{\"id\":\"%v\"}", i), newItem.ExchangeConfigJson)
+=======
+		require.Equal(t, fmt.Sprintf(`{"id":"%v"}`, i), newItem.ExchangeConfigJson)
+>>>>>>> dea84f7 (comments)
 		keepertest.AssertMarketModifyEventInIndexerBlock(t, keeper, ctx, newItem)
 	}
 }

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -49,7 +49,7 @@ func TestModifyMarketParam(t *testing.T) {
 }
 
 func TestModifyMarketParam_Errors(t *testing.T) {
-	validExchangeConfigJson := "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]}"
+	validExchangeConfigJson := `{"exchanges":[{"exchangeName":"Binance","ticker":"BTCUSDT"}]}`
 	tests := map[string]struct {
 		// Setup
 		targetId           uint32

--- a/protocol/x/prices/keeper/market_test.go
+++ b/protocol/x/prices/keeper/market_test.go
@@ -1,10 +1,11 @@
 package keeper_test
 
 import (
-	errorsmod "cosmossdk.io/errors"
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
 	"testing"
 
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
+
+	errorsmod "cosmossdk.io/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
@@ -22,7 +23,7 @@ func TestCreateMarket(t *testing.T) {
 			Id:                 0,
 			Pair:               constants.BtcUsdPair,
 			Exponent:           int32(-6),
-			ExchangeConfigJson: "test_config_placeholder",
+			ExchangeConfigJson: "{\"test_config_placeholder\":{}}",
 			MinExchanges:       2,
 			MinPriceChangePpm:  uint32(9_999),
 		},
@@ -41,7 +42,7 @@ func TestCreateMarket(t *testing.T) {
 	require.Equal(t, uint32(0), marketParam.Id)
 	require.Equal(t, constants.BtcUsdPair, marketParam.Pair)
 	require.Equal(t, int32(-6), marketParam.Exponent)
-	require.Equal(t, "test_config_placeholder", marketParam.ExchangeConfigJson)
+	require.Equal(t, "{\"test_config_placeholder\":{}}", marketParam.ExchangeConfigJson)
 	require.Equal(t, uint32(2), marketParam.MinExchanges)
 	require.Equal(t, uint32(9999), marketParam.MinPriceChangePpm)
 
@@ -57,6 +58,7 @@ func TestCreateMarket(t *testing.T) {
 }
 
 func TestCreateMarket_Errors(t *testing.T) {
+	validExchangeConfigJson := "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]}"
 	tests := map[string]struct {
 		// Setup
 		pair                                              string
@@ -65,22 +67,25 @@ func TestCreateMarket_Errors(t *testing.T) {
 		price                                             uint64
 		marketPriceIdDoesntMatchMarketParamId             bool
 		marketPriceExponentDoesntMatchMarketParamExponent bool
+		exchangeConfigJson                                string
 		// Expected
 		expectedErr string
 	}{
 		"Empty pair": {
-			pair:              "", // pair cannot be empty
-			minExchanges:      uint32(2),
-			minPriceChangePpm: uint32(50),
-			price:             constants.FiveBillion,
-			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgMarketPairCannotBeEmpty).Error(),
+			pair:               "", // pair cannot be empty
+			minExchanges:       uint32(2),
+			minPriceChangePpm:  uint32(50),
+			price:              constants.FiveBillion,
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgMarketPairCannotBeEmpty).Error(),
 		},
 		"Invalid min price change: zero": {
-			pair:              constants.BtcUsdPair,
-			minExchanges:      uint32(2),
-			minPriceChangePpm: uint32(0), // must be > 0
-			price:             constants.FiveBillion,
-			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
+			pair:               constants.BtcUsdPair,
+			minExchanges:       uint32(2),
+			minPriceChangePpm:  uint32(0), // must be > 0
+			price:              constants.FiveBillion,
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
 		},
 		"Invalid min price change: ten thousand": {
 			pair:              constants.BtcUsdPair,
@@ -90,11 +95,12 @@ func TestCreateMarket_Errors(t *testing.T) {
 			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, constants.ErrorMsgInvalidMinPriceChange).Error(),
 		},
 		"Min exchanges cannot be zero": {
-			pair:              constants.BtcUsdPair,
-			minExchanges:      uint32(0), // cannot be zero
-			minPriceChangePpm: uint32(50),
-			price:             constants.FiveBillion,
-			expectedErr:       types.ErrZeroMinExchanges.Error(),
+			pair:               constants.BtcUsdPair,
+			minExchanges:       uint32(0), // cannot be zero
+			minPriceChangePpm:  uint32(50),
+			price:              constants.FiveBillion,
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        types.ErrZeroMinExchanges.Error(),
 		},
 		"Market param and price ids don't match": {
 			pair:                                  constants.BtcUsdPair,
@@ -102,6 +108,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 			minPriceChangePpm:                     uint32(50),
 			price:                                 constants.FiveBillion,
 			marketPriceIdDoesntMatchMarketParamId: true,
+			exchangeConfigJson:                    validExchangeConfigJson,
 			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidInput,
 				"market param id 0 does not match market price id 1",
@@ -113,17 +120,19 @@ func TestCreateMarket_Errors(t *testing.T) {
 			minPriceChangePpm: uint32(50),
 			price:             constants.FiveBillion,
 			marketPriceExponentDoesntMatchMarketParamExponent: true,
+			exchangeConfigJson: validExchangeConfigJson,
 			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidInput,
 				"market param 0 exponent -6 does not match market price 0 exponent -5",
 			).Error(),
 		},
 		"Market price is 0": {
-			pair:              constants.BtcUsdPair,
-			minExchanges:      uint32(2),
-			minPriceChangePpm: uint32(50),
-			price:             uint64(0),
-			expectedErr:       errorsmod.Wrap(types.ErrInvalidInput, "market 0 price cannot be zero").Error(),
+			pair:               constants.BtcUsdPair,
+			minExchanges:       uint32(2),
+			minPriceChangePpm:  uint32(50),
+			price:              uint64(0),
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr:        errorsmod.Wrap(types.ErrInvalidInput, "market 0 price cannot be zero").Error(),
 		},
 	}
 	for name, tc := range tests {
@@ -144,11 +153,12 @@ func TestCreateMarket_Errors(t *testing.T) {
 			_, err := keeper.CreateMarket(
 				ctx,
 				types.MarketParam{
-					Id:                0,
-					Pair:              tc.pair,
-					Exponent:          int32(-6),
-					MinExchanges:      tc.minExchanges,
-					MinPriceChangePpm: tc.minPriceChangePpm,
+					Id:                 0,
+					Pair:               tc.pair,
+					Exponent:           int32(-6),
+					MinExchanges:       tc.minExchanges,
+					MinPriceChangePpm:  tc.minPriceChangePpm,
+					ExchangeConfigJson: tc.exchangeConfigJson,
 				},
 				types.MarketPrice{
 					Id:       0 + marketPriceIdOffset,

--- a/protocol/x/prices/keeper/market_test.go
+++ b/protocol/x/prices/keeper/market_test.go
@@ -23,7 +23,7 @@ func TestCreateMarket(t *testing.T) {
 			Id:                 0,
 			Pair:               constants.BtcUsdPair,
 			Exponent:           int32(-6),
-			ExchangeConfigJson: "{\"test_config_placeholder\":{}}",
+			ExchangeConfigJson: `{"test_config_placeholder":{}}`,
 			MinExchanges:       2,
 			MinPriceChangePpm:  uint32(9_999),
 		},
@@ -42,7 +42,7 @@ func TestCreateMarket(t *testing.T) {
 	require.Equal(t, uint32(0), marketParam.Id)
 	require.Equal(t, constants.BtcUsdPair, marketParam.Pair)
 	require.Equal(t, int32(-6), marketParam.Exponent)
-	require.Equal(t, "{\"test_config_placeholder\":{}}", marketParam.ExchangeConfigJson)
+	require.Equal(t, `{"test_config_placeholder":{}}`, marketParam.ExchangeConfigJson)
 	require.Equal(t, uint32(2), marketParam.MinExchanges)
 	require.Equal(t, uint32(9999), marketParam.MinPriceChangePpm)
 
@@ -58,7 +58,7 @@ func TestCreateMarket(t *testing.T) {
 }
 
 func TestCreateMarket_Errors(t *testing.T) {
-	validExchangeConfigJson := "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]}"
+	validExchangeConfigJson := `{"exchanges":[{"exchangeName":"Binance","ticker":"BTCUSDT"}]}`
 	tests := map[string]struct {
 		// Setup
 		pair                                              string

--- a/protocol/x/prices/module_test.go
+++ b/protocol/x/prices/module_test.go
@@ -2,12 +2,13 @@ package prices_test
 
 import (
 	"bytes"
-	errorsmod "cosmossdk.io/errors"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	errorsmod "cosmossdk.io/errors"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -32,7 +33,7 @@ const (
 	// This genesis state is formatted to export back to itself. It explicitly defines all fields using valid defaults.
 	validGenesisState = `{` +
 		`"market_params":[{"id":0,"pair":"DENT-USD","exponent":0,"min_exchanges":1,"min_price_change_ppm":1,` +
-		`"exchange_config_json":""}],` +
+		`"exchange_config_json":"{}"}],` +
 		`"market_prices":[{"id":0,"exponent":0,"price":"1"}]` +
 		`}`
 )
@@ -138,8 +139,8 @@ func TestAppModuleBasic_ValidateGenesisErr(t *testing.T) {
 		},
 		"Bad state: duplicate market param id": {
 			genesisJson: `{"market_params": [` +
-				`{"id":0,"pair": "DENT-USD","minExchanges":1,"minPriceChangePpm":1},` +
-				`{"id":0,"pair": "LINK-USD","minExchanges":1,"minPriceChangePpm":1}` +
+				`{"id":0,"pair": "DENT-USD","minExchanges":1,"minPriceChangePpm":1,"exchangeConfigJson":"{}"},` +
+				`{"id":0,"pair": "LINK-USD","minExchanges":1,"minPriceChangePpm":1,"exchangeConfigJson":"{}"}` +
 				`]}`,
 			expectedErr: "duplicated market param id",
 		},
@@ -148,12 +149,13 @@ func TestAppModuleBasic_ValidateGenesisErr(t *testing.T) {
 			expectedErr: errorsmod.Wrap(pricestypes.ErrInvalidInput, "Pair cannot be empty").Error(),
 		},
 		"Bad state: Mismatch between params and prices": {
-			genesisJson: `{"market_params": [{"pair": "DENT-USD","minExchanges":1,"minPriceChangePpm":1}]}`,
+			genesisJson: `{"market_params": [{"pair": "DENT-USD","minExchanges":1,"minPriceChangePpm":1,` +
+				`"exchangeConfigJson":"{}"}]}`,
 			expectedErr: "expected the same number of market prices and market params",
 		},
 		"Bad state: Invalid price": {
-			genesisJson: `{"market_params":[{"pair": "DENT-USD","minExchanges":1,"minPriceChangePpm":1}],` +
-				`"market_prices": [{"exponent":1,"price": "0"}]}`,
+			genesisJson: `{"market_params":[{"pair": "DENT-USD","minExchanges":1,"minPriceChangePpm":1,` +
+				`"exchangeConfigJson":"{}"}],"market_prices": [{"exponent":1,"price": "0"}]}`,
 			expectedErr: errorsmod.Wrap(
 				pricestypes.ErrInvalidInput,
 				"market param 0 exponent 0 does not match market price 0 exponent 1",

--- a/protocol/x/prices/types/errors.go
+++ b/protocol/x/prices/types/errors.go
@@ -34,4 +34,11 @@ var (
 		ModuleName, 401, "Market price update is invalid: deterministic.")
 	ErrInvalidMarketPriceUpdateNonDeterministic = errorsmod.Register(
 		ModuleName, 402, "Market price update is invalid: non-deterministic.")
+
+	// 500 - 599: sdk.Msg related errors.
+	ErrInvalidAuthority = errorsmod.Register(
+		ModuleName,
+		500,
+		"Authority is invalid",
+	)
 )

--- a/protocol/x/prices/types/genesis_test.go
+++ b/protocol/x/prices/types/genesis_test.go
@@ -1,10 +1,12 @@
 package types_test
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"errors"
 	"testing"
 
+	errorsmod "cosmossdk.io/errors"
+
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"github.com/stretchr/testify/require"
@@ -23,16 +25,18 @@ func TestGenesisState_Validate(t *testing.T) {
 			genState: &types.GenesisState{
 				MarketParams: []types.MarketParam{
 					{
-						Id:                0,
-						Pair:              constants.BtcUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 0,
+						Pair:               constants.BtcUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 					},
 					{
-						Id:                1,
-						Pair:              constants.EthUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 1,
+						Pair:               constants.EthUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_ETH_USD],
 					},
 				},
 				MarketPrices: []types.MarketPrice{
@@ -48,20 +52,42 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		"invalid: empty ExchangeConfigJson": {
+			genState: &types.GenesisState{
+				MarketParams: []types.MarketParam{
+					{
+						Id:                 0,
+						Pair:               constants.BtcUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: "",
+					},
+				},
+				MarketPrices: []types.MarketPrice{
+					{
+						Id:    0,
+						Price: constants.FiveBillion,
+					},
+				},
+			},
+			expectedError: errors.New("ExchangeConfigJson string is not valid"),
+		},
 		"invalid: duplicate market param ids": {
 			genState: &types.GenesisState{
 				MarketParams: []types.MarketParam{
 					{
-						Id:                0,
-						Pair:              constants.BtcUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 0,
+						Pair:               constants.BtcUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 					},
 					{
-						Id:                0,
-						Pair:              constants.EthUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 0,
+						Pair:               constants.EthUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_ETH_USD],
 					},
 				},
 			},
@@ -71,8 +97,9 @@ func TestGenesisState_Validate(t *testing.T) {
 			genState: &types.GenesisState{
 				MarketParams: []types.MarketParam{
 					{
-						Id:   0,
-						Pair: "",
+						Id:                 0,
+						Pair:               "",
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 					},
 				},
 			},
@@ -82,16 +109,18 @@ func TestGenesisState_Validate(t *testing.T) {
 			genState: &types.GenesisState{
 				MarketParams: []types.MarketParam{
 					{
-						Id:                0,
-						Pair:              constants.BtcUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 0,
+						Pair:               constants.BtcUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 					},
 					{
-						Id:                1,
-						Pair:              constants.EthUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 1,
+						Pair:               constants.EthUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_ETH_USD],
 					},
 				},
 				MarketPrices: []types.MarketPrice{
@@ -107,16 +136,18 @@ func TestGenesisState_Validate(t *testing.T) {
 			genState: &types.GenesisState{
 				MarketParams: []types.MarketParam{
 					{
-						Id:                0,
-						Pair:              constants.BtcUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 0,
+						Pair:               constants.BtcUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 					},
 					{
-						Id:                1,
-						Pair:              constants.EthUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 1,
+						Pair:               constants.EthUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_ETH_USD],
 					},
 				},
 				MarketPrices: []types.MarketPrice{
@@ -136,16 +167,18 @@ func TestGenesisState_Validate(t *testing.T) {
 			genState: &types.GenesisState{
 				MarketParams: []types.MarketParam{
 					{
-						Id:                0,
-						Pair:              constants.BtcUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 0,
+						Pair:               constants.BtcUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_BTC_USD],
 					},
 					{
-						Id:                1,
-						Pair:              constants.EthUsdPair,
-						MinExchanges:      1,
-						MinPriceChangePpm: 1,
+						Id:                 1,
+						Pair:               constants.EthUsdPair,
+						MinExchanges:       1,
+						MinPriceChangePpm:  1,
+						ExchangeConfigJson: constants.TestMarketExchangeConfigs[exchange_common.MARKET_ETH_USD],
 					},
 				},
 				MarketPrices: []types.MarketPrice{

--- a/protocol/x/prices/types/market_param.go
+++ b/protocol/x/prices/types/market_param.go
@@ -3,6 +3,7 @@ package types
 import (
 	errorsmod "cosmossdk.io/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/json"
 )
 
 // Validate checks that the MarketParam is valid.
@@ -22,6 +23,15 @@ func (mp *MarketParam) Validate() error {
 			ErrInvalidInput,
 			"Min price change in parts-per-million must be greater than 0 and less than %d",
 			lib.MaxPriceChangePpm)
+	}
+
+	if err := json.IsValidJSON(mp.ExchangeConfigJson); err != nil {
+		return errorsmod.Wrapf(
+			ErrInvalidInput,
+			"ExchangeConfigJson string is not valid: err=%v, input=%v",
+			err,
+			mp.ExchangeConfigJson,
+		)
 	}
 
 	return nil

--- a/protocol/x/prices/types/market_param_test.go
+++ b/protocol/x/prices/types/market_param_test.go
@@ -60,7 +60,7 @@ func TestMarketParam_Validate(t *testing.T) {
 				Pair:               "BTC-USD",
 				MinExchanges:       1,
 				MinPriceChangePpm:  1_000,
-				ExchangeConfigJson: "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]", // missing a bracket
+				ExchangeConfigJson: "{\"exchanges\":[]", // missing a bracket
 			},
 			expErrMsg: "ExchangeConfigJson string is not valid",
 		},

--- a/protocol/x/prices/types/market_param_test.go
+++ b/protocol/x/prices/types/market_param_test.go
@@ -1,0 +1,79 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarketParam_Validate(t *testing.T) {
+	validExchangeConfigJson := "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]}"
+	testCases := []struct {
+		name      string
+		input     types.MarketParam
+		expErrMsg string
+	}{
+		{
+			name: "Valid MarketParam",
+			input: types.MarketParam{
+				Pair:               "BTC-USD",
+				MinExchanges:       1,
+				MinPriceChangePpm:  1_000,
+				ExchangeConfigJson: validExchangeConfigJson,
+			},
+			expErrMsg: "",
+		},
+		{
+			name: "Empty pair",
+			input: types.MarketParam{
+				Pair:               "",
+				MinExchanges:       1,
+				MinPriceChangePpm:  1_000,
+				ExchangeConfigJson: validExchangeConfigJson,
+			},
+			expErrMsg: "Pair cannot be empty",
+		},
+		{
+			name: "Invalid MinPriceChangePpm",
+			input: types.MarketParam{
+				Pair:               "BTC-USD",
+				MinExchanges:       1,
+				MinPriceChangePpm:  0,
+				ExchangeConfigJson: validExchangeConfigJson,
+			},
+			expErrMsg: "Min price change in parts-per-million must be greater than 0",
+		},
+		{
+			name: "Empty ExchangeConfigJson",
+			input: types.MarketParam{
+				Pair:               "BTC-USD",
+				MinExchanges:       1,
+				MinPriceChangePpm:  1_000,
+				ExchangeConfigJson: "",
+			},
+			expErrMsg: "ExchangeConfigJson string is not valid",
+		},
+		{
+			name: "Typo in ExchangeConfigJson",
+			input: types.MarketParam{
+				Pair:               "BTC-USD",
+				MinExchanges:       1,
+				MinPriceChangePpm:  1_000,
+				ExchangeConfigJson: "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]", // missing a bracket
+			},
+			expErrMsg: "ExchangeConfigJson string is not valid",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.input.Validate()
+			if tc.expErrMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expErrMsg)
+			}
+		})
+	}
+}

--- a/protocol/x/prices/types/market_param_test.go
+++ b/protocol/x/prices/types/market_param_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMarketParam_Validate(t *testing.T) {
-	validExchangeConfigJson := "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]}"
+	validExchangeConfigJson := `{"exchanges":[{"exchangeName":"Binance","ticker":"BTCUSDT"}]}`
 	testCases := []struct {
 		name      string
 		input     types.MarketParam
@@ -60,7 +60,7 @@ func TestMarketParam_Validate(t *testing.T) {
 				Pair:               "BTC-USD",
 				MinExchanges:       1,
 				MinPriceChangePpm:  1_000,
-				ExchangeConfigJson: "{\"exchanges\":[]", // missing a bracket
+				ExchangeConfigJson: `{"exchanges":[]`, // missing a bracket
 			},
 			expErrMsg: "ExchangeConfigJson string is not valid",
 		},

--- a/protocol/x/prices/types/message_create_oracle_market.go
+++ b/protocol/x/prices/types/message_create_oracle_market.go
@@ -1,9 +1,8 @@
 package types
 
 import (
-	"errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var _ sdk.Msg = &MsgCreateOracleMarket{}
@@ -14,6 +13,8 @@ func (msg *MsgCreateOracleMarket) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgCreateOracleMarket) ValidateBasic() error {
-	// TODO(CORE-504): Implement message validation.
-	return errors.New("not implemented")
+	if msg.Authority == "" {
+		return sdkerrors.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	}
+	return msg.Params.Validate()
 }

--- a/protocol/x/prices/types/message_create_oracle_market_test.go
+++ b/protocol/x/prices/types/message_create_oracle_market_test.go
@@ -17,7 +17,7 @@ func TestMsgCreateOracleMarket_GetSigners(t *testing.T) {
 }
 
 func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
-	validExchangeConfigJson := "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]}"
+	validExchangeConfigJson := `{"exchanges":[{"exchangeName":"Binance","ticker":"BTCUSDT"}]}`
 	tests := []struct {
 		desc        string
 		msg         types.MsgCreateOracleMarket
@@ -88,7 +88,7 @@ func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
 					Pair:               "BTC-USD",
 					MinExchanges:       1,
 					MinPriceChangePpm:  1_000,
-					ExchangeConfigJson: "{\"exchanges\":[]", // missing a bracket
+					ExchangeConfigJson: `{"exchanges":[]`, // missing a bracket
 				},
 			},
 			expectedErr: "ExchangeConfigJson string is not valid",

--- a/protocol/x/prices/types/message_create_oracle_market_test.go
+++ b/protocol/x/prices/types/message_create_oracle_market_test.go
@@ -88,7 +88,7 @@ func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
 					Pair:               "BTC-USD",
 					MinExchanges:       1,
 					MinPriceChangePpm:  1_000,
-					ExchangeConfigJson: "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]", // missing a bracket
+					ExchangeConfigJson: "{\"exchanges\":[]", // missing a bracket
 				},
 			},
 			expectedErr: "ExchangeConfigJson string is not valid",

--- a/protocol/x/prices/types/message_create_oracle_market_test.go
+++ b/protocol/x/prices/types/message_create_oracle_market_test.go
@@ -1,0 +1,108 @@
+package types_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	types "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgCreateOracleMarket_GetSigners(t *testing.T) {
+	msg := types.MsgCreateOracleMarket{
+		Authority: constants.AliceAccAddress.String(),
+	}
+	require.Equal(t, []sdk.AccAddress{constants.AliceAccAddress}, msg.GetSigners())
+}
+
+func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
+	validExchangeConfigJson := "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]}"
+	tests := []struct {
+		desc        string
+		msg         types.MsgCreateOracleMarket
+		expectedErr string
+	}{
+		{
+			desc:        "Empty authority",
+			msg:         types.MsgCreateOracleMarket{},
+			expectedErr: "authority cannot be empty",
+		},
+		{
+			desc: "Valid MsgCreateOracleMarket",
+			msg: types.MsgCreateOracleMarket{
+				Authority: "test",
+				Params: types.MarketParam{
+					Pair:               "BTC-USD",
+					MinExchanges:       1,
+					MinPriceChangePpm:  1_000,
+					ExchangeConfigJson: validExchangeConfigJson,
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			desc: "Empty pair",
+			msg: types.MsgCreateOracleMarket{
+				Authority: "test",
+				Params: types.MarketParam{
+					Pair:               "",
+					MinExchanges:       1,
+					MinPriceChangePpm:  1_000,
+					ExchangeConfigJson: validExchangeConfigJson,
+				},
+			},
+			expectedErr: "Pair cannot be empty",
+		},
+		{
+			desc: "Invalid MinPriceChangePpm",
+			msg: types.MsgCreateOracleMarket{
+				Authority: "test",
+				Params: types.MarketParam{
+					Pair:               "BTC-USD",
+					MinExchanges:       1,
+					MinPriceChangePpm:  0,
+					ExchangeConfigJson: validExchangeConfigJson,
+				},
+			},
+			expectedErr: "Min price change in parts-per-million must be greater than 0",
+		},
+		{
+			desc: "Empty ExchangeConfigJson",
+			msg: types.MsgCreateOracleMarket{
+				Authority: "test",
+				Params: types.MarketParam{
+					Pair:               "BTC-USD",
+					MinExchanges:       1,
+					MinPriceChangePpm:  1_000,
+					ExchangeConfigJson: "",
+				},
+			},
+			expectedErr: "ExchangeConfigJson string is not valid",
+		},
+		{
+			desc: "Typo in ExchangeConfigJson",
+			msg: types.MsgCreateOracleMarket{
+				Authority: "test",
+				Params: types.MarketParam{
+					Pair:               "BTC-USD",
+					MinExchanges:       1,
+					MinPriceChangePpm:  1_000,
+					ExchangeConfigJson: "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"\\\"BTCUSDT\\\"\"}]", // missing a bracket
+				},
+			},
+			expectedErr: "ExchangeConfigJson string is not valid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/protocol/x/rewards/keeper/keeper_test.go
+++ b/protocol/x/rewards/keeper/keeper_test.go
@@ -623,11 +623,12 @@ func TestProcessRewardsForBlock(t *testing.T) {
 			_, err := tApp.App.PricesKeeper.CreateMarket(
 				ctx,
 				pricestypes.MarketParam{
-					Id:                testRewardTokenMarketId,
-					Pair:              testRewardTokenMarket,
-					Exponent:          tc.tokenPrice.Exponent,
-					MinExchanges:      uint32(1),
-					MinPriceChangePpm: uint32(50),
+					Id:                 testRewardTokenMarketId,
+					Pair:               testRewardTokenMarket,
+					Exponent:           tc.tokenPrice.Exponent,
+					MinExchanges:       uint32(1),
+					MinPriceChangePpm:  uint32(50),
+					ExchangeConfigJson: "{}",
 				},
 				tc.tokenPrice,
 			)


### PR DESCRIPTION
- Implement `GetSigners` and `ValidateBasic`. 
- Added `ExchangeConfigJson` validation in `MarketParams.Validate` which is run in `MsgCreateOracleMarket.ValidateBasic`. This necessitated changes in a bunch of tests since previously tests are set up with empty `ExchangeConfigJson`. 