### PR TITLE
[IND-372] Add caching / rate-limiting logic to screen endpoint.

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/compliance-data-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/compliance-data-table.test.ts
@@ -185,6 +185,54 @@ describe('Compliance data store', () => {
     });
   });
 
+  it('Successfully upserts a new compliance data', async () => {
+    await ComplianceDataTable.upsert(nonBlockedComplianceData);
+
+    const complianceData: ComplianceDataFromDatabase[] = await ComplianceDataTable.findAll(
+      {},
+      [],
+      { readReplica: true },
+    );
+    expect(complianceData.length).toEqual(1);
+    expect(complianceData[0]).toEqual(nonBlockedComplianceData);
+  });
+
+  it('Successfully upserts an existing compliance data', async () => {
+    await ComplianceDataTable.upsert(nonBlockedComplianceData);
+
+    const complianceData: ComplianceDataFromDatabase[] = await ComplianceDataTable.findAll(
+      {},
+      [],
+      { readReplica: true },
+    );
+    expect(complianceData.length).toEqual(1);
+
+    const updatedTime: string = DateTime.fromISO(
+      nonBlockedComplianceData.updatedAt!,
+    ).plus(10).toUTC().toISO();
+
+    await ComplianceDataTable.upsert({
+      address: nonBlockedComplianceData.address,
+      provider: nonBlockedComplianceData.provider,
+      riskScore: '30.00',
+      blocked: true,
+      updatedAt: updatedTime,
+    });
+    const updatedComplianceData:
+    ComplianceDataFromDatabase | undefined = await ComplianceDataTable.findByAddressAndProvider(
+      nonBlockedComplianceData.address,
+      nonBlockedComplianceData.provider,
+      { readReplica: true },
+    );
+
+    expect(updatedComplianceData).toEqual({
+      ...nonBlockedComplianceData,
+      riskScore: '30.00',
+      blocked: true,
+      updatedAt: updatedTime,
+    });
+  });
+
   it('Successfully bulk upserts compliance data', async () => {
     await ComplianceDataTable.create(nonBlockedComplianceData);
 

--- a/indexer/packages/postgres/src/models/compliance-data-model.ts
+++ b/indexer/packages/postgres/src/models/compliance-data-model.ts
@@ -1,6 +1,7 @@
 import { Model } from 'objection';
 
 import { NumericPattern } from '../lib/validators';
+import UpsertQueryBuilder from '../query-builders/upsert';
 import { ComplianceProvider, IsoString } from '../types';
 
 export default class ComplianceDataModel extends Model {
@@ -33,6 +34,8 @@ export default class ComplianceDataModel extends Model {
       },
     };
   }
+
+  QueryBuilderType!: UpsertQueryBuilder<this>;
 
   address!: string;
 

--- a/indexer/packages/postgres/src/stores/compliance-table.ts
+++ b/indexer/packages/postgres/src/stores/compliance-table.ts
@@ -118,6 +118,31 @@ export async function update(
   return updatedComplianceData as unknown as (ComplianceDataFromDatabase | undefined);
 }
 
+export async function upsert(
+  complianceDataToUpsert: ComplianceDataCreateObject,
+  options: Options = { txId: undefined },
+): Promise<ComplianceDataFromDatabase> {
+  const complianceData: ComplianceDataFromDatabase | undefined = await findByAddressAndProvider(
+    complianceDataToUpsert.address,
+    complianceDataToUpsert.provider,
+  );
+  if (complianceData === undefined) {
+    return create({
+      ...complianceDataToUpsert,
+    }, options);
+  }
+
+  const updatedComplianceData: ComplianceDataFromDatabase | undefined = await update({
+    ...complianceDataToUpsert,
+  }, options);
+
+  if (updatedComplianceData === undefined) {
+    throw Error('order must exist after update');
+  }
+
+  return updatedComplianceData;
+}
+
 export async function findByAddressAndProvider(
   address: string,
   provider: string,

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
@@ -1,0 +1,167 @@
+import { RequestMethod } from '../../../../src/types';
+import { sendRequest } from '../../../helpers/helpers';
+import {
+  ComplianceDataFromDatabase,
+  ComplianceTable,
+  dbHelpers,
+  testConstants,
+  testMocks,
+} from '@dydxprotocol-indexer/postgres';
+import { stats } from '@dydxprotocol-indexer/base';
+import { placeHolderProvider } from '../../../../src/helpers/compliance/compliance-clients';
+import { ComplianceClientResponse } from '@dydxprotocol-indexer/compliance';
+import { ratelimitRedis } from '../../../../src/caches/rate-limiters';
+import { redis } from '@dydxprotocol-indexer/redis';
+import { DateTime } from 'luxon';
+import config from '../../../../src/config';
+import { getIpAddr } from '../../../../src/lib/rate-limit';
+
+jest.mock('../../../../src/lib/rate-limit', () => ({
+  ...jest.requireActual('../../../../src/lib/rate-limit'),
+  getIpAddr: jest.fn(),
+}));
+
+describe('compliance-controller#V4', () => {
+  const riskScore: string = '10.00';
+  const blocked: boolean = false;
+  const ipAddr: string = '192.168.1.1';
+
+  const ipAddrMock: jest.Mock = (getIpAddr as unknown as jest.Mock);
+
+  beforeAll(async () => {
+    await dbHelpers.migrate();
+    jest.spyOn(stats, 'increment');
+    jest.spyOn(stats, 'timing');
+  });
+
+  afterAll(async () => {
+    await dbHelpers.teardown();
+  });
+
+  describe('GET', () => {
+    beforeEach(async () => {
+      jest.spyOn(placeHolderProvider.client, 'getComplianceResponse').mockImplementation(
+        (address: string): Promise<ComplianceClientResponse> => {
+          return Promise.resolve({
+            address,
+            blocked,
+            riskScore,
+          });
+        },
+      );
+      ipAddrMock.mockReturnValue(ipAddr);
+      await testMocks.seedData();
+    });
+
+    afterEach(async () => {
+      await redis.deleteAllAsync(ratelimitRedis.client);
+      await dbHelpers.clearData();
+    });
+
+    it('Get /screen with new address gets and stores compliance data from provider', async () => {
+      let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
+      expect(data).toHaveLength(0);
+
+      const response: any = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/screen?address=${testConstants.defaultAddress}`,
+      });
+
+      expect(response.body.restricted).toEqual(false);
+      expect(stats.timing).toHaveBeenCalledTimes(1);
+      expect(placeHolderProvider.client.getComplianceResponse).toHaveBeenCalledTimes(1);
+
+      data = await ComplianceTable.findAll({}, [], {});
+      expect(data).toHaveLength(1);
+      expect(data[0]).toEqual(expect.objectContaining({
+        address: testConstants.defaultAddress,
+        provider: placeHolderProvider.provider,
+        blocked,
+        riskScore,
+      }));
+    });
+
+    it('Get /screen with existing address retrieves compliance data from database', async () => {
+      // Seed the database with a compliance record
+      await ComplianceTable.create(testConstants.nonBlockedComplianceData);
+      let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
+      expect(data).toHaveLength(1);
+
+      const response: any = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/screen?address=${testConstants.defaultAddress}`,
+      });
+
+      expect(response.body.restricted).toEqual(false);
+      expect(stats.timing).toHaveBeenCalledTimes(1);
+      expect(placeHolderProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
+
+      data = await ComplianceTable.findAll({}, [], {});
+      expect(data).toHaveLength(1);
+      expect(data[0]).toEqual(testConstants.nonBlockedComplianceData);
+    });
+
+    it('Get /screen with old existing address refreshes compliance data', async () => {
+      // Seed the database with an old compliance record
+      await ComplianceTable.create({
+        ...testConstants.nonBlockedComplianceData,
+        updatedAt: DateTime.utc().minus({
+          seconds: config.MAX_AGE_SCREENED_ADDRESS_COMPLIANCE_DATA_SECONDS * 2,
+        }).toISO(),
+      });
+      let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
+      expect(data).toHaveLength(1);
+
+      const response: any = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/screen?address=${testConstants.defaultAddress}`,
+      });
+
+      expect(response.body.restricted).toEqual(false);
+      expect(stats.timing).toHaveBeenCalledTimes(1);
+      expect(placeHolderProvider.client.getComplianceResponse).toHaveBeenCalledTimes(1);
+
+      data = await ComplianceTable.findAll({}, [], {});
+      expect(data).toHaveLength(1);
+      expect(data[0]).not.toEqual({
+        address: testConstants.defaultAddress,
+        provider: placeHolderProvider.provider,
+        blocked,
+        riskScore,
+      });
+    });
+
+    it('Get /screen with multiple new address from same IP gets rate-limited', async () => {
+      for (let i: number = 0; i < config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_POINTS; i++) {
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/screen?address=${i}`,
+        });
+      }
+
+      await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/screen?address=${testConstants.defaultAddress}`,
+        errorMsg: 'Too many requests',
+        expectedStatus: 429,
+      });
+    });
+
+    it('Get /screen with multiple new address globally gets rate-limited', async () => {
+      ipAddrMock.mockImplementation(() => Math.random().toString());
+      for (let i: number = 0; i < config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_POINTS; i++) {
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/screen?address=${i}`,
+        });
+      }
+
+      await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/screen?address=${testConstants.defaultAddress}`,
+        errorMsg: 'Too many requests',
+        expectedStatus: 429,
+      });
+    });
+  });
+});

--- a/indexer/services/comlink/src/caches/rate-limiters.ts
+++ b/indexer/services/comlink/src/caches/rate-limiters.ts
@@ -17,3 +17,17 @@ export const getReqRateLimiter: RateLimiterRedis = new RateLimiterRedis({
   duration: config.RATE_LIMIT_GET_DURATION_SECONDS,
   keyPrefix: `${config.SERVICE_NAME}/get`,
 });
+
+export const screenProviderLimiter: RateLimiterRedis = new RateLimiterRedis({
+  storeClient: ratelimitRedis.client,
+  points: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_POINTS,
+  duration: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_DURATION_SECONDS,
+  keyPrefix: `${config.SERVICE_NAME}/screen_providers`,
+});
+
+export const screenProviderGlobalLimiter: RateLimiterRedis = new RateLimiterRedis({
+  storeClient: ratelimitRedis.client,
+  points: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_POINTS,
+  duration: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_DURATION_SECONDS,
+  keyPrefix: `${config.SERVICE_NAME}/screen_providers_global`,
+});

--- a/indexer/services/comlink/src/caches/rate-limiters.ts
+++ b/indexer/services/comlink/src/caches/rate-limiters.ts
@@ -11,6 +11,7 @@ export const ratelimitRedis: {
   config.RATE_LIMIT_REDIS_URL, config.REDIS_RECONNECT_TIMEOUT_MS,
 );
 
+// Generic rate limiter for all GET requests, limits per IP
 export const getReqRateLimiter: RateLimiterRedis = new RateLimiterRedis({
   storeClient: ratelimitRedis.client,
   points: config.RATE_LIMIT_GET_POINTS,
@@ -18,6 +19,7 @@ export const getReqRateLimiter: RateLimiterRedis = new RateLimiterRedis({
   keyPrefix: `${config.SERVICE_NAME}/get`,
 });
 
+// Rate-limiter for /screen endpoint querying a compliance provider, limits per IP
 export const screenProviderLimiter: RateLimiterRedis = new RateLimiterRedis({
   storeClient: ratelimitRedis.client,
   points: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_POINTS,
@@ -25,6 +27,8 @@ export const screenProviderLimiter: RateLimiterRedis = new RateLimiterRedis({
   keyPrefix: `${config.SERVICE_NAME}/screen_providers`,
 });
 
+// Rate-limiter for /screen endpoint querying a compliance provider, limits the total calls made
+// across all IPs
 export const screenProviderGlobalLimiter: RateLimiterRedis = new RateLimiterRedis({
   storeClient: ratelimitRedis.client,
   points: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_POINTS,

--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -42,6 +42,15 @@ export const configSchema = {
   // point
   RATE_LIMIT_GET_POINTS: parseInteger({ default: 100 }),
   RATE_LIMIT_GET_DURATION_SECONDS: parseInteger({ default: 10 }), // 100 requests / 10 seconds
+
+  // Rate limit for screening new / refreshed addresses
+  RATE_LIMIT_SCREEN_QUERY_PROVIDER_POINTS: parseInteger({ default: 2 }),
+  RATE_LIMIT_SCREEN_QUERY_PROVIDER_DURATION_SECONDS: parseInteger({ default: 60 }), // 2 reqs / min
+  RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_POINTS: parseInteger({ default: 100 }),
+  // 100 req / min
+  RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_DURATION_SECONDS: parseInteger({ default: 60 }),
+  // Threshold for refreshing compliance data for an address when screened
+  MAX_AGE_SCREENED_ADDRESS_COMPLIANCE_DATA_SECONDS: parseInteger({ default: 86_400 }), //  1 day
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -1,46 +1,78 @@
-import { stats } from '@dydxprotocol-indexer/base';
+import { logger, stats } from '@dydxprotocol-indexer/base';
 import { ComplianceClientResponse } from '@dydxprotocol-indexer/compliance';
+import { ComplianceDataFromDatabase, ComplianceTable } from '@dydxprotocol-indexer/postgres';
 import express from 'express';
 import { checkSchema, matchedData } from 'express-validator';
+import { DateTime } from 'luxon';
 import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import {
+  getReqRateLimiter,
+  screenProviderLimiter,
+  screenProviderGlobalLimiter,
+} from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { placeHolderProvider } from '../../../helpers/compliance/compliance-clients';
 import { complianceCheck } from '../../../lib/compliance-check';
-import { handleControllerError } from '../../../lib/helpers';
-import { rateLimiterMiddleware } from '../../../lib/rate-limit';
+import { TooManyRequestsError } from '../../../lib/errors';
+import { create4xxResponse, handleControllerError } from '../../../lib/helpers';
+import { getIpAddr, rateLimiterMiddleware } from '../../../lib/rate-limit';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { ComplianceRequest, ComplianceResponse } from '../../../types';
 
 const router: express.Router = express.Router();
 const controllerName: string = 'compliance-controller';
+const uncachedQueryPoints: number = 1;
+const globalRateLimitKey: string = 'screenQueryProviderGlobal';
 
 @Route('screen')
 class ComplianceController extends Controller {
+  private ipAddress: string;
+
+  constructor(ipAddress: string) {
+    super();
+    this.ipAddress = ipAddress;
+  }
+
   @Get('/')
   async screen(
     @Query() address: string,
   ): Promise<ComplianceResponse> {
-    // TODO(IND-372): Add logic to either use cached data or query provider
-    // TODO(IND-369): Use Ellptic client
-    const response:
-    ComplianceClientResponse = await placeHolderProvider.client.getComplianceResponse(
+    const ageThreshold: DateTime = DateTime.utc().minus({
+      seconds: config.MAX_AGE_SCREENED_ADDRESS_COMPLIANCE_DATA_SECONDS,
+    });
+
+    let complianceData:
+    ComplianceDataFromDatabase | undefined = await ComplianceTable.findByAddressAndProvider(
       address,
+      placeHolderProvider.provider,
     );
 
+    if (complianceData === undefined || DateTime.fromISO(complianceData.updatedAt) < ageThreshold) {
+      await checkRateLimit(this.ipAddress);
+      // TODO(IND-369): Use Ellptic client
+      const response:
+      ComplianceClientResponse = await placeHolderProvider.client.getComplianceResponse(
+        address,
+      );
+      complianceData = await ComplianceTable.upsert({
+        ...response,
+        provider: placeHolderProvider.provider,
+        updatedAt: DateTime.utc().toISO(),
+      });
+    }
+
     return {
-      restricted: response.blocked,
+      restricted: complianceData.blocked,
     };
   }
 }
 
 router.get(
   '/',
-  // TODO(IND-372): Add custom rate-limiter around un-cached requests / global rate-limit
   rateLimiterMiddleware(getReqRateLimiter),
   ...checkSchema({
     address: {
@@ -61,11 +93,22 @@ router.get(
     } = matchedData(req) as ComplianceRequest;
 
     try {
-      const controller: ComplianceController = new ComplianceController();
+      // Rate limiter middleware ensures the ip address can be found from the request
+      const ipAddress: string = getIpAddr(req)!;
+
+      const controller: ComplianceController = new ComplianceController(ipAddress);
       const response: ComplianceResponse = await controller.screen(address);
 
       return res.send(response);
     } catch (error) {
+      if (error instanceof TooManyRequestsError) {
+        return create4xxResponse(
+          res,
+          'Too many requests',
+          429,
+        );
+      }
+      console.log(error);
       return handleControllerError(
         'ComplianceController GET /',
         'Compliance error',
@@ -80,5 +123,24 @@ router.get(
     }
   },
 );
+
+async function checkRateLimit(ipAddress: string) {
+  try {
+    await Promise.all([
+      screenProviderLimiter.consume(ipAddress, uncachedQueryPoints),
+      screenProviderGlobalLimiter.consume(globalRateLimitKey, uncachedQueryPoints),
+    ]);
+  } catch (reject) {
+    if (reject instanceof Error) {
+      logger.error({
+        at: 'rate-limit',
+        message: 'redis error when checking rate limit',
+        reject,
+      });
+    } else {
+      throw new TooManyRequestsError('Too many requests');
+    }
+  }
+}
 
 export default router;

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -25,8 +25,8 @@ import { ComplianceRequest, ComplianceResponse } from '../../../types';
 
 const router: express.Router = express.Router();
 const controllerName: string = 'compliance-controller';
-const uncachedQueryPoints: number = 1;
-const globalRateLimitKey: string = 'screenQueryProviderGlobal';
+const UNCACHED_QUERY_POINTS: number = 1;
+const GLOBAL_RATE_LIMIT_KEY: string = 'screenQueryProviderGlobal';
 
 @Route('screen')
 class ComplianceController extends Controller {
@@ -127,8 +127,8 @@ router.get(
 async function checkRateLimit(ipAddress: string) {
   try {
     await Promise.all([
-      screenProviderLimiter.consume(ipAddress, uncachedQueryPoints),
-      screenProviderGlobalLimiter.consume(globalRateLimitKey, uncachedQueryPoints),
+      screenProviderLimiter.consume(ipAddress, UNCACHED_QUERY_POINTS),
+      screenProviderGlobalLimiter.consume(GLOBAL_RATE_LIMIT_KEY, UNCACHED_QUERY_POINTS),
     ]);
   } catch (reject) {
     if (reject instanceof Error) {

--- a/indexer/services/comlink/src/controllers/api/v4/height-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/height-controller.ts
@@ -44,8 +44,8 @@ router.get(
       return res.send(response);
     } catch (error) {
       return handleControllerError(
-        'FillsController GET /',
-        'Fills error',
+        'HeightController GET /',
+        'Height error',
         error,
         res,
       );

--- a/indexer/services/comlink/src/lib/errors.ts
+++ b/indexer/services/comlink/src/lib/errors.ts
@@ -18,3 +18,10 @@ export class NotFoundError extends Error {
     this.name = 'NotFoundError';
   }
 }
+
+export class TooManyRequestsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TooManyRequestsError';
+  }
+}

--- a/indexer/services/comlink/src/lib/rate-limit.ts
+++ b/indexer/services/comlink/src/lib/rate-limit.ts
@@ -73,7 +73,7 @@ export function rateLimiterMiddleware(
   };
 }
 
-function getIpAddr(req: express.Request): string | undefined {
+export function getIpAddr(req: express.Request): string | undefined {
   const {
     'cf-connecting-ip': cloudflareIP,
     'x-forwarded-for': loadBalancerHeader,


### PR DESCRIPTION
Add logic to `/screen` endpoint to either retrieve the compliance data from the provider for new addresses / addresses with out-dated data or gets the data from the database.

Added rate-limiting logic directly into the controller as the custom logic depends on finding the compliance data in the database first.

Added `upsert` function for compliance data table.