### PR TITLE
[DEC-2084] - `lib/error` audit refactors

### DIFF
--- a/protocol/lib/error/log_contextualizer.go
+++ b/protocol/lib/error/log_contextualizer.go
@@ -2,6 +2,10 @@ package error
 
 import "github.com/cometbft/cometbft/libs/log"
 
+// LogContextualizer describes an object that can add context - that is, descriptive key-value pairs, to a logger.
+// This interface is implemented by ErrorWithLogContext, which wraps some errors that are returned from the protocol,
+// and can be used to add context to log statements from the process proposal handler that helps with debugging
+// erroneous unexpected and/or non-deterministic behaviors.
 type LogContextualizer interface {
 	AddLoggingContext(logger log.Logger) log.Logger
 	Unwrap() error

--- a/protocol/lib/error/log_contextualizer.go
+++ b/protocol/lib/error/log_contextualizer.go
@@ -3,9 +3,9 @@ package error
 import "github.com/cometbft/cometbft/libs/log"
 
 // LogContextualizer describes an object that can add context - that is, descriptive key-value pairs, to a logger.
-// This interface is implemented by ErrorWithLogContext, which wraps some errors that are returned from the protocol,
-// and can be used to add context to log statements from the process proposal handler that helps with debugging
-// erroneous unexpected and/or non-deterministic behaviors.
+// This interface is implemented by ErrorWithLogContext, which wraps some errors that are returned from the protocol.
+// This can be used, for example, to add context to log statements from the process proposal handler that helps with
+// debugging erroneous unexpected and/or non-deterministic behaviors.
 type LogContextualizer interface {
 	AddLoggingContext(logger log.Logger) log.Logger
 	Unwrap() error

--- a/protocol/lib/error/logging.go
+++ b/protocol/lib/error/logging.go
@@ -29,9 +29,9 @@ func LogErrorWithOptionalContext(
 }
 
 // WrapErrorWithPricesSourceModuleContext wraps an error with a LogContextualizer that contains a key-value pair for
-// the specified source module. This is useful for logging the error within the process proposal handler (or from any
-// other location that uses LogErrorWithOptionalContext) with metadata that can be used to identify the source of the
-// error.
+// the specified source module. This can be used, for example, for wrapping validation failure errors that are logged
+// within the process proposal handler (or from any other location that uses LogErrorWithOptionalContext) with metadata
+// that helps to more easily identify the source of the error and correlate logs.
 func WrapErrorWithSourceModuleContext(err error, module string) error {
 	return NewErrorWithLogContext(err).
 		WithLogKeyValue(SourceModuleKey, fmt.Sprintf("x/%v", module))

--- a/protocol/lib/error/logging.go
+++ b/protocol/lib/error/logging.go
@@ -11,7 +11,8 @@ const (
 )
 
 // LogErrorWithOptionalContext logs an error, optionally adding context to the logger iff the error implements
-// the LogContextualizer interface.
+// the LogContextualizer interface. This method is appropriate for logging errors that may or may not be wrapped
+// in an ErrorWithLogContext.
 func LogErrorWithOptionalContext(
 	logger log.Logger,
 	msg string,
@@ -27,9 +28,10 @@ func LogErrorWithOptionalContext(
 	logger.Error(msg, "error", err)
 }
 
-// WrapErrorWithPricesSourceModuleContext wraps an error with a LogContextualizer that the spercified source module.
-// This is useful for logging the error within the process proposal handler (or any other location that uses
-// LogErrorWithOptionalContext) with metadata that can be used to identify the source of the error.
+// WrapErrorWithPricesSourceModuleContext wraps an error with a LogContextualizer that contains a key-value pair for
+// the specified source module. This is useful for logging the error within the process proposal handler (or from any
+// other location that uses LogErrorWithOptionalContext) with metadata that can be used to identify the source of the
+// error.
 func WrapErrorWithSourceModuleContext(err error, module string) error {
 	return NewErrorWithLogContext(err).
 		WithLogKeyValue(SourceModuleKey, fmt.Sprintf("x/%v", module))

--- a/protocol/lib/error/logging_test.go
+++ b/protocol/lib/error/logging_test.go
@@ -1,66 +1,35 @@
-package error
+package error_test
 
 import (
 	"fmt"
-	"github.com/cometbft/cometbft/libs/log"
-	"github.com/stretchr/testify/require"
+	liberror "github.com/dydxprotocol/v4-chain/protocol/lib/error"
+	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"testing"
 )
 
-type MockLogger struct {
-	loggingContext map[string]interface{}
-
-	// addedContext tracks if context was added before logging.
-	addedContext bool
-	// errorMsg and keyVals store the parameters of the last log.Error call.
-	errorMsg string
-	keyVals  []interface{}
-}
-
-func (ml *MockLogger) Debug(msg string, keyvals ...interface{}) {
-	if !ml.addedContext {
-		panic("attempted to log without adding context")
-	}
-}
-
-func (ml *MockLogger) Info(msg string, keyvals ...interface{}) {
-	if !ml.addedContext {
-		panic("attempted to log without adding context")
-	}
-}
-
-func (ml *MockLogger) Error(msg string, keyvals ...interface{}) {
-	if !ml.addedContext {
-		panic("attempted to log without adding context")
-	}
-	ml.errorMsg = msg
-	ml.keyVals = keyvals
-}
-
-func (ml *MockLogger) With(keyvals ...interface{}) log.Logger {
-	for i := 0; i < len(keyvals); i += 2 {
-		ml.loggingContext[keyvals[i].(string)] = keyvals[i+1]
-	}
-	ml.addedContext = true
-	return ml
-}
-
-func TestWrapErrorWithSourceModuleContext(t *testing.T) {
+func TestWrapErrorWithSourceModuleContext_ErrorWithLogContext(t *testing.T) {
 	err := fmt.Errorf("test error")
-	wrappedErr := WrapErrorWithSourceModuleContext(err, "test-module")
-	logger := &MockLogger{loggingContext: map[string]interface{}{}}
+	wrappedErr := liberror.WrapErrorWithSourceModuleContext(err, "test-module")
+	logger := &mocks.Logger{}
 
-	LogErrorWithOptionalContext(logger, "test message", wrappedErr)
+	// Expect that source module context will be added to the logger,
+	// and then the original error will be logged.
+	call := logger.On("With", liberror.SourceModuleKey, "x/test-module").Return(logger)
+	logger.On("Error", "test message", "error", err).Return().NotBefore(call)
 
-	// Assert that logging context was added to the logger.
-	require.Len(t, logger.loggingContext, 1)
-	source_module, ok := logger.loggingContext[SourceModuleKey]
-	require.True(t, ok)
-	require.Equal(t, "x/test-module", source_module)
+	liberror.LogErrorWithOptionalContext(logger, "test message", wrappedErr)
 
-	// Assert that the error was logged with expected keyVals.
-	require.Equal(t, "test message", logger.errorMsg)
-	require.Len(t, logger.keyVals, 2)
-	require.Equal(t, "error", logger.keyVals[0])
-	require.Equal(t, err, logger.keyVals[1])
+	logger.AssertExpectations(t)
+}
+
+func TestLogErrorWithOptionalContext_PlainError(t *testing.T) {
+	logger := &mocks.Logger{}
+	err := fmt.Errorf("test error")
+
+	// Plain error messages will be logged without any additional context.
+	logger.On("Error", "test message", "error", err).Return()
+
+	liberror.LogErrorWithOptionalContext(logger, "test message", err)
+
+	logger.AssertExpectations(t)
 }


### PR DESCRIPTION
- coverage was already 100%
- added more comments
- removed homecooked mock logger and replaced it with a generated mock class, then refactored test case to use expectations to validate logger calls.
- added an additinoal test case for logging plain errors.