### PR TITLE
[DEC-2071] - Increase x/rewards test coverage

### DIFF
--- a/protocol/x/rewards/client/cli/query_params.go
+++ b/protocol/x/rewards/client/cli/query_params.go
@@ -1,5 +1,3 @@
-//go:build all || integration_test
-
 package cli
 
 import (

--- a/protocol/x/rewards/client/cli/query_params.go
+++ b/protocol/x/rewards/client/cli/query_params.go
@@ -1,3 +1,5 @@
+//go:build all || integration_test
+
 package cli
 
 import (

--- a/protocol/x/rewards/client/cli/query_params_test.go
+++ b/protocol/x/rewards/client/cli/query_params_test.go
@@ -1,0 +1,63 @@
+//go:build all || integration_test
+
+package cli_test
+
+import (
+	"fmt"
+	tmcli "github.com/cometbft/cometbft/libs/cli"
+	"github.com/cosmos/cosmos-sdk/client"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/dydxprotocol/v4-chain/protocol/app/stoppable"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/network"
+	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/client/cli"
+	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+// Prevent strconv unused error
+var _ = strconv.IntSize
+
+func setupNetwork(
+	t *testing.T,
+) (
+	*network.Network,
+	client.Context,
+) {
+	t.Helper()
+	cfg := network.DefaultConfig(nil)
+
+	// Init state.
+	state := types.GenesisState{}
+	require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
+
+	state = *types.DefaultGenesis()
+
+	buf, err := cfg.Codec.MarshalJSON(&state)
+	require.NoError(t, err)
+	cfg.GenesisState[types.ModuleName] = buf
+	net := network.New(t, cfg)
+	ctx := net.Validators[0].ClientCtx
+
+	t.Cleanup(func() {
+		stoppable.StopServices(t, cfg.GRPCAddress)
+	})
+
+	return net, ctx
+}
+
+func TestQueryParams(t *testing.T) {
+	net, ctx := setupNetwork(t)
+
+	out, err := clitestutil.ExecTestCLICmd(
+		ctx,
+		cli.CmdQueryParams(),
+		[]string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
+	)
+
+	require.NoError(t, err)
+	var resp types.QueryParamsResponse
+	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+	require.Equal(t, types.DefaultGenesis().Params, resp.Params)
+}

--- a/protocol/x/rewards/module_test.go
+++ b/protocol/x/rewards/module_test.go
@@ -135,8 +135,8 @@ func TestAppModule_InitExportGenesis(t *testing.T) {
 	params := keeper.GetParams(ctx)
 
 	require.Equal(t, "rewards_treasury", params.TreasuryAccount)
-	require.Equal(t, "dv4tnt", params.Denom)
-	require.Equal(t, int32(-6), params.DenomExponent)
+	require.Equal(t, "adv4tnt", params.Denom)
+	require.Equal(t, int32(-18), params.DenomExponent)
 	require.Equal(t, uint32(1), params.MarketId)
 	require.Equal(t, uint32(990000), params.FeeMultiplierPpm)
 

--- a/protocol/x/rewards/module_test.go
+++ b/protocol/x/rewards/module_test.go
@@ -1,0 +1,145 @@
+package rewards_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/daemons/pricefeed"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/rewards"
+	rewards_keeper "github.com/dydxprotocol/v4-chain/protocol/x/rewards/keeper"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Returns the keeper and context along with the AppModule.
+// This is useful for tests which want to write/read state
+// to/from the keeper.
+func createAppModuleWithKeeper(t *testing.T) (rewards.AppModule, *rewards_keeper.Keeper, sdk.Context) {
+	interfaceRegistry := types.NewInterfaceRegistry()
+	appCodec := codec.NewProtoCodec(interfaceRegistry)
+
+	ctx, keeper, _, _, _, _, _ := keepertest.RewardsKeepers(t)
+
+	return rewards.NewAppModule(
+		appCodec,
+		*keeper,
+	), keeper, ctx
+}
+
+func createAppModuleBasic(t *testing.T) rewards.AppModuleBasic {
+	interfaceRegistry := types.NewInterfaceRegistry()
+	appCodec := codec.NewProtoCodec(interfaceRegistry)
+
+	appModule := rewards.NewAppModuleBasic(appCodec)
+	require.NotNil(t, appModule)
+
+	return appModule
+}
+
+func TestAppModuleBasic_RegisterCodecLegacyAmino(t *testing.T) {
+	am := createAppModuleBasic(t)
+
+	cdc := codec.NewLegacyAmino()
+	am.RegisterLegacyAminoCodec(cdc)
+
+	var buf bytes.Buffer
+	err := cdc.Amino.PrintTypes(&buf)
+	require.NoError(t, err)
+}
+
+func TestAppModuleBasic_ValidateGenesisErr(t *testing.T) {
+	tests := map[string]struct {
+		genesisJson string
+		expectedErr string
+	}{
+		"Invalid json": {
+			genesisJson: `{"missingClosingQuote: true}`,
+			expectedErr: "failed to unmarshal rewards genesis state: unexpected EOF",
+		},
+		"Invalid state": {
+			genesisJson: `{"params":{}}`,
+			expectedErr: "treasury account cannot have empty name: invalid treasury account",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			am := createAppModuleBasic(t)
+
+			interfaceRegistry := types.NewInterfaceRegistry()
+			cdc := codec.NewProtoCodec(interfaceRegistry)
+
+			err := am.ValidateGenesis(cdc, nil, json.RawMessage(tc.genesisJson))
+			require.EqualError(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func TestAppModuleBasic_RegisterGRPCGatewayRoutes(t *testing.T) {
+	am := createAppModuleBasic(t)
+
+	router := runtime.NewServeMux()
+
+	am.RegisterGRPCGatewayRoutes(client.Context{}, router)
+
+	// Expect NumMessages route registered
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/dydxprotocol/v4/rewards/params", nil)
+	require.NoError(t, err)
+	router.ServeHTTP(recorder, req)
+	require.Contains(t, recorder.Body.String(), "no RPC client is defined in offline mode")
+
+	// Expect unexpected route not registered
+	recorder = httptest.NewRecorder()
+	req, err = http.NewRequest("GET", "/dydxprotocol/v4/rewards/foo/bar/baz", nil)
+	require.NoError(t, err)
+	router.ServeHTTP(recorder, req)
+	require.Equal(t, 404, recorder.Code)
+}
+
+func TestAppModuleBasic_GetTxCmd(t *testing.T) {
+	am := createAppModuleBasic(t)
+
+	cmd := am.GetTxCmd()
+	require.Equal(t, "rewards", cmd.Use)
+	require.Equal(t, 0, len(cmd.Commands()))
+}
+
+func TestAppModuleBasic_GetQueryCmd(t *testing.T) {
+	am := createAppModuleBasic(t)
+
+	cmd := am.GetQueryCmd()
+	require.Equal(t, "rewards", cmd.Use)
+	require.Equal(t, 1, len(cmd.Commands()))
+	require.Equal(t, "params", cmd.Commands()[0].Name())
+}
+
+func TestAppModule_InitExportGenesis(t *testing.T) {
+	am, keeper, ctx := createAppModuleWithKeeper(t)
+	interfaceRegistry := types.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+
+	validGenesisState := pricefeed.ReadJsonTestFile(t, "expected_default_genesis.json")
+
+	gs := json.RawMessage(validGenesisState)
+
+	result := am.InitGenesis(ctx, cdc, gs)
+	require.Equal(t, 0, len(result))
+
+	params := keeper.GetParams(ctx)
+
+	require.Equal(t, "rewards_treasury", params.TreasuryAccount)
+	require.Equal(t, "dv4tnt", params.Denom)
+	require.Equal(t, int32(-6), params.DenomExponent)
+	require.Equal(t, uint32(1), params.MarketId)
+	require.Equal(t, uint32(990000), params.FeeMultiplierPpm)
+
+	genesisJson := am.ExportGenesis(ctx, cdc)
+	require.Equal(t, validGenesisState, string(genesisJson))
+}

--- a/protocol/x/rewards/testdata/expected_default_genesis.json
+++ b/protocol/x/rewards/testdata/expected_default_genesis.json
@@ -1,8 +1,8 @@
 {
   "params": {
     "treasury_account":"rewards_treasury",
-    "denom":"dv4tnt",
-    "denom_exponent":-6,
+    "denom":"adv4tnt",
+    "denom_exponent":-18,
     "market_id":1,
     "fee_multiplier_ppm":990000
   }

--- a/protocol/x/rewards/testdata/expected_default_genesis.json
+++ b/protocol/x/rewards/testdata/expected_default_genesis.json
@@ -1,0 +1,9 @@
+{
+  "params": {
+    "treasury_account":"rewards_treasury",
+    "denom":"dv4tnt",
+    "denom_exponent":-6,
+    "market_id":1,
+    "fee_multiplier_ppm":990000
+  }
+}

--- a/protocol/x/rewards/types/tx.go
+++ b/protocol/x/rewards/types/tx.go
@@ -6,15 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-const TypeMsgUpdateParams = "update_params"
-
 var _ sdk.Msg = &MsgUpdateParams{}
-
-func NewMsgUpdateParams(params Params) *MsgUpdateParams {
-	return &MsgUpdateParams{
-		Params: params,
-	}
-}
 
 func (msg *MsgUpdateParams) GetSigners() []sdk.AccAddress {
 	addr, _ := sdk.AccAddressFromBech32(msg.Authority)


### PR DESCRIPTION
increase coverage for cli, module.go. Remove some unused code in tx.go.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:

- New Feature: Added a new function `RewardsKeepers` in the `keeper` package for initializing and returning various keepers used in the rewards module.
- Test: Introduced new test cases in the `rewards` module to validate genesis state, register codecs, GRPC gateway routes, and transaction and query commands. Also added a new test function `TestQueryParams` to verify the default genesis parameters.
- Refactor: Removed `NewMsgUpdateParams` function and `TypeMsgUpdateParams` constant from `types/tx.go`. Updated `GetSigners` method to return an array of addresses instead of a single address.
- Chore: Added build constraint comment for integration tests in `client/cli/query_params.go`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->