### PR TITLE
[DEC-2081] Audit app/middleware/middleware.go

### DIFF
--- a/protocol/app/middleware/middleware.go
+++ b/protocol/app/middleware/middleware.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	Logger log.Logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+	Logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 )
 
 func NewRunTxPanicLoggingMiddleware() baseapp.RecoveryHandler {

--- a/protocol/app/middleware/middleware_test.go
+++ b/protocol/app/middleware/middleware_test.go
@@ -1,68 +1,73 @@
 package middleware_test
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/cometbft/cometbft/libs/log"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/app/middleware"
-	"github.com/dydxprotocol/v4-chain/protocol/mocks"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRunTxPanicLoggingMiddleware(t *testing.T) {
-	logger := &mocks.Logger{}
-	middleware.Logger = logger
+	tests := map[string]struct {
+		function     func()
+		expectedLogs []string
+	}{
+		"no panic": {
+			function: func() {
+				// Do something that does not panic.
+			},
+		},
+		"panic with string": {
+			function: func() {
+				panic("test123")
+			},
+			expectedLogs: []string{
+				"E[202",                       // error and date prefix
+				"runTx panic'ed with test123", // message
+				"middleware_test.go",          // part of stack trace
+			},
+		},
+		"panic with error": {
+			function: func() {
+				panic(fmt.Errorf("test456"))
+			},
+			expectedLogs: []string{
+				"E[202",                       // error and date prefix
+				"runTx panic'ed with test456", // message
+				"middleware_test.go",          // part of stack trace
+			},
+		},
+	}
 
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				handler := middleware.NewRunTxPanicLoggingMiddleware()
-				err := handler(r)
-				require.Nil(t, err)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Restore the old logger after the test runs
+			oldLogger := middleware.Logger
+			defer func() { middleware.Logger = oldLogger }()
+
+			buf := new(bytes.Buffer)
+			middleware.Logger = log.NewTMLogger(buf)
+
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						handler := middleware.NewRunTxPanicLoggingMiddleware()
+						err := handler(r)
+						require.Nil(t, err)
+					}
+				}()
+				tc.function()
+			}()
+
+			if tc.expectedLogs == nil {
+				require.Equal(t, "", buf.String())
 			}
-		}()
-		// Do something that does not panic.
-	}()
-	logger.AssertExpectations(t)
-
-	logger.On(
-		"Error",
-		"runTx panic'ed with a problem",
-		"stack trace",
-		mock.Anything,
-	).Return(nil).Once()
-
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				handler := middleware.NewRunTxPanicLoggingMiddleware()
-				err := handler(r)
-				require.Nil(t, err)
+			for _, expectedLog := range tc.expectedLogs {
+				require.Contains(t, buf.String(), expectedLog)
 			}
-		}()
-		// Panic with a string.
-		panic("a problem")
-	}()
-	logger.AssertExpectations(t)
-
-	logger.On(
-		"Error",
-		"runTx panic'ed with a problem",
-		"stack trace",
-		mock.Anything,
-	).Return(nil).Once()
-
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				handler := middleware.NewRunTxPanicLoggingMiddleware()
-				err := handler(r)
-				require.Nil(t, err)
-			}
-		}()
-		// Panic with an error.
-		panic(fmt.Errorf("a problem"))
-	}()
-	logger.AssertExpectations(t)
+		})
+	}
 }

--- a/protocol/app/middleware/middleware_test.go
+++ b/protocol/app/middleware/middleware_test.go
@@ -44,7 +44,7 @@ func TestRunTxPanicLoggingMiddleware(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Restore the old logger after the test runs
+			// Restore the old logger after the test runs since middleware.Logger is a global variable.
 			oldLogger := middleware.Logger
 			defer func() { middleware.Logger = oldLogger }()
 
@@ -63,7 +63,7 @@ func TestRunTxPanicLoggingMiddleware(t *testing.T) {
 			}()
 
 			if tc.expectedLogs == nil {
-				require.Equal(t, "", buf.String())
+				require.Empty(t, buf.String())
 			}
 			for _, expectedLog := range tc.expectedLogs {
 				require.Contains(t, buf.String(), expectedLog)


### PR DESCRIPTION
Changes:
* swap to use test cases
* ensure that the middle ware logger is restored after the test finishes