### PR TITLE
[IND-368] Add middleware to check compliance.

### DIFF
--- a/indexer/services/comlink/__tests__/lib/compliance-check.test.ts
+++ b/indexer/services/comlink/__tests__/lib/compliance-check.test.ts
@@ -1,0 +1,122 @@
+import express from 'express';
+
+import { RequestMethod } from '../../src/types';
+import Server from '../../src/request-helpers/server';
+import { sendRequestToApp } from '../helpers/helpers';
+import { complianceCheck } from '../../src/lib/compliance-check';
+import { handleValidationErrors } from '../../src/request-helpers/error-handler';
+import { checkSchema } from 'express-validator';
+import {
+  ComplianceTable, dbHelpers, testConstants, testMocks,
+} from '@dydxprotocol-indexer/postgres';
+import { blockedComplianceData, nonBlockedComplianceData } from '@dydxprotocol-indexer/postgres/build/__tests__/helpers/constants';
+
+// Create a router to test the middleware with
+const router: express.Router = express.Router();
+
+router.get(
+  '/check-compliance-query',
+  checkSchema({
+    address: {
+      in: ['query'],
+      isString: true,
+      optional: true,
+    },
+  }),
+  handleValidationErrors,
+  complianceCheck,
+  (req: express.Request, res: express.Response) => {
+    res.sendStatus(200);
+  },
+);
+
+router.get(
+  '/check-compliance-param/:address',
+  checkSchema({
+    address: {
+      in: ['params'],
+      isString: true,
+    },
+  }),
+  handleValidationErrors,
+  complianceCheck,
+  (req: express.Request, res: express.Response) => {
+    res.sendStatus(200);
+  },
+);
+
+export const complianceCheckApp = Server(router);
+
+describe('compliance-check', () => {
+  beforeAll(async () => {
+    await dbHelpers.migrate();
+  });
+
+  beforeEach(async () => {
+    await testMocks.seedData();
+  });
+
+  afterAll(async () => {
+    await dbHelpers.teardown();
+  });
+
+  afterEach(async () => {
+    await dbHelpers.clearData();
+  });
+
+  it('does not return 403 if no address in request', async () => {
+    await sendRequestToApp({
+      type: RequestMethod.GET,
+      path: '/v4/check-compliance-query',
+      expressApp: complianceCheckApp,
+      expectedStatus: 200,
+    });
+  });
+
+  it.each([
+    ['query', '/v4/check-compliance-query?address=random'],
+    ['param', '/v4/check-compliance-param/random'],
+  ])('does not return 403 if address in request is not in database (%s)', async (
+    _name: string,
+    path: string,
+  ) => {
+    await sendRequestToApp({
+      type: RequestMethod.GET,
+      path,
+      expressApp: complianceCheckApp,
+      expectedStatus: 200,
+    });
+  });
+
+  it.each([
+    ['query', `/v4/check-compliance-query?address=${testConstants.defaultAddress}`],
+    ['param', `/v4/check-compliance-param/${testConstants.defaultAddress}`],
+  ])('does not return 403 if address in request is not blocked (%s)', async (
+    _name: string,
+    path: string,
+  ) => {
+    await ComplianceTable.create(nonBlockedComplianceData);
+    await sendRequestToApp({
+      type: RequestMethod.GET,
+      path,
+      expressApp: complianceCheckApp,
+      expectedStatus: 200,
+    });
+  });
+
+  it.each([
+    ['query', `/v4/check-compliance-query?address=${testConstants.blockedAddress}`],
+    ['param', `/v4/check-compliance-param/${testConstants.blockedAddress}`],
+  ])('does return 403 if address in request is blocked (%s)', async (
+    _name: string,
+    path: string,
+  ) => {
+    await ComplianceTable.create(blockedComplianceData);
+    await sendRequestToApp({
+      type: RequestMethod.GET,
+      path,
+      expressApp: complianceCheckApp,
+      expectedStatus: 403,
+    });
+  });
+});

--- a/indexer/services/comlink/src/controllers/api/v4/addresses-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/addresses-controller.ts
@@ -36,6 +36,7 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
+import { complianceCheck } from '../../../lib/compliance-check';
 import { NotFoundError } from '../../../lib/errors';
 import {
   adjustUSDCAssetPosition,
@@ -283,6 +284,7 @@ router.get(
     },
   }),
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const {
@@ -316,6 +318,7 @@ router.get(
   rateLimiterMiddleware(getReqRateLimiter),
   ...CheckSubaccountSchema,
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/controllers/api/v4/asset-positions-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/asset-positions-controller.ts
@@ -25,6 +25,7 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
+import { complianceCheck } from '../../../lib/compliance-check';
 import {
   adjustUSDCAssetPosition,
   filterAssetPositions,
@@ -154,6 +155,7 @@ router.get(
   rateLimiterMiddleware(getReqRateLimiter),
   ...CheckSubaccountSchema,
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -9,6 +9,7 @@ import {
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { placeHolderProvider } from '../../../helpers/compliance/compliance-clients';
+import { complianceCheck } from '../../../lib/compliance-check';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
@@ -48,6 +49,7 @@ router.get(
     },
   }),
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
@@ -21,6 +21,7 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
+import { complianceCheck } from '../../../lib/compliance-check';
 import { NotFoundError } from '../../../lib/errors';
 import {
   getClobPairId, handleControllerError, isDefined,
@@ -125,6 +126,7 @@ router.get(
     },
   }),
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
@@ -16,6 +16,7 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
+import { complianceCheck } from '../../../lib/compliance-check';
 import { NotFoundError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
@@ -93,6 +94,7 @@ router.get(
   ...CheckSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtAndOnOrAfterSchema,
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
@@ -27,6 +27,7 @@ import {
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { redisClient } from '../../../helpers/redis/redis-controller';
+import { complianceCheck } from '../../../lib/compliance-check';
 import { NotFoundError } from '../../../lib/errors';
 import {
   handleControllerError,
@@ -219,6 +220,7 @@ router.get(
   query('goodTilBlock').if(query('goodTilBlockTime').exists()).isEmpty()
     .withMessage('Cannot provide both goodTilBlock and goodTilBlockTime'),
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/controllers/api/v4/perpetual-positions-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/perpetual-positions-controller.ts
@@ -29,6 +29,7 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
+import { complianceCheck } from '../../../lib/compliance-check';
 import { NotFoundError } from '../../../lib/errors';
 import {
   getFundingIndexMaps,
@@ -168,6 +169,7 @@ router.get(
     },
   }),
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
@@ -22,6 +22,7 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
+import { complianceCheck } from '../../../lib/compliance-check';
 import { NotFoundError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
@@ -134,6 +135,7 @@ router.get(
   ...CheckSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtSchema,
   handleValidationErrors,
+  complianceCheck,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/lib/compliance-check.ts
+++ b/indexer/services/comlink/src/lib/compliance-check.ts
@@ -1,0 +1,42 @@
+import { ComplianceDataFromDatabase, ComplianceTable } from '@dydxprotocol-indexer/postgres';
+import express from 'express';
+import { matchedData } from 'express-validator';
+
+import { AddressRequest } from '../types';
+import { create4xxResponse } from './helpers';
+
+/**
+ * Checks if the address in the request is blocked or not.
+ * Returns 403 if the address is blocked, otherwise if there is no address in the request, or the
+ * address does not exist in the database or is not blocked, continue onto the next middleware.
+ * NOTE: This middleware must be used after `checkSchema` to ensure `matchData` can get the
+ * address parameter from the request.
+ */
+export async function complianceCheck(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+) {
+  // Check for the address parameter in either query params or path params
+  const { address }: AddressRequest = matchedData(req) as AddressRequest;
+  if (address === undefined) {
+    return next();
+  }
+
+  // Search for any compliance data indicating the address is blocked
+  const complianceData: ComplianceDataFromDatabase[] = await ComplianceTable.findAll(
+    { address: [address], blocked: true },
+    [],
+    { readReplica: true },
+  );
+  if (complianceData.length > 0) {
+    return create4xxResponse(
+      res,
+      // TODO(IND-368): Update default message to send for blocked addresses
+      '',
+      403,
+    );
+  }
+
+  return next();
+}


### PR DESCRIPTION
Middleware that extracts the `address` parameter from the request and checks if it is blocked according to the compliance data stored in the Indexer.
Does not make any new queries to compliance providers as a separate `roundtable` job will be querying for both new addresses and refreshing the compliance data for existing addresses.

See [spec](https://www.notion.so/dydx/OFAC-Checks-and-Geo-blocking-d4f749e8f4314fa1b258cd52033fb30d?pvs=4#2b58e5c947b54a1da1b86d9029e4478f) for more details.