### PR TITLE
Stop including multiple copies of binary in images

### DIFF
--- a/protocol/testing/snapshotting/snapshot.sh
+++ b/protocol/testing/snapshotting/snapshot.sh
@@ -68,8 +68,6 @@ setup_cosmovisor() {
     export DAEMON_HOME="$HOME/chain/local_node"
 
     cosmovisor init /bin/dydxprotocold
-
-    cp /bin/dydxprotocold "$VAL_HOME_DIR/cosmovisor/genesis/bin/"
 }
 
 install_prerequisites

--- a/protocol/testing/testnet-dev/dev.sh
+++ b/protocol/testing/testnet-dev/dev.sh
@@ -191,8 +191,6 @@ setup_cosmovisor() {
 		export DAEMON_HOME="$HOME/chain/.full-node-$i"
 
 		cosmovisor init /bin/dydxprotocold
-
-		cp /bin/dydxprotocold "$FULL_NODE_HOME_DIR/cosmovisor/genesis/bin/"
 	done
 
 	for i in "${!MONIKERS[@]}"; do
@@ -201,8 +199,6 @@ setup_cosmovisor() {
 		export DAEMON_HOME="$HOME/chain/.${MONIKERS[$i]}"
 
 		cosmovisor init /bin/dydxprotocold
-
-		cp /bin/dydxprotocold "$VAL_HOME_DIR/cosmovisor/genesis/bin/"
 	done
 }
 

--- a/protocol/testing/testnet-local/local.sh
+++ b/protocol/testing/testnet-local/local.sh
@@ -150,8 +150,6 @@ setup_cosmovisor() {
 		export DAEMON_HOME="$HOME/chain/.${MONIKERS[$i]}"
 
 		cosmovisor init /bin/dydxprotocold
-
-		cp /bin/dydxprotocold "$VAL_HOME_DIR/cosmovisor/genesis/bin/"
 	done
 }
 

--- a/protocol/testing/testnet-staging/staging.sh
+++ b/protocol/testing/testnet-staging/staging.sh
@@ -245,8 +245,6 @@ setup_cosmovisor() {
 		export DAEMON_HOME="$HOME/chain/.full-node-$i"
 
 		cosmovisor init /bin/dydxprotocold
-
-		cp /bin/dydxprotocold "$FULL_NODE_HOME_DIR/cosmovisor/genesis/bin/"
 	done
 
 	for i in "${!MONIKERS[@]}"; do
@@ -255,8 +253,6 @@ setup_cosmovisor() {
 		export DAEMON_HOME="$HOME/chain/.${MONIKERS[$i]}"
 
 		cosmovisor init /bin/dydxprotocold
-
-		cp /bin/dydxprotocold "$VAL_HOME_DIR/cosmovisor/genesis/bin/"
 	done
 }
 


### PR DESCRIPTION
`cosmovisor init /bin/dydxprotocold` already adds a symlink in this location; there's no need to copy the binary each time. I verified this works by running the localnet.