### PR TITLE
Height gate missing index price err log

### DIFF
--- a/protocol/x/prices/types/constants.go
+++ b/protocol/x/prices/types/constants.go
@@ -3,5 +3,6 @@ package types
 import "time"
 
 const (
-	MarketIsRecentDuration = 20 * time.Second
+	MarketIsRecentDuration    = 20 * time.Second
+	PriceInitializationBlocks = 10
 )

--- a/protocol/x/prices/types/constants.go
+++ b/protocol/x/prices/types/constants.go
@@ -3,6 +3,6 @@ package types
 import "time"
 
 const (
-	MarketIsRecentDuration    = 20 * time.Second
-	PriceInitializationBlocks = 10
+	MarketIsRecentDuration          = 20 * time.Second
+	PriceDaemonInitializationBlocks = 20
 )


### PR DESCRIPTION
Do not log error/increment stats if missing index price is observed during the first 20 blocks (price daemon initialization period)
[Context](https://dydx-team.slack.com/archives/C05AWN29RS4/p1695396499623849?thread_ts=1695391605.690219&cid=C05AWN29RS4)
Safe to backport - no application behavior change