### PR TITLE
Add backport rule for mergify bot

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,15 @@
+defaults:
+  actions:
+    backport:
+      assignees:
+        - "{{ author }}"
+
+pull_request_rules:
+  - name: backport to release/protocol/v0.3.x branch
+    conditions:
+      - base=main
+      - label=backport/v0.3.x
+    actions:
+      backport:
+        branches:
+          - release/protocol/v0.3.x


### PR DESCRIPTION
This rule will allow users to backport to the latest release branch.