### PR TITLE
[CORE-322] - Up time to 20s to account for extra 2-3s of errors we're seeing in dev.

### DIFF
--- a/protocol/x/prices/keeper/update_price.go
+++ b/protocol/x/prices/keeper/update_price.go
@@ -63,7 +63,7 @@ func (k Keeper) GetValidMarketPriceUpdates(
 		// Skip proposal logic in the event of invalid inputs, which is only likely to occur around network genesis.
 		if !indexPriceExists {
 			metrics.IncrCountMetricWithLabels(types.ModuleName, metrics.IndexPriceDoesNotExist, marketMetricsLabel)
-			// Conditionally escalate log level to error 10s after genesis/restart. We expect that it may take a few
+			// Conditionally escalate log level to error 20s after genesis/restart. We expect that it may take a few
 			// seconds for the index price to populate after network genesis or a network restart.
 			logMethod := k.Logger(ctx).Error
 			if k.IsRecentlyAdded(marketId) {
@@ -85,7 +85,7 @@ func (k Keeper) GetValidMarketPriceUpdates(
 		// We generally expect to have a smoothed price history for each market, except during the first few blocks
 		// after network genesis or a network restart. In this scenario, we use the index price as the smoothed price.
 		if len(historicalSmoothedPrices) == 0 {
-			// Conditionally escalate log level to error 10s after genesis/restart. We expect that there will be a delay
+			// Conditionally escalate log level to error 20s after genesis/restart. We expect that there will be a delay
 			// in populating historical smoothed prices after network genesis or a network restart, because they
 			// depend on present index prices.
 			logMethod := k.Logger(ctx).Error

--- a/protocol/x/prices/types/constants.go
+++ b/protocol/x/prices/types/constants.go
@@ -3,5 +3,5 @@ package types
 import "time"
 
 const (
-	MarketIsRecentDuration = 10 * time.Second
+	MarketIsRecentDuration = 20 * time.Second
 )


### PR DESCRIPTION
Looks like 10s did not fully cover the time it takes for the pricefeed daemon to populate valid index prices. delay the escalation of these logs to error level for another 10s - that's 7-8 seconds of extra margin over the 12-13 seconds we're seeing in dev.