### PR TITLE
[CORE-627] - Fix daemon panics by delaying daemon start until gRPC service is available

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -282,6 +282,12 @@ type App struct {
 
 	IndexerEventManager indexer_manager.IndexerEventManager
 	Server              *daemonserver.Server
+
+	// startDaemons encapsulates the logic that starts all daemons and daemon services. This function contains a
+	// closure of all relevant data structures that are shared with various keepers. Daemon services startup is
+	// delayed until after the gRPC service is initialized so that the gRPC service will be available and the daemons
+	// can correctly operate.
+	startDaemons func()
 }
 
 // New returns a reference to an initialized blockchain app
@@ -552,16 +558,43 @@ func New(
 	bridgeEventManager := bridgedaemontypes.NewBridgeEventManager(timeProvider)
 	app.Server.WithBridgeEventManager(bridgeEventManager)
 
-	// Start server for handling gRPC messages from daemons.
-	go app.Server.Start()
+	// Create a closure for starting daemons and daemon server. Daemon services are delayed until after the gRPC
+	// service is started because daemons depend on the gRPC service being available. If a node is initialized
+	// with a genesis time in the future, then the gRPC service will not be available until the genesis time, the
+	// daemons will not be able to connect to the cosmos gRPC query service and finish initialization, and the daemon
+	// monitoring service will panic.
+	app.startDaemons = func() {
+		// Start server for handling gRPC messages from daemons.
+		go app.Server.Start()
 
-	// Start liquidations client for sending potentially liquidatable subaccounts to the application.
-	if daemonFlags.Liquidation.Enabled {
-		app.Server.ExpectLiquidationsDaemon(
-			daemonservertypes.MaximumAcceptableUpdateDelay(daemonFlags.Liquidation.LoopDelayMs),
-		)
-		go func() {
-			if err := liquidationclient.Start(
+		// Start liquidations client for sending potentially liquidatable subaccounts to the application.
+		if daemonFlags.Liquidation.Enabled {
+			app.Server.ExpectLiquidationsDaemon(
+				daemonservertypes.MaximumAcceptableUpdateDelay(daemonFlags.Liquidation.LoopDelayMs),
+			)
+			go func() {
+				if err := liquidationclient.Start(
+					// The client will use `context.Background` so that it can have a different context from
+					// the main application.
+					context.Background(),
+					daemonFlags,
+					appFlags,
+					logger,
+					&lib.GrpcClientImpl{},
+				); err != nil {
+					panic(err)
+				}
+			}()
+		}
+
+		// Non-validating full-nodes have no need to run the price daemon.
+		if !appFlags.NonValidatingFullNode && daemonFlags.Price.Enabled {
+			exchangeStartupConfig := configs.ReadExchangeStartupConfigFile(homePath)
+			app.Server.ExpectPricefeedDaemon(daemonservertypes.MaximumAcceptableUpdateDelay(daemonFlags.Price.LoopDelayMs))
+			// Start pricefeed client for sending prices for the pricefeed server to consume. These prices
+			// are retrieved via third-party APIs like Binance and then are encoded in-memory and
+			// periodically sent via gRPC to a shared socket with the server.
+			client := pricefeedclient.StartNewClient(
 				// The client will use `context.Background` so that it can have a different context from
 				// the main application.
 				context.Background(),
@@ -569,53 +602,33 @@ func New(
 				appFlags,
 				logger,
 				&lib.GrpcClientImpl{},
-			); err != nil {
-				panic(err)
-			}
-		}()
-	}
+				exchangeStartupConfig,
+				constants.StaticExchangeDetails,
+				&pricefeedclient.SubTaskRunnerImpl{},
+			)
+			stoppable.RegisterServiceForTestCleanup(appFlags.GrpcAddress, client)
+		}
 
-	// Non-validating full-nodes have no need to run the price daemon.
-	if !appFlags.NonValidatingFullNode && daemonFlags.Price.Enabled {
-		exchangeStartupConfig := configs.ReadExchangeStartupConfigFile(homePath)
-		app.Server.ExpectPricefeedDaemon(daemonservertypes.MaximumAcceptableUpdateDelay(daemonFlags.Price.LoopDelayMs))
-		// Start pricefeed client for sending prices for the pricefeed server to consume. These prices
-		// are retrieved via third-party APIs like Binance and then are encoded in-memory and
-		// periodically sent via gRPC to a shared socket with the server.
-		client := pricefeedclient.StartNewClient(
-			// The client will use `context.Background` so that it can have a different context from
-			// the main application.
-			context.Background(),
-			daemonFlags,
-			appFlags,
-			logger,
-			&lib.GrpcClientImpl{},
-			exchangeStartupConfig,
-			constants.StaticExchangeDetails,
-			&pricefeedclient.SubTaskRunnerImpl{},
-		)
-		stoppable.RegisterServiceForTestCleanup(appFlags.GrpcAddress, client)
-	}
-
-	// Start Bridge Daemon.
-	// Non-validating full-nodes have no need to run the bridge daemon.
-	if !appFlags.NonValidatingFullNode && daemonFlags.Bridge.Enabled {
-		// TODO(CORE-582): Re-enable bridge daemon registration once the bridge daemon is fixed in local / CI
-		// environments.
-		// app.Server.ExpectBridgeDaemon(daemonservertypes.MaximumAcceptableUpdateDelay(daemonFlags.Bridge.LoopDelayMs))
-		go func() {
-			if err := bridgeclient.Start(
-				// The client will use `context.Background` so that it can have a different context from
-				// the main application.
-				context.Background(),
-				daemonFlags,
-				appFlags,
-				logger,
-				&lib.GrpcClientImpl{},
-			); err != nil {
-				panic(err)
-			}
-		}()
+		// Start Bridge Daemon.
+		// Non-validating full-nodes have no need to run the bridge daemon.
+		if !appFlags.NonValidatingFullNode && daemonFlags.Bridge.Enabled {
+			// TODO(CORE-582): Re-enable bridge daemon registration once the bridge daemon is fixed in local / CI
+			// environments.
+			// app.Server.ExpectBridgeDaemon(daemonservertypes.MaximumAcceptableUpdateDelay(daemonFlags.Bridge.LoopDelayMs))
+			go func() {
+				if err := bridgeclient.Start(
+					// The client will use `context.Background` so that it can have a different context from
+					// the main application.
+					context.Background(),
+					daemonFlags,
+					appFlags,
+					logger,
+					&lib.GrpcClientImpl{},
+				); err != nil {
+					panic(err)
+				}
+			}()
+		}
 	}
 
 	app.PricesKeeper = *pricesmodulekeeper.NewKeeper(
@@ -1314,6 +1327,9 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig
 	if apiConfig.Swagger {
 		RegisterSwaggerAPI(clientCtx, apiSvr.Router)
 	}
+
+	// Now that the API server has been configured, start the daemons.
+	app.startDaemons()
 }
 
 // RegisterTxService implements the Application.RegisterTxService method.

--- a/protocol/x/prices/keeper/update_price.go
+++ b/protocol/x/prices/keeper/update_price.go
@@ -66,7 +66,7 @@ func (k Keeper) GetValidMarketPriceUpdates(
 			// Conditionally escalate log level to error 20s after genesis/restart. We expect that it may take a few
 			// seconds for the index price to populate after network genesis or a network restart.
 			logMethod := k.Logger(ctx).Error
-			if k.IsRecentlyAdded(marketId) {
+			if k.IsRecentlyAvailable(ctx, marketId) {
 				logMethod = k.Logger(ctx).Info
 			}
 			logMethod(fmt.Sprintf("Index price for market (%v) does not exist", marketId))
@@ -89,7 +89,7 @@ func (k Keeper) GetValidMarketPriceUpdates(
 			// in populating historical smoothed prices after network genesis or a network restart, because they
 			// depend on present index prices.
 			logMethod := k.Logger(ctx).Error
-			if k.IsRecentlyAdded(marketId) {
+			if k.IsRecentlyAvailable(ctx, marketId) {
 				logMethod = k.Logger(ctx).Info
 			}
 			logMethod(fmt.Sprintf("Smoothed price for market (%v) does not exist", marketId))


### PR DESCRIPTION
The code change to cause daemon panics when daemons fail to respond in a timely fashion has led to an unintended effect: when genesis time is delayed after a node starts, the node will sleep, and the daemon monitoring service will cause a panic.  The root cause of this is unavailability of the cosmos gRPC service - daemons will hang when trying to establish a connection to this service and will never send calls to the daemon server.

This PR delays daemon / daemon service start until after the gRPC service is initilialized.

I implemented with a minimal change by adding a closure function that is called whenever gRPC routes are registered on the gRPC server. Open to other suggestions. This fixes the issue locally and all tests pass.