### PR TITLE
[DEC-2104] move `time.go` to `lib/time` and add unit tests

### DIFF
--- a/protocol/lib/time/time.go
+++ b/protocol/lib/time/time.go
@@ -1,4 +1,4 @@
-package lib
+package time
 
 import (
 	"time"

--- a/protocol/lib/time/time_test.go
+++ b/protocol/lib/time/time_test.go
@@ -1,0 +1,60 @@
+package time_test
+
+import (
+	"testing"
+	"time"
+
+	libtime "github.com/dydxprotocol/v4-chain/protocol/lib/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustParseDuration(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		expectPanic    bool
+		expectedOutput time.Duration
+	}{
+		"valid: zero": {
+			input:          "0",
+			expectedOutput: time.Duration(0),
+		},
+		"valid: zero with unit": {
+			input:          "0ms",
+			expectedOutput: time.Duration(0),
+		},
+		"valid: positive decimal": {
+			input:          "1.137120913s",
+			expectedOutput: time.Duration(1137120913) * time.Nanosecond,
+		},
+		"valid: negative decimal": {
+			input:          "-0.123457913s",
+			expectedOutput: time.Duration(-123457913) * time.Nanosecond,
+		},
+		"invalid: empty string": {
+			input:       "", // empty input
+			expectPanic: true,
+		},
+		"invalid: invalid format": {
+			input:       "1.137120913", // no unit
+			expectPanic: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.expectPanic {
+				require.Panics(
+					t,
+					func() {
+						v := libtime.MustParseDuration(tc.input)
+						require.Nil(t, v)
+					},
+				)
+				return
+			}
+
+			v := libtime.MustParseDuration(tc.input)
+			require.Equal(t, tc.expectedOutput, v)
+		})
+	}
+}

--- a/protocol/x/bridge/types/genesis.go
+++ b/protocol/x/bridge/types/genesis.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/time"
 )
 
 // DefaultGenesis returns the default bridge genesis state.
@@ -14,9 +14,9 @@ func DefaultGenesis() *GenesisState {
 		},
 		ProposeParams: ProposeParams{
 			MaxBridgesPerBlock:           10,
-			ProposeDelayDuration:         lib.MustParseDuration("60s"),
+			ProposeDelayDuration:         time.MustParseDuration("60s"),
 			SkipRatePpm:                  800_000, // 80%
-			SkipIfBlockDelayedByDuration: lib.MustParseDuration("5s"),
+			SkipIfBlockDelayedByDuration: time.MustParseDuration("5s"),
 		},
 		SafetyParams: SafetyParams{
 			IsDisabled:  false,


### PR DESCRIPTION
1. Move `lib/time.go` to `lib/time/time.go`. I intend to move `time_provider.go` under this new dir in a future PR
2. Add unit tests for `lib/time/time.go`