### PR TITLE
Remove NumLiquidityTiersKey in upgrade handler

### DIFF
--- a/protocol/app/upgrades/v0.3.0/upgrade.go
+++ b/protocol/app/upgrades/v0.3.0/upgrade.go
@@ -53,6 +53,10 @@ func CreateUpgradeHandler(
 		pepePerpetual.Params.AtomicResolution = 1
 		perpetualsKeeper.UnsafeSetPerpetual(ctx, pepePerpetual)
 
+		// https://github.com/dydxprotocol/v4-chain/pull/279 removes usage of this key, but this key has
+		// a prefix that is now iterated over. This needs to be removed or else that iterator will break.
+		perpetualsKeeper.UnsafeDeleteNumLiquidityTiersKey(ctx)
+
 		// Update market price exponent for PEPE.
 		pepePrice, err := pricesKeeper.GetMarketPrice(ctx, PEPE_ID)
 		if err != nil {

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1518,3 +1518,10 @@ func (k Keeper) UnsafeSetPerpetual(
 		indexerevents.UpdatePerpetualEventVersion,
 	)
 }
+
+func (k Keeper) UnsafeDeleteNumLiquidityTiersKey(
+	ctx sdk.Context,
+) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(types.KeyPrefix(types.NumLiquidityTiersKey))
+}


### PR DESCRIPTION
For reference, the old writer is [here](https://github.com/dydxprotocol/v4-chain/pull/279/files#diff-e08f57dcab4d145924734fc1d6be83f85c3db4eae51dcd3597d0145a720e6ffbL1362).