### PR TITLE
[DEC-2117] - Update all internal msgs to use stricter authority validation

### DIFF
--- a/protocol/x/blocktime/types/errors.go
+++ b/protocol/x/blocktime/types/errors.go
@@ -15,4 +15,9 @@ var (
 		401,
 		"Durations must be in ascending order by length",
 	)
+	ErrInvalidAuthority = errorsmod.Register(
+		ModuleName,
+		402,
+		"Authority is invalid",
+	)
 )

--- a/protocol/x/blocktime/types/tx.go
+++ b/protocol/x/blocktime/types/tx.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -10,6 +12,16 @@ func (msg *MsgUpdateDowntimeParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateDowntimeParams) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
 	return msg.Params.Validate()
 }
 

--- a/protocol/x/blocktime/types/tx_test.go
+++ b/protocol/x/blocktime/types/tx_test.go
@@ -1,0 +1,74 @@
+package types_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var (
+	validAuthority = constants.AliceAccAddress.String()
+)
+
+func TestMsgUpdateDowntimeParams_GetSigners(t *testing.T) {
+	msg := types.MsgUpdateDowntimeParams{
+		Authority: validAuthority,
+	}
+	require.Equal(t, []sdk.AccAddress{constants.AliceAccAddress}, msg.GetSigners())
+}
+
+func TestMsgUpdateDowntimeParams_ValidateBasic(t *testing.T) {
+	tests := map[string]struct {
+		msg         types.MsgUpdateDowntimeParams
+		expectedErr error
+	}{
+		"Success": {
+			msg: types.MsgUpdateDowntimeParams{
+				Authority: validAuthority,
+				Params: types.DowntimeParams{
+					ClockDriftGracePeriodDuration: 1 * time.Second,
+				},
+			},
+		},
+		"Failure: Invalid authority": {
+			msg: types.MsgUpdateDowntimeParams{
+				Authority: "", // invalid
+			},
+			expectedErr: types.ErrInvalidAuthority,
+		},
+		"Failure: Invalid params": {
+			msg: types.MsgUpdateDowntimeParams{
+				Authority: validAuthority,
+				Params: types.DowntimeParams{
+					ClockDriftGracePeriodDuration: 0, // invalid
+				},
+			},
+			expectedErr: types.ErrNonpositiveDuration,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestMsgIsDelayedBlock_GetSigners(t *testing.T) {
+	msg := types.MsgIsDelayedBlock{
+		DelayDuration: 5 * time.Minute,
+	}
+	require.Equal(t, []sdk.AccAddress{}, msg.GetSigners())
+}
+
+func TestMsgIsDelayedBlock_ValidateBasic(t *testing.T) {
+	msg := types.MsgIsDelayedBlock{}
+	require.NoError(t, msg.ValidateBasic())
+}

--- a/protocol/x/bridge/types/msg_update_event_params.go
+++ b/protocol/x/bridge/types/msg_update_event_params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -11,8 +12,15 @@ func (msg *MsgUpdateEventParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateEventParams) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return nil
 }

--- a/protocol/x/bridge/types/msg_update_event_params_test.go
+++ b/protocol/x/bridge/types/msg_update_event_params_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	// validAuthority is a valid bech32 address string.
+	validAuthority = constants.AliceAccAddress.String()
+)
+
 func TestMsgUpdateEventParams_GetSigners(t *testing.T) {
 	msg := types.MsgUpdateEventParams{
 		Authority: constants.CarlAccAddress.String(),
@@ -19,11 +24,11 @@ func TestMsgUpdateEventParams_GetSigners(t *testing.T) {
 func TestMsgUpdateEventParams_ValidateBasic(t *testing.T) {
 	tests := map[string]struct {
 		msg         types.MsgUpdateEventParams
-		expectedErr string
+		expectedErr error
 	}{
 		"Success": {
 			msg: types.MsgUpdateEventParams{
-				Authority: "test",
+				Authority: validAuthority,
 				Params: types.EventParams{
 					Denom:      "test-denom",
 					EthChainId: 0,
@@ -31,21 +36,21 @@ func TestMsgUpdateEventParams_ValidateBasic(t *testing.T) {
 				},
 			},
 		},
-		"Failure: Empty authority": {
+		"Failure: Invalid authority": {
 			msg: types.MsgUpdateEventParams{
 				Authority: "",
 			},
-			expectedErr: "authority cannot be empty",
+			expectedErr: types.ErrInvalidAuthority,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-			if tc.expectedErr == "" {
+			if tc.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
-				require.ErrorContains(t, err, tc.expectedErr)
+				require.ErrorIs(t, err, tc.expectedErr)
 			}
 		})
 	}

--- a/protocol/x/bridge/types/msg_update_propose_params.go
+++ b/protocol/x/bridge/types/msg_update_propose_params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -11,8 +12,15 @@ func (msg *MsgUpdateProposeParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateProposeParams) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return nil
 }

--- a/protocol/x/bridge/types/msg_update_propose_params_test.go
+++ b/protocol/x/bridge/types/msg_update_propose_params_test.go
@@ -19,11 +19,11 @@ func TestMsgUpdateProposeParams_GetSigners(t *testing.T) {
 func TestMsgUpdateProposeParams_ValidateBasic(t *testing.T) {
 	tests := map[string]struct {
 		msg         types.MsgUpdateProposeParams
-		expectedErr string
+		expectedErr error
 	}{
 		"Success": {
 			msg: types.MsgUpdateProposeParams{
-				Authority: "test",
+				Authority: validAuthority,
 				Params: types.ProposeParams{
 					MaxBridgesPerBlock:           5,
 					ProposeDelayDuration:         10_000,
@@ -32,21 +32,19 @@ func TestMsgUpdateProposeParams_ValidateBasic(t *testing.T) {
 				},
 			},
 		},
-		"Failure: Empty authority": {
-			msg: types.MsgUpdateProposeParams{
-				Authority: "",
-			},
-			expectedErr: "authority cannot be empty",
+		"Failure: Invalid authority": {
+			msg:         types.MsgUpdateProposeParams{},
+			expectedErr: types.ErrInvalidAuthority,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-			if tc.expectedErr == "" {
+			if tc.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
-				require.ErrorContains(t, err, tc.expectedErr)
+				require.ErrorIs(t, err, tc.expectedErr)
 			}
 		})
 	}

--- a/protocol/x/bridge/types/msg_update_propose_params_test.go
+++ b/protocol/x/bridge/types/msg_update_propose_params_test.go
@@ -33,7 +33,9 @@ func TestMsgUpdateProposeParams_ValidateBasic(t *testing.T) {
 			},
 		},
 		"Failure: Invalid authority": {
-			msg:         types.MsgUpdateProposeParams{},
+			msg: types.MsgUpdateProposeParams{
+				Authority: "",
+			},
 			expectedErr: types.ErrInvalidAuthority,
 		},
 	}

--- a/protocol/x/bridge/types/msg_update_safety_params.go
+++ b/protocol/x/bridge/types/msg_update_safety_params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -11,8 +12,15 @@ func (msg *MsgUpdateSafetyParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateSafetyParams) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return nil
 }

--- a/protocol/x/bridge/types/msg_update_safety_params_test.go
+++ b/protocol/x/bridge/types/msg_update_safety_params_test.go
@@ -19,32 +19,30 @@ func TestMsgUpdateSafetyParams_GetSigners(t *testing.T) {
 func TestMsgUpdateSafetyParams_ValidateBasic(t *testing.T) {
 	tests := map[string]struct {
 		msg         types.MsgUpdateSafetyParams
-		expectedErr string
+		expectedErr error
 	}{
 		"Success": {
 			msg: types.MsgUpdateSafetyParams{
-				Authority: "test",
+				Authority: validAuthority,
 				Params: types.SafetyParams{
 					IsDisabled:  false,
 					DelayBlocks: 500,
 				},
 			},
 		},
-		"Failure: Empty authority": {
-			msg: types.MsgUpdateSafetyParams{
-				Authority: "",
-			},
-			expectedErr: "authority cannot be empty",
+		"Failure: Invalid authority": {
+			msg:         types.MsgUpdateSafetyParams{},
+			expectedErr: types.ErrInvalidAuthority,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-			if tc.expectedErr == "" {
+			if tc.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
-				require.ErrorContains(t, err, tc.expectedErr)
+				require.ErrorIs(t, err, tc.expectedErr)
 			}
 		})
 	}

--- a/protocol/x/bridge/types/msg_update_safety_params_test.go
+++ b/protocol/x/bridge/types/msg_update_safety_params_test.go
@@ -31,11 +31,12 @@ func TestMsgUpdateSafetyParams_ValidateBasic(t *testing.T) {
 			},
 		},
 		"Failure: Invalid authority": {
-			msg:         types.MsgUpdateSafetyParams{},
+			msg: types.MsgUpdateSafetyParams{
+				Authority: "",
+			},
 			expectedErr: types.ErrInvalidAuthority,
 		},
 	}
-
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()

--- a/protocol/x/clob/types/message_update_block_rate_limit_config.go
+++ b/protocol/x/clob/types/message_update_block_rate_limit_config.go
@@ -1,6 +1,10 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 func (msg *MsgUpdateBlockRateLimitConfiguration) GetSigners() []sdk.AccAddress {
 	addr, _ := sdk.AccAddressFromBech32(msg.Authority)
@@ -8,5 +12,15 @@ func (msg *MsgUpdateBlockRateLimitConfiguration) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateBlockRateLimitConfiguration) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
 	return msg.BlockRateLimitConfig.Validate()
 }

--- a/protocol/x/clob/types/message_update_clob_pair.go
+++ b/protocol/x/clob/types/message_update_clob_pair.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -14,5 +16,15 @@ func (msg *MsgUpdateClobPair) GetSigners() []sdk.AccAddress {
 
 // ValidateBasic validates that the message's ClobPair status is a supported status.
 func (msg *MsgUpdateClobPair) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
 	return msg.ClobPair.Validate()
 }

--- a/protocol/x/clob/types/message_update_clob_pair_test.go
+++ b/protocol/x/clob/types/message_update_clob_pair_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	// validAuthority is a valid bech32 address.
+	validAuthority = constants.AliceAccAddress.String()
+)
+
 func TestMsgUpdateClobPair_GetSigners(t *testing.T) {
 	msg := types.MsgUpdateClobPair{
 		Authority: constants.AliceAccAddress.String(),
@@ -19,11 +24,13 @@ func TestMsgUpdateClobPair_GetSigners(t *testing.T) {
 func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 	tests := []struct {
 		desc        string
+		authority   string
 		clobPair    types.ClobPair
 		expectedErr string
 	}{
 		{
-			desc: "Invalid Metadata (SpotClobMetadata)",
+			desc:      "Invalid Metadata (SpotClobMetadata)",
+			authority: validAuthority,
 			clobPair: types.ClobPair{
 				Metadata:         &types.ClobPair_SpotClobMetadata{},
 				StepBaseQuantums: 1,
@@ -33,7 +40,8 @@ func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 			expectedErr: "is not a perpetual CLOB",
 		},
 		{
-			desc: "UNSPECIFIED Status",
+			desc:      "UNSPECIFIED Status",
+			authority: validAuthority,
 			clobPair: types.ClobPair{
 				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
@@ -43,7 +51,8 @@ func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 			expectedErr: "has unsupported status",
 		},
 		{
-			desc: "invalid negative status integer",
+			desc:      "invalid negative status integer",
+			authority: validAuthority,
 			clobPair: types.ClobPair{
 				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
@@ -53,7 +62,8 @@ func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 			expectedErr: "has unsupported status",
 		},
 		{
-			desc: "invalid positive status integer",
+			desc:      "invalid positive status integer",
+			authority: validAuthority,
 			clobPair: types.ClobPair{
 				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
@@ -63,7 +73,8 @@ func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 			expectedErr: "has unsupported status",
 		},
 		{
-			desc: "StepBaseQuantums <= 0",
+			desc:      "StepBaseQuantums <= 0",
+			authority: validAuthority,
 			clobPair: types.ClobPair{
 				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 0,
@@ -73,7 +84,8 @@ func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 			expectedErr: "StepBaseQuantums must be > 0.",
 		},
 		{
-			desc: "SubticksPerTick <= 0",
+			desc:      "SubticksPerTick <= 0",
+			authority: validAuthority,
 			clobPair: types.ClobPair{
 				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
@@ -83,7 +95,18 @@ func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 			expectedErr: "SubticksPerTick must be > 0",
 		},
 		{
-			desc: "Valid ClobPair",
+			desc: "Invalid authority",
+			clobPair: types.ClobPair{
+				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
+				StepBaseQuantums: 1,
+				SubticksPerTick:  1,
+				Status:           types.ClobPair_STATUS_ACTIVE,
+			},
+			expectedErr: "Authority is invalid",
+		},
+		{
+			desc:      "Valid ClobPair",
+			authority: validAuthority,
 			clobPair: types.ClobPair{
 				Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 				StepBaseQuantums: 1,
@@ -96,7 +119,8 @@ func TestMsgUpdateClobPair_ValidateBasic(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			msg := types.MsgUpdateClobPair{
-				ClobPair: tc.clobPair,
+				Authority: tc.authority,
+				ClobPair:  tc.clobPair,
 			}
 			err := msg.ValidateBasic()
 			if tc.expectedErr == "" {

--- a/protocol/x/clob/types/message_update_equity_tier_limit_config.go
+++ b/protocol/x/clob/types/message_update_equity_tier_limit_config.go
@@ -1,6 +1,10 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 func (msg *MsgUpdateEquityTierLimitConfiguration) GetSigners() []sdk.AccAddress {
 	addr, _ := sdk.AccAddressFromBech32(msg.Authority)
@@ -8,5 +12,15 @@ func (msg *MsgUpdateEquityTierLimitConfiguration) GetSigners() []sdk.AccAddress 
 }
 
 func (msg *MsgUpdateEquityTierLimitConfiguration) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
 	return msg.EquityTierLimitConfig.Validate()
 }

--- a/protocol/x/clob/types/message_update_liquidation_config_test.go
+++ b/protocol/x/clob/types/message_update_liquidation_config_test.go
@@ -45,7 +45,7 @@ func TestMsgUpdateLiquidationsConfig_ValidateBasic(t *testing.T) {
 			msg: types.MsgUpdateLiquidationsConfig{
 				LiquidationsConfig: constants.LiquidationsConfig_No_Limit,
 			},
-			expectedError: "authority cannot be empty",
+			expectedError: "Authority is invalid",
 		},
 	}
 

--- a/protocol/x/clob/types/message_update_liquidations_config.go
+++ b/protocol/x/clob/types/message_update_liquidations_config.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -16,8 +17,15 @@ func (msg *MsgUpdateLiquidationsConfig) GetSigners() []sdk.AccAddress {
 // ValidateBasic validates the message's LiquidationConfig. Returns an error if the authority
 // is empty or if the LiquidationsConfig is invalid.
 func (msg *MsgUpdateLiquidationsConfig) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 
 	return msg.LiquidationsConfig.Validate()

--- a/protocol/x/feetiers/types/errors.go
+++ b/protocol/x/feetiers/types/errors.go
@@ -25,4 +25,9 @@ var (
 		403,
 		"No maker and taker fee combination should result in a net rebate",
 	)
+	ErrInvalidAuthority = errorsmod.Register(
+		ModuleName,
+		404,
+		"Authority is invalid",
+	)
 )

--- a/protocol/x/feetiers/types/tx.go
+++ b/protocol/x/feetiers/types/tx.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -10,5 +12,15 @@ func (msg *MsgUpdatePerpetualFeeParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdatePerpetualFeeParams) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
 	return msg.Params.Validate()
 }

--- a/protocol/x/feetiers/types/tx_test.go
+++ b/protocol/x/feetiers/types/tx_test.go
@@ -1,0 +1,67 @@
+package types_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	types "github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var (
+	validAuthority = constants.BobAccAddress.String()
+)
+
+func TestGetSigners(t *testing.T) {
+	msg := types.MsgUpdatePerpetualFeeParams{
+		Authority: validAuthority,
+	}
+	require.Equal(t, []sdk.AccAddress{constants.BobAccAddress}, msg.GetSigners())
+}
+
+func TestValidateBasic(t *testing.T) {
+	tests := map[string]struct {
+		msg         types.MsgUpdatePerpetualFeeParams
+		expectedErr error
+	}{
+		"Success": {
+			msg: types.MsgUpdatePerpetualFeeParams{
+				Authority: validAuthority,
+				Params: types.PerpetualFeeParams{
+					Tiers: []*types.PerpetualFeeTier{
+						{
+							AbsoluteVolumeRequirement:      0,
+							TotalVolumeShareRequirementPpm: 0,
+							MakerVolumeShareRequirementPpm: 0,
+						},
+					},
+				},
+			},
+		},
+		"Failure: Invalid authority": {
+			msg: types.MsgUpdatePerpetualFeeParams{
+				Authority: "",
+			},
+			expectedErr: types.ErrInvalidAuthority,
+		},
+		"Failure: Invalid params": {
+			msg: types.MsgUpdatePerpetualFeeParams{
+				Authority: validAuthority,
+				Params: types.PerpetualFeeParams{
+					Tiers: []*types.PerpetualFeeTier{}, // invalid - empty
+				},
+			},
+			expectedErr: types.ErrNoTiersExist,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/protocol/x/perpetuals/types/message_create_perpetual.go
+++ b/protocol/x/perpetuals/types/message_create_perpetual.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -13,8 +14,15 @@ func (msg *MsgCreatePerpetual) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgCreatePerpetual) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return msg.Params.Validate()
 }

--- a/protocol/x/perpetuals/types/message_create_perpetual_test.go
+++ b/protocol/x/perpetuals/types/message_create_perpetual_test.go
@@ -28,8 +28,10 @@ func TestMsgCreatePerpetual_ValidateBasic(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			desc:        "Invalid authority",
-			msg:         types.MsgCreatePerpetual{},
+			desc: "Invalid authority",
+			msg: types.MsgCreatePerpetual{
+				Authority: "",
+			},
 			expectedErr: "Authority is invalid",
 		},
 		{

--- a/protocol/x/perpetuals/types/message_create_perpetual_test.go
+++ b/protocol/x/perpetuals/types/message_create_perpetual_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	// validAuthority is a valid bech32 address string.
+	validAuthority = constants.AliceAccAddress.String()
+)
+
 func TestMsgCreatePerpetual_GetSigners(t *testing.T) {
 	msg := types.MsgCreatePerpetual{
 		Authority: constants.AliceAccAddress.String(),
@@ -23,14 +28,14 @@ func TestMsgCreatePerpetual_ValidateBasic(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			desc:        "Empty authority",
+			desc:        "Invalid authority",
 			msg:         types.MsgCreatePerpetual{},
-			expectedErr: "authority cannot be empty",
+			expectedErr: "Authority is invalid",
 		},
 		{
 			desc: "Empty ticker",
 			msg: types.MsgCreatePerpetual{
-				Authority: "test",
+				Authority: validAuthority,
 				Params: types.PerpetualParams{
 					Ticker: "",
 				},
@@ -40,7 +45,7 @@ func TestMsgCreatePerpetual_ValidateBasic(t *testing.T) {
 		{
 			desc: "DefaultFundingPpm >= MaxDefaultFundingPpmAbs",
 			msg: types.MsgCreatePerpetual{
-				Authority: "test",
+				Authority: validAuthority,
 				Params: types.PerpetualParams{
 					Ticker:            "test",
 					DefaultFundingPpm: 100_000_000,

--- a/protocol/x/perpetuals/types/message_set_liquidity_tier.go
+++ b/protocol/x/perpetuals/types/message_set_liquidity_tier.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -13,8 +14,15 @@ func (msg *MsgSetLiquidityTier) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgSetLiquidityTier) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return msg.LiquidityTier.Validate()
 }

--- a/protocol/x/perpetuals/types/message_set_liquidity_tier_test.go
+++ b/protocol/x/perpetuals/types/message_set_liquidity_tier_test.go
@@ -35,7 +35,9 @@ func TestMsgSetLiquidityTier_ValidateBasic(t *testing.T) {
 			},
 		},
 		"Failure: Invalid authority": {
-			msg:         types.MsgSetLiquidityTier{},
+			msg: types.MsgSetLiquidityTier{
+				Authority: "",
+			},
 			expectedErr: "Authority is invalid",
 		},
 		"Failure: Initial Margin Ppm is greater than 100%": {

--- a/protocol/x/perpetuals/types/message_set_liquidity_tier_test.go
+++ b/protocol/x/perpetuals/types/message_set_liquidity_tier_test.go
@@ -23,7 +23,7 @@ func TestMsgSetLiquidityTier_ValidateBasic(t *testing.T) {
 	}{
 		"Success": {
 			msg: types.MsgSetLiquidityTier{
-				Authority: "test",
+				Authority: validAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     1,
 					Name:                   "test",
@@ -34,13 +34,13 @@ func TestMsgSetLiquidityTier_ValidateBasic(t *testing.T) {
 				},
 			},
 		},
-		"Failure: Empty authority": {
+		"Failure: Invalid authority": {
 			msg:         types.MsgSetLiquidityTier{},
-			expectedErr: "authority cannot be empty",
+			expectedErr: "Authority is invalid",
 		},
 		"Failure: Initial Margin Ppm is greater than 100%": {
 			msg: types.MsgSetLiquidityTier{
-				Authority: "test",
+				Authority: validAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     1,
 					Name:                   "test",
@@ -54,7 +54,7 @@ func TestMsgSetLiquidityTier_ValidateBasic(t *testing.T) {
 		},
 		"Failure: Maintenance Fraction Ppm is greater than 100%": {
 			msg: types.MsgSetLiquidityTier{
-				Authority: "test",
+				Authority: validAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     1,
 					Name:                   "test",
@@ -68,7 +68,7 @@ func TestMsgSetLiquidityTier_ValidateBasic(t *testing.T) {
 		},
 		"Failure: base position notional is zero": {
 			msg: types.MsgSetLiquidityTier{
-				Authority: "test",
+				Authority: validAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     1,
 					Name:                   "test",
@@ -82,7 +82,7 @@ func TestMsgSetLiquidityTier_ValidateBasic(t *testing.T) {
 		},
 		"Failure: impact notional is zero": {
 			msg: types.MsgSetLiquidityTier{
-				Authority: "test",
+				Authority: validAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     1,
 					Name:                   "test",

--- a/protocol/x/perpetuals/types/message_update_params.go
+++ b/protocol/x/perpetuals/types/message_update_params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -13,8 +14,15 @@ func (msg *MsgUpdateParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateParams) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return msg.Params.Validate()
 }

--- a/protocol/x/perpetuals/types/message_update_params_test.go
+++ b/protocol/x/perpetuals/types/message_update_params_test.go
@@ -23,7 +23,7 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 	}{
 		"Success": {
 			msg: types.MsgUpdateParams{
-				Authority: "test",
+				Authority: validAuthority,
 				Params: types.Params{
 					FundingRateClampFactorPpm: 400_000,
 					PremiumVoteClampFactorPpm: 400_000,
@@ -31,13 +31,13 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 				},
 			},
 		},
-		"Failure: Empty authority": {
+		"Failure: Invalid authority": {
 			msg:         types.MsgUpdateParams{},
-			expectedErr: "authority cannot be empty",
+			expectedErr: "Authority is invalid",
 		},
 		"Failure: 0 FundingRateClampFactorPpm": {
 			msg: types.MsgUpdateParams{
-				Authority: "test",
+				Authority: validAuthority,
 				Params: types.Params{
 					FundingRateClampFactorPpm: 0,
 					PremiumVoteClampFactorPpm: 400_000,
@@ -48,7 +48,7 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 		},
 		"Failure: 0 PremiumVoteClampFactorPpm": {
 			msg: types.MsgUpdateParams{
-				Authority: "test",
+				Authority: validAuthority,
 				Params: types.Params{
 					FundingRateClampFactorPpm: 400_000,
 					PremiumVoteClampFactorPpm: 0,

--- a/protocol/x/perpetuals/types/message_update_params_test.go
+++ b/protocol/x/perpetuals/types/message_update_params_test.go
@@ -32,7 +32,9 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 			},
 		},
 		"Failure: Invalid authority": {
-			msg:         types.MsgUpdateParams{},
+			msg: types.MsgUpdateParams{
+				Authority: "",
+			},
 			expectedErr: "Authority is invalid",
 		},
 		"Failure: 0 FundingRateClampFactorPpm": {

--- a/protocol/x/perpetuals/types/message_update_perpetual_params.go
+++ b/protocol/x/perpetuals/types/message_update_perpetual_params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -13,8 +14,15 @@ func (msg *MsgUpdatePerpetualParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdatePerpetualParams) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return msg.PerpetualParams.Validate()
 }

--- a/protocol/x/perpetuals/types/message_update_perpetual_params_test.go
+++ b/protocol/x/perpetuals/types/message_update_perpetual_params_test.go
@@ -23,20 +23,20 @@ func TestMsgUpdatePerpetualParams_ValidateBasic(t *testing.T) {
 	}{
 		"Success": {
 			msg: types.MsgUpdatePerpetualParams{
-				Authority: "test",
+				Authority: validAuthority,
 				PerpetualParams: types.PerpetualParams{
 					Ticker:            "test",
 					DefaultFundingPpm: 217,
 				},
 			},
 		},
-		"Failure: Empty authority": {
+		"Failure: Invalid authority": {
 			msg:         types.MsgUpdatePerpetualParams{},
-			expectedErr: "authority cannot be empty",
+			expectedErr: "Authority is invalid",
 		},
 		"Failure: Empty ticker": {
 			msg: types.MsgUpdatePerpetualParams{
-				Authority: "test",
+				Authority: validAuthority,
 				PerpetualParams: types.PerpetualParams{
 					Ticker: "",
 				},
@@ -45,7 +45,7 @@ func TestMsgUpdatePerpetualParams_ValidateBasic(t *testing.T) {
 		},
 		"Failure: DefaultFundingPpm >= MaxDefaultFundingPpmAbs": {
 			msg: types.MsgUpdatePerpetualParams{
-				Authority: "test",
+				Authority: validAuthority,
 				PerpetualParams: types.PerpetualParams{
 					Ticker:            "test",
 					DefaultFundingPpm: 100_000_000,

--- a/protocol/x/perpetuals/types/message_update_perpetual_params_test.go
+++ b/protocol/x/perpetuals/types/message_update_perpetual_params_test.go
@@ -31,7 +31,9 @@ func TestMsgUpdatePerpetualParams_ValidateBasic(t *testing.T) {
 			},
 		},
 		"Failure: Invalid authority": {
-			msg:         types.MsgUpdatePerpetualParams{},
+			msg: types.MsgUpdatePerpetualParams{
+				Authority: "",
+			},
 			expectedErr: "Authority is invalid",
 		},
 		"Failure: Empty ticker": {

--- a/protocol/x/prices/client/testutil/constants.go
+++ b/protocol/x/prices/client/testutil/constants.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants/exchange_common"
 	pricefeed "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -99,4 +100,7 @@ var (
 			Tickers:      []JsonResponse{bitfinexTicker_Eth9002},
 		},
 	}
+
+	// ValidAuthority is an authority address that passes basic validation.
+	ValidAuthority = authtypes.NewModuleAddress("test").String()
 )

--- a/protocol/x/prices/types/message_create_oracle_market.go
+++ b/protocol/x/prices/types/message_create_oracle_market.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -13,8 +14,15 @@ func (msg *MsgCreateOracleMarket) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgCreateOracleMarket) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrap(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return msg.Params.Validate()
 }

--- a/protocol/x/prices/types/message_create_oracle_market_test.go
+++ b/protocol/x/prices/types/message_create_oracle_market_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/x/prices/client/testutil"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -24,14 +25,23 @@ func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			desc:        "Empty authority",
-			msg:         types.MsgCreateOracleMarket{},
-			expectedErr: "authority cannot be empty",
+			desc: "Empty authority",
+			msg:  types.MsgCreateOracleMarket{},
+			expectedErr: "authority '' must be a valid bech32 address, but got error 'empty address string is not " +
+				"allowed': Authority is invalid",
+		},
+		{
+			desc: "Malformatted authority",
+			msg: types.MsgCreateOracleMarket{
+				Authority: "invalid",
+			},
+			expectedErr: "authority 'invalid' must be a valid bech32 address, but got error 'decoding bech32 " +
+				"failed: invalid bech32 string length 7': Authority is invalid",
 		},
 		{
 			desc: "Valid MsgCreateOracleMarket",
 			msg: types.MsgCreateOracleMarket{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				Params: types.MarketParam{
 					Pair:               "BTC-USD",
 					MinExchanges:       1,
@@ -44,7 +54,7 @@ func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
 		{
 			desc: "Empty pair",
 			msg: types.MsgCreateOracleMarket{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				Params: types.MarketParam{
 					Pair:               "",
 					MinExchanges:       1,
@@ -57,7 +67,7 @@ func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
 		{
 			desc: "Invalid MinPriceChangePpm",
 			msg: types.MsgCreateOracleMarket{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				Params: types.MarketParam{
 					Pair:               "BTC-USD",
 					MinExchanges:       1,
@@ -70,7 +80,7 @@ func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
 		{
 			desc: "Empty ExchangeConfigJson",
 			msg: types.MsgCreateOracleMarket{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				Params: types.MarketParam{
 					Pair:               "BTC-USD",
 					MinExchanges:       1,
@@ -83,7 +93,7 @@ func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
 		{
 			desc: "Typo in ExchangeConfigJson",
 			msg: types.MsgCreateOracleMarket{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				Params: types.MarketParam{
 					Pair:               "BTC-USD",
 					MinExchanges:       1,

--- a/protocol/x/prices/types/message_create_oracle_market_test.go
+++ b/protocol/x/prices/types/message_create_oracle_market_test.go
@@ -26,7 +26,9 @@ func TestMsgCreateOracleMarket_ValidateBasic(t *testing.T) {
 	}{
 		{
 			desc: "Empty authority",
-			msg:  types.MsgCreateOracleMarket{},
+			msg: types.MsgCreateOracleMarket{
+				Authority: "",
+			},
 			expectedErr: "authority '' must be a valid bech32 address, but got error 'empty address string is not " +
 				"allowed': Authority is invalid",
 		},

--- a/protocol/x/prices/types/message_update_market_param.go
+++ b/protocol/x/prices/types/message_update_market_param.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -13,8 +14,15 @@ func (msg *MsgUpdateMarketParam) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateMarketParam) ValidateBasic() error {
-	if msg.Authority == "" {
-		return errorsmod.Wrapf(ErrInvalidAuthority, "authority cannot be empty")
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
 	}
 	return msg.MarketParam.Validate()
 }

--- a/protocol/x/prices/types/message_update_market_param_test.go
+++ b/protocol/x/prices/types/message_update_market_param_test.go
@@ -34,7 +34,9 @@ func TestMsgUpdateMarketParam_ValidateBasic(t *testing.T) {
 			},
 		},
 		"Failure: Empty authority": {
-			msg: types.MsgUpdateMarketParam{},
+			msg: types.MsgUpdateMarketParam{
+				Authority: "",
+			},
 			expectedErr: "authority '' must be a valid bech32 address, but got error 'empty address string is not " +
 				"allowed': Authority is invalid",
 		},

--- a/protocol/x/prices/types/message_update_market_param_test.go
+++ b/protocol/x/prices/types/message_update_market_param_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/x/prices/client/testutil"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -23,7 +24,7 @@ func TestMsgUpdateMarketParam_ValidateBasic(t *testing.T) {
 	}{
 		"Success": {
 			msg: types.MsgUpdateMarketParam{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				MarketParam: types.MarketParam{
 					Pair:               "test",
 					MinExchanges:       1,
@@ -33,12 +34,20 @@ func TestMsgUpdateMarketParam_ValidateBasic(t *testing.T) {
 			},
 		},
 		"Failure: Empty authority": {
-			msg:         types.MsgUpdateMarketParam{},
-			expectedErr: "authority cannot be empty",
+			msg: types.MsgUpdateMarketParam{},
+			expectedErr: "authority '' must be a valid bech32 address, but got error 'empty address string is not " +
+				"allowed': Authority is invalid",
+		},
+		"Failure: Invalid authority": {
+			msg: types.MsgUpdateMarketParam{
+				Authority: "invalid",
+			},
+			expectedErr: "authority 'invalid' must be a valid bech32 address, but got error 'decoding bech32 " +
+				"failed: invalid bech32 string length 7': Authority is invalid",
 		},
 		"Failure: Empty pair": {
 			msg: types.MsgUpdateMarketParam{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				MarketParam: types.MarketParam{
 					Pair:              "",
 					MinExchanges:      1,
@@ -49,7 +58,7 @@ func TestMsgUpdateMarketParam_ValidateBasic(t *testing.T) {
 		},
 		"Failure: 0 MinExchanges": {
 			msg: types.MsgUpdateMarketParam{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				MarketParam: types.MarketParam{
 					Pair:              "test",
 					MinExchanges:      0,
@@ -60,7 +69,7 @@ func TestMsgUpdateMarketParam_ValidateBasic(t *testing.T) {
 		},
 		"Failure: 0 MinPriceChangePpm": {
 			msg: types.MsgUpdateMarketParam{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				MarketParam: types.MarketParam{
 					Pair:              "test",
 					MinExchanges:      2,
@@ -71,7 +80,7 @@ func TestMsgUpdateMarketParam_ValidateBasic(t *testing.T) {
 		},
 		"Failure: 10_000 MinPriceChangePpm": {
 			msg: types.MsgUpdateMarketParam{
-				Authority: "test",
+				Authority: testutil.ValidAuthority,
 				MarketParam: types.MarketParam{
 					Pair:              "test",
 					MinExchanges:      2,

--- a/protocol/x/rewards/types/errors.go
+++ b/protocol/x/rewards/types/errors.go
@@ -8,4 +8,5 @@ import errorsmod "cosmossdk.io/errors"
 var (
 	ErrInvalidTreasuryAccount  = errorsmod.Register(ModuleName, 1001, "invalid treasury account")
 	ErrInvalidFeeMultiplierPpm = errorsmod.Register(ModuleName, 1002, "invalid FeeMultiplierPpm")
+	ErrInvalidAuthority        = errorsmod.Register(ModuleName, 1003, "Authority is invalid")
 )

--- a/protocol/x/rewards/types/tx.go
+++ b/protocol/x/rewards/types/tx.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -20,5 +22,15 @@ func (msg *MsgUpdateParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateParams) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
 	return msg.Params.Validate()
 }

--- a/protocol/x/rewards/types/tx_test.go
+++ b/protocol/x/rewards/types/tx_test.go
@@ -1,0 +1,62 @@
+package types_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var (
+	validAuthority = constants.BobAccAddress.String()
+)
+
+func TestGetSigners(t *testing.T) {
+	msg := types.MsgUpdateParams{
+		Authority: validAuthority,
+	}
+	require.Equal(t, []sdk.AccAddress{constants.BobAccAddress}, msg.GetSigners())
+}
+
+func TestValidateBasic(t *testing.T) {
+	test := map[string]struct {
+		msg         types.MsgUpdateParams
+		expectedErr error
+	}{
+		"Success": {
+			msg: types.MsgUpdateParams{
+				Authority: validAuthority,
+				Params: types.Params{
+					TreasuryAccount: "treasury_account",
+					Denom:           "denom",
+				},
+			},
+		},
+		"Failure: Invalid authority": {
+			msg: types.MsgUpdateParams{
+				Authority: "", // invalid - empty
+			},
+			expectedErr: types.ErrInvalidAuthority,
+		},
+		"Failure: Invalid params": {
+			msg: types.MsgUpdateParams{
+				Authority: validAuthority,
+				Params: types.Params{
+					TreasuryAccount: "", // invalid - empty
+				},
+			},
+			expectedErr: types.ErrInvalidTreasuryAccount,
+		},
+	}
+	for name, tc := range test {
+		t.Run(name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/protocol/x/sending/types/errors.go
+++ b/protocol/x/sending/types/errors.go
@@ -13,6 +13,7 @@ var (
 	ErrMissingFields               = errorsmod.Register(ModuleName, 5, "Transfer does not contain all required fields")
 	ErrInvalidAccountAddress       = errorsmod.Register(ModuleName, 6, "Account address is invalid")
 	ErrEmptyModuleName             = errorsmod.Register(ModuleName, 7, "Module name is empty")
+	ErrInvalidAuthority            = errorsmod.Register(ModuleName, 8, "Authority is invalid")
 	ErrKeeperMethodsNotImplemented = errorsmod.Register(
 		ModuleName,
 		1100,

--- a/protocol/x/sending/types/message_send_from_module_to_account.go
+++ b/protocol/x/sending/types/message_send_from_module_to_account.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -30,6 +32,17 @@ func (msg *MsgSendFromModuleToAccount) GetSigners() []sdk.AccAddress {
 
 // ValidateBasic runs validation on the fields of a MsgSendFromModuleToAccount.
 func (msg *MsgSendFromModuleToAccount) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
+
 	// Validate sender module name is non-empty.
 	if len(msg.SenderModuleName) == 0 {
 		return ErrEmptyModuleName

--- a/protocol/x/sending/types/message_send_from_module_to_account_test.go
+++ b/protocol/x/sending/types/message_send_from_module_to_account_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	validAuthority = constants.AliceAccAddress.String()
+)
+
 func TestMsgSendFromModuleToAccount_ValidateBasic(t *testing.T) {
 	tests := map[string]struct {
 		msg types.MsgSendFromModuleToAccount
@@ -17,6 +21,7 @@ func TestMsgSendFromModuleToAccount_ValidateBasic(t *testing.T) {
 	}{
 		"Valid": {
 			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
 				SenderModuleName: "gov",
 				Recipient:        constants.AliceAccAddress.String(),
 				Coin:             sdk.NewCoin("dv4tnt", sdk.NewInt(1)),
@@ -24,13 +29,19 @@ func TestMsgSendFromModuleToAccount_ValidateBasic(t *testing.T) {
 		},
 		"Valid - module name has underscore": {
 			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
 				SenderModuleName: "insurance_fund",
 				Recipient:        constants.AliceAccAddress.String(),
 				Coin:             sdk.NewCoin("dv4tnt", sdk.NewInt(100)),
 			},
 		},
+		"Invalid authority": {
+			msg: types.MsgSendFromModuleToAccount{},
+			err: types.ErrInvalidAuthority,
+		},
 		"Invalid sender module name": {
 			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
 				SenderModuleName: "", // empty module name
 				Recipient:        constants.BobAccAddress.String(),
 				Coin:             sdk.NewCoin("dv4tnt", sdk.NewInt(100)),
@@ -39,6 +50,7 @@ func TestMsgSendFromModuleToAccount_ValidateBasic(t *testing.T) {
 		},
 		"Invalid recipient address": {
 			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
 				SenderModuleName: "bridge",
 				Recipient:        "invalid_address",
 				Coin:             sdk.NewCoin("dv4tnt", sdk.NewInt(100)),
@@ -47,6 +59,7 @@ func TestMsgSendFromModuleToAccount_ValidateBasic(t *testing.T) {
 		},
 		"Invalid coin denom": {
 			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
 				SenderModuleName: "bridge",
 				Recipient:        constants.CarlAccAddress.String(),
 				Coin: sdk.Coin{
@@ -58,6 +71,7 @@ func TestMsgSendFromModuleToAccount_ValidateBasic(t *testing.T) {
 		},
 		"Invalid coin amount": {
 			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
 				SenderModuleName: "rewards",
 				Recipient:        constants.CarlAccAddress.String(),
 				Coin: sdk.Coin{

--- a/protocol/x/sending/types/message_send_from_module_to_account_test.go
+++ b/protocol/x/sending/types/message_send_from_module_to_account_test.go
@@ -36,7 +36,9 @@ func TestMsgSendFromModuleToAccount_ValidateBasic(t *testing.T) {
 			},
 		},
 		"Invalid authority": {
-			msg: types.MsgSendFromModuleToAccount{},
+			msg: types.MsgSendFromModuleToAccount{
+				Authority: "",
+			},
 			err: types.ErrInvalidAuthority,
 		},
 		"Invalid sender module name": {

--- a/protocol/x/stats/types/errors.go
+++ b/protocol/x/stats/types/errors.go
@@ -10,4 +10,9 @@ var (
 		400,
 		"Duration is nonpositive",
 	)
+	ErrInvalidAuthority = errorsmod.Register(
+		ModuleName,
+		401,
+		"Autority is invalid",
+	)
 )

--- a/protocol/x/stats/types/tx.go
+++ b/protocol/x/stats/types/tx.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -10,5 +12,15 @@ func (msg *MsgUpdateParams) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgUpdateParams) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
 	return msg.Params.Validate()
 }

--- a/protocol/x/stats/types/tx_test.go
+++ b/protocol/x/stats/types/tx_test.go
@@ -1,0 +1,62 @@
+package types_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/stats/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var (
+	validAuthority = constants.BobAccAddress.String()
+)
+
+func TestGetSigners(t *testing.T) {
+	msg := types.MsgUpdateParams{
+		Authority: validAuthority,
+	}
+	require.Equal(t, []sdk.AccAddress{constants.BobAccAddress}, msg.GetSigners())
+}
+
+func TestValidateBasic(t *testing.T) {
+	tests := map[string]struct {
+		msg         types.MsgUpdateParams
+		expectedErr error
+	}{
+		"Success": {
+			msg: types.MsgUpdateParams{
+				Authority: validAuthority,
+				Params: types.Params{
+					WindowDuration: 1 * time.Second,
+				},
+			},
+		},
+		"Failure: Invalid authority": {
+			msg: types.MsgUpdateParams{
+				Authority: "", // invalid - empty
+			},
+			expectedErr: types.ErrInvalidAuthority,
+		},
+		"Failure: Invalid params": {
+			msg: types.MsgUpdateParams{
+				Authority: validAuthority,
+				Params: types.Params{
+					WindowDuration: 0, // invalid - zero
+				},
+			},
+			expectedErr: types.ErrNonpositiveDuration,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
internal messages for x/prices were using nonempty string checks for authority validation - fixed in this PR.

According to Taehoon's request, I updated this PR to include this change across the repo, minus delaymsg and vest, which have outstanding PRs with fixes already.
- [delaymsg](https://github.com/dydxprotocol/v4-chain/pull/411)
- [vest](https://github.com/dydxprotocol/v4-chain/pull/422)