### PR TITLE
[CORE-535] - Remove duplicate daemon flag for grpc.address config.

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -285,6 +285,10 @@ func New(
 ) *App {
 	// dYdX specific command-line flags.
 	appFlags := flags.GetFlagValuesFromOptions(appOpts)
+	// Panic if gRPC is disabled.
+	if err := appFlags.Validate(); err != nil {
+		panic(err)
+	}
 
 	initDatadogProfiler(logger, appFlags.DdAgentHost, appFlags.DdTraceAgentPort)
 

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -510,7 +510,7 @@ func New(
 		grpc.NewServer(),
 		&lib.FileHandlerImpl{},
 		daemonFlags.Shared.SocketAddress,
-		daemonFlags.Shared.GrpcServerAddress,
+		appFlags.GrpcAddress,
 	)
 	// Setup server for pricefeed messages. The server will wait for gRPC messages containing price
 	// updates and then encode them into an in-memory cache shared by the prices module.
@@ -544,6 +544,7 @@ func New(
 				// the main application.
 				context.Background(),
 				daemonFlags,
+				appFlags,
 				logger,
 				&lib.GrpcClientImpl{},
 			); err != nil {
@@ -564,13 +565,14 @@ func New(
 			// the main application.
 			context.Background(),
 			daemonFlags,
+			appFlags,
 			logger,
 			&lib.GrpcClientImpl{},
 			exchangeStartupConfig,
 			constants.StaticExchangeDetails,
 			&pricefeedclient.SubTaskRunnerImpl{},
 		)
-		stoppable.RegisterServiceForTestCleanup(daemonFlags.Shared.GrpcServerAddress, client)
+		stoppable.RegisterServiceForTestCleanup(appFlags.GrpcAddress, client)
 	}
 
 	// Start Bridge Daemon.
@@ -585,6 +587,7 @@ func New(
 				// the main application.
 				context.Background(),
 				daemonFlags,
+				appFlags,
 				logger,
 				&lib.GrpcClientImpl{},
 			); err != nil {

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -285,7 +285,7 @@ func New(
 ) *App {
 	// dYdX specific command-line flags.
 	appFlags := flags.GetFlagValuesFromOptions(appOpts)
-	// Panic if gRPC is disabled.
+	// Panic if this is not a full node and gRPC is disabled.
 	if err := appFlags.Validate(); err != nil {
 		panic(err)
 	}

--- a/protocol/app/app_test.go
+++ b/protocol/app/app_test.go
@@ -104,6 +104,13 @@ func TestAppIsFullyInitialized(t *testing.T) {
 	}
 }
 
+func TestAppPanicsWithGrpcDisabled(t *testing.T) {
+	customFlags := map[string]interface{}{
+		flags.GrpcEnable: false,
+	}
+	require.Panics(t, func() { testapp.DefaultTestApp(customFlags) })
+}
+
 func TestClobKeeperMemStoreHasBeenInitialized(t *testing.T) {
 	dydxApp := testapp.DefaultTestApp(nil)
 	ctx := dydxApp.NewUncachedContext(true, tmproto.Header{})

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"fmt"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ type Flags struct {
 
 	// Existing flags
 	GrpcAddress string
+	GrpcEnable  bool
 }
 
 // List of CLI flags.
@@ -24,6 +26,7 @@ const (
 
 	// Cosmos flags below. These config values can be set as flags or in config.toml.
 	GrpcAddress = "grpc.address"
+	GrpcEnable  = "grpc.enable"
 )
 
 // Default values.
@@ -56,6 +59,14 @@ func AddFlagsToCmd(cmd *cobra.Command) {
 	)
 }
 
+// Validate checks that the flags are valid.
+func (f *Flags) Validate() error {
+	if !f.GrpcEnable {
+		return fmt.Errorf("grpc.enable must be set to true - application requires gRPC server")
+	}
+	return nil
+}
+
 // GetFlagValuesFromOptions gets values from the `AppOptions` struct which contains values
 // from the command-line flags.
 func GetFlagValuesFromOptions(
@@ -66,7 +77,10 @@ func GetFlagValuesFromOptions(
 		NonValidatingFullNode: DefaultNonValidatingFullNode,
 		DdAgentHost:           DefaultDdAgentHost,
 		DdTraceAgentPort:      DefaultDdTraceAgentPort,
-		GrpcAddress:           config.DefaultGRPCAddress,
+
+		// These are the default values from the Cosmos flags.
+		GrpcAddress: config.DefaultGRPCAddress,
+		GrpcEnable:  true,
 	}
 
 	// Populate the flags if they exist.
@@ -84,6 +98,10 @@ func GetFlagValuesFromOptions(
 
 	if v, ok := appOpts.Get(GrpcAddress).(string); ok {
 		result.GrpcAddress = v
+	}
+
+	if v, ok := appOpts.Get(GrpcEnable).(bool); ok {
+		result.GrpcEnable = v
 	}
 
 	return result

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/spf13/cobra"
 )
@@ -10,6 +11,9 @@ type Flags struct {
 	DdAgentHost           string
 	DdTraceAgentPort      uint16
 	NonValidatingFullNode bool
+
+	// Existing flags
+	GrpcAddress string
 }
 
 // List of CLI flags.
@@ -17,6 +21,9 @@ const (
 	DdAgentHost               = "dd-agent-host"
 	DdTraceAgentPort          = "dd-trace-agent-port"
 	NonValidatingFullNodeFlag = "non-validating-full-node"
+
+	// Cosmos flags below. These config values can be set as flags or in config.toml.
+	GrpcAddress = "grpc.address"
 )
 
 // Default values.
@@ -59,6 +66,7 @@ func GetFlagValuesFromOptions(
 		NonValidatingFullNode: DefaultNonValidatingFullNode,
 		DdAgentHost:           DefaultDdAgentHost,
 		DdTraceAgentPort:      DefaultDdTraceAgentPort,
+		GrpcAddress:           config.DefaultGRPCAddress,
 	}
 
 	// Populate the flags if they exist.
@@ -72,6 +80,10 @@ func GetFlagValuesFromOptions(
 
 	if v, ok := appOpts.Get(DdTraceAgentPort).(uint16); ok {
 		result.DdTraceAgentPort = v
+	}
+
+	if v, ok := appOpts.Get(GrpcAddress).(string); ok {
+		result.GrpcAddress = v
 	}
 
 	return result

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -61,8 +61,9 @@ func AddFlagsToCmd(cmd *cobra.Command) {
 
 // Validate checks that the flags are valid.
 func (f *Flags) Validate() error {
-	if !f.GrpcEnable {
-		return fmt.Errorf("grpc.enable must be set to true - application requires gRPC server")
+	// Validtors must have cosmos grpc services enabled.
+	if !f.NonValidatingFullNode && !f.GrpcEnable {
+		return fmt.Errorf("grpc.enable must be set to true - validating requires gRPC server")
 	}
 	return nil
 }

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -2,6 +2,7 @@ package flags_test
 
 import (
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/server/config"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/app/flags"
@@ -35,6 +36,39 @@ func TestAddFlagsToCommand(t *testing.T) {
 	}
 }
 
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		flags       flags.Flags
+		expectedErr error
+	}{
+		"success (default values)": {
+			flags: flags.Flags{
+				NonValidatingFullNode: flags.DefaultNonValidatingFullNode,
+				DdAgentHost:           flags.DefaultDdAgentHost,
+				DdTraceAgentPort:      flags.DefaultDdTraceAgentPort,
+				GrpcAddress:           config.DefaultGRPCAddress,
+				GrpcEnable:            true,
+			},
+		},
+		"failure - gRPC disabled": {
+			flags: flags.Flags{
+				GrpcEnable: false,
+			},
+			expectedErr: fmt.Errorf("grpc.enable must be set to true - application requires gRPC server"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.flags.Validate()
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}
+
 func TestGetFlagValuesFromOptions(t *testing.T) {
 	tests := map[string]struct {
 		// Parameters.
@@ -44,21 +78,29 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 		expectedNonValidatingFullNodeFlag bool
 		expectedDdAgentHost               string
 		expectedDdTraceAgentPort          uint16
+		expectedGrpcAddress               string
+		expectedGrpcEnable                bool
 	}{
 		"Sets to default if unset": {
 			expectedNonValidatingFullNodeFlag: false,
 			expectedDdAgentHost:               "",
 			expectedDdTraceAgentPort:          8126,
+			expectedGrpcAddress:               "localhost:9090",
+			expectedGrpcEnable:                true,
 		},
 		"Sets values from options": {
 			optsMap: map[string]any{
 				flags.NonValidatingFullNodeFlag: true,
 				flags.DdAgentHost:               "agentHostTest",
 				flags.DdTraceAgentPort:          uint16(777),
+				flags.GrpcEnable:                false,
+				flags.GrpcAddress:               "localhost:9091",
 			},
 			expectedNonValidatingFullNodeFlag: true,
 			expectedDdAgentHost:               "agentHostTest",
 			expectedDdTraceAgentPort:          777,
+			expectedGrpcEnable:                false,
+			expectedGrpcAddress:               "localhost:9091",
 		},
 	}
 
@@ -85,6 +127,16 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 				t,
 				tc.expectedDdTraceAgentPort,
 				flags.DdTraceAgentPort,
+			)
+			require.Equal(
+				t,
+				tc.expectedGrpcEnable,
+				flags.GrpcEnable,
+			)
+			require.Equal(
+				t,
+				tc.expectedGrpcAddress,
+				flags.GrpcAddress,
 			)
 		})
 	}

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -50,11 +50,17 @@ func TestValidate(t *testing.T) {
 				GrpcEnable:            true,
 			},
 		},
+		"success - full node & gRPC disabled": {
+			flags: flags.Flags{
+				GrpcEnable:            false,
+				NonValidatingFullNode: true,
+			},
+		},
 		"failure - gRPC disabled": {
 			flags: flags.Flags{
 				GrpcEnable: false,
 			},
-			expectedErr: fmt.Errorf("grpc.enable must be set to true - application requires gRPC server"),
+			expectedErr: fmt.Errorf("grpc.enable must be set to true - validating requires gRPC server"),
 		},
 	}
 	for name, tc := range tests {

--- a/protocol/daemons/bridge/client/client.go
+++ b/protocol/daemons/bridge/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"math/big"
 	"time"
 
@@ -27,11 +28,12 @@ import (
 func Start(
 	ctx context.Context,
 	flags flags.DaemonFlags,
+	appFlags appflags.Flags,
 	logger log.Logger,
 	grpcClient lib.GrpcClient,
 ) error {
 	// Make a connection to the Cosmos gRPC query services.
-	queryConn, err := grpcClient.NewTcpConnection(ctx, flags.Shared.GrpcServerAddress)
+	queryConn, err := grpcClient.NewTcpConnection(ctx, appFlags.GrpcAddress)
 	if err != nil {
 		logger.Error("Failed to establish gRPC connection to Cosmos gRPC query services", "error", err)
 		return err

--- a/protocol/daemons/bridge/client/client_test.go
+++ b/protocol/daemons/bridge/client/client_test.go
@@ -3,6 +3,8 @@ package client_test
 import (
 	"errors"
 	"fmt"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/appoptions"
 	"math/big"
 	"testing"
 
@@ -30,6 +32,7 @@ func TestStart_TcpConnectionFails(t *testing.T) {
 		client.Start(
 			grpc.Ctx,
 			flags.GetDefaultDaemonFlags(),
+			appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
 			log.NewNopLogger(),
 			mockGrpcClient,
 		),
@@ -53,6 +56,7 @@ func TestStart_UnixSocketConnectionFails(t *testing.T) {
 		client.Start(
 			grpc.Ctx,
 			flags.GetDefaultDaemonFlags(),
+			appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
 			log.NewNopLogger(),
 			mockGrpcClient,
 		),

--- a/protocol/daemons/flags/flags.go
+++ b/protocol/daemons/flags/flags.go
@@ -2,14 +2,12 @@ package flags
 
 import (
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/constants"
 	"github.com/spf13/cobra"
 )
 
 // List of CLI flags for Server and Client.
 const (
 	// Flag names
-	FlagGrpcAddress       = "grpc-address"
 	FlagUnixSocketAddress = "unix-socket-address"
 
 	FlagPriceDaemonEnabled     = "price-daemon-enabled"
@@ -25,8 +23,7 @@ const (
 )
 
 type SharedFlags struct {
-	GrpcServerAddress string
-	SocketAddress     string
+	SocketAddress string
 }
 
 type BridgeFlags struct {
@@ -59,8 +56,7 @@ func GetDefaultDaemonFlags() DaemonFlags {
 	if defaultDaemonFlags == nil {
 		defaultDaemonFlags = &DaemonFlags{
 			Shared: SharedFlags{
-				SocketAddress:     "/tmp/daemons.sock",
-				GrpcServerAddress: constants.DefaultGrpcEndpoint,
+				SocketAddress: "/tmp/daemons.sock",
 			},
 			Bridge: BridgeFlags{
 				Enabled:        true,
@@ -91,11 +87,6 @@ func AddDaemonFlagsToCmd(
 	df := GetDefaultDaemonFlags()
 
 	// Shared Flags.
-	cmd.Flags().String(
-		FlagGrpcAddress,
-		df.Shared.GrpcServerAddress,
-		"Address for the gRPC server",
-	)
 	cmd.Flags().String(
 		FlagUnixSocketAddress,
 		df.Shared.SocketAddress,
@@ -158,9 +149,6 @@ func GetDaemonFlagValuesFromOptions(
 	result := GetDefaultDaemonFlags()
 
 	// Shared Flags
-	if v, ok := appOpts.Get(FlagGrpcAddress).(string); ok {
-		result.Shared.GrpcServerAddress = v
-	}
 	if v, ok := appOpts.Get(FlagUnixSocketAddress).(string); ok {
 		result.Shared.SocketAddress = v
 	}

--- a/protocol/daemons/flags/flags_test.go
+++ b/protocol/daemons/flags/flags_test.go
@@ -16,7 +16,6 @@ func TestAddDaemonFlagsToCmd(t *testing.T) {
 
 	flags.AddDaemonFlagsToCmd(&cmd)
 	tests := []string{
-		flags.FlagGrpcAddress,
 		flags.FlagUnixSocketAddress,
 
 		flags.FlagBridgeDaemonEnabled,
@@ -42,7 +41,6 @@ func TestGetDaemonFlagValuesFromOptions_Custom(t *testing.T) {
 	optsMap := make(map[string]interface{})
 
 	optsMap[flags.FlagUnixSocketAddress] = "test-socket-address"
-	optsMap[flags.FlagGrpcAddress] = "test-grpc-server-address"
 
 	optsMap[flags.FlagBridgeDaemonEnabled] = true
 	optsMap[flags.FlagBridgeDaemonLoopDelayMs] = uint32(1111)
@@ -64,7 +62,6 @@ func TestGetDaemonFlagValuesFromOptions_Custom(t *testing.T) {
 	r := flags.GetDaemonFlagValuesFromOptions(&mockOpts)
 
 	// Shared.
-	require.Equal(t, optsMap[flags.FlagGrpcAddress], r.Shared.GrpcServerAddress)
 	require.Equal(t, optsMap[flags.FlagUnixSocketAddress], r.Shared.SocketAddress)
 
 	// Bridge Daemon.

--- a/protocol/daemons/liquidation/client/client.go
+++ b/protocol/daemons/liquidation/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"time"
 
 	"github.com/cometbft/cometbft/libs/log"
@@ -22,11 +23,12 @@ import (
 func Start(
 	ctx context.Context,
 	flags flags.DaemonFlags,
+	appFlags appflags.Flags,
 	logger log.Logger,
 	grpcClient lib.GrpcClient,
 ) error {
 	// Make a connection to the Cosmos gRPC query services.
-	queryConn, err := grpcClient.NewTcpConnection(ctx, flags.Shared.GrpcServerAddress)
+	queryConn, err := grpcClient.NewTcpConnection(ctx, appFlags.GrpcAddress)
 	if err != nil {
 		logger.Error("Failed to establish gRPC connection to Cosmos gRPC query services", "error", err)
 		return err

--- a/protocol/daemons/liquidation/client/client_test.go
+++ b/protocol/daemons/liquidation/client/client_test.go
@@ -3,6 +3,8 @@ package client_test
 import (
 	"context"
 	"errors"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/appoptions"
 	"testing"
 
 	"github.com/cometbft/cometbft/libs/log"
@@ -31,6 +33,7 @@ func TestStart_TcpConnectionFails(t *testing.T) {
 		client.Start(
 			grpc.Ctx,
 			flags.GetDefaultDaemonFlags(),
+			appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
 			log.NewNopLogger(),
 			mockGrpcClient,
 		),
@@ -54,6 +57,7 @@ func TestStart_UnixSocketConnectionFails(t *testing.T) {
 		client.Start(
 			grpc.Ctx,
 			flags.GetDefaultDaemonFlags(),
+			appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
 			log.NewNopLogger(),
 			mockGrpcClient,
 		),

--- a/protocol/testutil/appoptions/app_options.go
+++ b/protocol/testutil/appoptions/app_options.go
@@ -2,6 +2,8 @@ package appoptions
 
 import (
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/server/config"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -52,6 +54,9 @@ func GetDefaultTestAppOptions(homePath string, customFlags map[string]interface{
 
 	// Disable the Liquidation Daemon for all end-to-end and integration tests by default.
 	fao.Set(daemonflags.FlagLiquidationDaemonEnabled, false)
+
+	// Populate the default value for gRPC.
+	fao.Set(appflags.GrpcAddress, config.DefaultGRPCAddress)
 
 	for flag, value := range customFlags {
 		fao.Set(flag, value)

--- a/protocol/x/clob/client/cli/cancel_order_cli_test.go
+++ b/protocol/x/clob/client/cli/cancel_order_cli_test.go
@@ -73,8 +73,6 @@ func (s *CancelOrderIntegrationTestSuite) SetupTest() {
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, false)
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
 
-			// Enable the liquidations daemon in the integration tests.
-			appOptions.Set(daemonflags.FlagGrpcAddress, testval.AppConfig.GRPC.Address)
 			// Make sure all daemon-related services are properly stopped.
 			s.T().Cleanup(func() {
 				stoppable.StopServices(s.T(), testval.AppConfig.GRPC.Address)

--- a/protocol/x/clob/client/cli/cancel_order_cli_test.go
+++ b/protocol/x/clob/client/cli/cancel_order_cli_test.go
@@ -5,6 +5,7 @@ package cli_test
 import (
 	"fmt"
 	networktestutil "github.com/cosmos/cosmos-sdk/testutil/network"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/app/stoppable"
 	daemonflags "github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/appoptions"
@@ -72,6 +73,9 @@ func (s *CancelOrderIntegrationTestSuite) SetupTest() {
 			// Disable the Bridge and Price daemons in the integration tests.
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, false)
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
+
+			// Make sure the daemon is using the correct GRPC address.
+			appOptions.Set(appflags.GrpcAddress, testval.AppConfig.GRPC.Address)
 
 			// Make sure all daemon-related services are properly stopped.
 			s.T().Cleanup(func() {

--- a/protocol/x/clob/client/cli/liquidations_cli_test.go
+++ b/protocol/x/clob/client/cli/liquidations_cli_test.go
@@ -4,6 +4,7 @@ package cli_test
 
 import (
 	"fmt"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/app/stoppable"
 
 	"math/big"
@@ -72,6 +73,9 @@ func TestLiquidationOrderIntegrationTestSuite(t *testing.T) {
 			// Disable the Bridge and Price daemons in the integration tests.
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, false)
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
+
+			// Make sure the daemon is using the correct GRPC address.
+			appOptions.Set(appflags.GrpcAddress, testval.AppConfig.GRPC.Address)
 
 			// Enable the liquidations daemon in the integration tests.
 			appOptions.Set(daemonflags.FlagUnixSocketAddress, liqTestUnixSocketAddress)

--- a/protocol/x/clob/client/cli/liquidations_cli_test.go
+++ b/protocol/x/clob/client/cli/liquidations_cli_test.go
@@ -74,7 +74,6 @@ func TestLiquidationOrderIntegrationTestSuite(t *testing.T) {
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
 
 			// Enable the liquidations daemon in the integration tests.
-			appOptions.Set(daemonflags.FlagGrpcAddress, testval.AppConfig.GRPC.Address)
 			appOptions.Set(daemonflags.FlagUnixSocketAddress, liqTestUnixSocketAddress)
 			// Make sure all daemon-related services are properly stopped.
 			t.Cleanup(func() {

--- a/protocol/x/clob/client/cli/place_order_cli_test.go
+++ b/protocol/x/clob/client/cli/place_order_cli_test.go
@@ -4,6 +4,7 @@ package cli_test
 
 import (
 	"fmt"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/app/stoppable"
 	"math/big"
 	"testing"
@@ -67,6 +68,9 @@ func TestPlaceOrderIntegrationTestSuite(t *testing.T) {
 			// Disable the Bridge and Price daemons in the integration tests.
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, false)
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
+
+			// Make sure the daemon is using the correct GRPC address.
+			appOptions.Set(appflags.GrpcAddress, testval.AppConfig.GRPC.Address)
 
 			// Make sure all daemon-related services are properly stopped.
 			t.Cleanup(func() {

--- a/protocol/x/clob/client/cli/place_order_cli_test.go
+++ b/protocol/x/clob/client/cli/place_order_cli_test.go
@@ -68,8 +68,6 @@ func TestPlaceOrderIntegrationTestSuite(t *testing.T) {
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, false)
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
 
-			// Enable the liquidations daemon in the integration tests.
-			appOptions.Set(daemonflags.FlagGrpcAddress, testval.AppConfig.GRPC.Address)
 			// Make sure all daemon-related services are properly stopped.
 			t.Cleanup(func() {
 				stoppable.StopServices(t, testval.AppConfig.GRPC.Address)

--- a/protocol/x/prices/client/cli/prices_cli_test.go
+++ b/protocol/x/prices/client/cli/prices_cli_test.go
@@ -99,8 +99,6 @@ func (s *PricesIntegrationTestSuite) SetupTest() {
 			configs.WriteDefaultPricefeedExchangeToml(homeDir) // must manually create config file.
 			appOptions.Set(daemonflags.FlagPriceDaemonLoopDelayMs, 1_000)
 
-			// Enable the common gRPC daemon server.
-			appOptions.Set(daemonflags.FlagGrpcAddress, testval.AppConfig.GRPC.Address)
 			// Make sure all daemon-related services are properly stopped.
 			s.T().Cleanup(func() {
 				stoppable.StopServices(s.T(), testval.AppConfig.GRPC.Address)

--- a/protocol/x/prices/client/cli/prices_cli_test.go
+++ b/protocol/x/prices/client/cli/prices_cli_test.go
@@ -4,6 +4,7 @@ package cli_test
 
 import (
 	"fmt"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/app/stoppable"
 	"time"
 
@@ -95,6 +96,10 @@ func (s *PricesIntegrationTestSuite) SetupTest() {
 
 			// Enable the Price daemon.
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, true)
+
+			// Make sure the daemon is using the correct GRPC address.
+			appOptions.Set(appflags.GrpcAddress, testval.AppConfig.GRPC.Address)
+
 			homeDir := filepath.Join(testval.Dir, "simd")
 			configs.WriteDefaultPricefeedExchangeToml(homeDir) // must manually create config file.
 			appOptions.Set(daemonflags.FlagPriceDaemonLoopDelayMs, 1_000)


### PR DESCRIPTION
As a P1 result from the prices outage, eliminate duplicate flag configuring gRPC address for daemons. Additionally, panic if the app starts with gRCP disabled, as for now it is required to operate. (The application would have panicked anyway if an expected daemon did not come up, but this way the error source is more clear.)

Tests:
- existing unit / integration
- make localnet-startd looks good
- built this image locally and modified container to have grpc disabled - causes panic.
- built this image locally and modified container to have grpc address of 10101 - protocol runs and netstat on the container shows port 10101 in use, 9090 not in use.

Sanity checks:
- vanilla build from main with grcp disabled in config causes daemon panics
- vanilla build from main with grpc address changed, but daemon flag unchanged, causes daemon panics.

