### PR TITLE
Double startup daemon grace period to 1 minute

### DIFF
--- a/protocol/daemons/server/types/constants.go
+++ b/protocol/daemons/server/types/constants.go
@@ -7,7 +7,7 @@ const (
 	// the daemon server. This is used to ensure that spurious panics aren't produced due to the daemons waiting for
 	// the cosmos grpc service to start. If cli tests are failing due to panics because it is taking the network
 	// a long time to start the protocol, it's possible this value could be increased.
-	DaemonStartupGracePeriod = 30 * time.Second
+	DaemonStartupGracePeriod = 60 * time.Second
 
 	// MaximumLoopDelayMultiple defines the maximum acceptable update delay for a daemon as a multiple of the
 	// daemon's loop delay.


### PR DESCRIPTION
Addressing issue in [this thread](https://dydx-team.slack.com/archives/C041FHN48G0/p1695840754499849).