### PR TITLE
Build images so they can be run with cosmovisor in addition to the binary directly

### DIFF
--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -10,7 +10,8 @@ services:
         RUNNER_IMAGE: alpine:3.16
         GO_VERSION: 1.19
     entrypoint:
-      - dydxprotocold
+      - cosmovisor
+      - run
       - start
       - --log_level
       # Note that only this validator has a log-level of `info`; other validators use `error` by default.
@@ -24,6 +25,7 @@ services:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}
       - DD_AGENT_HOST=datadog-agent
+      - DAEMON_HOME=/dydxprotocol/chain/.alice
     volumes:
       - ./localnet/dydxprotocol0:/dydxprotocol/chain/.alice/data
     ports:
@@ -34,7 +36,8 @@ services:
   dydxprotocold1:
     image: local:dydxprotocol
     entrypoint:
-       - dydxprotocold
+       - cosmovisor
+       - run
        - start
        - --log_level
        - error
@@ -46,6 +49,7 @@ services:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}
       - DD_AGENT_HOST=datadog-agent
+      - DAEMON_HOME=/dydxprotocol/chain/.bob
     volumes:
       - ./localnet/dydxprotocol1:/dydxprotocol/chain/.bob/data
     ports:
@@ -54,7 +58,8 @@ services:
   dydxprotocold2:
     image: local:dydxprotocol
     entrypoint:
-       - dydxprotocold
+       - cosmovisor
+       - run
        - start
        - --log_level
        - error
@@ -66,13 +71,15 @@ services:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}
       - DD_AGENT_HOST=datadog-agent
+      - DAEMON_HOME=/dydxprotocol/chain/.carl
     volumes:
       - ./localnet/dydxprotocol2:/dydxprotocol/chain/.carl/data
   
   dydxprotocold3:
     image: local:dydxprotocol
     entrypoint:
-       - dydxprotocold
+       - cosmovisor
+       - run
        - start
        - --log_level
        - error
@@ -84,6 +91,7 @@ services:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}
       - DD_AGENT_HOST=datadog-agent
+      - DAEMON_HOME=/dydxprotocol/chain/.dave
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
 

--- a/protocol/testing/snapshotting/Dockerfile.snapshot
+++ b/protocol/testing/snapshotting/Dockerfile.snapshot
@@ -2,4 +2,6 @@ FROM dydxprotocol-base
 
 COPY ./testing/snapshotting/snapshot.sh /dydxprotocol/snapshot.sh
 
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.4.0
+
 ENTRYPOINT ["/dydxprotocol/snapshot.sh"]

--- a/protocol/testing/snapshotting/snapshot.sh
+++ b/protocol/testing/snapshotting/snapshot.sh
@@ -62,6 +62,16 @@ install_prerequisites() {
     && rm -rf /var/cache/apk/*
 }
 
+setup_cosmovisor() {
+    VAL_HOME_DIR="$HOME/chain/local_node"
+    export DAEMON_NAME=dydxprotocold
+    export DAEMON_HOME="$HOME/chain/local_node"
+
+    cosmovisor init /bin/dydxprotocold
+
+    cp /bin/dydxprotocold "$VAL_HOME_DIR/cosmovisor/genesis/bin/"
+}
+
 install_prerequisites
 
 # log messages prefixed by highlighted timestamp
@@ -76,19 +86,16 @@ log_this() {
 mkdir -p $SNAP_PATH
 touch $LOG_PATH
 sleep 10
-dydxprotocold init --chain-id=${CHAIN_ID} --home /dydxprotocol/chain/local_node local_node
+cosmovisor run init --chain-id=${CHAIN_ID} --home /dydxprotocol/chain/local_node local_node
 curl -X GET ${genesis_file_rpc_address}/genesis | jq '.result.genesis' > /dydxprotocol/chain/local_node/config/genesis.json
 
 # TODO: add metrics around snapshot upload latency/frequency/success rate
 while true; do
   # p2p.seeds taken from --p2p.persistent_peers flag of full node
-  dydxprotocold start --log_level info --home /dydxprotocol/chain/local_node --p2p.seeds "${p2p_seeds}" --non-validating-full-node=true &
+  cosmovisor run start --log_level info --home /dydxprotocol/chain/local_node --p2p.seeds "${p2p_seeds}" --non-validating-full-node=true &
 
   sleep ${upload_period}
-  kill -TERM $(pidof dydxprotocold)
-
-  LAST_BLOCK_HEIGHT=$(curl -s ${RPC_ADDRESS}/status | jq -r .result.sync_info.latest_block_height)
-  log_this "LAST_BLOCK_HEIGHT ${LAST_BLOCK_HEIGHT}"
+  kill -TERM $(pidof cosmovisor)
 
   log_this "Creating new snapshot"
   SNAP_NAME=$(echo "${CHAIN_ID}_$(date '+%Y-%m-%d-%M-%H').tar.gz")

--- a/protocol/testing/start.sh
+++ b/protocol/testing/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eo pipefail
+
+# For legacy reasons, our internal dev environment runs `/dydxprotocol/start.sh` as the entrypoint for
+# cosmovisor images. This file serves a stub we can provide in those images.
+
+cosmovisor "$@"

--- a/protocol/testing/testnet-dev/Dockerfile
+++ b/protocol/testing/testnet-dev/Dockerfile
@@ -2,9 +2,13 @@ FROM dydxprotocol-base
 
 COPY ./testing/testnet-dev/dev.sh /dydxprotocol/dev.sh
 COPY ./testing/genesis.sh /dydxprotocol/genesis.sh
+COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.4.0
+
 RUN /dydxprotocol/dev.sh
 
-ENTRYPOINT ["dydxprotocold"]
+ENV DAEMON_NAME=dydxprotocold
+ENTRYPOINT ["cosmovisor", "run"]

--- a/protocol/testing/testnet-dev/dev.sh
+++ b/protocol/testing/testnet-dev/dev.sh
@@ -184,6 +184,18 @@ create_validators() {
 	done
 }
 
+setup_cosmovisor() {
+	for i in "${!MONIKERS[@]}"; do
+		VAL_HOME_DIR="$HOME/chain/.${MONIKERS[$i]}"
+		export DAEMON_NAME=dydxprotocold
+		export DAEMON_HOME="$HOME/chain/.${MONIKERS[$i]}"
+
+		cosmovisor init /bin/dydxprotocold
+
+		cp /bin/dydxprotocold "$VAL_HOME_DIR/cosmovisor/genesis/bin/"
+	done
+}
+
 # TODO(DEC-1894): remove this function once we migrate off of persistent peers.
 # Note: DO NOT add more config modifications in this method. Use `cmd/config.go` to configure
 # the default config values.
@@ -196,3 +208,4 @@ edit_config() {
 
 install_prerequisites
 create_validators
+setup_cosmovisor

--- a/protocol/testing/testnet-local/Dockerfile
+++ b/protocol/testing/testnet-local/Dockerfile
@@ -2,9 +2,13 @@ FROM dydxprotocol-base
 
 COPY ./testing/testnet-local/local.sh /dydxprotocol/local.sh
 COPY ./testing/genesis.sh /dydxprotocol/genesis.sh
+COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.4.0
+
 RUN /dydxprotocol/local.sh
 
-ENTRYPOINT ["dydxprotocold"]
+ENV DAEMON_NAME=dydxprotocold
+ENTRYPOINT ["cosmovisor", "run"]

--- a/protocol/testing/testnet-local/local.sh
+++ b/protocol/testing/testnet-local/local.sh
@@ -143,6 +143,18 @@ create_validators() {
 	done
 }
 
+setup_cosmovisor() {
+	for i in "${!MONIKERS[@]}"; do
+		VAL_HOME_DIR="$HOME/chain/.${MONIKERS[$i]}"
+		export DAEMON_NAME=dydxprotocold
+		export DAEMON_HOME="$HOME/chain/.${MONIKERS[$i]}"
+
+		cosmovisor init /bin/dydxprotocold
+
+		cp /bin/dydxprotocold "$VAL_HOME_DIR/cosmovisor/genesis/bin/"
+	done
+}
+
 # TODO(DEC-1894): remove this function once we migrate off of persistent peers.
 # Note: DO NOT add more config modifications in this method. Use `cmd/config.go` to configure
 # the default config values.
@@ -159,3 +171,4 @@ edit_config() {
 
 install_prerequisites
 create_validators
+setup_cosmovisor

--- a/protocol/testing/testnet-staging/Dockerfile
+++ b/protocol/testing/testnet-staging/Dockerfile
@@ -2,9 +2,13 @@ FROM dydxprotocol-base
 
 COPY ./testing/testnet-staging/staging.sh /dydxprotocol/staging.sh
 COPY ./testing/genesis.sh /dydxprotocol/genesis.sh
+COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.4.0
+
 RUN /dydxprotocol/staging.sh
 
-ENTRYPOINT ["dydxprotocold"]
+ENV DAEMON_NAME=dydxprotocold
+ENTRYPOINT ["cosmovisor", "run"]

--- a/protocol/testing/testnet-staging/staging.sh
+++ b/protocol/testing/testnet-staging/staging.sh
@@ -238,6 +238,18 @@ create_validators() {
 	done
 }
 
+setup_cosmovisor() {
+	for i in "${!MONIKERS[@]}"; do
+		VAL_HOME_DIR="$HOME/chain/.${MONIKERS[$i]}"
+		export DAEMON_NAME=dydxprotocold
+		export DAEMON_HOME="$HOME/chain/.${MONIKERS[$i]}"
+
+		cosmovisor init /bin/dydxprotocold
+
+		cp /bin/dydxprotocold "$VAL_HOME_DIR/cosmovisor/genesis/bin/"
+	done
+}
+
 # TODO(DEC-1894): remove this function once we migrate off of persistent peers.
 # Note: DO NOT add more config modifications in this method. Use `cmd/config.go` to configure
 # the default config values.
@@ -250,3 +262,4 @@ edit_config() {
 
 install_prerequisites
 create_validators
+setup_cosmovisor


### PR DESCRIPTION
- Setup cosmovisor in all local, dev, staging images. They can still be run with the binary.
- Change the snapshotting image to use cosmovisor.