### PR TITLE
[DEC-2070] - x/prices audit: add test cases to util, clarifying comments

### DIFF
--- a/protocol/x/prices/keeper/util.go
+++ b/protocol/x/prices/keeper/util.go
@@ -10,7 +10,8 @@ import (
 )
 
 // getProposalPrice returns the proposed price update for the next block, which is either the smoothed price or the
-// index price - whichever is closer to the current market price.
+// index price - whichever is closer to the current market price. In cases where the smoothed price and the index price
+// are equidistant from the current market price, the smoothed price is chosen.
 func getProposalPrice(smoothedPrice uint64, indexPrice uint64, marketPrice uint64) uint64 {
 	if lib.AbsDiffUint64(smoothedPrice, marketPrice) > lib.AbsDiffUint64(indexPrice, marketPrice) {
 		return indexPrice
@@ -26,7 +27,8 @@ func isAboveRequiredMinPriceChange(marketParamPrice types.MarketParamPrice, newP
 }
 
 // getMinPriceChangeAmountForMarket returns the amount of price change that is needed to trigger
-// a price update in accordance with the min price change parts-per-million value.
+// a price update in accordance with the min price change parts-per-million value. This method always rounds down,
+// which slightly biases towards price updates.
 func getMinPriceChangeAmountForMarket(marketParamPrice types.MarketParamPrice) uint64 {
 	bigPrice := new(big.Int).SetUint64(marketParamPrice.Price.Price)
 	// There's no need to multiply this by the market's exponent, because `Price` comparisons are

--- a/protocol/x/prices/keeper/util_test.go
+++ b/protocol/x/prices/keeper/util_test.go
@@ -58,6 +58,12 @@ func TestGetProposalPrice(t *testing.T) {
 			marketPrice:   uint64(1_000_000),
 			expectedPrice: uint64(900_000),
 		},
+		"smoothedPrice: smoothedPrice < marketPrice < indexPrice": {
+			smoothedPrice: uint64(900_000),
+			indexPrice:    uint64(1_100_000),
+			marketPrice:   uint64(1_000_000),
+			expectedPrice: uint64(900_000),
+		},
 		"indexPrice: indexPrice < marketPrice << smoothedPrice": {
 			smoothedPrice: uint64(1_500_000),
 			indexPrice:    uint64(900_000),
@@ -67,6 +73,12 @@ func TestGetProposalPrice(t *testing.T) {
 		"smoothedPrice: indexPrice << marketPrice < smoothedPrice": {
 			smoothedPrice: uint64(1_100_000),
 			indexPrice:    uint64(500_000),
+			marketPrice:   uint64(1_000_000),
+			expectedPrice: uint64(1_100_000),
+		},
+		"smoothedPrice: indexPrice < marketPrice < smoothedPrice": {
+			smoothedPrice: uint64(1_100_000),
+			indexPrice:    uint64(900_000),
 			marketPrice:   uint64(1_000_000),
 			expectedPrice: uint64(1_100_000),
 		},
@@ -178,7 +190,7 @@ func TestIsTowardsIndexPrice(t *testing.T) {
 			indexPrice:     2,
 			expectedResult: true,
 		},
-		"Towards: idx < curr == new": {
+		"Towards: idx < new == curr": {
 			oldPrice:       2,
 			newPrice:       2,
 			indexPrice:     1,
@@ -190,7 +202,7 @@ func TestIsTowardsIndexPrice(t *testing.T) {
 			indexPrice:     2,
 			expectedResult: true,
 		},
-		"Towards: new == idx < curr": {
+		"Towards: idx == new < curr": {
 			oldPrice:       2,
 			newPrice:       1,
 			indexPrice:     1,
@@ -285,6 +297,12 @@ func TestIsCrossingIndexPrice(t *testing.T) {
 			indexPrice:     3,
 			expectedResult: false,
 		},
+		"Not Crossing: new = curr < index": {
+			oldPrice:       1,
+			newPrice:       1,
+			indexPrice:     3,
+			expectedResult: false,
+		},
 		"Not Crossing: curr < new = index": {
 			oldPrice:       1,
 			newPrice:       2,
@@ -311,6 +329,24 @@ func TestIsCrossingIndexPrice(t *testing.T) {
 		},
 		"Not Crossing: index < new < curr": {
 			oldPrice:       3,
+			newPrice:       2,
+			indexPrice:     1,
+			expectedResult: false,
+		},
+		"Not Crossing: index < new = curr": {
+			oldPrice:       2,
+			newPrice:       2,
+			indexPrice:     1,
+			expectedResult: false,
+		},
+		"Not Crossing: index = new < curr": {
+			oldPrice:       2,
+			newPrice:       1,
+			indexPrice:     1,
+			expectedResult: false,
+		},
+		"Not Crossing: index = curr < new": {
+			oldPrice:       1,
 			newPrice:       2,
 			indexPrice:     1,
 			expectedResult: false,


### PR DESCRIPTION
math methods generally look fine in x/prices, with a few apparent exceptions. I added some comments here to show why those exceptions are actually fine. Also added a little extra test coverage for our `isCrossing*Price` methods. Confirmed on slack with Brendan that medianization rounding behavior [is fine](https://dydx-team.slack.com/archives/C03TDPD3MC4/p1695848350401879) for x/prices, also.