### PR TITLE
allow bridge daemon to add events that have IDs greater than off-chain recognized event ID

### DIFF
--- a/protocol/daemons/bridge/client/client.go
+++ b/protocol/daemons/bridge/client/client.go
@@ -3,18 +3,17 @@ package client
 import (
 	"context"
 	"fmt"
-	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"math/big"
 	"time"
 
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/telemetry"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/bridge/api"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/bridge/client/types"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
-
 	libeth "github.com/dydxprotocol/v4-chain/protocol/lib/eth"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	bridgetypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"

--- a/protocol/daemons/server/types/bridge/bridge_event_manager.go
+++ b/protocol/daemons/server/types/bridge/bridge_event_manager.go
@@ -75,31 +75,12 @@ func (b *BridgeEventManager) AddBridgeEvents(
 		}
 	}
 
-	// Event IDs cannot be skipped.
-	if events[0].Id > b.recognizedEventInfo.NextId {
-		telemetry.IncrCounter(1, metrics.BridgeServer, metrics.AddBridgeEvents, metrics.EventIdNotNextExpected)
-		return fmt.Errorf(
-			"AddBridgeEvents: Event ID %d is greater than the Next Id %d.",
-			events[0].Id,
-			b.recognizedEventInfo.NextId,
-		)
-	}
-
 	now := b.timeProvider.Now()
 	for _, event := range events {
 		// Ignore stale events which may be the result of a race condition.
 		if event.Id < b.recognizedEventInfo.NextId {
 			telemetry.IncrCounter(1, metrics.BridgeServer, metrics.AddBridgeEvents, metrics.EventIdAlreadyRecognized)
 			continue
-		}
-
-		// Due to the above validation, the eventId should always be the next expected.
-		if event.Id != b.recognizedEventInfo.NextId {
-			panic(fmt.Errorf(
-				"Event ID %d does not match the Next Id %d",
-				event.Id,
-				b.recognizedEventInfo.NextId,
-			))
 		}
 
 		// Update BridgeEventManager with the new event.

--- a/protocol/daemons/server/types/bridge/bridge_event_manager_test.go
+++ b/protocol/daemons/server/types/bridge/bridge_event_manager_test.go
@@ -167,16 +167,6 @@ func TestBridgeEventManager_AddBridgeEvents(t *testing.T) {
 			},
 			errorMsg: "contiguous",
 		},
-		"Error Skip": {
-			initialREI: types.BridgeEventInfo{
-				NextId:         0,
-				EthBlockHeight: 0,
-			},
-			events: []types.BridgeEvent{
-				constants.BridgeEvent_Id1_Height0,
-			},
-			errorMsg: "is greater than the Next Id",
-		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -82,7 +82,6 @@ const (
 	EthBlockHeight           = "eth_block_height"
 	EventIdAlreadyRecognized = "event_id_already_recognized"
 	EventIdNotSequential     = "event_id_not_sequential"
-	EventIdNotNextExpected   = "event_id_not_next_expected"
 	NextId                   = "next_id"
 	RecognizedEventInfo      = "recognized_event_info"
 


### PR DESCRIPTION
If recognized event ID is smaller than acknowledged event ID (see [here](https://github.com/dydxprotocol/v4-chain/pull/365/files#diff-1e30e65863b15e431d8c52fb682f4b60d4e80aab68dc1535a69af96f501bdf71R266-R272) for what can cause this), bridge server will throw an error like:
```
AddBridgeEvents: Event ID 2 is greater than the Next Id 0.
```

1st commit adds a test case that demonstrates the issue ([see error here](https://github.com/dydxprotocol/v4-chain/actions/runs/6303972749/job/17114348754?pr=365#step:5:133))