### PR TITLE
Fix localnet docker issues

### DIFF
--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -245,7 +245,6 @@ test-container-accept:
 
 test-container-build:
 	$(MAKE) localnet-build
-	@docker build . -t dydxprotocol-localnet -f testing/testnet-local/Dockerfile --no-cache
 	@docker build . -t dydxprotocol-container-test -f testing/containertest/Dockerfile --no-cache
 
 .PHONY: test test-all test-cover test-unit test-race test-container
@@ -366,11 +365,13 @@ localnet-init:
 
 localnet-compose-up:
 	@echo "Launching localnet at commit ${GIT_COMMIT_HASH}"
-	@docker-compose -f docker-compose.yml up --build --force-recreate $(ARGS)
+	@docker build . -t local:dydxprotocol -f testing/testnet-local/Dockerfile --no-cache
+	@docker-compose -f docker-compose.yml up --force-recreate $(ARGS)
 
 localnet-compose-upd:
 	@echo "Launching localnet at commit ${GIT_COMMIT_HASH}"
-	@docker-compose -f docker-compose.yml up --build --force-recreate -d $(ARGS)
+	@docker build . -t local:dydxprotocol -f testing/testnet-local/Dockerfile --no-cache
+	@docker-compose -f docker-compose.yml up --force-recreate -d $(ARGS)
 
 localnet-start: localnet-init localnet-compose-up
 localnet-startd: localnet-init localnet-compose-upd

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -3,12 +3,6 @@ version: "3"
 services:
   dydxprotocold0:
     image: local:dydxprotocol
-    build:
-      context: .
-      dockerfile: ./testing/testnet-local/Dockerfile
-      args:
-        RUNNER_IMAGE: alpine:3.16
-        GO_VERSION: 1.19
     entrypoint:
       - dydxprotocold
       - start


### PR DESCRIPTION
Gradually more and more people have been having the issue where docker compose is looking for `dydxprotocol-base` in docker hub when it exists locally already. Building outside of docker compose fixes this.