### PR TITLE
[DEC-2075] - Remove panic from ProcessVesting, called in BeginBlocker

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -205,6 +205,8 @@ const (
 	VestAmount            = "vest_amount"
 	BalanceAfterVestEvent = "balance_after_vest_event"
 	VesterAccount         = "vester_account"
+	ProcessVesting        = "process_vesting"
+	AccountTransfer       = "account_transfer"
 
 	// Block Time.
 	BlockTimeMs = "block_time_ms"

--- a/protocol/x/vest/keeper/keeper.go
+++ b/protocol/x/vest/keeper/keeper.go
@@ -123,7 +123,7 @@ func (k Keeper) ProcessVesting(ctx sdk.Context) {
 			); err != nil {
 				// This should never happen. However, if it does, we should not panic.
 				// ProcessVesting is called in BeginBlocker, and panicking in BeginBlocker could cause liveness issues.
-				// Instead, we log the error and continue.
+				// Instead, we generate an informative error log, emit an error metric, and continue.
 				k.Logger(ctx).Error(
 					"unexpected internal error: failed to transfer vest amount to treasury account",
 					constants.ErrorLogKey,
@@ -139,6 +139,8 @@ func (k Keeper) ProcessVesting(ctx sdk.Context) {
 					"vest_account_balance",
 					vesterBalance,
 				)
+				// Increment error counter.
+				telemetry.IncrCounter(1, metrics.ProcessVesting, metrics.AccountTransfer, metrics.Error)
 				continue
 			}
 		}

--- a/protocol/x/vest/keeper/keeper.go
+++ b/protocol/x/vest/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants"
 	"math/big"
 	"time"
 
@@ -120,7 +121,25 @@ func (k Keeper) ProcessVesting(ctx sdk.Context) {
 				entry.TreasuryAccount,
 				sdk.NewCoins(sdk.NewCoin(entry.Denom, vestAmount)),
 			); err != nil {
-				panic(err)
+				// This should never happen. However, if it does, we should not panic.
+				// ProcessVesting is called in BeginBlocker, and panicking in BeginBlocker could cause liveness issues.
+				// Instead, we log the error and continue.
+				k.Logger(ctx).Error(
+					"unexpected internal error: failed to transfer vest amount to treasury account",
+					constants.ErrorLogKey,
+					err,
+					"vester_account",
+					entry.VesterAccount,
+					"treasury_account",
+					entry.TreasuryAccount,
+					"denom",
+					entry.Denom,
+					"vest_amount",
+					vestAmount,
+					"vest_account_balance",
+					vesterBalance,
+				)
+				continue
 			}
 		}
 


### PR DESCRIPTION
This panic is highly unlikely and represents an unexpected error. Replace it with an emitted error metric + a log statement and continue so we don't cause liveness issue in the event of vesting transfer failure. Validator operators can alert on the metric and investigate based on the log statement.