### PR TITLE
Remove swagger gen workflow.

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -114,9 +114,3 @@ jobs:
           npm install
           npm run transpile
           npm run build
-  swagger-gen:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - working-directory: ./protocol
-        run: make proto-swagger-gen && git diff --exit-code


### PR DESCRIPTION
The swagger gen command is currently incorrectly pulling in the latest Cosmos / IBC protos to generate the swagger, instead of the protos depended on by the built binary.