### PR TITLE
Add prod_genesis.sh and `sample_pregenesis.json`

### DIFF
--- a/protocol/app/testdata/default_genesis_state.json
+++ b/protocol/app/testdata/default_genesis_state.json
@@ -351,7 +351,7 @@
       "treasury_account":"rewards_treasury",
       "denom":"dv4tnt",
       "denom_exponent":-18,
-      "market_id":11,
+      "market_id":1,
       "fee_multiplier_ppm":990000
     }
   },

--- a/protocol/app/testdata/default_genesis_state.json
+++ b/protocol/app/testdata/default_genesis_state.json
@@ -350,7 +350,7 @@
     "params": {
       "treasury_account":"rewards_treasury",
       "denom":"dv4tnt",
-      "denom_exponent":-6,
+      "denom_exponent":-18,
       "market_id":1,
       "fee_multiplier_ppm":990000
     }
@@ -406,8 +406,15 @@
     "vest_entries": [
       {
         "denom": "dv4tnt",
-        "end_time": "2023-10-13T00:00:00Z",
-        "start_time": "2023-09-13T00:00:00Z",
+        "end_time": "2025-01-01T00:00:00Z",
+        "start_time": "2023-01-01T00:00:00Z",
+        "treasury_account": "community_treasury",
+        "vester_account": "community_vester"
+      },
+      {
+        "denom": "dv4tnt",
+        "end_time": "2025-01-01T00:00:00Z",
+        "start_time": "2023-01-01T00:00:00Z",
         "treasury_account": "rewards_treasury",
         "vester_account": "rewards_vester"
       }

--- a/protocol/app/testdata/default_genesis_state.json
+++ b/protocol/app/testdata/default_genesis_state.json
@@ -351,7 +351,7 @@
       "treasury_account":"rewards_treasury",
       "denom":"dv4tnt",
       "denom_exponent":-18,
-      "market_id":1,
+      "market_id":11,
       "fee_multiplier_ppm":990000
     }
   },

--- a/protocol/lib/constants.go
+++ b/protocol/lib/constants.go
@@ -17,6 +17,9 @@ const (
 	UsdcAssetId                   = uint32(0)
 
 	ZeroUint64 = uint64(0)
+
+	// 10^BaseDenomExponent denotes how much full coin is represented by 1 base denom.
+	BaseDenomExponent = -18
 )
 
 // PowerReduction defines the default power reduction value for staking.

--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -36,12 +36,12 @@ NATIVE_TOKEN="adv4tnt"
 NATIVE_TOKEN_WHOLE_COIN="dv4tnt"
 # Human readable name of token.
 COIN_NAME="dYdX Testnet Token"
-# Market ID in the oracle price list for the rwards token.
+# Market ID in the oracle price list for the rewards token.
 REWARDS_TOKEN_MARKET_ID=11
 # The numerical chain ID of the Ethereum chain for bridge daemon to query.
 ETH_CHAIN_ID=1
 # The address of the Ethereum contract for bridge daemon to monitor for logs.
-ETH_BRIDGE_ADDRESS="0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0"
+ETH_BRIDGE_ADDRESS="0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0" # default value points to a Sepolia contract
 # The next event id (the last processed id plus one) of the logs from the Ethereum contract.
 BRIDGE_GENESIS_ACKNOWLEDGED_NEXT_ID=0
 # The Ethereum block height of the most recently processed bridge event.
@@ -57,7 +57,7 @@ REWARDS_VEST_START_TIME="2001-01-01T00:00:00Z"
 # End time of the rewards vesting schedule.
 REWARDS_VEST_END_TIME="2050-01-01T00:00:00Z"
 
-################## Start of required values to be updated ##################
+################## End of required values to be updated ##################
 
 cleanup_tmp_dir() {
 	if [ -d "$TMP_EXCHANGE_CONFIG_JSON_DIR" ]; then
@@ -121,11 +121,15 @@ function overwrite_genesis_production() {
     dasel put -t int -f "$GENESIS" '.app_state.rewards.params.fee_multiplier_ppm' -v '0'
 
     # Vest params
-    # For communmity treasury
+    # For community treasury
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].vester_account' -v "community_vester"
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].treasury_account' -v "community_treasury"
     dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].denom' -v "$NATIVE_TOKEN"
     dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].start_time' -v "$COMMUNITY_VEST_START_TIME"
     dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].end_time' -v "$COMMUNITY_VEST_END_TIME"
     # For rewards treasury
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].vester_account' -v "rewards_vester"
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].treasury_account' -v "rewards_treasury"
     dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].denom' -v "$NATIVE_TOKEN"
     dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].start_time' -v "$REWARDS_VEST_START_TIME"
     dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].end_time' -v "$REWARDS_VEST_END_TIME"

--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -30,16 +30,29 @@ source "./testing/genesis.sh"
 # TODO(GENESIS): Update below values before running this script. Sample values are shown.
 ################## Start of required values to be updated ##################
 CHAIN_ID="dydx-1"
-NATIVE_TOKEN="dv4tnt"
+# Base denomination of the native token. Usually comes with a prefix "u-", "a-" to indicate unit.
+NATIVE_TOKEN="adv4tnt"
+# Denomination of the native token in whole coins.
+NATIVE_TOKEN_WHOLE_COIN="dv4tnt"
+# Market ID in the oracle price list for the rwards token.
 REWARDS_TOKEN_MARKET_ID=11
+# The numerical chain ID of the Ethereum chain for bridge daemon to query.
 ETH_CHAIN_ID=1
+# The address of the Ethereum contract for bridge daemon to monitor for logs.
 ETH_BRIDGE_ADDRESS="0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0"
+# The next event id (the last processed id plus one) of the logs from the Ethereum contract.
 BRIDGE_GENESIS_ACKNOWLEDGED_NEXT_ID=0
+# The Ethereum block height of the most recently processed bridge event.
 BRIDGE_GENESIS_ACKNOWLEDGED_ETH_BLOCK_HEIGHT=0
+# Genesis time of the chain.
 GENESIS_TIME="2023-12-31T00:00:00Z"
+# Start time of the community vesting schedule.
 COMMUNITY_VEST_START_TIME="2001-01-01T00:00:00Z"
+# End time of the community vesting schedule.
 COMMUNITY_VEST_END_TIME="2050-01-01T00:00:00Z"
+# Start time of the rewards vesting schedule.
 REWARDS_VEST_START_TIME="2001-01-01T00:00:00Z"
+# End time of the rewards vesting schedule.
 REWARDS_VEST_END_TIME="2050-01-01T00:00:00Z"
 
 ################## Start of required values to be updated ##################
@@ -74,6 +87,7 @@ function overwrite_genesis_production() {
 	dasel put -t string -f "$GENESIS" '.app_state.distribution.params.community_tax' -v '0.0' # 0%
 	dasel put -t bool -f "$GENESIS" '.app_state.distribution.params.withdraw_addr_enabled' -v 'true'
 
+	# Bank params
     # Initialize bank balance of bridge module account.
     dasel put -t json -f "$GENESIS" ".app_state.bank.balances" -v "[]"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[]" -v "{}"
@@ -81,6 +95,9 @@ function overwrite_genesis_production() {
 	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[0].coins.[]" -v "{}"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].coins.[0].denom" -v "${NATIVE_TOKEN}"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].coins.[0].amount" -v "${BRIDGE_MODACC_BALANCE}"
+	# Set denom metadata
+	set_denom_metadata "$NATIVE_TOKEN" "$NATIVE_TOKEN_WHOLE_COIN"
+
 	# Governance params
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_deposit.[0].amount' -v "10000$EIGHTEEN_ZEROS" # 10k whole coins of native token
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_deposit.[0].denom' -v "$NATIVE_TOKEN"
@@ -130,7 +147,7 @@ function overwrite_genesis_production() {
 	dasel put -t int -f "$GENESIS" '.app_state.bridge.acknowledged_event_info.eth_block_height' -v "$BRIDGE_GENESIS_ACKNOWLEDGED_ETH_BLOCK_HEIGHT"
 
     # Crisis module
-    dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.amount' -v "1$EIGHTEEN_ZEROS"
+    dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.amount' -v "1$EIGHTEEN_ZEROS" # 1 whole coin of native denom
     dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.denom' -v "$NATIVE_TOKEN"
 
     # Genesis time

--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -34,6 +34,8 @@ CHAIN_ID="dydx-1"
 NATIVE_TOKEN="adv4tnt"
 # Denomination of the native token in whole coins.
 NATIVE_TOKEN_WHOLE_COIN="dv4tnt"
+# Human readable name of token.
+COIN_NAME="dYdX Testnet Token"
 # Market ID in the oracle price list for the rwards token.
 REWARDS_TOKEN_MARKET_ID=11
 # The numerical chain ID of the Ethereum chain for bridge daemon to query.
@@ -96,7 +98,7 @@ function overwrite_genesis_production() {
 	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].coins.[0].denom" -v "${NATIVE_TOKEN}"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].coins.[0].amount" -v "${BRIDGE_MODACC_BALANCE}"
 	# Set denom metadata
-	set_denom_metadata "$NATIVE_TOKEN" "$NATIVE_TOKEN_WHOLE_COIN"
+	set_denom_metadata "$NATIVE_TOKEN" "$NATIVE_TOKEN_WHOLE_COIN" "$COIN_NAME"
 
 	# Governance params
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_deposit.[0].amount' -v "10000$EIGHTEEN_ZEROS" # 10k whole coins of native token
@@ -131,6 +133,7 @@ function overwrite_genesis_production() {
     # Delayed message params
     # Schedule a delayed message to swap fee tiers to the standard schedule after ~120 days of blocks.
 	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.num_messages' -v '1'
+	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages' -v "[]"
 	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[]' -v "{}"
 	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].id' -v '0'
 

--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+set -eo pipefail
+
+# This script creates the pregenesis file for the public testnet.
+#
+# The script must be run from the root of the `v4-chain` repo.
+#
+# example usage:
+# $ ./scripts/genesis/prod_pregenesis.sh ./build/dydxprotocold
+
+# Check for missing required arguments
+if [ -z "$1" ]; then
+  echo "Error: Missing required argument DYDX_BINARY."
+  echo "Usage: $0 <DYDX_BINARY> [-s|--SEED_FAUCET_USDC]"
+  exit 1
+fi
+
+# Capture the required argument
+DYDX_BINARY="$1"
+
+TMP_CHAIN_DIR="/tmp/prod-chain"
+TMP_EXCHANGE_CONFIG_JSON_DIR="/tmp/prod-exchange_config"
+FIFTEEN_ZEROS="000000000000000"
+EIGHTEEN_ZEROS="000$FIFTEEN_ZEROS"
+BRIDGE_MODACC_BALANCE="1000000000$EIGHTEEN_ZEROS" # 1e27
+BRIDGE_MODACC_ADDR="dydx1zlefkpe3g0vvm9a4h0jf9000lmqutlh9jwjnsv"
+
+source "./testing/genesis.sh"
+# TODO(GENESIS): Update below values before running this script. Sample values are shown.
+################## Start of required values to be updated ##################
+CHAIN_ID="dydx-1"
+NATIVE_TOKEN="dv4tnt"
+REWARDS_TOKEN_MARKET_ID=11
+ETH_CHAIN_ID=1
+ETH_BRIDGE_ADDRESS="0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0"
+BRIDGE_GENESIS_ACKNOWLEDGED_NEXT_ID=0
+BRIDGE_GENESIS_ACKNOWLEDGED_ETH_BLOCK_HEIGHT=0
+GENESIS_TIME="2023-12-31T00:00:00Z"
+COMMUNITY_VEST_START_TIME="2001-01-01T00:00:00Z"
+COMMUNITY_VEST_END_TIME="2050-01-01T00:00:00Z"
+REWARDS_VEST_START_TIME="2001-01-01T00:00:00Z"
+REWARDS_VEST_END_TIME="2050-01-01T00:00:00Z"
+
+################## Start of required values to be updated ##################
+
+cleanup_tmp_dir() {
+	if [ -d "$TMP_EXCHANGE_CONFIG_JSON_DIR" ]; then
+		rm -r "$TMP_EXCHANGE_CONFIG_JSON_DIR"
+	fi
+	if [ -d "$TMP_CHAIN_DIR" ]; then
+		rm -r "$TMP_CHAIN_DIR"
+	fi
+}
+
+# Set production default genesis params.
+function overwrite_genesis_production() {	
+	# Slashing params
+	dasel put -t string -f "$GENESIS" '.app_state.slashing.params.signed_blocks_window' -v '12288' # ~5 hr
+	dasel put -t string -f "$GENESIS" '.app_state.slashing.params.min_signed_per_window' -v '0.2' # 20%
+	dasel put -t string -f "$GENESIS" '.app_state.slashing.params.downtime_jail_duration' -v '3600s'
+	dasel put -t string -f "$GENESIS" '.app_state.slashing.params.slash_fraction_double_sign' -v '0.0' # 0%
+	dasel put -t string -f "$GENESIS" '.app_state.slashing.params.slash_fraction_downtime' -v '0.0' # 0%
+
+	# Staking params
+	dasel put -t string -f "$GENESIS" '.app_state.staking.params.bond_denom' -v "$NATIVE_TOKEN"
+	dasel put -t int -f "$GENESIS" '.app_state.staking.params.max_validators' -v '60'
+	dasel put -t string -f "$GENESIS" '.app_state.staking.params.min_commission_rate' -v '0.05' # 5%
+	dasel put -t string -f "$GENESIS" '.app_state.staking.params.unbonding_time' -v '2592000s' # 30 days
+	dasel put -t int -f "$GENESIS" '.app_state.staking.params.max_entries' -v '7'
+	dasel put -t int -f "$GENESIS" '.app_state.staking.params.historical_entries' -v '10000'
+
+	# Distribution params
+	dasel put -t string -f "$GENESIS" '.app_state.distribution.params.community_tax' -v '0.0' # 0%
+	dasel put -t bool -f "$GENESIS" '.app_state.distribution.params.withdraw_addr_enabled' -v 'true'
+
+    # Initialize bank balance of bridge module account.
+    dasel put -t json -f "$GENESIS" ".app_state.bank.balances" -v "[]"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[]" -v "{}"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].address" -v "${BRIDGE_MODACC_ADDR}"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[0].coins.[]" -v "{}"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].coins.[0].denom" -v "${NATIVE_TOKEN}"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].coins.[0].amount" -v "${BRIDGE_MODACC_BALANCE}"
+	# Governance params
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_deposit.[0].amount' -v "10000$EIGHTEEN_ZEROS" # 10k whole coins of native token
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_deposit.[0].denom' -v "$NATIVE_TOKEN"
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.max_deposit_period' -v '172800s' # 2 days
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.voting_period' -v '345600s' # 4 days
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.quorum' -v '0.33400' # 33.4%
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.threshold' -v '0.50000' # 50%
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.veto_threshold' -v '0.33400' # 33.4%
+    dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_proposal_deposit_prevote' -v 'false' 
+	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_vote_quorum' -v 'false' 
+	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_vote_veto' -v 'true'
+
+	# Consensus params
+	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_bytes' -v '4194304'
+	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_gas' -v '-1'
+
+    # Rewards params
+    dasel put -t string -f "$GENESIS" '.app_state.rewards.params.denom' -v "$NATIVE_TOKEN"
+    dasel put -t int -f "$GENESIS" '.app_state.rewards.params.fee_multiplier_ppm' -v '0'
+
+    # Vest params
+    # For communmity treasury
+    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].denom' -v "$NATIVE_TOKEN"
+    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].start_time' -v "$COMMUNITY_VEST_START_TIME"
+    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].end_time' -v "$COMMUNITY_VEST_END_TIME"
+    # For rewards treasury
+    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].denom' -v "$NATIVE_TOKEN"
+    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].start_time' -v "$REWARDS_VEST_START_TIME"
+    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].end_time' -v "$REWARDS_VEST_END_TIME"
+
+    # Delayed message params
+    # Schedule a delayed message to swap fee tiers to the standard schedule after ~120 days of blocks.
+	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.num_messages' -v '1'
+	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[]' -v "{}"
+	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].id' -v '0'
+
+	delaymsg=$(cat "$DELAY_MSG_JSON_DIR/perpetual_fee_params_msg.json" | jq -c '.')
+	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].msg' -v "$delaymsg"
+	# Schedule the message to execute in ~120 days (at 1.5s per block)
+	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].block_height' -v '6912000'
+
+    # Bridge module params.
+	dasel put -t string -f "$GENESIS" '.app_state.bridge.event_params.denom' -v "$NATIVE_TOKEN"
+	dasel put -t int -f "$GENESIS" '.app_state.bridge.event_params.eth_chain_id' -v "$ETH_CHAIN_ID"
+	dasel put -t string -f "$GENESIS" '.app_state.bridge.event_params.eth_address' -v "$ETH_BRIDGE_ADDRESS"
+	dasel put -t int -f "$GENESIS" '.app_state.bridge.acknowledged_event_info.next_id' -v "$BRIDGE_GENESIS_ACKNOWLEDGED_NEXT_ID"
+	dasel put -t int -f "$GENESIS" '.app_state.bridge.acknowledged_event_info.eth_block_height' -v "$BRIDGE_GENESIS_ACKNOWLEDGED_ETH_BLOCK_HEIGHT"
+
+    # Crisis module
+    dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.amount' -v "1$EIGHTEEN_ZEROS"
+    dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.denom' -v "$NATIVE_TOKEN"
+
+    # Genesis time
+    dasel put -t string -f "$GENESIS" '.genesis_time' -v "$GENESIS_TIME"
+}
+
+create_pregenesis_file() {
+	VAL_HOME_DIR="$TMP_CHAIN_DIR/.dydxprotocol"
+	VAL_CONFIG_DIR="$VAL_HOME_DIR/config"
+	# This initializes the $VAL_HOME_DIR folder.
+	$DYDX_BINARY init "test-moniker" -o --chain-id=$CHAIN_ID --home "$VAL_HOME_DIR"
+
+	# Create temporary directory for exchange config jsons.
+	echo "Copying exchange config jsons to $TMP_EXCHANGE_CONFIG_JSON_DIR"
+	cp -R ./daemons/pricefeed/client/constants/testdata $TMP_EXCHANGE_CONFIG_JSON_DIR
+
+	edit_genesis "$VAL_CONFIG_DIR" "" "" "$TMP_EXCHANGE_CONFIG_JSON_DIR" "./testing/delaymsg_config"
+	overwrite_genesis_production
+}
+
+cleanup_tmp_dir
+create_pregenesis_file
+echo "Wrote pregenesis file to $VAL_CONFIG_DIR/genesis.json"

--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -90,7 +90,7 @@ function overwrite_genesis_production() {
 	dasel put -t bool -f "$GENESIS" '.app_state.distribution.params.withdraw_addr_enabled' -v 'true'
 
 	# Bank params
-    # Initialize bank balance of bridge module account.
+	# Initialize bank balance of bridge module account.
 	dasel put -t json -f "$GENESIS" ".app_state.bank.balances" -v "[]"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[]" -v "{}"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].address" -v "${BRIDGE_MODACC_ADDR}"
@@ -116,26 +116,26 @@ function overwrite_genesis_production() {
 	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_bytes' -v '4194304'
 	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_gas' -v '-1'
 
-    # Rewards params
-    dasel put -t string -f "$GENESIS" '.app_state.rewards.params.denom' -v "$NATIVE_TOKEN"
-    dasel put -t int -f "$GENESIS" '.app_state.rewards.params.fee_multiplier_ppm' -v '0'
+	# Rewards params
+	dasel put -t string -f "$GENESIS" '.app_state.rewards.params.denom' -v "$NATIVE_TOKEN"
+	dasel put -t int -f "$GENESIS" '.app_state.rewards.params.fee_multiplier_ppm' -v '0'
 
-    # Vest params
-    # For community treasury
+	# Vest params
+	# For community treasury
 	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].vester_account' -v "community_vester"
 	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].treasury_account' -v "community_treasury"
-    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].denom' -v "$NATIVE_TOKEN"
-    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].start_time' -v "$COMMUNITY_VEST_START_TIME"
-    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].end_time' -v "$COMMUNITY_VEST_END_TIME"
-    # For rewards treasury
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].denom' -v "$NATIVE_TOKEN"
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].start_time' -v "$COMMUNITY_VEST_START_TIME"
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[0].end_time' -v "$COMMUNITY_VEST_END_TIME"
+	# For rewards treasury
 	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].vester_account' -v "rewards_vester"
 	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].treasury_account' -v "rewards_treasury"
-    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].denom' -v "$NATIVE_TOKEN"
-    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].start_time' -v "$REWARDS_VEST_START_TIME"
-    dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].end_time' -v "$REWARDS_VEST_END_TIME"
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].denom' -v "$NATIVE_TOKEN"
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].start_time' -v "$REWARDS_VEST_START_TIME"
+	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].end_time' -v "$REWARDS_VEST_END_TIME"
 
-    # Delayed message params
-    # Schedule a delayed message to swap fee tiers to the standard schedule after ~120 days of blocks.
+	# Delayed message params
+	# Schedule a delayed message to swap fee tiers to the standard schedule after ~120 days of blocks.
 	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.num_messages' -v '1'
 	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages' -v "[]"
 	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[]' -v "{}"
@@ -145,19 +145,19 @@ function overwrite_genesis_production() {
 	# Schedule the message to execute in ~120 days (at 1.5s per block)
 	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].block_height' -v '6912000'
 
-    # Bridge module params.
+	# Bridge module params.
 	dasel put -t string -f "$GENESIS" '.app_state.bridge.event_params.denom' -v "$NATIVE_TOKEN"
 	dasel put -t int -f "$GENESIS" '.app_state.bridge.event_params.eth_chain_id' -v "$ETH_CHAIN_ID"
 	dasel put -t string -f "$GENESIS" '.app_state.bridge.event_params.eth_address' -v "$ETH_BRIDGE_ADDRESS"
 	dasel put -t int -f "$GENESIS" '.app_state.bridge.acknowledged_event_info.next_id' -v "$BRIDGE_GENESIS_ACKNOWLEDGED_NEXT_ID"
 	dasel put -t int -f "$GENESIS" '.app_state.bridge.acknowledged_event_info.eth_block_height' -v "$BRIDGE_GENESIS_ACKNOWLEDGED_ETH_BLOCK_HEIGHT"
 
-    # Crisis module
-    dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.amount' -v "1$EIGHTEEN_ZEROS" # 1 whole coin of native denom
-    dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.denom' -v "$NATIVE_TOKEN"
+	# Crisis module
+	dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.amount' -v "1$EIGHTEEN_ZEROS" # 1 whole coin of native denom
+	dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.denom' -v "$NATIVE_TOKEN"
 
-    # Genesis time
-    dasel put -t string -f "$GENESIS" '.genesis_time' -v "$GENESIS_TIME"
+	# Genesis time
+	dasel put -t string -f "$GENESIS" '.genesis_time' -v "$GENESIS_TIME"
 }
 
 create_pregenesis_file() {

--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -20,9 +20,9 @@ DYDX_BINARY="$1"
 
 TMP_CHAIN_DIR="/tmp/prod-chain"
 TMP_EXCHANGE_CONFIG_JSON_DIR="/tmp/prod-exchange_config"
-FIFTEEN_ZEROS="000000000000000"
-EIGHTEEN_ZEROS="000$FIFTEEN_ZEROS"
-BRIDGE_MODACC_BALANCE="1000000000$EIGHTEEN_ZEROS" # 1e27
+NINE_ZEROS="000000000"
+EIGHTEEN_ZEROS="$NINE_ZEROS$NINE_ZEROS"
+BRIDGE_MODACC_BALANCE="1$NINE_ZEROS$EIGHTEEN_ZEROS" # 1e27
 BRIDGE_MODACC_ADDR="dydx1zlefkpe3g0vvm9a4h0jf9000lmqutlh9jwjnsv"
 
 source "./testing/genesis.sh"
@@ -91,7 +91,7 @@ function overwrite_genesis_production() {
 
 	# Bank params
     # Initialize bank balance of bridge module account.
-    dasel put -t json -f "$GENESIS" ".app_state.bank.balances" -v "[]"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.balances" -v "[]"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[]" -v "{}"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[0].address" -v "${BRIDGE_MODACC_ADDR}"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[0].coins.[]" -v "{}"
@@ -108,7 +108,7 @@ function overwrite_genesis_production() {
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.quorum' -v '0.33400' # 33.4%
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.threshold' -v '0.50000' # 50%
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.veto_threshold' -v '0.33400' # 33.4%
-    dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_proposal_deposit_prevote' -v 'false' 
+	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_proposal_deposit_prevote' -v 'false' 
 	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_vote_quorum' -v 'false' 
 	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_vote_veto' -v 'true'
 
@@ -136,7 +136,6 @@ function overwrite_genesis_production() {
 	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages' -v "[]"
 	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[]' -v "{}"
 	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].id' -v '0'
-
 	delaymsg=$(cat "$DELAY_MSG_JSON_DIR/perpetual_fee_params_msg.json" | jq -c '.')
 	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].msg' -v "$delaymsg"
 	# Schedule the message to execute in ~120 days (at 1.5s per block)

--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-# This script creates the pregenesis file for the public testnet.
+# This script creates the pregenesis file for a production network.
 #
 # The script must be run from the root of the `v4-chain` repo.
 #
@@ -26,6 +26,7 @@ BRIDGE_MODACC_BALANCE="1000000000$EIGHTEEN_ZEROS" # 1e27
 BRIDGE_MODACC_ADDR="dydx1zlefkpe3g0vvm9a4h0jf9000lmqutlh9jwjnsv"
 
 source "./testing/genesis.sh"
+
 # TODO(GENESIS): Update below values before running this script. Sample values are shown.
 ################## Start of required values to be updated ##################
 CHAIN_ID="dydx-1"

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -32,12 +32,27 @@
           "coins": [
             {
               "amount": "1000000000000000000000000000",
-              "denom": "dv4tnt"
+              "denom": "adv4tnt"
             }
           ]
         }
       ],
-      "denom_metadata": [],
+      "denom_metadata": [
+        {
+          "base": "adv4tnt",
+          "denom_units": [
+            {
+              "denom": "adv4tnt"
+            },
+            {
+              "denom": "dv4tnt",
+              "exponent": 18
+            }
+          ],
+          "description": "The native token of the network",
+          "display": "dv4tnt"
+        }
+      ],
       "params": {
         "default_send_enabled": true,
         "send_enabled": []
@@ -60,7 +75,7 @@
         "next_id": 0
       },
       "event_params": {
-        "denom": "dv4tnt",
+        "denom": "adv4tnt",
         "eth_address": "0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0",
         "eth_chain_id": 1
       },
@@ -510,7 +525,7 @@
     "crisis": {
       "constant_fee": {
         "amount": "1000000000000000000",
-        "denom": "dv4tnt"
+        "denom": "adv4tnt"
       }
     },
     "delaymsg": {
@@ -750,7 +765,7 @@
         "min_deposit": [
           {
             "amount": "10000000000000000000000",
-            "denom": "dv4tnt"
+            "denom": "adv4tnt"
           }
         ],
         "min_initial_deposit_ratio": "0.000000000000000000",
@@ -1610,7 +1625,7 @@
     },
     "rewards": {
       "params": {
-        "denom": "dv4tnt",
+        "denom": "adv4tnt",
         "denom_exponent": -18,
         "fee_multiplier_ppm": 0,
         "market_id": 11,
@@ -1635,7 +1650,7 @@
       "last_total_power": "0",
       "last_validator_powers": [],
       "params": {
-        "bond_denom": "dv4tnt",
+        "bond_denom": "adv4tnt",
         "historical_entries": 10000,
         "max_entries": 7,
         "max_validators": 60,
@@ -1667,14 +1682,14 @@
     "vest": {
       "vest_entries": [
         {
-          "denom": "dv4tnt",
+          "denom": "adv4tnt",
           "end_time": "2050-01-01T00:00:00Z",
           "start_time": "2001-01-01T00:00:00Z",
           "treasury_account": "community_treasury",
           "vester_account": "community_vester"
         },
         {
-          "denom": "dv4tnt",
+          "denom": "adv4tnt",
           "end_time": "2050-01-01T00:00:00Z",
           "start_time": "2001-01-01T00:00:00Z",
           "treasury_account": "rewards_treasury",

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -590,7 +590,7 @@
                 },
                 {
                   "absolute_volume_requirement": "125000000000000",
-                  "maker_fee_ppm": -90,
+                  "maker_fee_ppm": -70,
                   "maker_volume_share_requirement_ppm": 10000,
                   "name": "7",
                   "taker_fee_ppm": 250,
@@ -598,7 +598,7 @@
                 },
                 {
                   "absolute_volume_requirement": "125000000000000",
-                  "maker_fee_ppm": -110,
+                  "maker_fee_ppm": -90,
                   "maker_volume_share_requirement_ppm": 20000,
                   "name": "8",
                   "taker_fee_ppm": 250,

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -50,7 +50,9 @@
             }
           ],
           "description": "The native token of the network",
-          "display": "dv4tnt"
+          "display": "dv4tnt",
+          "name": "dYdX Testnet Token",
+          "symbol": "dv4tnt"
         }
       ],
       "params": {
@@ -613,8 +615,7 @@
               ]
             }
           }
-        },
-        {}
+        }
       ],
       "num_messages": 1
     },

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -1,0 +1,1708 @@
+{
+  "app_hash": "",
+  "app_state": {
+    "assets": {
+      "assets": [
+        {
+          "atomic_resolution": -6,
+          "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+          "denom_exponent": "-6",
+          "has_market": false,
+          "id": 0,
+          "long_interest": 0,
+          "market_id": 0,
+          "symbol": "USDC"
+        }
+      ]
+    },
+    "auth": {
+      "accounts": [],
+      "params": {
+        "max_memo_characters": "256",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10"
+      }
+    },
+    "bank": {
+      "balances": [
+        {
+          "address": "dydx1zlefkpe3g0vvm9a4h0jf9000lmqutlh9jwjnsv",
+          "coins": [
+            {
+              "amount": "1000000000000000000000000000",
+              "denom": "dv4tnt"
+            }
+          ]
+        }
+      ],
+      "denom_metadata": [],
+      "params": {
+        "default_send_enabled": true,
+        "send_enabled": []
+      },
+      "send_enabled": [],
+      "supply": []
+    },
+    "blocktime": {
+      "params": {
+        "clock_drift_grace_period_duration": "5s",
+        "durations": [
+          "300s",
+          "1800s"
+        ]
+      }
+    },
+    "bridge": {
+      "acknowledged_event_info": {
+        "eth_block_height": 0,
+        "next_id": 0
+      },
+      "event_params": {
+        "denom": "dv4tnt",
+        "eth_address": "0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0",
+        "eth_chain_id": 1
+      },
+      "propose_params": {
+        "max_bridges_per_block": 10,
+        "propose_delay_duration": "60s",
+        "skip_if_block_delayed_by_duration": "5s",
+        "skip_rate_ppm": 800000
+      },
+      "safety_params": {
+        "delay_blocks": 86400,
+        "is_disabled": false
+      }
+    },
+    "capability": {
+      "index": "1",
+      "owners": []
+    },
+    "clob": {
+      "block_rate_limit_config": {
+        "max_short_term_order_cancellations_per_n_blocks": [
+          {
+            "limit": 50,
+            "num_blocks": 1
+          }
+        ],
+        "max_short_term_orders_per_n_blocks": [
+          {
+            "limit": 50,
+            "num_blocks": 1
+          }
+        ],
+        "max_stateful_orders_per_n_blocks": [
+          {
+            "limit": 2,
+            "num_blocks": 1
+          },
+          {
+            "limit": 20,
+            "num_blocks": 100
+          }
+        ]
+      },
+      "clob_pairs": [
+        {
+          "id": 0,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 0
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 100000
+        },
+        {
+          "id": 1,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 1
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 100000
+        },
+        {
+          "id": 2,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 2
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 3,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 3
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 4,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 4
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 5,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 5
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 6,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 6
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 7,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 7
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 8,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 8
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 9,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 9
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 10,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 10
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 11,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 11
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 12,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 12
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 13,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 13
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 14,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 14
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 15,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 15
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 16,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 16
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 17,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 17
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 18,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 18
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 19,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 19
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 20,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 20
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 21,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 21
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 22,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 22
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 23,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 23
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 24,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 24
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 25,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 25
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 26,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 26
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 27,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 27
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 28,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 28
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 29,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 29
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 30,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 30
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 31,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 31
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 32,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 32
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_ACTIVE",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        }
+      ],
+      "equity_tier_limit_config": {
+        "short_term_order_equity_tiers": [
+          {
+            "limit": 0,
+            "usd_tnc_required": "0"
+          },
+          {
+            "limit": 1,
+            "usd_tnc_required": "20000000"
+          },
+          {
+            "limit": 5,
+            "usd_tnc_required": "100000000"
+          },
+          {
+            "limit": 10,
+            "usd_tnc_required": "1000000000"
+          },
+          {
+            "limit": 100,
+            "usd_tnc_required": "10000000000"
+          },
+          {
+            "limit": 200,
+            "usd_tnc_required": "100000000000"
+          }
+        ],
+        "stateful_order_equity_tiers": [
+          {
+            "limit": 0,
+            "usd_tnc_required": "0"
+          },
+          {
+            "limit": 1,
+            "usd_tnc_required": "20000000"
+          },
+          {
+            "limit": 5,
+            "usd_tnc_required": "100000000"
+          },
+          {
+            "limit": 10,
+            "usd_tnc_required": "1000000000"
+          },
+          {
+            "limit": 100,
+            "usd_tnc_required": "10000000000"
+          },
+          {
+            "limit": 200,
+            "usd_tnc_required": "100000000000"
+          }
+        ]
+      },
+      "liquidations_config": {
+        "fillable_price_config": {
+          "bankruptcy_adjustment_ppm": 1000000,
+          "spread_to_maintenance_margin_ratio_ppm": 1500000
+        },
+        "max_insurance_fund_quantums_for_deleveraging": 100000000000,
+        "max_liquidation_fee_ppm": 15000,
+        "position_block_limits": {
+          "max_position_portion_liquidated_ppm": 100000,
+          "min_position_notional_liquidated": 1000
+        },
+        "subaccount_block_limits": {
+          "max_notional_liquidated": 100000000000,
+          "max_quantums_insurance_lost": 1000000000000
+        }
+      }
+    },
+    "crisis": {
+      "constant_fee": {
+        "amount": "1000000000000000000",
+        "denom": "dv4tnt"
+      }
+    },
+    "delaymsg": {
+      "delayed_messages": [
+        {
+          "block_height": 6912000,
+          "id": 0,
+          "msg": {
+            "@type": "/dydxprotocol.feetiers.MsgUpdatePerpetualFeeParams",
+            "authority": "dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr",
+            "params": {
+              "tiers": [
+                {
+                  "absolute_volume_requirement": "0",
+                  "maker_fee_ppm": 100,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "1",
+                  "taker_fee_ppm": 500,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "1000000000000",
+                  "maker_fee_ppm": 100,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "2",
+                  "taker_fee_ppm": 450,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "5000000000000",
+                  "maker_fee_ppm": 50,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "3",
+                  "taker_fee_ppm": 400,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "25000000000000",
+                  "maker_fee_ppm": 0,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "4",
+                  "taker_fee_ppm": 350,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": 0,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "5",
+                  "taker_fee_ppm": 300,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": -50,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "6",
+                  "taker_fee_ppm": 250,
+                  "total_volume_share_requirement_ppm": 5000
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": -90,
+                  "maker_volume_share_requirement_ppm": 10000,
+                  "name": "7",
+                  "taker_fee_ppm": 250,
+                  "total_volume_share_requirement_ppm": 5000
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": -110,
+                  "maker_volume_share_requirement_ppm": 20000,
+                  "name": "8",
+                  "taker_fee_ppm": 250,
+                  "total_volume_share_requirement_ppm": 5000
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": -110,
+                  "maker_volume_share_requirement_ppm": 40000,
+                  "name": "9",
+                  "taker_fee_ppm": 250,
+                  "total_volume_share_requirement_ppm": 5000
+                }
+              ]
+            }
+          }
+        },
+        {}
+      ],
+      "num_messages": 1
+    },
+    "distribution": {
+      "delegator_starting_infos": [],
+      "delegator_withdraw_infos": [],
+      "fee_pool": {
+        "community_pool": []
+      },
+      "outstanding_rewards": [],
+      "params": {
+        "base_proposer_reward": "0.000000000000000000",
+        "bonus_proposer_reward": "0.000000000000000000",
+        "community_tax": "0.0",
+        "withdraw_addr_enabled": true
+      },
+      "previous_proposer": "",
+      "validator_accumulated_commissions": [],
+      "validator_current_rewards": [],
+      "validator_historical_rewards": [],
+      "validator_slash_events": []
+    },
+    "epochs": {
+      "epoch_info_list": [
+        {
+          "current_epoch": 0,
+          "current_epoch_start_block": 0,
+          "duration": 60,
+          "fast_forward_next_tick": true,
+          "is_initialized": false,
+          "name": "funding-sample",
+          "next_tick": 30
+        },
+        {
+          "current_epoch": 0,
+          "current_epoch_start_block": 0,
+          "duration": 3600,
+          "fast_forward_next_tick": true,
+          "is_initialized": false,
+          "name": "funding-tick",
+          "next_tick": 0
+        },
+        {
+          "current_epoch": 0,
+          "current_epoch_start_block": 0,
+          "duration": 3600,
+          "fast_forward_next_tick": true,
+          "is_initialized": false,
+          "name": "stats-epoch",
+          "next_tick": 0
+        }
+      ]
+    },
+    "evidence": {
+      "evidence": []
+    },
+    "feegrant": {
+      "allowances": []
+    },
+    "feetiers": {
+      "params": {
+        "tiers": [
+          {
+            "absolute_volume_requirement": "0",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 0,
+            "name": "1",
+            "taker_fee_ppm": 500,
+            "total_volume_share_requirement_ppm": 0
+          },
+          {
+            "absolute_volume_requirement": "1000000000000",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 0,
+            "name": "2",
+            "taker_fee_ppm": 450,
+            "total_volume_share_requirement_ppm": 0
+          },
+          {
+            "absolute_volume_requirement": "5000000000000",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 0,
+            "name": "3",
+            "taker_fee_ppm": 400,
+            "total_volume_share_requirement_ppm": 0
+          },
+          {
+            "absolute_volume_requirement": "25000000000000",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 0,
+            "name": "4",
+            "taker_fee_ppm": 350,
+            "total_volume_share_requirement_ppm": 0
+          },
+          {
+            "absolute_volume_requirement": "125000000000000",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 0,
+            "name": "5",
+            "taker_fee_ppm": 300,
+            "total_volume_share_requirement_ppm": 0
+          },
+          {
+            "absolute_volume_requirement": "125000000000000",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 0,
+            "name": "6",
+            "taker_fee_ppm": 250,
+            "total_volume_share_requirement_ppm": 5000
+          },
+          {
+            "absolute_volume_requirement": "125000000000000",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 10000,
+            "name": "7",
+            "taker_fee_ppm": 250,
+            "total_volume_share_requirement_ppm": 5000
+          },
+          {
+            "absolute_volume_requirement": "125000000000000",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 20000,
+            "name": "8",
+            "taker_fee_ppm": 250,
+            "total_volume_share_requirement_ppm": 5000
+          },
+          {
+            "absolute_volume_requirement": "125000000000000",
+            "maker_fee_ppm": -110,
+            "maker_volume_share_requirement_ppm": 40000,
+            "name": "9",
+            "taker_fee_ppm": 250,
+            "total_volume_share_requirement_ppm": 5000
+          }
+        ]
+      }
+    },
+    "genutil": {
+      "gen_txs": []
+    },
+    "gov": {
+      "deposits": [],
+      "params": {
+        "burn_proposal_deposit_prevote": false,
+        "burn_vote_quorum": false,
+        "burn_vote_veto": true,
+        "max_deposit_period": "172800s",
+        "min_deposit": [
+          {
+            "amount": "10000000000000000000000",
+            "denom": "dv4tnt"
+          }
+        ],
+        "min_initial_deposit_ratio": "0.000000000000000000",
+        "quorum": "0.33400",
+        "threshold": "0.50000",
+        "veto_threshold": "0.33400",
+        "voting_period": "345600s"
+      },
+      "proposals": [],
+      "starting_proposal_id": "1",
+      "votes": []
+    },
+    "ibc": {
+      "channel_genesis": {
+        "ack_sequences": [],
+        "acknowledgements": [],
+        "channels": [],
+        "commitments": [],
+        "next_channel_sequence": "0",
+        "receipts": [],
+        "recv_sequences": [],
+        "send_sequences": []
+      },
+      "client_genesis": {
+        "clients": [],
+        "clients_consensus": [],
+        "clients_metadata": [],
+        "create_localhost": false,
+        "next_client_sequence": "0",
+        "params": {
+          "allowed_clients": [
+            "07-tendermint"
+          ]
+        }
+      },
+      "connection_genesis": {
+        "client_connection_paths": [],
+        "connections": [],
+        "next_connection_sequence": "0",
+        "params": {
+          "max_expected_time_per_block": "30000000000"
+        }
+      }
+    },
+    "perpetuals": {
+      "liquidity_tiers": [
+        {
+          "base_position_notional": 1000000000000,
+          "id": 0,
+          "impact_notional": 10000000000,
+          "initial_margin_ppm": 50000,
+          "maintenance_fraction_ppm": 600000,
+          "name": "Large-Cap"
+        },
+        {
+          "base_position_notional": 1000000000,
+          "id": 1,
+          "impact_notional": 5000000000,
+          "initial_margin_ppm": 100000,
+          "maintenance_fraction_ppm": 500000,
+          "name": "Mid-Cap"
+        },
+        {
+          "base_position_notional": 1000000000,
+          "id": 2,
+          "impact_notional": 2500000000,
+          "initial_margin_ppm": 200000,
+          "maintenance_fraction_ppm": 250000,
+          "name": "Long-Tail"
+        }
+      ],
+      "params": {
+        "funding_rate_clamp_factor_ppm": 6000000,
+        "min_num_votes_per_sample": 15,
+        "premium_vote_clamp_factor_ppm": 60000000
+      },
+      "perpetuals": [
+        {
+          "params": {
+            "atomic_resolution": -10,
+            "default_funding_ppm": 0,
+            "id": 0,
+            "liquidity_tier": 0,
+            "market_id": 0,
+            "ticker": "BTC-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -9,
+            "default_funding_ppm": 0,
+            "id": 1,
+            "liquidity_tier": 0,
+            "market_id": 1,
+            "ticker": "ETH-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 2,
+            "liquidity_tier": 1,
+            "market_id": 2,
+            "ticker": "LINK-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -5,
+            "default_funding_ppm": 0,
+            "id": 3,
+            "liquidity_tier": 1,
+            "market_id": 3,
+            "ticker": "MATIC-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -5,
+            "default_funding_ppm": 0,
+            "id": 4,
+            "liquidity_tier": 1,
+            "market_id": 4,
+            "ticker": "CRV-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -7,
+            "default_funding_ppm": 0,
+            "id": 5,
+            "liquidity_tier": 1,
+            "market_id": 5,
+            "ticker": "SOL-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -5,
+            "default_funding_ppm": 0,
+            "id": 6,
+            "liquidity_tier": 1,
+            "market_id": 6,
+            "ticker": "ADA-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -7,
+            "default_funding_ppm": 0,
+            "id": 7,
+            "liquidity_tier": 1,
+            "market_id": 7,
+            "ticker": "AVAX-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 8,
+            "liquidity_tier": 1,
+            "market_id": 8,
+            "ticker": "FIL-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -7,
+            "default_funding_ppm": 0,
+            "id": 9,
+            "liquidity_tier": 1,
+            "market_id": 9,
+            "ticker": "LTC-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -4,
+            "default_funding_ppm": 0,
+            "id": 10,
+            "liquidity_tier": 1,
+            "market_id": 10,
+            "ticker": "DOGE-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 11,
+            "liquidity_tier": 1,
+            "market_id": 11,
+            "ticker": "ATOM-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 12,
+            "liquidity_tier": 1,
+            "market_id": 12,
+            "ticker": "DOT-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 13,
+            "liquidity_tier": 1,
+            "market_id": 13,
+            "ticker": "UNI-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -8,
+            "default_funding_ppm": 0,
+            "id": 14,
+            "liquidity_tier": 1,
+            "market_id": 14,
+            "ticker": "BCH-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -4,
+            "default_funding_ppm": 0,
+            "id": 15,
+            "liquidity_tier": 1,
+            "market_id": 15,
+            "ticker": "TRX-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 16,
+            "liquidity_tier": 1,
+            "market_id": 16,
+            "ticker": "NEAR-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -9,
+            "default_funding_ppm": 0,
+            "id": 17,
+            "liquidity_tier": 2,
+            "market_id": 17,
+            "ticker": "MKR-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -5,
+            "default_funding_ppm": 0,
+            "id": 18,
+            "liquidity_tier": 1,
+            "market_id": 18,
+            "ticker": "XLM-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -7,
+            "default_funding_ppm": 0,
+            "id": 19,
+            "liquidity_tier": 1,
+            "market_id": 19,
+            "ticker": "ETC-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -7,
+            "default_funding_ppm": 0,
+            "id": 20,
+            "liquidity_tier": 2,
+            "market_id": 20,
+            "ticker": "COMP-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 21,
+            "liquidity_tier": 1,
+            "market_id": 21,
+            "ticker": "WLD-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 22,
+            "liquidity_tier": 2,
+            "market_id": 22,
+            "ticker": "APE-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 23,
+            "liquidity_tier": 1,
+            "market_id": 23,
+            "ticker": "APT-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 24,
+            "liquidity_tier": 1,
+            "market_id": 24,
+            "ticker": "ARB-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -5,
+            "default_funding_ppm": 0,
+            "id": 25,
+            "liquidity_tier": 2,
+            "market_id": 25,
+            "ticker": "BLUR-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 26,
+            "liquidity_tier": 1,
+            "market_id": 26,
+            "ticker": "LDO-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 27,
+            "liquidity_tier": 1,
+            "market_id": 27,
+            "ticker": "OP-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": 1,
+            "default_funding_ppm": 0,
+            "id": 28,
+            "liquidity_tier": 1,
+            "market_id": 28,
+            "ticker": "PEPE-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -5,
+            "default_funding_ppm": 0,
+            "id": 29,
+            "liquidity_tier": 2,
+            "market_id": 29,
+            "ticker": "SEI-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": 0,
+            "default_funding_ppm": 0,
+            "id": 30,
+            "liquidity_tier": 1,
+            "market_id": 30,
+            "ticker": "SHIB-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -5,
+            "default_funding_ppm": 0,
+            "id": 31,
+            "liquidity_tier": 1,
+            "market_id": 31,
+            "ticker": "SUI-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -5,
+            "default_funding_ppm": 0,
+            "id": 32,
+            "liquidity_tier": 1,
+            "market_id": 32,
+            "ticker": "XRP-USD"
+          }
+        }
+      ]
+    },
+    "prices": {
+      "market_params": [
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"BTCUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"BTC/USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"BTCUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"BTC-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"BTC_USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"XXBTZUSD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"BTC_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"BTC-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -5,
+          "id": 0,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 1000,
+          "pair": "BTC-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"ETHUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"ETH/USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"ETHUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"ETH-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"ETH_USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"XETHZUSD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"ETH_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"ETH-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -6,
+          "id": 1,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 1000,
+          "pair": "ETH-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"LINKUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"LINK/USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"LINKUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"LINK-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"LINK_USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"LINKUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"LINK-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"LINK_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"LINK-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 2,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "LINK-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"MATICUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"MATIC-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"MATIC_USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"MATIC_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"maticusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"MATIC-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"MATIC-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -10,
+          "id": 3,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "MATIC-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"CRVUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"CRV-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"CRV_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"crvusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"CRVUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"CRV-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"CRV-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -10,
+          "id": 4,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "CRV-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"SOLUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"SOLUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"SOL-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"SOL_USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"solusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"SOLUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"SOL-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"SOL_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"SOL-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -8,
+          "id": 5,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "SOL-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"ADAUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"ADA/USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"ADAUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"ADA-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"ADA_USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"ADA_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"adausdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"ADAUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"ADA-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"ADA_USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -10,
+          "id": 6,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "ADA-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"AVAXUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"AVAX-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"AVAX_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"avaxusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"AVAXUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"AVAX-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"AVAX-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -8,
+          "id": 7,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "AVAX-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"FILUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"FIL-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"FIL_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"filusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"FILUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"FIL-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"FIL_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"FIL-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 8,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "FIL-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"LTCUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"LTC/USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"LTCUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"LTC-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"LTC_USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"ltcusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"XLTCZUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"LTC-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"LTC_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"LTC-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -8,
+          "id": 9,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "LTC-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"DOGEUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"DOGEUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"DOGE-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"DOGE_USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"DOGE_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"dogeusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"XDGUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"DOGE-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"DOGE_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"DOGE-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -11,
+          "id": 10,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "DOGE-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"ATOMUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"ATOMUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"ATOM-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"ATOM_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"ATOMUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"ATOM-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"ATOM-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 11,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "ATOM-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"DOTUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"DOT-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"DOT_USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"DOT_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"DOTUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"DOT-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"DOT-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 12,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "DOT-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"UNIUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"UNIUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"UNI-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"UNI_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"UNIUSD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"UNI_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"UNI-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 13,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "UNI-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"BCHUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"BCH/USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"BCH-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"BCH_USD\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"BCH_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"bchusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"BCHUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"BCH-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"BCH-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -7,
+          "id": 14,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "BCH-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"TRXUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"TRXUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"TRX_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"trxusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"TRX-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"TRX_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"TRX-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -11,
+          "id": 15,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "TRX-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"NEARUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"NEAR-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"NEAR_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"NEAR_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"nearusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"NEAR-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"NEAR_USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 16,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "NEAR-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"MKRUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"MKR-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"MKR_USD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"MKR-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"MKR_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"MKR-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -6,
+          "id": 17,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 4000,
+          "pair": "MKR-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"XLMUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"XLM/USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"XLMUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"XLM-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"XLM_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"XXLMZUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"XLM-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"XLM_USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -10,
+          "id": 18,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "XLM-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"ETCUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"ETC-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"ETC_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"etcusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"XETCZUSD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"ETC-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -8,
+          "id": 19,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "ETC-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"COMPUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"COMP-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"COMP_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"COMP_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"COMPUSD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"COMP-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -8,
+          "id": 20,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 4000,
+          "pair": "COMP-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"WLDUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"WLDUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"WLD_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"wldusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"WLD-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"WLD_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"WLD-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 21,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "WLD-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"APEUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"APE-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"APE_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"APE_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"APEUSD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"APE_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"APE-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 22,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 4000,
+          "pair": "APE-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"APTUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"APTUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"APT-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"APT_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"aptusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"APT_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"APT-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 23,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "APT-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"ARBUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"ARBUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"ARB-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"ARB_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"arbusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"ARBUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"ARB-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"ARB_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"ARB-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 24,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "ARB-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"BLUR-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"BLUR_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"BLURUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"BLUR-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"BLUR_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"BLUR-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -10,
+          "id": 25,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 4000,
+          "pair": "BLUR-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"LDOUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"LDO-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"LDOUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"LDO-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"LDO_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"LDO-USDT\"}]}",
+          "exponent": -9,
+          "id": 26,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "LDO-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"OPUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"OPUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"OP-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"OP_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"OP-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"OP_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"OP-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -9,
+          "id": 27,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "OP-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"PEPEUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"PEPEUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"PEPE_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"PEPEUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"PEPE-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"PEPE_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"PEPE-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -16,
+          "id": 28,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "PEPE-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"SEIUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"SEIUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"SEI-USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"SEI_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"seiusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"SEI-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"SEI_USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -10,
+          "id": 29,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 4000,
+          "pair": "SEI-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"SHIBUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"SHIBUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"SHIB-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"SHIB_USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"SHIB_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"SHIBUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"SHIB-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"SHIB_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"SHIB-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -15,
+          "id": 30,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "SHIB-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"SUIUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"SUIUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"SUI-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"SUI_USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"SUI_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"suiusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"SUI-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"SUI_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"SUI-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -10,
+          "id": 31,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "SUI-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"XRPUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"XRP/USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"XRPUSDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"XRP-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"XRP_USD\"},{\"exchangeName\":\"Gate\",\"ticker\":\"XRP_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"xrpusdt\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Kraken\",\"ticker\":\"XXRPZUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"XRP-USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Mexc\",\"ticker\":\"XRP_USDT\",\"adjustByMarket\":\"USDT-USD\"},{\"exchangeName\":\"Okx\",\"ticker\":\"XRP-USDT\",\"adjustByMarket\":\"USDT-USD\"}]}",
+          "exponent": -10,
+          "id": 32,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 2500,
+          "pair": "XRP-USD"
+        },
+        {
+          "exchange_config_json": "{\"exchanges\":[{\"exchangeName\":\"Binance\",\"ticker\":\"USDCUSDT\",\"invert\":true},{\"exchangeName\":\"Bitstamp\",\"ticker\":\"USDT/USD\"},{\"exchangeName\":\"Bybit\",\"ticker\":\"USDCUSDT\",\"invert\":true},{\"exchangeName\":\"CoinbasePro\",\"ticker\":\"USDT-USD\"},{\"exchangeName\":\"CryptoCom\",\"ticker\":\"USDT_USD\"},{\"exchangeName\":\"Huobi\",\"ticker\":\"ethusdt\",\"adjustByMarket\":\"ETH-USD\",\"invert\":true},{\"exchangeName\":\"Kraken\",\"ticker\":\"USDTZUSD\"},{\"exchangeName\":\"Kucoin\",\"ticker\":\"BTC-USDT\",\"adjustByMarket\":\"BTC-USD\",\"invert\":true},{\"exchangeName\":\"Okx\",\"ticker\":\"BTC-USDT\",\"adjustByMarket\":\"BTC-USD\",\"invert\":true}]}",
+          "exponent": -9,
+          "id": 1000000,
+          "min_exchanges": 3,
+          "min_price_change_ppm": 1000,
+          "pair": "USDT-USD"
+        }
+      ],
+      "market_prices": [
+        {
+          "exponent": -5,
+          "id": 0,
+          "price": 2868819524
+        },
+        {
+          "exponent": -6,
+          "id": 1,
+          "price": 1811985252
+        },
+        {
+          "exponent": -9,
+          "id": 2,
+          "price": 7204646989
+        },
+        {
+          "exponent": -10,
+          "id": 3,
+          "price": 6665746387
+        },
+        {
+          "exponent": -10,
+          "id": 4,
+          "price": 6029316660
+        },
+        {
+          "exponent": -8,
+          "id": 5,
+          "price": 2350695125
+        },
+        {
+          "exponent": -10,
+          "id": 6,
+          "price": 2918831290
+        },
+        {
+          "exponent": -8,
+          "id": 7,
+          "price": 1223293720
+        },
+        {
+          "exponent": -9,
+          "id": 8,
+          "price": 4050336602
+        },
+        {
+          "exponent": -8,
+          "id": 9,
+          "price": 8193604950
+        },
+        {
+          "exponent": -11,
+          "id": 10,
+          "price": 7320836895
+        },
+        {
+          "exponent": -9,
+          "id": 11,
+          "price": 8433494428
+        },
+        {
+          "exponent": -9,
+          "id": 12,
+          "price": 4937186533
+        },
+        {
+          "exponent": -9,
+          "id": 13,
+          "price": 5852293356
+        },
+        {
+          "exponent": -7,
+          "id": 14,
+          "price": 2255676327
+        },
+        {
+          "exponent": -11,
+          "id": 15,
+          "price": 7795369902
+        },
+        {
+          "exponent": -9,
+          "id": 16,
+          "price": 1312325536
+        },
+        {
+          "exponent": -6,
+          "id": 17,
+          "price": 1199517382
+        },
+        {
+          "exponent": -10,
+          "id": 18,
+          "price": 1398578933
+        },
+        {
+          "exponent": -8,
+          "id": 19,
+          "price": 1741060746
+        },
+        {
+          "exponent": -8,
+          "id": 20,
+          "price": 5717635307
+        },
+        {
+          "exponent": -9,
+          "id": 21,
+          "price": 1943019371
+        },
+        {
+          "exponent": -9,
+          "id": 22,
+          "price": 1842365656
+        },
+        {
+          "exponent": -9,
+          "id": 23,
+          "price": 6787621897
+        },
+        {
+          "exponent": -9,
+          "id": 24,
+          "price": 1127629325
+        },
+        {
+          "exponent": -10,
+          "id": 25,
+          "price": 2779565892
+        },
+        {
+          "exponent": -9,
+          "id": 26,
+          "price": 1855061997
+        },
+        {
+          "exponent": -9,
+          "id": 27,
+          "price": 1562218603
+        },
+        {
+          "exponent": -16,
+          "id": 28,
+          "price": 2481900353
+        },
+        {
+          "exponent": -10,
+          "id": 29,
+          "price": 1686998025
+        },
+        {
+          "exponent": -15,
+          "id": 30,
+          "price": 8895882688
+        },
+        {
+          "exponent": -10,
+          "id": 31,
+          "price": 5896318772
+        },
+        {
+          "exponent": -10,
+          "id": 32,
+          "price": 6327613800
+        },
+        {
+          "exponent": -9,
+          "id": 1000000,
+          "price": 1000000000
+        }
+      ]
+    },
+    "rewards": {
+      "params": {
+        "denom": "dv4tnt",
+        "denom_exponent": -18,
+        "fee_multiplier_ppm": 0,
+        "market_id": 11,
+        "treasury_account": "rewards_treasury"
+      }
+    },
+    "sending": {},
+    "slashing": {
+      "missed_blocks": [],
+      "params": {
+        "downtime_jail_duration": "3600s",
+        "min_signed_per_window": "0.2",
+        "signed_blocks_window": "12288",
+        "slash_fraction_double_sign": "0.0",
+        "slash_fraction_downtime": "0.0"
+      },
+      "signing_infos": []
+    },
+    "staking": {
+      "delegations": [],
+      "exported": false,
+      "last_total_power": "0",
+      "last_validator_powers": [],
+      "params": {
+        "bond_denom": "dv4tnt",
+        "historical_entries": 10000,
+        "max_entries": 7,
+        "max_validators": 60,
+        "min_commission_rate": "0.05",
+        "unbonding_time": "2592000s"
+      },
+      "redelegations": [],
+      "unbonding_delegations": [],
+      "validators": []
+    },
+    "stats": {
+      "params": {
+        "window_duration": "2592000s"
+      }
+    },
+    "subaccounts": {
+      "subaccounts": []
+    },
+    "transfer": {
+      "denom_traces": [],
+      "params": {
+        "receive_enabled": true,
+        "send_enabled": true
+      },
+      "port_id": "transfer",
+      "total_escrowed": []
+    },
+    "upgrade": {},
+    "vest": {
+      "vest_entries": [
+        {
+          "denom": "dv4tnt",
+          "end_time": "2050-01-01T00:00:00Z",
+          "start_time": "2001-01-01T00:00:00Z",
+          "treasury_account": "community_treasury",
+          "vester_account": "community_vester"
+        },
+        {
+          "denom": "dv4tnt",
+          "end_time": "2050-01-01T00:00:00Z",
+          "start_time": "2001-01-01T00:00:00Z",
+          "treasury_account": "rewards_treasury",
+          "vester_account": "rewards_vester"
+        }
+      ]
+    }
+  },
+  "chain_id": "dydx-1",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "4194304",
+      "max_gas": "-1"
+    },
+    "evidence": {
+      "max_age_duration": "172800000000000",
+      "max_age_num_blocks": "100000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    },
+    "version": {
+      "app": "0"
+    }
+  },
+  "genesis_time": "2023-12-31T00:00:00Z",
+  "initial_height": "1"
+}

--- a/protocol/testing/delaymsg_config/perpetual_fee_params_msg.json
+++ b/protocol/testing/delaymsg_config/perpetual_fee_params_msg.json
@@ -56,7 +56,7 @@
         "absolute_volume_requirement": "125000000000000",
         "total_volume_share_requirement_ppm": 5000,
         "maker_volume_share_requirement_ppm": 10000,
-        "maker_fee_ppm": -90,
+        "maker_fee_ppm": -70,
         "taker_fee_ppm": 250
       },
       {
@@ -64,7 +64,7 @@
         "absolute_volume_requirement": "125000000000000",
         "total_volume_share_requirement_ppm": 5000,
         "maker_volume_share_requirement_ppm": 20000,
-        "maker_fee_ppm": -110,
+        "maker_fee_ppm": -90,
         "taker_fee_ppm": 250
       },
       {

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -22,16 +22,11 @@ DEFAULT_SUBACCOUNT_QUOTE_BALANCE_FAUCET=900000000000000000
 TESTNET_VALIDATOR_NATIVE_TOKEN_BALANCE=1000000000000000000000000 # 1e24
 # Each testnet validator self-delegates 500k whole coins of native token.
 TESTNET_VALIDATOR_SELF_DELEGATE_AMOUNT=500000000000000000000000 # 5e23
-# TODO(GENESIS): 11155111 is the chain ID for sepolia testnet.
 ETH_CHAIN_ID=11155111 # sepolia
-# TODO(GENESIS): below is the bridge contract on sepolia testnet.
 # https://sepolia.etherscan.io/address/0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0
 ETH_BRIDGE_ADDRESS="0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0"
-# TODO(GENESIS): verify below balance is desired amount.
 BRIDGE_MODACC_BALANCE=1000000000000000000000000000 # 1e27
-# TODO(GENESIS): determine bridge events to manually include in genesis.
 BRIDGE_GENESIS_ACKNOWLEDGED_NEXT_ID=0 # TODO(CORE-329)
-# TODO(GENESIS): determine bridge events to manually include in genesis.
 BRIDGE_GENESIS_ACKNOWLEDGED_ETH_BLOCK_HEIGHT=0 # TODO(CORE-329)
 
 function edit_genesis() {

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -1497,6 +1497,7 @@ update_genesis_complete_bridge_delay() {
 set_denom_metadata() {
 	local BASE_DENOM=$1
 	local WHOLE_COIN_DENOM=$2
+	local COIN_NAME=$3
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata" -v "[]"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[]" -v "{}"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].description" -v "The native token of the network"
@@ -1507,5 +1508,7 @@ set_denom_metadata() {
 	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[1].denom" -v "$WHOLE_COIN_DENOM"
 	dasel put -t int -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[1].exponent" -v 18
 	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].base" -v "$BASE_DENOM"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].name" -v "$COIN_NAME"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].display" -v "$WHOLE_COIN_DENOM"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].symbol" -v "$WHOLE_COIN_DENOM"
 }

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -1493,3 +1493,19 @@ update_genesis_complete_bridge_delay() {
 	# Reduce complete bridge delay to 600 blocks.
 	dasel put -t int -f "$GENESIS" '.app_state.bridge.safety_params.delay_blocks' -v "$2"
 }
+
+set_denom_metadata() {
+	local BASE_DENOM=$1
+	local WHOLE_COIN_DENOM=$2
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata" -v "[]"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[]" -v "{}"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].description" -v "The native token of dYdX Chain"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units" -v "[]"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[]" -v "{}"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[0].denom" -v "$BASE_DENOM"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[]" -v "{}"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[1].denom" -v "$WHOLE_COIN_DENOM"
+	dasel put -t int -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[1].exponent" -v 18
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].base" -v "$BASE_DENOM"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].display" -v "$WHOLE_COIN_DENOM"
+}

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -1499,7 +1499,7 @@ set_denom_metadata() {
 	local WHOLE_COIN_DENOM=$2
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata" -v "[]"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[]" -v "{}"
-	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].description" -v "The native token of dYdX Chain"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].description" -v "The native token of the network"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units" -v "[]"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[]" -v "{}"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[0].denom" -v "$BASE_DENOM"

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -1494,6 +1494,7 @@ update_genesis_complete_bridge_delay() {
 	dasel put -t int -f "$GENESIS" '.app_state.bridge.safety_params.delay_blocks' -v "$2"
 }
 
+# Set the denom metadata, which is for human readability.
 set_denom_metadata() {
 	local BASE_DENOM=$1
 	local WHOLE_COIN_DENOM=$2
@@ -1503,6 +1504,7 @@ set_denom_metadata() {
 	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].description" -v "The native token of the network"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units" -v "[]"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[]" -v "{}"
+	# Base denom is the minimum unit of the a token and the denom used by `x/bank`.
 	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[0].denom" -v "$BASE_DENOM"
 	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[]" -v "{}"
 	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[1].denom" -v "$WHOLE_COIN_DENOM"

--- a/protocol/testutil/constants/genesis.go
+++ b/protocol/testutil/constants/genesis.go
@@ -1348,7 +1348,7 @@ const GenesisState = `{
         "treasury_account":"rewards_treasury",
         "denom":"dv4tnt",
         "denom_exponent":-18,
-        "market_id":1,
+        "market_id":11,
         "fee_multiplier_ppm":990000
       }
     },

--- a/protocol/testutil/constants/genesis.go
+++ b/protocol/testutil/constants/genesis.go
@@ -1348,7 +1348,7 @@ const GenesisState = `{
         "treasury_account":"rewards_treasury",
         "denom":"dv4tnt",
         "denom_exponent":-18,
-        "market_id":11,
+        "market_id":1,
         "fee_multiplier_ppm":990000
       }
     },

--- a/protocol/testutil/constants/genesis.go
+++ b/protocol/testutil/constants/genesis.go
@@ -1347,7 +1347,7 @@ const GenesisState = `{
       "params": {
         "treasury_account":"rewards_treasury",
         "denom":"dv4tnt",
-        "denom_exponent":-6,
+        "denom_exponent":-18,
         "market_id":1,
         "fee_multiplier_ppm":990000
       }
@@ -1473,8 +1473,15 @@ const GenesisState = `{
       "vest_entries": [
         {
           "denom": "dv4tnt",
-          "end_time": "2023-10-13T00:00:00Z",
-          "start_time": "2023-09-13T00:00:00Z",
+          "end_time": "2025-01-01T00:00:00Z",
+          "start_time": "2023-01-01T00:00:00Z",
+          "treasury_account": "community_treasury",
+          "vester_account": "community_vester"
+        },
+        {
+          "denom": "dv4tnt",
+          "end_time": "2025-01-01T00:00:00Z",
+          "start_time": "2023-01-01T00:00:00Z",
           "treasury_account": "rewards_treasury",
           "vester_account": "rewards_vester"
         }

--- a/protocol/x/rewards/types/genesis_test.go
+++ b/protocol/x/rewards/types/genesis_test.go
@@ -14,7 +14,7 @@ func TestDefaultGenesis(t *testing.T) {
 		Params: types.Params{
 			TreasuryAccount:  "rewards_treasury",
 			Denom:            "dv4tnt",
-			DenomExponent:    -6,
+			DenomExponent:    -18,
 			MarketId:         1,
 			FeeMultiplierPpm: 990_000, // 0.99
 		},

--- a/protocol/x/rewards/types/genesis_test.go
+++ b/protocol/x/rewards/types/genesis_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +15,7 @@ func TestDefaultGenesis(t *testing.T) {
 		Params: types.Params{
 			TreasuryAccount:  "rewards_treasury",
 			Denom:            "dv4tnt",
-			DenomExponent:    -18,
+			DenomExponent:    lib.BaseDenomExponent,
 			MarketId:         1,
 			FeeMultiplierPpm: 990_000, // 0.99
 		},

--- a/protocol/x/rewards/types/params.go
+++ b/protocol/x/rewards/types/params.go
@@ -12,8 +12,8 @@ func DefaultParams() Params {
 		// Corresponds to module account address: dydx16wrau2x4tsg033xfrrdpae6kxfn9kyuerr5jjp
 		TreasuryAccount:  TreasuryAccountName,
 		Denom:            "dv4tnt",
-		DenomExponent:    -18,
-		MarketId:         1,
+		DenomExponent:    lib.BaseDenomExponent,
+		MarketId:         11,
 		FeeMultiplierPpm: 990_000, // 0.99
 	}
 }

--- a/protocol/x/rewards/types/params.go
+++ b/protocol/x/rewards/types/params.go
@@ -13,7 +13,7 @@ func DefaultParams() Params {
 		TreasuryAccount:  TreasuryAccountName,
 		Denom:            "dv4tnt",
 		DenomExponent:    lib.BaseDenomExponent,
-		MarketId:         11,
+		MarketId:         1,
 		FeeMultiplierPpm: 990_000, // 0.99
 	}
 }

--- a/protocol/x/rewards/types/params.go
+++ b/protocol/x/rewards/types/params.go
@@ -10,9 +10,9 @@ import (
 func DefaultParams() Params {
 	return Params{
 		// Corresponds to module account address: dydx16wrau2x4tsg033xfrrdpae6kxfn9kyuerr5jjp
-		TreasuryAccount:  "rewards_treasury",
+		TreasuryAccount:  TreasuryAccountName,
 		Denom:            "dv4tnt",
-		DenomExponent:    -6,
+		DenomExponent:    -18,
 		MarketId:         1,
 		FeeMultiplierPpm: 990_000, // 0.99
 	}

--- a/protocol/x/vest/client/cli/query_vest_entry_test.go
+++ b/protocol/x/vest/client/cli/query_vest_entry_test.go
@@ -2,6 +2,9 @@ package cli_test
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	tmcli "github.com/cometbft/cometbft/libs/cli"
 	"github.com/cosmos/cosmos-sdk/client"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
@@ -10,8 +13,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/vest/client/cli"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
 	"github.com/stretchr/testify/require"
-	"strconv"
-	"testing"
 )
 
 // Prevent strconv unused error
@@ -48,6 +49,17 @@ func setupNetwork(
 func TestQueryVestEntry(t *testing.T) {
 	net, ctx := setupNetwork(t)
 
+	queryAndCheckVestEntry(t, ctx, net, "treausry_vester", types.DefaultGenesis().VestEntries[0])
+	queryAndCheckVestEntry(t, ctx, net, "rewards_vester", types.DefaultGenesis().VestEntries[1])
+}
+
+func queryAndCheckVestEntry(
+	t *testing.T,
+	ctx client.Context,
+	net *network.Network,
+	vester_account string,
+	expectedEntry types.VestEntry,
+) {
 	out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdQueryVestEntry(), []string{
 		"rewards_vester",
 		fmt.Sprintf("--%s=json", tmcli.OutputFlag), // specify output format as json
@@ -57,5 +69,5 @@ func TestQueryVestEntry(t *testing.T) {
 	var resp types.QueryVestEntryResponse
 	outBytes := out.Bytes()
 	require.NoError(t, net.Config.Codec.UnmarshalJSON(outBytes, &resp))
-	require.Equal(t, types.DefaultGenesis().VestEntries[0], resp.Entry)
+	require.Equal(t, types.DefaultGenesis().VestEntries[1], resp.Entry)
 }

--- a/protocol/x/vest/keeper/keeper_test.go
+++ b/protocol/x/vest/keeper/keeper_test.go
@@ -80,6 +80,7 @@ func TestGetAllVestEntries(t *testing.T) {
 	gotEntries := k.GetAllVestEntries(ctx)
 	expectedEntries := []types.VestEntry{
 		types.DefaultGenesis().VestEntries[0],
+		types.DefaultGenesis().VestEntries[1],
 		TestValidEntry,
 		TestValidEntry2,
 		TestValidEntry3,

--- a/protocol/x/vest/keeper/keeper_test.go
+++ b/protocol/x/vest/keeper/keeper_test.go
@@ -85,8 +85,8 @@ func TestGetAllVestEntries(t *testing.T) {
 		TestValidEntry3,
 	}
 
-	// 1 default from genesis + 3 added
-	require.Len(t, gotEntries, 4)
+	// 2 default from genesis + 3 added
+	require.Len(t, gotEntries, 5)
 	for i := range gotEntries {
 		require.Equal(t, expectedEntries[i], gotEntries[i])
 	}

--- a/protocol/x/vest/module_test.go
+++ b/protocol/x/vest/module_test.go
@@ -3,6 +3,10 @@ package vest_test
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -15,12 +19,10 @@ import (
 	bridgetypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vest"
 	vest_keeper "github.com/dydxprotocol/v4-chain/protocol/x/vest/keeper"
+	vesttypes "github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func createAppModule(t *testing.T) vest.AppModule {
@@ -219,12 +221,8 @@ func TestAppModule_InitExportGenesis(t *testing.T) {
 
 	vestEntries := keeper.GetAllVestEntries(ctx)
 
-	require.Equal(t, 1, len(vestEntries))
-	require.Equal(t, "rewards_vester", vestEntries[0].VesterAccount)
-	require.Equal(t, "rewards_treasury", vestEntries[0].TreasuryAccount)
-	require.Equal(t, "dv4tnt", vestEntries[0].Denom)
-	require.Equal(t, int64(1694563200), vestEntries[0].StartTime.Unix())
-	require.Equal(t, int64(1697155200), vestEntries[0].EndTime.Unix())
+	require.Equal(t, 2, len(vestEntries))
+	require.Equal(t, vesttypes.DefaultGenesis().VestEntries, vestEntries)
 
 	genesisJson := am.ExportGenesis(ctx, cdc)
 	require.Equal(t, validGenesisState, string(genesisJson))

--- a/protocol/x/vest/testdata/expected_default_genesis.json
+++ b/protocol/x/vest/testdata/expected_default_genesis.json
@@ -1,11 +1,18 @@
 {
-  "vest_entries":[
+  "vest_entries": [
     {
-      "vester_account":"rewards_vester",
-      "treasury_account":"rewards_treasury",
-      "denom":"dv4tnt",
-      "start_time":"2023-09-13T00:00:00Z",
-      "end_time":"2023-10-13T00:00:00Z"
+      "vester_account": "community_vester",
+      "treasury_account": "community_treasury",
+      "denom": "dv4tnt",
+      "start_time": "2023-01-01T00:00:00Z",
+      "end_time": "2025-01-01T00:00:00Z"
+    },
+    {
+      "vester_account": "rewards_vester",
+      "treasury_account": "rewards_treasury",
+      "denom": "dv4tnt",
+      "start_time": "2023-01-01T00:00:00Z",
+      "end_time": "2025-01-01T00:00:00Z"
     }
   ]
 }

--- a/protocol/x/vest/types/genesis.go
+++ b/protocol/x/vest/types/genesis.go
@@ -12,11 +12,18 @@ func DefaultGenesis() *GenesisState {
 		// TODO(CORE-530): in genesis.sh, overwrite start and end times dynamically for testnets.
 		VestEntries: []VestEntry{
 			{
+				VesterAccount:   CommunityVesterAccountName,
+				TreasuryAccount: CommunityTreasuryAccountName,
+				Denom:           "dv4tnt",
+				StartTime:       time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC),
+				EndTime:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC),
+			},
+			{
 				VesterAccount:   rewardstypes.VesterAccountName,
 				TreasuryAccount: rewardstypes.TreasuryAccountName,
 				Denom:           "dv4tnt",
-				StartTime:       time.Date(2023, 9, 13, 0, 0, 0, 0, time.UTC).In(time.UTC),
-				EndTime:         time.Date(2023, 10, 13, 0, 0, 0, 0, time.UTC).In(time.UTC),
+				StartTime:       time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC),
+				EndTime:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC),
 			},
 		},
 	}

--- a/protocol/x/vest/types/genesis.go
+++ b/protocol/x/vest/types/genesis.go
@@ -6,6 +6,11 @@ import (
 	rewardstypes "github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 )
 
+var (
+	DefaultVestingStartTime = time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC)
+	DefaultVestingEndTime   = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC)
+)
+
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
@@ -15,15 +20,15 @@ func DefaultGenesis() *GenesisState {
 				VesterAccount:   CommunityVesterAccountName,
 				TreasuryAccount: CommunityTreasuryAccountName,
 				Denom:           "dv4tnt",
-				StartTime:       time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC),
-				EndTime:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC),
+				StartTime:       DefaultVestingStartTime,
+				EndTime:         DefaultVestingEndTime,
 			},
 			{
 				VesterAccount:   rewardstypes.VesterAccountName,
 				TreasuryAccount: rewardstypes.TreasuryAccountName,
 				Denom:           "dv4tnt",
-				StartTime:       time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC),
-				EndTime:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).In(time.UTC),
+				StartTime:       DefaultVestingStartTime,
+				EndTime:         DefaultVestingEndTime,
 			},
 		},
 	}


### PR DESCRIPTION
# Overview
Goal of script: the genesis coordination party can simply modify  values under `TODO(GENESIS)` and have a production-ready genesis. 

Unfortunately due to historical reasons, the genesis state is written at 3 layers, each overwriting the previous one. In the interest of minimum refactoring, this PR assumes the following convention for "what to put in each layer"

1. `DefaultParams` (in `x/module/types`): 
Generally, values here are basis shared among different networks (Unfortunately due to historical reasons, clob, perpetual, prices state, liquiditiers were all in `genesis.sh` instead of default params)

2. `genesis.sh` (overwrites default params):
Testnet specific setup and other common setup due to historical reasons (e.g. clobpairs)

3. `prod_pregenesis.sh` (further overwrites genesis.sh)
Default production values. 

# Test 
Tested locally by running generated genesis with `.alice` validator









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a bash script to generate pregenesis files for production networks, allowing customization of various genesis parameters.
- Refactor: Updated the `DefaultParams` function in `params.go` and `GenesisState` constant in `genesis.go` to reflect changes in currency denomination precision and vesting entries.
- Test: Modified tests in `keeper_test.go`, `genesis_test.go`, and `query_vest_entry_test.go` to accommodate changes in vesting entries and denomination precision.
- Chore: Updated `genesis.sh` script to include new functions for setting token metadata and editing genesis file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->