### PR TITLE
[DEC-2089] - Audit lib/prices

### DIFF
--- a/protocol/lib/prices/utils.go
+++ b/protocol/lib/prices/utils.go
@@ -1,9 +1,23 @@
 package prices
 
 import (
+	"fmt"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/types"
 	"github.com/shopspring/decimal"
 	"math/big"
+)
+
+const (
+	// maxPriceInversionLog10 describes the maximum deviation of an invertable price in units of log10.
+	// A maxPriceInversionLog10 of 2 means that the range of invertible prices have an absolute value of .01 to 100.
+	// We set this limit to prevent accidental loss of precision when inverting prices that could result in
+	// inaccurate index prices in the protocol.
+	maxPriceInversionLog10 = 2
+)
+
+var (
+	maxInversionPrice = decimal.NewFromBigInt(new(big.Int).SetUint64(1), maxPriceInversionLog10)
+	minInversionPrice = decimal.NewFromBigInt(new(big.Int).SetUint64(1), -maxPriceInversionLog10)
 )
 
 /*
@@ -27,13 +41,28 @@ import (
 // Invert inverts a price, returning the inverted price multiplied by 10^-exponent.
 // This method is meant to be used for inverting stablecoin ticker prices. For the sake of precision, price inversion
 // is only intended to be used for pricing markets that are close to 1:1 price-wise, e.g. USD-USDT. Inverting a price
-// that is <<>> 1 could result in a loss of precision.
-func Invert(price uint64, exponent types.Exponent) uint64 {
+// that is <<>> 1 could result in a loss of precision, and the method will return and error if the price to invert
+// deviates by 1 from more than 2 orders of magnitude.
+func Invert(price uint64, exponent types.Exponent) (uint64, error) {
+	if price == 0 {
+		return 0, fmt.Errorf("cannot invert price of 0")
+	}
+
 	decimalPrice := decimal.NewFromBigInt(new(big.Int).SetUint64(price), exponent)
-	invertedPrice := decimal.NewFromInt(1).Div(decimalPrice).Mul(
+
+	if decimalPrice.LessThan(minInversionPrice) || decimalPrice.GreaterThan(maxInversionPrice) {
+		return 0, fmt.Errorf("price %s is outside of invertible range", decimalPrice.String())
+	}
+
+	invertedPriceBigInt := decimal.NewFromInt(1).Div(decimalPrice).Mul(
 		decimal.NewFromBigInt(new(big.Int).SetUint64(1), -exponent),
-	).BigInt().Uint64()
-	return invertedPrice
+	).BigInt()
+
+	if !invertedPriceBigInt.IsUint64() {
+		return 0, fmt.Errorf("inverted price overflows uint64")
+	}
+
+	return invertedPriceBigInt.Uint64(), nil
 }
 
 // Multiply multiplies two prices, returning the resulting price as a uint64 multiplied by the first exponent.
@@ -80,7 +109,7 @@ func Divide(
 }
 
 // PriceToFloat32ForLogging converts a price, exponent to a float32 for logging purposes. This is not meant to be used
-// for price calucations within the protocol, as it could result in an arbitrary loss of precision.
+// for price calculations within the protocol, as it could result in an arbitrary loss of precision.
 func PriceToFloat32ForLogging(price uint64, exponent types.Exponent) float32 {
 	// We're not concerned about truncation here.
 	priceFloat32, _ := decimal.NewFromBigInt(new(big.Int).SetUint64(price), exponent).BigFloat().Float32()


### PR DESCRIPTION
Found Issues:
- Inversion is meant to be used to compute stablecoin prices, and only produces accurate / precise results when the inverted price is close to 1, but input prices were not being validated. I updated the logic to return an error if a price is off from 1 by more than 2 orders of magnitude, and this also prevents accidental panics due to divide by 0.
- Added rounding behavior in multiply and test cases to assert.
- Divide was able to panic on 0 prices.
- Divide is meant to compute stablecoin prices by dividing the price of an asset in two different stablecoin quote currencies to get the implicit ratio of stablecoin prices. Dividing prices that do not have similar values could result in a loss of precision that negatively affects the accuracy of the oracle price, so I added a check to assert that these prices are within 2 orders of magnitude of each other, and test cases.
- Price encoder updates + test cases to handle failed inversions and divides
