### PR TITLE
Up USDT min change ppm to 1k

### DIFF
--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -921,7 +921,7 @@ function edit_genesis() {
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[33].id' -v '1000000'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[33].exponent' -v '-9'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[33].min_exchanges' -v '3'
-	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[33].min_price_change_ppm' -v '400'  # 0.040%
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[33].min_price_change_ppm' -v '1000'  # 0.100%
 	dasel put -t json -f "$GENESIS" '.app_state.prices.market_prices.[]' -v "{}"
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[33].id' -v '1000000'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[33].exponent' -v '-9'


### PR DESCRIPTION
Since we don't use the oracle price for anything (because usdt index prices are used for adjustments on the daemon), let's go ahead and up this to 1k in order to reduce the frequency of USDT price change proposals, which cause the majority of price rejections.

See https://dydx-team.slack.com/archives/C05FTK5D8QG/p1695071966395639?thread_ts=1695067680.294969&cid=C05FTK5D8QG for context.