### PR TITLE
[CORE-494] Reject subaccount update if it's for a market with `0` oracle price.

### DIFF
--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -1,10 +1,11 @@
 package keeper
 
 import (
+	"math/big"
+
 	errorsmod "cosmossdk.io/errors"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
-	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -389,4 +390,20 @@ func (k Keeper) ConvertAssetToCoin(
 	bigConvertedQuantums := bigRatConvertedQuantums.Num()
 
 	return bigConvertedQuantums, sdk.NewCoin(asset.Denom, sdk.NewIntFromBigInt(bigConvertedDenomAmount)), nil
+}
+
+// IsPositionUpdatable returns whether position of an asset is updatable.
+func (k Keeper) IsPositionUpdatable(
+	ctx sdk.Context,
+	id uint32,
+) (
+	updatable bool,
+	err error,
+) {
+	_, err = k.GetAsset(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	// All existing assets are by default updatable.
+	return true, nil
 }

--- a/protocol/x/assets/keeper/asset_test.go
+++ b/protocol/x/assets/keeper/asset_test.go
@@ -619,3 +619,18 @@ func TestConvertAssetToCoin_Failure(t *testing.T) {
 		types.ErrInvalidAssetAtomicResolution,
 	)
 }
+
+func TestIsPositionUpdatable(t *testing.T) {
+	ctx, keeper, pricesKeeper, _, _, _ := keepertest.AssetsKeepers(t, true)
+	_, err := createNAssets(t, ctx, keeper, pricesKeeper, 1)
+	require.NoError(t, err)
+
+	// Check Usdc asset is updatable.
+	updatable, err := keeper.IsPositionUpdatable(ctx, lib.UsdcAssetId)
+	require.NoError(t, err)
+	require.True(t, updatable)
+
+	// Return error for non-existent asset
+	_, err = keeper.IsPositionUpdatable(ctx, 100)
+	require.ErrorContains(t, err, "Asset does not exist")
+}

--- a/protocol/x/clob/keeper/liquidations_test.go
+++ b/protocol/x/clob/keeper/liquidations_test.go
@@ -2610,6 +2610,8 @@ func TestGetBankruptcyPriceInQuoteQuantums(t *testing.T) {
 			// Create liquidity tiers.
 			keepertest.CreateTestLiquidityTiers(t, ks.Ctx, ks.PerpetualsKeeper)
 
+			keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper)
+
 			// Create all perpetuals.
 			for _, p := range tc.perpetuals {
 				_, err := ks.PerpetualsKeeper.CreatePerpetual(

--- a/protocol/x/clob/keeper/liquidations_test.go
+++ b/protocol/x/clob/keeper/liquidations_test.go
@@ -2610,7 +2610,7 @@ func TestGetBankruptcyPriceInQuoteQuantums(t *testing.T) {
 			// Create liquidity tiers.
 			keepertest.CreateTestLiquidityTiers(t, ks.Ctx, ks.PerpetualsKeeper)
 
-			keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper)
+			require.NoError(t, keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper))
 
 			// Create all perpetuals.
 			for _, p := range tc.perpetuals {

--- a/protocol/x/clob/keeper/msg_server_place_order_test.go
+++ b/protocol/x/clob/keeper/msg_server_place_order_test.go
@@ -85,7 +85,7 @@ func TestPlaceOrder_Error(t *testing.T) {
 			ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, indexerEventManager)
 			msgServer := keeper.NewMsgServerImpl(ks.ClobKeeper)
 
-			keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper)
+			require.NoError(t, keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper))
 			// Create test markets.
 			keepertest.CreateTestMarkets(t, ks.Ctx, ks.PricesKeeper)
 
@@ -214,7 +214,7 @@ func TestPlaceOrder_Success(t *testing.T) {
 			ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, indexerEventManager)
 			msgServer := keeper.NewMsgServerImpl(ks.ClobKeeper)
 
-			keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper)
+			require.NoError(t, keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper))
 
 			ctx := ks.Ctx.WithBlockHeight(2)
 			ctx = ctx.WithBlockTime(time.Unix(int64(2), 0))

--- a/protocol/x/clob/keeper/msg_server_place_order_test.go
+++ b/protocol/x/clob/keeper/msg_server_place_order_test.go
@@ -85,6 +85,7 @@ func TestPlaceOrder_Error(t *testing.T) {
 			ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, indexerEventManager)
 			msgServer := keeper.NewMsgServerImpl(ks.ClobKeeper)
 
+			keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper)
 			// Create test markets.
 			keepertest.CreateTestMarkets(t, ks.Ctx, ks.PricesKeeper)
 
@@ -212,6 +213,8 @@ func TestPlaceOrder_Success(t *testing.T) {
 
 			ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, indexerEventManager)
 			msgServer := keeper.NewMsgServerImpl(ks.ClobKeeper)
+
+			keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper)
 
 			ctx := ks.Ctx.WithBlockHeight(2)
 			ctx = ctx.WithBlockTime(time.Unix(int64(2), 0))

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1483,7 +1483,7 @@ func (k Keeper) IsPositionUpdatable(
 	ctx sdk.Context,
 	perpetualId uint32,
 ) (
-	tradable bool,
+	updatable bool,
 	err error,
 ) {
 	_, oraclePrice, err := k.GetPerpetualAndMarketPrice(
@@ -1494,7 +1494,7 @@ func (k Keeper) IsPositionUpdatable(
 		return false, err
 	}
 
-	// If perpetual has zero oracle price, it is considered not tradable.
+	// If perpetual has zero oracle price, it is considered not updatable.
 	if oraclePrice.Price == 0 {
 		return false, nil
 	}

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1,11 +1,12 @@
 package keeper
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math/big"
 	"sort"
 	"time"
+
+	errorsmod "cosmossdk.io/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 
@@ -1472,4 +1473,30 @@ func (k Keeper) getLiquidityTiertoMaxAbsPremiumVotePpm(ctx sdk.Context) []*big.I
 		maxAbsPremiumVotePpms[i] = liquidityTier.GetMaxAbsFundingClampPpm(premiumVoteClampFactorPpm)
 	}
 	return maxAbsPremiumVotePpms
+}
+
+// IsPerpetualTradable returns whether the perptual is tradable.
+// A perpetual is non-trdable if it satifies:
+//   - Perpetual has zero oracle price. Since new oracle prices are created at zero by default,
+//     this indicates the absence of a valid oracle price update.
+func (k Keeper) IsPerpetualTradable(
+	ctx sdk.Context,
+	perpetualId uint32,
+) (
+	tradable bool,
+	err error,
+) {
+	_, oraclePrice, err := k.GetPerpetualAndMarketPrice(
+		ctx,
+		perpetualId,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	// If perpetual has zero oracle price, it is considered not tradable.
+	if oraclePrice.Price == 0 {
+		return false, nil
+	}
+	return true, nil
 }

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1475,11 +1475,11 @@ func (k Keeper) getLiquidityTiertoMaxAbsPremiumVotePpm(ctx sdk.Context) []*big.I
 	return maxAbsPremiumVotePpms
 }
 
-// IsPerpetualTradable returns whether the perptual is tradable.
-// A perpetual is not tradable if it satifies:
+// IsPositionUpdatable returns whether position of a perptual is updatable.
+// A perpetual is not updatable if it satifies:
 //   - Perpetual has zero oracle price. Since new oracle prices are created at zero by default and valid
 //     oracle priceupdates are non-zero, this indicates the absence of a valid oracle price update.
-func (k Keeper) IsPerpetualTradable(
+func (k Keeper) IsPositionUpdatable(
 	ctx sdk.Context,
 	perpetualId uint32,
 ) (

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1476,9 +1476,9 @@ func (k Keeper) getLiquidityTiertoMaxAbsPremiumVotePpm(ctx sdk.Context) []*big.I
 }
 
 // IsPerpetualTradable returns whether the perptual is tradable.
-// A perpetual is non-trdable if it satifies:
-//   - Perpetual has zero oracle price. Since new oracle prices are created at zero by default,
-//     this indicates the absence of a valid oracle price update.
+// A perpetual is not tradable if it satifies:
+//   - Perpetual has zero oracle price. Since new oracle prices are created at zero by default and valid
+//     oracle priceupdates are non-zero, this indicates the absence of a valid oracle price update.
 func (k Keeper) IsPerpetualTradable(
 	ctx sdk.Context,
 	perpetualId uint32,

--- a/protocol/x/perpetuals/keeper/perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/perpetual_test.go
@@ -3146,15 +3146,15 @@ func TestSetMinNumVotesPerSample(t *testing.T) {
 	}
 }
 
-func TestIsPerpetualTradable(t *testing.T) {
+func TestIsPositionUpdatable(t *testing.T) {
 	testCases := map[string]struct {
-		perp               types.Perpetual
-		marketParamPrice   pricestypes.MarketParamPrice
-		queryPerpId        uint32
-		expectedIsTradable bool
-		expectedErr        string
+		perp              types.Perpetual
+		marketParamPrice  pricestypes.MarketParamPrice
+		queryPerpId       uint32
+		expectedUpdatable bool
+		expectedErr       string
 	}{
-		"Tradable": {
+		"Updatable": {
 			perp: *perptest.GeneratePerpetual(
 				perptest.WithId(1),
 				perptest.WithMarketId(1),
@@ -3164,9 +3164,9 @@ func TestIsPerpetualTradable(t *testing.T) {
 				pricestest.WithId(1),
 				pricestest.WithPriceValue(1000), // non-zero
 			),
-			expectedIsTradable: true,
+			expectedUpdatable: true,
 		},
-		"Not tradable due to zero oracle price": {
+		"Not updatable due to zero oracle price": {
 			perp: *perptest.GeneratePerpetual(
 				perptest.WithId(1),
 				perptest.WithMarketId(1),
@@ -3176,7 +3176,7 @@ func TestIsPerpetualTradable(t *testing.T) {
 				pricestest.WithId(1),
 				pricestest.WithPriceValue(0),
 			),
-			expectedIsTradable: false,
+			expectedUpdatable: false,
 		},
 		"Error: Perp Id not found": {
 			perp: *perptest.GeneratePerpetual(
@@ -3203,10 +3203,10 @@ func TestIsPerpetualTradable(t *testing.T) {
 				[]pricestypes.MarketParamPrice{tc.marketParamPrice},
 			)
 
-			isTradable, err := perpKeeper.IsPerpetualTradable(ctx, tc.queryPerpId)
+			updatable, err := perpKeeper.IsPositionUpdatable(ctx, tc.queryPerpId)
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
-				require.Equal(t, tc.expectedIsTradable, isTradable)
+				require.Equal(t, tc.expectedUpdatable, updatable)
 			} else {
 				require.ErrorContains(t, err, tc.expectedErr)
 			}

--- a/protocol/x/perpetuals/keeper/perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/perpetual_test.go
@@ -3154,7 +3154,7 @@ func TestIsPerpetualTradable(t *testing.T) {
 		expectedIsTradable bool
 		expectedErr        string
 	}{
-		"Is tradable": {
+		"Tradable": {
 			perp: *perptest.GeneratePerpetual(
 				perptest.WithId(1),
 				perptest.WithMarketId(1),
@@ -3166,7 +3166,7 @@ func TestIsPerpetualTradable(t *testing.T) {
 			),
 			expectedIsTradable: true,
 		},
-		"Is non-tradable due to zero oracle price": {
+		"Not tradable due to zero oracle price": {
 			perp: *perptest.GeneratePerpetual(
 				perptest.WithId(1),
 				perptest.WithMarketId(1),

--- a/protocol/x/sending/keeper/transfer_test.go
+++ b/protocol/x/sending/keeper/transfer_test.go
@@ -116,7 +116,7 @@ func assertWithdrawEventInIndexerBlock(
 }
 
 func runProcessTransferTest(t *testing.T, tc TransferTestCase) {
-	ctx, keeper, accountKeeper, pricesKeeper, perpKeeper, _, saKeeper, _ := keepertest.SendingKeepers(t)
+	ctx, keeper, accountKeeper, pricesKeeper, perpKeeper, aKeeper, saKeeper, _ := keepertest.SendingKeepers(t)
 	ctx = ctx.WithBlockHeight(5)
 	keepertest.CreateTestMarkets(t, ctx, pricesKeeper)
 	keepertest.CreateTestLiquidityTiers(t, ctx, perpKeeper)
@@ -124,6 +124,8 @@ func runProcessTransferTest(t *testing.T, tc TransferTestCase) {
 	perpetuals := []perptypes.Perpetual{
 		constants.BtcUsd_100PercentMarginRequirement,
 	}
+	keepertest.CreateUsdcAsset(ctx, aKeeper)
+
 	for _, p := range perpetuals {
 		_, err := perpKeeper.CreatePerpetual(
 			ctx,
@@ -240,7 +242,7 @@ func TestProcessTransfer(t *testing.T) {
 }
 
 func TestProcessTransfer_CreateRecipientAccount(t *testing.T) {
-	ctx, keeper, accountKeeper, pricesKeeper, perpKeeper, _, saKeeper, _ := keepertest.SendingKeepers(t)
+	ctx, keeper, accountKeeper, pricesKeeper, perpKeeper, aKeeper, saKeeper, _ := keepertest.SendingKeepers(t)
 	ctx = ctx.WithBlockHeight(5)
 	keepertest.CreateTestMarkets(t, ctx, pricesKeeper)
 	keepertest.CreateTestLiquidityTiers(t, ctx, perpKeeper)
@@ -248,6 +250,8 @@ func TestProcessTransfer_CreateRecipientAccount(t *testing.T) {
 	perpetuals := []perptypes.Perpetual{
 		constants.BtcUsd_100PercentMarginRequirement,
 	}
+	keepertest.CreateUsdcAsset(ctx, aKeeper)
+
 	for _, p := range perpetuals {
 		_, err := perpKeeper.CreatePerpetual(
 			ctx,

--- a/protocol/x/sending/keeper/transfer_test.go
+++ b/protocol/x/sending/keeper/transfer_test.go
@@ -124,7 +124,7 @@ func runProcessTransferTest(t *testing.T, tc TransferTestCase) {
 	perpetuals := []perptypes.Perpetual{
 		constants.BtcUsd_100PercentMarginRequirement,
 	}
-	keepertest.CreateUsdcAsset(ctx, aKeeper)
+	require.NoError(t, keepertest.CreateUsdcAsset(ctx, aKeeper))
 
 	for _, p := range perpetuals {
 		_, err := perpKeeper.CreatePerpetual(
@@ -250,7 +250,7 @@ func TestProcessTransfer_CreateRecipientAccount(t *testing.T) {
 	perpetuals := []perptypes.Perpetual{
 		constants.BtcUsd_100PercentMarginRequirement,
 	}
-	keepertest.CreateUsdcAsset(ctx, aKeeper)
+	require.NoError(t, keepertest.CreateUsdcAsset(ctx, aKeeper))
 
 	for _, p := range perpetuals {
 		_, err := perpKeeper.CreatePerpetual(

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -419,7 +419,7 @@ func (k Keeper) getSettledSubaccount(
 	return newSubaccount, fundingPayments, nil
 }
 
-func checkUpdatable(
+func checkPositionUpdateable(
 	ctx sdk.Context,
 	pk types.ProductKeeper,
 	p types.PositionSize,
@@ -471,7 +471,7 @@ func (k Keeper) internalCanUpdateSubaccounts(
 	for i, u := range settledUpdates {
 		// Check all updated perps are updatable.
 		for _, perpUpdate := range u.PerpetualUpdates {
-			err := checkUpdatable(ctx, k.perpetualsKeeper, perpUpdate)
+			err := checkPositionUpdateable(ctx, k.perpetualsKeeper, perpUpdate)
 			if err != nil {
 				return false, nil, err
 			}
@@ -479,7 +479,7 @@ func (k Keeper) internalCanUpdateSubaccounts(
 
 		// Check all updated assets are updatable.
 		for _, assetUpdate := range u.AssetUpdates {
-			err := checkUpdatable(ctx, k.assetsKeeper, assetUpdate)
+			err := checkPositionUpdateable(ctx, k.assetsKeeper, assetUpdate)
 			if err != nil {
 				return false, nil, err
 			}

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -419,7 +419,7 @@ func (k Keeper) getSettledSubaccount(
 	return newSubaccount, fundingPayments, nil
 }
 
-func checkPositionUpdateable(
+func checkPositionUpdatable(
 	ctx sdk.Context,
 	pk types.ProductKeeper,
 	p types.PositionSize,
@@ -471,7 +471,7 @@ func (k Keeper) internalCanUpdateSubaccounts(
 	for i, u := range settledUpdates {
 		// Check all updated perps are updatable.
 		for _, perpUpdate := range u.PerpetualUpdates {
-			err := checkPositionUpdateable(ctx, k.perpetualsKeeper, perpUpdate)
+			err := checkPositionUpdatable(ctx, k.perpetualsKeeper, perpUpdate)
 			if err != nil {
 				return false, nil, err
 			}
@@ -479,7 +479,7 @@ func (k Keeper) internalCanUpdateSubaccounts(
 
 		// Check all updated assets are updatable.
 		for _, assetUpdate := range u.AssetUpdates {
-			err := checkPositionUpdateable(ctx, k.assetsKeeper, assetUpdate)
+			err := checkPositionUpdatable(ctx, k.assetsKeeper, assetUpdate)
 			if err != nil {
 				return false, nil, err
 			}

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -2059,7 +2059,7 @@ func TestUpdateSubaccounts(t *testing.T) {
 			},
 			msgSenderEnabled: true,
 		},
-		"2 updates, 1 update involves not-tradable perp": {
+		"2 updates, 1 update involves not-updatable perp": {
 			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(1_000_000_000_000)),
 			expectedErr:    types.ErrProductPositionNotUpdatable,
 			perpetuals: []perptypes.Perpetual{
@@ -2704,7 +2704,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 			expectedSuccess:          true,
 			expectedSuccessPerUpdate: []types.UpdateResult{types.Success},
 		},
-		"2 updates, 1 update involves not-tradable perp": {
+		"2 updates, 1 update involves not-updatable perp": {
 			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(1_000_000_000_000)),
 			expectedErr:    types.ErrProductPositionNotUpdatable,
 			perpetuals: []perptypes.Perpetual{

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -15,8 +15,11 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/nullify"
+	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
+	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
 	asstypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
@@ -269,6 +272,7 @@ func TestUpdateSubaccounts(t *testing.T) {
 		perpetuals        []perptypes.Perpetual
 		newFundingIndices []*big.Int // 1:1 mapped to perpetuals list
 		assets            []*asstypes.Asset
+		marketParamPrices []pricestypes.MarketParamPrice
 
 		// subaccount state
 		perpetualPositions []*types.PerpetualPosition
@@ -2056,6 +2060,73 @@ func TestUpdateSubaccounts(t *testing.T) {
 			},
 			msgSenderEnabled: true,
 		},
+		"2 updates, 1 update involves non-tradable perp": {
+			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(1_000_000_000_000)),
+			expectedErr:    types.ErrPerpNotTradable,
+			perpetuals: []perptypes.Perpetual{
+				*perptest.GeneratePerpetual(
+					perptest.WithId(100),
+					perptest.WithMarketId(100),
+				),
+				*perptest.GeneratePerpetual(
+					perptest.WithId(101),
+					perptest.WithMarketId(101),
+				),
+			},
+			marketParamPrices: []pricestypes.MarketParamPrice{
+				*pricestest.GenerateMarketParamPrice(pricestest.WithId(100)),
+				*pricestest.GenerateMarketParamPrice(
+					pricestest.WithId(101),
+					pricestest.WithPriceValue(0),
+				),
+			},
+			perpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId:  uint32(100),
+					Quantums:     dtypes.NewInt(1_000_000_000),
+					FundingIndex: dtypes.NewInt(0),
+				},
+				{
+					PerpetualId:  uint32(101),
+					Quantums:     dtypes.NewInt(1_000_000_000),
+					FundingIndex: dtypes.NewInt(0),
+				},
+			},
+			expectedPerpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId:  uint32(100),
+					Quantums:     dtypes.NewInt(1_000_000_000),
+					FundingIndex: dtypes.NewInt(0),
+				},
+				{
+					PerpetualId:  uint32(101),
+					Quantums:     dtypes.NewInt(1_000_000_000),
+					FundingIndex: dtypes.NewInt(0),
+				},
+			},
+			expectedUpdatedPerpetualPositions: map[types.SubaccountId][]*types.PerpetualPosition{},
+			expectedAssetPositions: []*types.AssetPosition{
+				{
+					AssetId:  uint32(0),
+					Quantums: dtypes.NewInt(1_000_000_000_000),
+				},
+			},
+			updates: []types.Update{
+				{
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      uint32(100),
+							BigQuantumsDelta: big.NewInt(-1_000),
+						},
+						{
+							PerpetualId:      uint32(101),
+							BigQuantumsDelta: big.NewInt(1_000),
+						},
+					},
+				},
+			},
+			msgSenderEnabled: true,
+		},
 	}
 
 	for name, tc := range tests {
@@ -2067,6 +2138,15 @@ func TestUpdateSubaccounts(t *testing.T) {
 			ctx = ctx.WithTxBytes(constants.TestTxBytes)
 			testutil.CreateTestMarkets(t, ctx, pricesKeeper)
 			testutil.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
+
+			for _, m := range tc.marketParamPrices {
+				_, err := pricesKeeper.CreateMarket(
+					ctx,
+					m.Param,
+					m.Price,
+				)
+				require.NoError(t, err)
+			}
 
 			for _, a := range tc.assets {
 				_, err := assetsKeeper.CreateAsset(
@@ -2163,8 +2243,9 @@ func TestUpdateSubaccounts(t *testing.T) {
 func TestCanUpdateSubaccounts(t *testing.T) {
 	tests := map[string]struct {
 		// State.
-		perpetuals []perptypes.Perpetual
-		assets     []*asstypes.Asset
+		perpetuals        []perptypes.Perpetual
+		assets            []*asstypes.Asset
+		marketParamPrices []pricestypes.MarketParamPrice
 
 		// Subaccount state.
 		useEmptySubaccount bool
@@ -2622,6 +2703,53 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 			expectedSuccess:          true,
 			expectedSuccessPerUpdate: []types.UpdateResult{types.Success},
 		},
+		"2 updates, 1 update involves non-tradable perp": {
+			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(1_000_000_000_000)),
+			expectedErr:    types.ErrPerpNotTradable,
+			perpetuals: []perptypes.Perpetual{
+				*perptest.GeneratePerpetual(
+					perptest.WithId(100),
+					perptest.WithMarketId(100),
+				),
+				*perptest.GeneratePerpetual(
+					perptest.WithId(101),
+					perptest.WithMarketId(101),
+				),
+			},
+			marketParamPrices: []pricestypes.MarketParamPrice{
+				*pricestest.GenerateMarketParamPrice(pricestest.WithId(100)),
+				*pricestest.GenerateMarketParamPrice(
+					pricestest.WithId(101),
+					pricestest.WithPriceValue(0),
+				),
+			},
+			perpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId:  uint32(100),
+					Quantums:     dtypes.NewInt(1_000_000_000),
+					FundingIndex: dtypes.NewInt(0),
+				},
+				{
+					PerpetualId:  uint32(101),
+					Quantums:     dtypes.NewInt(1_000_000_000),
+					FundingIndex: dtypes.NewInt(0),
+				},
+			},
+			updates: []types.Update{
+				{
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      uint32(100),
+							BigQuantumsDelta: big.NewInt(-1_000),
+						},
+						{
+							PerpetualId:      uint32(101),
+							BigQuantumsDelta: big.NewInt(1_000),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -2639,6 +2767,15 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 					a.HasMarket,
 					a.MarketId,
 					a.AtomicResolution,
+				)
+				require.NoError(t, err)
+			}
+
+			for _, m := range tc.marketParamPrices {
+				_, err := pricesKeeper.CreateMarket(
+					ctx,
+					m.Param,
+					m.Price,
 				)
 				require.NoError(t, err)
 			}

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -812,7 +812,6 @@ func TestUpdateSubaccounts(t *testing.T) {
 		},
 		"update closes first asset position and updates 2nd": {
 			assets: []*asstypes.Asset{
-				constants.Usdc,
 				constants.BtcUsd,
 			},
 			assetPositions: append(
@@ -2062,7 +2061,7 @@ func TestUpdateSubaccounts(t *testing.T) {
 		},
 		"2 updates, 1 update involves not-tradable perp": {
 			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(1_000_000_000_000)),
-			expectedErr:    types.ErrPerpNotTradable,
+			expectedErr:    types.ErrProductPositionNotUpdatable,
 			perpetuals: []perptypes.Perpetual{
 				*perptest.GeneratePerpetual(
 					perptest.WithId(100),
@@ -2148,6 +2147,8 @@ func TestUpdateSubaccounts(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			// Always creates USDC asset first
+			require.NoError(t, testutil.CreateUsdcAsset(ctx, assetsKeeper))
 			for _, a := range tc.assets {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,
@@ -2705,7 +2706,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 		},
 		"2 updates, 1 update involves not-tradable perp": {
 			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(1_000_000_000_000)),
-			expectedErr:    types.ErrPerpNotTradable,
+			expectedErr:    types.ErrProductPositionNotUpdatable,
 			perpetuals: []perptypes.Perpetual{
 				*perptest.GeneratePerpetual(
 					perptest.WithId(100),
@@ -2758,6 +2759,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 			testutil.CreateTestMarkets(t, ctx, pricesKeeper)
 			testutil.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
 
+			require.NoError(t, testutil.CreateUsdcAsset(ctx, assetsKeeper))
 			for _, a := range tc.assets {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,
@@ -2813,6 +2815,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 			if tc.expectedErr != nil {
 				require.ErrorIs(t, tc.expectedErr, err)
 			} else {
+				require.NoError(t, err)
 				require.Equal(t, tc.expectedSuccessPerUpdate, successPerUpdate)
 				require.Equal(t, tc.expectedSuccess, success)
 			}
@@ -3180,17 +3183,7 @@ func TestGetNetCollateralAndMarginRequirements(t *testing.T) {
 			testutil.CreateTestMarkets(t, ctx, pricesKeeper)
 			testutil.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
 
-			_, err := assetsKeeper.CreateAsset(
-				ctx,
-				constants.Usdc.Symbol,
-				constants.Usdc.Denom,
-				constants.Usdc.DenomExponent,
-				constants.Usdc.HasMarket,
-				constants.Usdc.MarketId,
-				constants.Usdc.AtomicResolution,
-			)
-			require.NoError(t, err)
-
+			require.NoError(t, testutil.CreateUsdcAsset(ctx, assetsKeeper))
 			for _, a := range tc.assets {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -2060,7 +2060,7 @@ func TestUpdateSubaccounts(t *testing.T) {
 			},
 			msgSenderEnabled: true,
 		},
-		"2 updates, 1 update involves non-tradable perp": {
+		"2 updates, 1 update involves not-tradable perp": {
 			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(1_000_000_000_000)),
 			expectedErr:    types.ErrPerpNotTradable,
 			perpetuals: []perptypes.Perpetual{
@@ -2703,7 +2703,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 			expectedSuccess:          true,
 			expectedSuccessPerUpdate: []types.UpdateResult{types.Success},
 		},
-		"2 updates, 1 update involves non-tradable perp": {
+		"2 updates, 1 update involves not-tradable perp": {
 			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(1_000_000_000_000)),
 			expectedErr:    types.ErrPerpNotTradable,
 			perpetuals: []perptypes.Perpetual{

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -31,6 +31,7 @@ var (
 	// 400 - 499: perpetual position related.
 	ErrPerpPositionsOutOfOrder = errorsmod.Register(ModuleName, 400, "perpetual positions are out of order")
 	ErrPerpPositionZeroQuantum = errorsmod.Register(ModuleName, 401, "perpetual position's quantum cannot be zero")
+	ErrPerpNotTradable         = errorsmod.Register(ModuleName, 402, "perpetual is not tradable")
 
 	// 500 - 599: transfer related.
 	ErrAssetTransferQuantumsNotPositive = errorsmod.Register(

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -14,7 +14,8 @@ var (
 		ModuleName, 100, "multiple updates were specified for the same position id")
 	ErrNonUniqueUpdatesSubaccount = errorsmod.Register(
 		ModuleName, 101, "multiple updates were specified for the same subaccountId")
-	ErrFailedToUpdateSubaccounts = errorsmod.Register(ModuleName, 102, "failed to apply subaccount updates")
+	ErrFailedToUpdateSubaccounts   = errorsmod.Register(ModuleName, 102, "failed to apply subaccount updates")
+	ErrProductPositionNotUpdatable = errorsmod.Register(ModuleName, 103, "product position is not updatable")
 
 	// 200 - 299: subaccount id related.
 	ErrInvalidSubaccountIdNumber = errorsmod.Register(ModuleName, 200, "subaccount id number cannot exceed 127")
@@ -31,7 +32,6 @@ var (
 	// 400 - 499: perpetual position related.
 	ErrPerpPositionsOutOfOrder = errorsmod.Register(ModuleName, 400, "perpetual positions are out of order")
 	ErrPerpPositionZeroQuantum = errorsmod.Register(ModuleName, 401, "perpetual position's quantum cannot be zero")
-	ErrPerpNotTradable         = errorsmod.Register(ModuleName, 402, "perpetual is not tradable")
 
 	// 500 - 599: transfer related.
 	ErrAssetTransferQuantumsNotPositive = errorsmod.Register(

--- a/protocol/x/subaccounts/types/expected_keepers.go
+++ b/protocol/x/subaccounts/types/expected_keepers.go
@@ -28,6 +28,13 @@ type ProductKeeper interface {
 		bigMaintenanceMarginQuoteQuantums *big.Int,
 		err error,
 	)
+	IsPositionUpdatable(
+		ctx sdk.Context,
+		id uint32,
+	) (
+		updatable bool,
+		err error,
+	)
 }
 
 type AssetsKeeper interface {
@@ -63,13 +70,6 @@ type PerpetualsKeeper interface {
 		err error,
 	)
 	GetAllPerpetuals(ctx sdk.Context) []perptypes.Perpetual
-	IsPerpetualTradable(
-		ctx sdk.Context,
-		id uint32,
-	) (
-		tradable bool,
-		err error,
-	)
 }
 
 // AccountKeeper defines the expected account keeper used for simulations (noalias)

--- a/protocol/x/subaccounts/types/expected_keepers.go
+++ b/protocol/x/subaccounts/types/expected_keepers.go
@@ -63,6 +63,13 @@ type PerpetualsKeeper interface {
 		err error,
 	)
 	GetAllPerpetuals(ctx sdk.Context) []perptypes.Perpetual
+	IsPerpetualTradable(
+		ctx sdk.Context,
+		id uint32,
+	) (
+		tradable bool,
+		err error,
+	)
 }
 
 // AccountKeeper defines the expected account keeper used for simulations (noalias)

--- a/protocol/x/subaccounts/types/position_size.go
+++ b/protocol/x/subaccounts/types/position_size.go
@@ -1,10 +1,16 @@
 package types
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"math/big"
 
+	errorsmod "cosmossdk.io/errors"
+
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+)
+
+const (
+	AssetProductType     = "asset"
+	PerpetualProductType = "perpetual"
 )
 
 // PositionSize is an interface for expressing the size of a position
@@ -14,6 +20,7 @@ type PositionSize interface {
 	// Returns the signed position size in big.Int.
 	GetBigQuantums() *big.Int
 	GetId() uint32
+	GetProductType() string
 }
 
 type PositionUpdate struct {
@@ -66,6 +73,10 @@ func (m *AssetPosition) GetIsLong() bool {
 	return m.GetBigQuantums().Sign() > 0
 }
 
+func (m *AssetPosition) GetProductType() string {
+	return AssetProductType
+}
+
 func (m *PerpetualPosition) GetId() uint32 {
 	return m.GetPerpetualId()
 }
@@ -98,6 +109,10 @@ func (m *PerpetualPosition) GetIsLong() bool {
 	return m.GetBigQuantums().Sign() > 0
 }
 
+func (m *PerpetualPosition) GetProductType() string {
+	return PerpetualProductType
+}
+
 func (au AssetUpdate) GetIsLong() bool {
 	return au.GetBigQuantums().Sign() > 0
 }
@@ -110,6 +125,10 @@ func (au AssetUpdate) GetId() uint32 {
 	return au.AssetId
 }
 
+func (au AssetUpdate) GetProductType() string {
+	return AssetProductType
+}
+
 func (pu PerpetualUpdate) GetBigQuantums() *big.Int {
 	return pu.BigQuantumsDelta
 }
@@ -120,6 +139,10 @@ func (pu PerpetualUpdate) GetId() uint32 {
 
 func (pu PerpetualUpdate) GetIsLong() bool {
 	return pu.GetBigQuantums().Sign() > 0
+}
+
+func (pu PerpetualUpdate) GetProductType() string {
+	return PerpetualProductType
 }
 
 func (pu PositionUpdate) GetId() uint32 {
@@ -136,4 +159,8 @@ func (pu PositionUpdate) SetBigQuantums(bigQuantums *big.Int) {
 
 func (pu PositionUpdate) GetBigQuantums() *big.Int {
 	return pu.BigQuantums
+}
+func (pu PositionUpdate) GetProductType() string {
+	// PositionUpdate is generic and doesn't have a product type.
+	return ""
 }

--- a/protocol/x/subaccounts/types/position_size.go
+++ b/protocol/x/subaccounts/types/position_size.go
@@ -11,6 +11,7 @@ import (
 const (
 	AssetProductType     = "asset"
 	PerpetualProductType = "perpetual"
+	UnknownProductTYpe   = "unknown"
 )
 
 // PositionSize is an interface for expressing the size of a position
@@ -162,5 +163,5 @@ func (pu PositionUpdate) GetBigQuantums() *big.Int {
 }
 func (pu PositionUpdate) GetProductType() string {
 	// PositionUpdate is generic and doesn't have a product type.
-	return ""
+	return UnknownProductTYpe
 }


### PR DESCRIPTION
Per discussion with @BrendanChou, added logic to reject a `SubaccountUpdate` if *any* of any of the `update.PerpetualUpdate` involves a perpetual market with `0` oracle price.