### PR TITLE
[CORE-594] - Remove all bitfinex exchange symbols. Update Binance USDT ticker to 1 / USDCUSDT

### DIFF
--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config.go
@@ -155,41 +155,8 @@ var (
 					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
 				},
 				exchange_common.MARKET_USDT_USD: {
-					Ticker:         "BTCUSDT", // Adjusted with BTC index price.
-					Invert:         true,
-					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_BTC_USD),
-				},
-			},
-		},
-		exchange_common.EXCHANGE_ID_BITFINEX: {
-			Id: exchange_common.EXCHANGE_ID_BITFINEX,
-			// Note: we treat all Bitfinex pairs as USDT.
-			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
-				exchange_common.MARKET_BTC_USD: {
-					Ticker: "tBTCUSD",
-				},
-				exchange_common.MARKET_ETH_USD: {
-					Ticker: "tETHUSD",
-				},
-				exchange_common.MARKET_SOL_USD: {
-					Ticker:         "tSOLUSD",
-					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
-				},
-				exchange_common.MARKET_ADA_USD: {
-					Ticker: "tADAUSD",
-				},
-				exchange_common.MARKET_DOT_USD: {
-					Ticker: "tDOTUSD",
-				},
-				exchange_common.MARKET_XLM_USD: {
-					Ticker:         "tXLMUSD",
-					AdjustByMarket: newMarketIdWithValue(exchange_common.MARKET_USDT_USD),
-				},
-				exchange_common.MARKET_XRP_USD: {
-					Ticker: "tXRPUSD",
-				},
-				exchange_common.MARKET_USDT_USD: {
-					Ticker: "tUSTUSD",
+					Ticker: "USDCUSDT",
+					Invert: true,
 				},
 			},
 		},

--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
@@ -1,7 +1,6 @@
 package constants
 
 import (
-	"os"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
@@ -182,11 +181,11 @@ func TestGenerateExchangeConfigJson(t *testing.T) {
 			configs := GenerateExchangeConfigJson(StaticExchangeMarketConfig)
 
 			// Uncomment to update test data
-			f, err := os.OpenFile("testdata/"+tc.expectedExchangeConfigJsonFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-			require.NoError(t, err)
-			defer f.Close()
-			_, err = f.WriteString(configs[tc.id] + "\n") // Final newline added manually.
-			require.NoError(t, err)
+			//f, err := os.OpenFile("testdata/"+tc.expectedExchangeConfigJsonFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+			//require.NoError(t, err)
+			//defer f.Close()
+			//_, err = f.WriteString(configs[tc.id] + "\n") // Final newline added manually.
+			//require.NoError(t, err)
 
 			actualExchangeConfigJson := json.CompactJsonString(t, configs[tc.id])
 			expectedExchangeConfigJson := pricefeed.ReadJsonTestFile(t, tc.expectedExchangeConfigJsonFile)

--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"os"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
@@ -11,7 +12,7 @@ import (
 )
 
 func TestStaticExchangeMarketConfigCacheLen(t *testing.T) {
-	require.Len(t, StaticExchangeMarketConfig, 14)
+	require.Len(t, StaticExchangeMarketConfig, 13)
 }
 
 func TestGenerateExchangeConfigJsonLength(t *testing.T) {
@@ -181,11 +182,11 @@ func TestGenerateExchangeConfigJson(t *testing.T) {
 			configs := GenerateExchangeConfigJson(StaticExchangeMarketConfig)
 
 			// Uncomment to update test data
-			//f, err := os.OpenFile("testdata/"+tc.expectedExchangeConfigJsonFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-			//require.NoError(t, err)
-			//defer f.Close()
-			//_, err = f.WriteString(configs[tc.id] + "\n") // Final newline added manually.
-			//require.NoError(t, err)
+			f, err := os.OpenFile("testdata/"+tc.expectedExchangeConfigJsonFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+			require.NoError(t, err)
+			defer f.Close()
+			_, err = f.WriteString(configs[tc.id] + "\n") // Final newline added manually.
+			require.NoError(t, err)
 
 			actualExchangeConfigJson := json.CompactJsonString(t, configs[tc.id])
 			expectedExchangeConfigJson := pricefeed.ReadJsonTestFile(t, tc.expectedExchangeConfigJsonFile)

--- a/protocol/daemons/pricefeed/client/constants/testdata/ada_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/ada_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitfinex",
-      "ticker": "tADAUSD"
-    },
-    {
       "exchangeName": "Bitstamp",
       "ticker": "ADA/USD"
     },

--- a/protocol/daemons/pricefeed/client/constants/testdata/btc_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/btc_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitfinex",
-      "ticker": "tBTCUSD"
-    },
-    {
       "exchangeName": "Bitstamp",
       "ticker": "BTC/USD"
     },

--- a/protocol/daemons/pricefeed/client/constants/testdata/dot_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/dot_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitfinex",
-      "ticker": "tDOTUSD"
-    },
-    {
       "exchangeName": "CoinbasePro",
       "ticker": "DOT-USD"
     },

--- a/protocol/daemons/pricefeed/client/constants/testdata/eth_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/eth_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitfinex",
-      "ticker": "tETHUSD"
-    },
-    {
       "exchangeName": "Bitstamp",
       "ticker": "ETH/USD"
     },

--- a/protocol/daemons/pricefeed/client/constants/testdata/sol_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/sol_exchange_config.json
@@ -6,11 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitfinex",
-      "ticker": "tSOLUSD",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "SOLUSDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/usdt_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/usdt_exchange_config.json
@@ -2,13 +2,8 @@
   "exchanges": [
     {
       "exchangeName": "Binance",
-      "ticker": "BTCUSDT",
-      "adjustByMarket": "BTC-USD",
+      "ticker": "USDCUSDT",
       "invert": true
-    },
-    {
-      "exchangeName": "Bitfinex",
-      "ticker": "tUSTUSD"
     },
     {
       "exchangeName": "Bitstamp",

--- a/protocol/daemons/pricefeed/client/constants/testdata/xlm_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/xlm_exchange_config.json
@@ -6,11 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitfinex",
-      "ticker": "tXLMUSD",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
       "exchangeName": "Bitstamp",
       "ticker": "XLM/USD"
     },

--- a/protocol/daemons/pricefeed/client/constants/testdata/xrp_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/xrp_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitfinex",
-      "ticker": "tXRPUSD"
-    },
-    {
       "exchangeName": "Bitstamp",
       "ticker": "XRP/USD"
     },

--- a/protocol/testutil/pricefeed/exchangeserver.go
+++ b/protocol/testutil/pricefeed/exchangeserver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/price_function/testexchange"
 	pricefeed "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/prices/client/testutil"
 	"io"
 	"log"
 	"net/http"
@@ -31,8 +32,8 @@ func init() {
 	for marketId, config := range testExchangeConfig.MarketToMarketConfig {
 		testExchangeSymbolToMarketId[config.Ticker] = marketId
 	}
-	bitfinexExchangeConfig := constants.StaticExchangeMarketConfig[exchange_common.EXCHANGE_ID_BITFINEX]
-	for marketId, config := range bitfinexExchangeConfig.MarketToMarketConfig {
+
+	for marketId, config := range testutil.BitfinexExchangeConfig {
 		bitfinexExchangeSymbolToMarketId[config.Ticker] = marketId
 	}
 }

--- a/protocol/x/prices/client/testutil/bitfinex.go
+++ b/protocol/x/prices/client/testutil/bitfinex.go
@@ -1,8 +1,6 @@
 package testutil
 
 import (
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants"
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/handler"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/price_function/bitfinex"
 	"github.com/h2non/gock"
@@ -49,9 +47,7 @@ func NewGockBitfinexResponse(
 	tickers []JsonResponse,
 ) *gock.Response {
 	// Construct Bitfinex request URL.
-	sortedSymbols := GetTickersSortedByMarketId(
-		constants.StaticExchangeMarketConfig[exchange_common.EXCHANGE_ID_BITFINEX].MarketToMarketConfig,
-	)
+	sortedSymbols := GetTickersSortedByMarketId(BitfinexExchangeConfig)
 	url := handler.CreateRequestUrl(bitfinex.BitfinexDetails.Url, sortedSymbols)
 
 	// Construct Bitfinex response as a list of tickers.

--- a/protocol/x/prices/client/testutil/constants.go
+++ b/protocol/x/prices/client/testutil/constants.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
+	pricefeed "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 )
 
@@ -18,6 +19,19 @@ var (
 
 	bitfinexTicker_Btc102  = NewBitfinexTicker("tBTCUSD", 101.0, 102.0, 103.0)
 	bitfinexTicker_Eth9002 = NewBitfinexTicker("tETHUSD", 9001.0, 9002.0, 9003.0)
+
+	// Test Bitfinex Config
+	BitfinexExchangeConfig = map[pricefeed.MarketId]pricefeed.MarketConfig{
+		exchange_common.MARKET_BTC_USD: {
+			Ticker: "tBTCUSD",
+		},
+		exchange_common.MARKET_ETH_USD: {
+			Ticker: "tETHUSD",
+		},
+		exchange_common.MARKET_USDT_USD: {
+			Ticker: "tUSTUSD",
+		},
+	}
 
 	// Exchange responses.
 	EmptyResponses_AllExchanges = map[ExchangeIdAndName]Response{


### PR DESCRIPTION
As per [this conversation](https://dydx-team.slack.com/archives/C05FTK5D8QG/p1695415034712729?thread_ts=1695067680.294969&cid=C05FTK5D8QG). BinanceUS already removed for all pairs, Gate USDT-USD also already removed.