### PR TITLE
Fix simulation test - use empty, valid exchange config json

### DIFF
--- a/protocol/x/prices/simulation/genesis.go
+++ b/protocol/x/prices/simulation/genesis.go
@@ -77,6 +77,8 @@ func RandomizedGenState(simState *module.SimulationState) {
 			Exponent:          int32(marketExponent),
 			MinExchanges:      uint32(minExchanges),
 			MinPriceChangePpm: uint32(simtypes.RandIntBetween(r, 1, int(lib.MaxPriceChangePpm))),
+			// The simulation tests don't run the daemon currently so we pass in empty exchange config.
+			ExchangeConfigJson: "{}",
 		}
 		marketPrices[i] = types.MarketPrice{
 			Id:       uint32(i),


### PR DESCRIPTION
Fix broken sim test on `main` after https://github.com/dydxprotocol/v4-chain/pull/228 introduces stateless validations on exchange config json