### PR TITLE
[IND-370] Add function to get subaccounts updated after date.

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/subaccount-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/subaccount-table.test.ts
@@ -106,6 +106,28 @@ describe('Subaccount store', () => {
     expect(subaccounts[0]).toEqual(expect.objectContaining(defaultSubaccount));
   });
 
+  it('Successfully finds Subaccount with updatedOnOrAfter', async () => {
+    await Promise.all([
+      SubaccountTable.create(defaultSubaccount),
+      SubaccountTable.create({
+        ...defaultSubaccount,
+        address: 'fake_address',
+        updatedAt: DateTime.fromISO(defaultSubaccount.updatedAt).minus(10).toISO(),
+      }),
+    ]);
+
+    const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll(
+      {
+        updatedOnOrAfter: defaultSubaccount.updatedAt,
+      },
+      [],
+      { readReplica: true },
+    );
+
+    expect(subaccounts.length).toEqual(1);
+    expect(subaccounts[0]).toEqual(expect.objectContaining(defaultSubaccount));
+  });
+
   it('Successfully finds a Subaccount', async () => {
     await SubaccountTable.create(defaultSubaccount);
 

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20230918143243_update_subaccount_table_add_updated_at_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20230918143243_update_subaccount_table_add_updated_at_index.ts
@@ -1,0 +1,20 @@
+import * as Knex from "knex";
+
+// Use raw SQL to ensure index creation / deletion does not lock the table
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "subaccounts_updatedat_index" on "subaccounts" ("updatedAt");
+  `);
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "subaccounts_updatedat_index";
+  `);
+}
+
+// `CONCURRENTLY` cannot be used within a transaction
+export const config = {
+  transaction: false,
+};

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20230918143243_update_subaccount_table_add_updated_at_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20230918143243_update_subaccount_table_add_updated_at_index.ts
@@ -1,4 +1,4 @@
-import * as Knex from "knex";
+import * as Knex from 'knex';
 
 // Use raw SQL to ensure index creation / deletion does not lock the table
 export async function up(knex: Knex): Promise<void> {
@@ -6,7 +6,6 @@ export async function up(knex: Knex): Promise<void> {
     CREATE INDEX CONCURRENTLY IF NOT EXISTS "subaccounts_updatedat_index" on "subaccounts" ("updatedAt");
   `);
 }
-
 
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`

--- a/indexer/packages/postgres/src/stores/subaccount-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-table.ts
@@ -36,6 +36,7 @@ export async function findAll(
     address,
     subaccountNumber,
     updatedBeforeOrAt,
+    updatedOnOrAfter,
     limit,
   }: SubaccountQueryConfig,
   requiredFields: QueryableField[],
@@ -71,6 +72,10 @@ export async function findAll(
 
   if (updatedBeforeOrAt) {
     baseQuery = baseQuery.where(SubaccountColumns.updatedAt, '<=', updatedBeforeOrAt);
+  }
+
+  if (updatedOnOrAfter) {
+    baseQuery = baseQuery.where(SubaccountColumns.updatedAt, '>=', updatedOnOrAfter);
   }
 
   if (options.orderBy !== undefined) {

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -68,6 +68,7 @@ export enum QueryableField {
   FEE = 'fee',
   TRIGGER_PRICE = 'triggerPrice',
   UPDATED_BEFORE_OR_AT = 'updatedBeforeOrAt',
+  UPDATED_ON_OR_AFTER = 'updatedOnOrAfter',
   PROVIDER = 'provider',
   BLOCKED = 'blocked',
 }
@@ -81,6 +82,7 @@ export interface SubaccountQueryConfig extends QueryConfig {
   [QueryableField.ADDRESS]?: string;
   [QueryableField.SUBACCOUNT_NUMBER]?: number;
   [QueryableField.UPDATED_BEFORE_OR_AT]?: string;
+  [QueryableField.UPDATED_ON_OR_AFTER]?: string;
 }
 
 export interface WalletQueryConfig extends QueryConfig {


### PR DESCRIPTION
- update `findAll` for subaccounts table to search for subaccounts updated after a certain date
- add an index for `updatedAt`

Preparation for round table task to find all active subaccounts, which are ones that have been updated after a certain date.