### PR TITLE
[CORE-627] - Nit from previous PR

### DIFF
--- a/protocol/x/prices/keeper/market.go
+++ b/protocol/x/prices/keeper/market.go
@@ -87,7 +87,9 @@ func (k Keeper) IsRecentlyAvailable(ctx sdk.Context, marketId uint32) bool {
 	}
 
 	// The comparison condition considers both market age and price daemon warmup time because a market can be
-	// created before or after the daemon starts.
+	// created before or after the daemon starts. We use block height as a proxy for daemon warmup time because
+	// the price daemon is started when the gRPC service comes up, which typically occurs just before the first
+	// block is processed.
 	return k.timeProvider.Now().Sub(createdAt) < types.MarketIsRecentDuration ||
 		ctx.BlockHeight() < types.PriceDaemonInitializationBlocks
 }


### PR DESCRIPTION
Accidentally merged without fixing [this nit](https://github.com/dydxprotocol/v4-chain/pull/437/files#r1343220343) from Vincent.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the `IsRecentlyAvailable` function in the `Keeper` struct of the `protocol/x/prices` module. The function now accurately determines if a market is recently available by considering both the market age and the price daemon warmup time. This ensures that the system correctly identifies newly available markets, improving the reliability of price data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->