### PR TITLE
Speed up order fill handler by creating an index on [subaccountId, perpetualId, createdAtHeight] in perpetual positions table

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20230922141210_create_perpetual_positions_subaccount_perpetual_created_at_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20230922141210_create_perpetual_positions_subaccount_perpetual_created_at_index.ts
@@ -1,0 +1,18 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/quotes
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "perpetual_positions_subaccount_perpetual_created_at_index" ON "perpetual_positions" ("subaccountId", "perpetualId", "createdAtHeight");
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "perpetual_positions_subaccount_perpetual_created_at_index";
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
Speed up order fill handler by creating an index on subaccountId, perpetualId, createdAtHeight in perpetual positions table