### PR TITLE
add a script to output hex from bech32

### DIFF
--- a/protocol/scripts/bech32_to_hex/bech32_to_hex.go
+++ b/protocol/scripts/bech32_to_hex/bech32_to_hex.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+)
+
+/*
+main converts a bech32 address to hexadecimal by removing the HRP, separator, and checksum from the address.
+This output can be used in an EVM bridge contract to emit the correct event to produce the bech32 address.
+
+Usage:
+
+	go run scripts/bech32_to_hex/bech32_to_hex.go \
+		-address <bech32_address>
+*/
+func main() {
+	// ------------ FLAGS ------------
+
+	// Get flags.
+	var bech32Address string
+	flag.StringVar(&bech32Address, "address", "dydx1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5kmz6xt", "bech32 address")
+	flag.Parse()
+
+	// Print the flags used for the user
+	fmt.Println("Using the following configuration (modifiable via flags):")
+	fmt.Println("address:", bech32Address)
+	fmt.Println()
+
+	// ------------ LOGIC ------------
+
+	hrp, decoded, err := bech32.DecodeAndConvert(bech32Address)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// ------------ OUTPUT ------------
+
+	fmt.Printf("HRP: %s\n", hrp)
+	fmt.Printf(
+		"Hexadecimal bytes (length %d): 0x%s\n",
+		len(decoded),
+		hex.EncodeToString(decoded),
+	)
+}

--- a/protocol/scripts/bridge_events/bridge_events.go
+++ b/protocol/scripts/bridge_events/bridge_events.go
@@ -28,7 +28,7 @@ relevant state that would be modified as a result of these events.
 
 Usage:
 
-	go run scripts/bridge_events.go \
+	go run scripts/bridge_events/bridge_events.go \
 		-denom <token_denom> \
 		-rpc <rpc_node_url> \
 		-address <bridge_contract_address> \


### PR DESCRIPTION
Adding a script to convert a `bech32` address to a hexadecimal bytes representation.

Minor change: Each script should be in it's own folder so it can be in a `main` package (as I have not set up Cobra for these scripts)
https://stackoverflow.com/questions/27140130/having-multiple-main-functions-on-go