### PR TITLE
[DEC-2127] Asset Id refactoring

### DIFF
--- a/protocol/testutil/keeper/assets.go
+++ b/protocol/testutil/keeper/assets.go
@@ -1,11 +1,12 @@
 package keeper
 
 import (
+	"testing"
+
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/common"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
-	"testing"
 
 	tmdb "github.com/cometbft/cometbft-db"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -24,6 +25,7 @@ import (
 func CreateUsdcAsset(ctx sdk.Context, assetsKeeper *keeper.Keeper) error {
 	_, err := assetsKeeper.CreateAsset(
 		ctx,
+		constants.Usdc.Id,
 		constants.Usdc.Symbol,
 		constants.Usdc.Denom,
 		constants.Usdc.DenomExponent,

--- a/protocol/x/assets/genesis.go
+++ b/protocol/x/assets/genesis.go
@@ -14,6 +14,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	for _, asset := range genState.Assets {
 		_, err := k.CreateAsset(
 			ctx,
+			asset.Id,
 			asset.Symbol,
 			asset.Denom,
 			asset.DenomExponent,

--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -39,7 +39,12 @@ func (k Keeper) CreateAsset(
 
 	// Ensure assetId zero is always USDC. This is a protocol-wide invariant.
 	if assetId == types.AssetUsdc.Id && denom != types.AssetUsdc.Denom {
-		return types.Asset{}, types.ErrAssetZeroNotUsdc
+		return types.Asset{}, types.ErrUsdcMustBeAssetZero
+	}
+
+	// Ensure USDC is not created with a non-zero assetId. This is a protocol-wide invariant.
+	if assetId != types.AssetUsdc.Id && denom == types.AssetUsdc.Denom {
+		return types.Asset{}, types.ErrUsdcMustBeAssetZero
 	}
 
 	// Create the asset

--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -37,6 +37,11 @@ func (k Keeper) CreateAsset(
 		return types.Asset{}, errorsmod.Wrap(types.ErrAssetDenomAlreadyExists, denom)
 	}
 
+	// Ensure assetId zero is always USDC. This is a protocol-wide invariant.
+	if assetId == types.AssetUsdc.Id && denom != types.AssetUsdc.Denom {
+		return types.Asset{}, types.ErrAssetZeroNotUsdc
+	}
+
 	// Create the asset
 	asset := types.Asset{
 		Id:               assetId,

--- a/protocol/x/assets/keeper/asset_test.go
+++ b/protocol/x/assets/keeper/asset_test.go
@@ -392,7 +392,7 @@ func TestModifyLongInterest_CannotNegative(t *testing.T) {
 	)
 	require.EqualError(t, err, errorsmod.Wrap(types.ErrNegativeLongInterest, "1").Error())
 	getAsset, exists = keeper.GetAsset(ctx, assetId)
-	require.True(t, true)
+	require.True(t, exists)
 	require.Equal(t, asset, getAsset)
 }
 

--- a/protocol/x/assets/keeper/grpc_query_asset.go
+++ b/protocol/x/assets/keeper/grpc_query_asset.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
@@ -51,23 +50,20 @@ func (k Keeper) Asset(c context.Context, req *types.QueryAssetRequest) (*types.Q
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 
-	val, err := k.GetAsset(
+	val, exists := k.GetAsset(
 		ctx,
 		req.Id,
 	)
-	if err != nil {
-		if errors.Is(err, types.ErrAssetDoesNotExist) {
-			return nil,
-				status.Error(
-					codes.NotFound,
-					fmt.Sprintf(
-						"Asset id %+v not found.",
-						req.Id,
-					),
-				)
-		}
 
-		return nil, status.Error(codes.Internal, "internal error")
+	if !exists {
+		return nil,
+			status.Error(
+				codes.NotFound,
+				fmt.Sprintf(
+					"Asset id %+v not found.",
+					req.Id,
+				),
+			)
 	}
 
 	return &types.QueryAssetResponse{Asset: val}, nil

--- a/protocol/x/assets/keeper/keeper.go
+++ b/protocol/x/assets/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 
 	"github.com/cometbft/cometbft/libs/log"
@@ -41,7 +42,6 @@ func (k Keeper) GetIndexerEventManager() indexer_manager.IndexerEventManager {
 }
 
 func (k Keeper) InitializeForGenesis(ctx sdk.Context) {
-	k.setNumAssets(ctx, uint32(0))
 }
 
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {

--- a/protocol/x/assets/types/errors.go
+++ b/protocol/x/assets/types/errors.go
@@ -12,7 +12,7 @@ var (
 	ErrAssetDenomAlreadyExists      = errorsmod.Register(ModuleName, 4, "Existing asset found with the same denom")
 	ErrAssetIdAlreadyExists         = errorsmod.Register(ModuleName, 5, "Existing asset found with the same asset id")
 	ErrGapFoundInAssetId            = errorsmod.Register(ModuleName, 6, "Found gap in asset Id")
-	ErrAssetZeroNotUsdc             = errorsmod.Register(ModuleName, 7, "First asset is not USDC")
+	ErrAssetZeroNotUsdc             = errorsmod.Register(ModuleName, 7, "Asset zero is not USDC")
 	ErrNoAssetInGenesis             = errorsmod.Register(ModuleName, 8, "No asset found in genesis state")
 	ErrInvalidMarketId              = errorsmod.Register(ModuleName, 9, "Found market id for asset without market")
 	ErrInvalidAssetAtomicResolution = errorsmod.Register(ModuleName, 10, "Invalid asset atomic resolution")

--- a/protocol/x/assets/types/errors.go
+++ b/protocol/x/assets/types/errors.go
@@ -17,6 +17,7 @@ var (
 	ErrInvalidMarketId              = errorsmod.Register(ModuleName, 9, "Found market id for asset without market")
 	ErrInvalidAssetAtomicResolution = errorsmod.Register(ModuleName, 10, "Invalid asset atomic resolution")
 	ErrInvalidDenomExponent         = errorsmod.Register(ModuleName, 11, "Invalid denom exponent")
+	ErrAssetAlreadyExists           = errorsmod.Register(ModuleName, 12, "Asset already exists")
 
 	// Errors for Not Implemented
 	ErrNotImplementedMulticollateral = errorsmod.Register(ModuleName, 401, "Not Implemented: Multi-Collateral")

--- a/protocol/x/assets/types/errors.go
+++ b/protocol/x/assets/types/errors.go
@@ -12,7 +12,7 @@ var (
 	ErrAssetDenomAlreadyExists      = errorsmod.Register(ModuleName, 4, "Existing asset found with the same denom")
 	ErrAssetIdAlreadyExists         = errorsmod.Register(ModuleName, 5, "Existing asset found with the same asset id")
 	ErrGapFoundInAssetId            = errorsmod.Register(ModuleName, 6, "Found gap in asset Id")
-	ErrAssetZeroNotUsdc             = errorsmod.Register(ModuleName, 7, "Asset zero is not USDC")
+	ErrUsdcMustBeAssetZero          = errorsmod.Register(ModuleName, 7, "USDC must be asset 0")
 	ErrNoAssetInGenesis             = errorsmod.Register(ModuleName, 8, "No asset found in genesis state")
 	ErrInvalidMarketId              = errorsmod.Register(ModuleName, 9, "Found market id for asset without market")
 	ErrInvalidAssetAtomicResolution = errorsmod.Register(ModuleName, 10, "Invalid asset atomic resolution")

--- a/protocol/x/assets/types/genesis.go
+++ b/protocol/x/assets/types/genesis.go
@@ -37,7 +37,7 @@ func (gs GenesisState) Validate() error {
 
 	// The first asset should always be USDC.
 	if gs.Assets[0] != AssetUsdc {
-		return ErrAssetZeroNotUsdc
+		return ErrUsdcMustBeAssetZero
 	}
 
 	// Provided assets should not contain duplicated asset ids, and denoms.

--- a/protocol/x/assets/types/genesis_test.go
+++ b/protocol/x/assets/types/genesis_test.go
@@ -58,7 +58,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: types.ErrAssetZeroNotUsdc,
+			expectedErr: types.ErrUsdcMustBeAssetZero,
 		},
 		"asset[0] is modified usdc": {
 			genState: &types.GenesisState{
@@ -73,7 +73,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: types.ErrAssetZeroNotUsdc,
+			expectedErr: types.ErrUsdcMustBeAssetZero,
 		},
 		"duplicated asset id": {
 			genState: &types.GenesisState{

--- a/protocol/x/assets/types/keys.go
+++ b/protocol/x/assets/types/keys.go
@@ -16,7 +16,4 @@ const (
 
 	// AssetKeyPrefix is the prefix to retrieve all Assets
 	AssetKeyPrefix = "asset/"
-
-	// NumAssetsKey is the prefix to retrieve the cardinality of Assets
-	NumAssetsKey = "num_assets"
 )

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -65,8 +65,8 @@ func (k Keeper) GetInsuranceFundBalance(
 ) (
 	balance *big.Int,
 ) {
-	usdcAsset, err := k.assetsKeeper.GetAsset(ctx, lib.UsdcAssetId)
-	if err != nil {
+	usdcAsset, exists := k.assetsKeeper.GetAsset(ctx, lib.UsdcAssetId)
+	if !exists {
 		panic("GetInsuranceFundBalance: Usdc asset not found in state")
 	}
 	insuranceFundBalance := k.bankKeeper.GetBalance(

--- a/protocol/x/clob/keeper/deleveraging_test.go
+++ b/protocol/x/clob/keeper/deleveraging_test.go
@@ -79,6 +79,7 @@ func TestGetInsuranceFundBalance(t *testing.T) {
 			for _, a := range tc.assets {
 				_, err := ks.AssetsKeeper.CreateAsset(
 					ks.Ctx,
+					a.Id,
 					a.Symbol,
 					a.Denom,
 					a.DenomExponent,
@@ -185,15 +186,7 @@ func TestIsValidInsuranceFundDelta(t *testing.T) {
 			bankMock := &mocks.BankKeeper{}
 			ks := keepertest.NewClobKeepersTestContext(t, memClob, bankMock, &mocks.IndexerEventManager{})
 
-			_, err := ks.AssetsKeeper.CreateAsset(
-				ks.Ctx,
-				constants.Usdc.Symbol,
-				constants.Usdc.Denom,
-				constants.Usdc.DenomExponent,
-				constants.Usdc.HasMarket,
-				constants.Usdc.MarketId,
-				constants.Usdc.AtomicResolution,
-			)
+			err := keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper)
 			require.NoError(t, err)
 
 			bankMock.On(
@@ -313,15 +306,7 @@ func TestCanDeleverageSubaccount(t *testing.T) {
 			bankMock := &mocks.BankKeeper{}
 			ks := keepertest.NewClobKeepersTestContext(t, memClob, bankMock, &mocks.IndexerEventManager{})
 
-			_, err := ks.AssetsKeeper.CreateAsset(
-				ks.Ctx,
-				constants.Usdc.Symbol,
-				constants.Usdc.Denom,
-				constants.Usdc.DenomExponent,
-				constants.Usdc.HasMarket,
-				constants.Usdc.MarketId,
-				constants.Usdc.AtomicResolution,
-			)
+			err := keepertest.CreateUsdcAsset(ks.Ctx, ks.AssetsKeeper)
 			require.NoError(t, err)
 
 			// Initialize the liquidations config.

--- a/protocol/x/clob/types/expected_keepers.go
+++ b/protocol/x/clob/types/expected_keepers.go
@@ -74,7 +74,7 @@ type SubaccountsKeeper interface {
 }
 
 type AssetsKeeper interface {
-	GetAsset(ctx sdk.Context, id uint32) (val assettypes.Asset, err error)
+	GetAsset(ctx sdk.Context, id uint32) (val assettypes.Asset, exists bool)
 }
 
 type BlockTimeKeeper interface {

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -233,9 +233,9 @@ func (k Keeper) ProcessRewardsForBlock(
 	params := k.GetParams(ctx)
 
 	// Calculate value of `F`.
-	usdcAsset, err := k.assetsKeeper.GetAsset(ctx, lib.UsdcAssetId)
-	if err != nil {
-		return fmt.Errorf("failed to get USDC asset: %w", err)
+	usdcAsset, exists := k.assetsKeeper.GetAsset(ctx, lib.UsdcAssetId)
+	if !exists {
+		return fmt.Errorf("failed to get USDC asset")
 	}
 	rewardTokenPrice, err := k.pricesKeeper.GetMarketPrice(ctx, params.GetMarketId())
 	if err != nil {

--- a/protocol/x/rewards/types/expected_keepers.go
+++ b/protocol/x/rewards/types/expected_keepers.go
@@ -34,5 +34,5 @@ type AssetsKeeper interface {
 	GetAsset(
 		ctx sdk.Context,
 		id uint32,
-	) (val assets.Asset, err error)
+	) (val assets.Asset, exists bool)
 }

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -2171,6 +2171,7 @@ func TestUpdateSubaccounts(t *testing.T) {
 			for _, a := range tc.assets {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,
+					a.Id,
 					a.Symbol,
 					a.Denom,
 					a.DenomExponent,
@@ -2782,6 +2783,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 			for _, a := range tc.assets {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,
+					a.Id,
 					a.Symbol,
 					a.Denom,
 					a.DenomExponent,
@@ -3206,6 +3208,7 @@ func TestGetNetCollateralAndMarginRequirements(t *testing.T) {
 			for _, a := range tc.assets {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,
+					a.Id,
 					a.Symbol,
 					a.Denom,
 					a.DenomExponent,

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -176,6 +176,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 
 			_, err = assetsKeeper.CreateAsset(
 				ctx,
+				tc.asset.Id,
 				tc.asset.Symbol,
 				tc.asset.Denom,
 				tc.asset.DenomExponent,
@@ -405,21 +406,14 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 
 			if !tc.skipSetUpUsdc {
 				// Always create USDC as the first asset unless specificed to skip.
-				_, err = assetsKeeper.CreateAsset(
-					ctx,
-					constants.Usdc.Symbol,
-					constants.Usdc.Denom,
-					constants.Usdc.DenomExponent,
-					constants.Usdc.HasMarket,
-					constants.Usdc.MarketId,
-					constants.Usdc.AtomicResolution,
-				)
+				err := keepertest.CreateUsdcAsset(ctx, assetsKeeper)
 				require.NoError(t, err)
 			}
 
 			if tc.asset.Denom != constants.Usdc.Denom {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,
+					tc.asset.Id,
 					tc.asset.Symbol,
 					tc.asset.Denom,
 					tc.asset.DenomExponent,
@@ -714,21 +708,14 @@ func TestTransferFundsFromSubaccountToModule_TransferFundsFromModuleToSubaccount
 
 			// Always create USDC as the first asset.
 			if !tc.skipSetUpUsdc {
-				_, err := assetsKeeper.CreateAsset(
-					ctx,
-					constants.Usdc.Symbol,
-					constants.Usdc.Denom,
-					constants.Usdc.DenomExponent,
-					constants.Usdc.HasMarket,
-					constants.Usdc.MarketId,
-					constants.Usdc.AtomicResolution,
-				)
+				err := keepertest.CreateUsdcAsset(ctx, assetsKeeper)
 				require.NoError(t, err)
 			}
 
 			if tc.asset.Denom != constants.Usdc.Denom {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,
+					tc.asset.Id,
 					tc.asset.Symbol,
 					tc.asset.Denom,
 					tc.asset.DenomExponent,
@@ -933,21 +920,14 @@ func TestTransferFeesToFeeCollectorModule(t *testing.T) {
 
 			// Always create USDC as the first asset.
 			if !tc.skipSetUpUsdc {
-				_, err := assetsKeeper.CreateAsset(
-					ctx,
-					constants.Usdc.Symbol,
-					constants.Usdc.Denom,
-					constants.Usdc.DenomExponent,
-					constants.Usdc.HasMarket,
-					constants.Usdc.MarketId,
-					constants.Usdc.AtomicResolution,
-				)
+				err := keepertest.CreateUsdcAsset(ctx, assetsKeeper)
 				require.NoError(t, err)
 			}
 
 			if tc.asset.Denom != constants.Usdc.Denom {
 				_, err := assetsKeeper.CreateAsset(
 					ctx,
+					tc.asset.Id,
 					tc.asset.Symbol,
 					tc.asset.Denom,
 					tc.asset.DenomExponent,
@@ -1109,15 +1089,7 @@ func TestTransferInsuranceFundPayments(t *testing.T) {
 			}
 
 			if !tc.skipSetUpUsdc {
-				_, err := assetsKeeper.CreateAsset(
-					ctx,
-					constants.Usdc.Symbol,
-					constants.Usdc.Denom,
-					constants.Usdc.DenomExponent,
-					constants.Usdc.HasMarket,
-					constants.Usdc.MarketId,
-					constants.Usdc.AtomicResolution,
-				)
+				err := keepertest.CreateUsdcAsset(ctx, assetsKeeper)
 				require.NoError(t, err)
 			}
 


### PR DESCRIPTION
- Drop `NumAsset` and consecutive asset ID requirement (similar to recent changes in `x/clob`, `x/perpetuals`, `x/prices`
- Reserve `assetId == 0` for USDC