### PR TITLE
Small fix to container test

### DIFF
--- a/protocol/testing/containertest/testnet.go
+++ b/protocol/testing/containertest/testnet.go
@@ -73,7 +73,7 @@ func (t *Testnet) Start() (err error) {
 	err = t.initialize()
 	if err != nil {
 		cleanUpErr := t.CleanUp()
-		if cleanUpErr != nil {
+		if cleanUpErr == nil {
 			return fmt.Errorf("testnet initialization failed with error: %w; resources successfully cleaned up", err)
 		}
 		return fmt.Errorf(

--- a/protocol/testing/containertest/testnet_test.go
+++ b/protocol/testing/containertest/testnet_test.go
@@ -3,10 +3,15 @@
 package containertest
 
 import (
-	sdkmath "cosmossdk.io/math"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/gogoproto/jsonpb"
@@ -20,10 +25,6 @@ import (
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 const expectDirName = "expect"
@@ -100,7 +101,7 @@ func TestPlaceOrder(t *testing.T) {
 				},
 				Side:     clob.Order_SIDE_BUY,
 				Quantums: 10_000_000,
-				Subticks: 10_000,
+				Subticks: 1_000_000,
 				GoodTilOneof: &clob.Order_GoodTilBlock{
 					GoodTilBlock: 20,
 				},

--- a/protocol/testing/containertest/testnet_test.go
+++ b/protocol/testing/containertest/testnet_test.go
@@ -109,6 +109,7 @@ func TestPlaceOrder(t *testing.T) {
 		},
 		constants.AliceAccAddress.String(),
 	))
+	// TODO(CLOB-905): place another matching order, and verify that the trade is executed.
 }
 
 func TestBankSend(t *testing.T) {


### PR DESCRIPTION
- Fixed `order.Sutbticks` to be multiple of `ClobPair.SubticksPerTick`
- Fixed a test error log

Current result:
```
code: 12
codespace: clob
data: ""
events: []
gas_used: "0"
gas_wanted: "0"
height: "0"
info: ""
logs: []
raw_log: 'Order subticks 10000 must be a multiple of the ClobPair''s SubticksPerTick
  100000: MsgPlaceOrder is invalid'
timestamp: ""
tx: null
txhash: 0295FA11536837BC3794DED6F7B56F8AD7B035D3C26F2F19896A46D638B1F363l
```

