### PR TITLE
[IND-379]: Breaking change: Add updatedAt, updatedAtBlock to Order

### DIFF
--- a/indexer/packages/postgres/__tests__/db/migrations.test.ts
+++ b/indexer/packages/postgres/__tests__/db/migrations.test.ts
@@ -12,7 +12,7 @@ import { seedData } from '../helpers/mock-generators';
 
 // NOTE: If a model is modified for a migration then these
 // tests must be skipped until the following migration
-describe('Test new migration', () => {
+describe.skip('Test new migration', () => {
   beforeEach(async () => {
     await migrate();
   });

--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -217,6 +217,8 @@ export const defaultOrder: OrderCreateObject = {
   goodTilBlock: '100',
   orderFlags: ORDER_FLAG_SHORT_TERM.toString(),
   clientMetadata: '0',
+  updatedAt: '2023-01-22T00:00:00.000Z',
+  updatedAtHeight: '1',
 };
 
 export const defaultOrderGoodTilBlockTime: OrderCreateObject = {

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20231003132007_add_updated_at_fields_to_order.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20231003132007_add_updated_at_fields_to_order.ts
@@ -1,0 +1,15 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('orders', (table) => {
+    table.timestamp('updatedAt');
+    table.bigInteger('updatedAtHeight');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('orders', (table) => {
+    table.dropColumn('updatedAt');
+    table.dropColumn('updatedAtHeight');
+  });
+}

--- a/indexer/packages/postgres/src/models/order-model.ts
+++ b/indexer/packages/postgres/src/models/order-model.ts
@@ -8,6 +8,7 @@ import {
 } from '../lib/validators';
 import UpsertQueryBuilder from '../query-builders/upsert';
 import {
+  IsoString,
   OrderSide,
   OrderStatus,
   OrderType,
@@ -71,6 +72,8 @@ export default class OrderModel extends BaseModel {
         'createdAtHeight',
         'clientMetadata',
         'triggerPrice',
+        'updatedAt',
+        'updatedAtHeight',
       ],
       properties: {
         id: { type: 'string', format: 'uuid' },
@@ -91,6 +94,8 @@ export default class OrderModel extends BaseModel {
         createdAtHeight: { type: ['string', 'null'], default: null, pattern: IntegerPattern },
         clientMetadata: { type: 'string', pattern: IntegerPattern },
         triggerPrice: { type: ['string', 'null'], default: null, pattern: NonNegativeNumericPattern },
+        updatedAt: { type: 'string', format: 'date-time' },
+        updatedAtHeight: { type: 'string', pattern: IntegerPattern },
       },
     };
   }
@@ -121,6 +126,8 @@ export default class OrderModel extends BaseModel {
       createdAtHeight: 'string',
       clientMetadata: 'string',
       triggerPrice: 'string',
+      updatedAt: 'date-time',
+      updatedAtHeight: 'string',
     };
   }
 
@@ -161,4 +168,8 @@ export default class OrderModel extends BaseModel {
   clientMetadata!: string;
 
   triggerPrice?: string;
+
+  updatedAt!: IsoString;
+
+  updatedAtHeight!: string;
 }

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -62,6 +62,8 @@ export interface OrderFromDatabase extends IdBasedModelFromDatabase {
   timeInForce: TimeInForce;
   reduceOnly: boolean;
   orderFlags: string;
+  updatedAt: IsoString;
+  updatedAtHeight: string;
   goodTilBlock?: string;
   goodTilBlockTime?: string;
   createdAtHeight?: string;

--- a/indexer/packages/postgres/src/types/order-types.ts
+++ b/indexer/packages/postgres/src/types/order-types.ts
@@ -1,5 +1,7 @@
 /* ------- ORDER TYPES ------- */
 
+import { IsoString } from './utility-types';
+
 export enum OrderSide {
   BUY = 'BUY',
   SELL = 'SELL',
@@ -56,6 +58,8 @@ export interface OrderCreateObject {
   timeInForce: TimeInForce;
   reduceOnly: boolean;
   orderFlags: string;
+  updatedAt: IsoString;
+  updatedAtHeight: string;
   goodTilBlock?: string;
   goodTilBlockTime?: string;
   createdAtHeight?: string;
@@ -75,6 +79,8 @@ export interface OrderUpdateObject {
   timeInForce?: TimeInForce;
   reduceOnly?: boolean;
   orderFlags?: string;
+  updatedAt?: IsoString;
+  updatedAtHeight?: string;
   goodTilBlock?: string | null;
   goodTilBlockTime?: string | null;
   clientMetadata?: string;
@@ -99,6 +105,8 @@ export enum OrderColumns {
   perpetualId = 'perpetualId',
   openEventId = 'openEventId',
   orderFlags = 'orderFlags',
+  updatedAt = 'updatedAt',
+  updatedAtHeight = 'updatedAtHeight',
   createdAtHeight = 'createdAtHeight',
   clientMetadata = 'clientMetadata',
   triggerPrice = 'triggerPrice',

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -115,6 +115,8 @@ export interface OrderSubaccountMessageContents {
   goodTilBlock?: string;
   goodTilBlockTime?: string;
   triggerPrice?: string;
+  updatedAt?: IsoString;
+  updatedAtHeight?: string;
 
   // This will only be filled if the order was removed
   removalReason?: string;

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1044,7 +1044,9 @@ fetch('https://indexer.v4testnet.dydx.exchange/v4/orders?address=string&subaccou
     "timeInForce": "GTT",
     "status": "OPEN",
     "postOnly": true,
-    "ticker": "string"
+    "ticker": "string",
+    "updatedAt": "string",
+    "updatedAtHeight": "string"
   }
 ]
 ```
@@ -1099,6 +1101,8 @@ Status Code **200**
 |---|---|---|---|---|
 |» postOnly|boolean|true|none|none|
 |» ticker|string|true|none|none|
+|» updatedAt|[IsoString](#schemaisostring)|false|none|none|
+|» updatedAtHeight|string|false|none|none|
 
 #### Enumerated Values
 
@@ -1201,7 +1205,9 @@ fetch('https://indexer.v4testnet.dydx.exchange/v4/orders/{orderId}',
   "timeInForce": "GTT",
   "status": "OPEN",
   "postOnly": true,
-  "ticker": "string"
+  "ticker": "string",
+  "updatedAt": "string",
+  "updatedAtHeight": "string"
 }
 ```
 
@@ -2746,7 +2752,9 @@ or
   "timeInForce": "GTT",
   "status": "OPEN",
   "postOnly": true,
-  "ticker": "string"
+  "ticker": "string",
+  "updatedAt": "string",
+  "updatedAtHeight": "string"
 }
 
 ```
@@ -2775,6 +2783,8 @@ or
 |status|[APIOrderStatus](#schemaapiorderstatus)|true|none|none|
 |postOnly|boolean|true|none|none|
 |ticker|string|true|none|none|
+|updatedAt|[IsoString](#schemaisostring)|false|none|none|
+|updatedAtHeight|string|false|none|none|
 
 ## PerpetualMarketStatus
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -647,6 +647,12 @@
           },
           "ticker": {
             "type": "string"
+          },
+          "updatedAt": {
+            "$ref": "#/components/schemas/IsoString"
+          },
+          "updatedAtHeight": {
+            "type": "string"
           }
         },
         "required": [

--- a/indexer/services/comlink/public/websocket-documentation.md
+++ b/indexer/services/comlink/public/websocket-documentation.md
@@ -181,6 +181,8 @@ export interface OrderSubaccountMessageContents {
   createdAtHeight?: string;
   clientMetadata: string;
   triggerPrice?: string;
+  updatedAt?: IsoString;
+  updatedAtHeight?: string;
 }
 
 export enum OrderSide {

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -8,6 +8,7 @@ import {
   FillType,
   IsoString,
   Liquidity,
+  OrderColumns,
   OrderFromDatabase,
   OrderSide,
   OrderStatus,
@@ -244,11 +245,13 @@ export interface OrderbookResponsePriceLevel {
 /* ------- ORDER TYPES ------- */
 // TimeInForce stored in the database is different from the TimeInForce expected in the API
 // The omitted field name have to be literal strings for Typescript to parse them correctly
-export interface OrderResponseObject extends Omit<OrderFromDatabase, 'timeInForce' | 'status'> {
+export interface OrderResponseObject extends Omit<OrderFromDatabase, 'timeInForce' | 'status' | 'updatedAt' | 'updatedAtHeight'> {
   timeInForce: APITimeInForce,
   status: APIOrderStatus,
   postOnly: boolean,
   ticker: string;
+  updatedAt?: IsoString;
+  updatedAtHeight?: string
 }
 
 export type RedisOrderMap = { [orderId: string]: RedisOrder };

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -8,7 +8,6 @@ import {
   FillType,
   IsoString,
   Liquidity,
-  OrderColumns,
   OrderFromDatabase,
   OrderSide,
   OrderStatus,

--- a/indexer/services/ender/__tests__/handlers/order-fills/liquidation-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/liquidation-handler.test.ts
@@ -305,6 +305,8 @@ describe('LiquidationHandler', () => {
         goodTilBlock: protocolTranslations.getGoodTilBlock(makerOrderProto)?.toString(),
         goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(makerOrderProto),
         clientMetadata: makerOrderProto.clientMetadata.toString(),
+        updatedAt: defaultDateTime.toISO(),
+        updatedAtHeight: defaultHeight.toString(),
       });
 
       // No orders should exist for the liquidated account since none are created, and there
@@ -454,6 +456,8 @@ describe('LiquidationHandler', () => {
         goodTilBlock: existingGoodTilBlock,
         goodTilBlockTime: existingGoodTilBlockTime,
         clientMetadata: '0',
+        updatedAt: defaultDateTime.toISO(),
+        updatedAtHeight: '0',
       };
 
       await Promise.all([
@@ -535,6 +539,8 @@ describe('LiquidationHandler', () => {
         goodTilBlock: protocolTranslations.getGoodTilBlock(makerOrderProto)?.toString(),
         goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(makerOrderProto),
         clientMetadata: makerOrderProto.clientMetadata.toString(),
+        updatedAt: defaultDateTime.toISO(),
+        updatedAtHeight: defaultHeight.toString(),
       });
 
       const eventId: Buffer = TendermintEventTable.createEventId(
@@ -701,6 +707,8 @@ describe('LiquidationHandler', () => {
       goodTilBlock: protocolTranslations.getGoodTilBlock(makerOrderProto)?.toString(),
       goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(makerOrderProto),
       clientMetadata: makerOrderProto.clientMetadata.toString(),
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
 
     const eventId: Buffer = TendermintEventTable.createEventId(

--- a/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
@@ -339,6 +339,8 @@ describe('OrderHandler', () => {
         goodTilBlock: protocolTranslations.getGoodTilBlock(makerOrderProto)?.toString(),
         goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(makerOrderProto),
         clientMetadata: makerOrderProto.clientMetadata.toString(),
+        updatedAt: defaultDateTime.toISO(),
+        updatedAtHeight: defaultHeight.toString(),
       });
 
       const takerOrderSize: string = '0.001'; // quantums in human = 1e7 * 1e-10 = 1e-3
@@ -357,6 +359,8 @@ describe('OrderHandler', () => {
         goodTilBlock: protocolTranslations.getGoodTilBlock(takerOrderProto)?.toString(),
         goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(takerOrderProto),
         clientMetadata: takerOrderProto.clientMetadata.toString(),
+        updatedAt: defaultDateTime.toISO(),
+        updatedAtHeight: defaultHeight.toString(),
       });
 
       const eventId: Buffer = TendermintEventTable.createEventId(
@@ -604,6 +608,8 @@ describe('OrderHandler', () => {
           goodTilBlockTime: existingGoodTilBlockTime,
           orderFlags: ORDER_FLAG_SHORT_TERM.toString(),
           clientMetadata: '0',
+          updatedAt: defaultDateTime.toISO(),
+          updatedAtHeight: defaultHeight.toString(),
         }),
         // taker order
         OrderTable.create({
@@ -622,6 +628,8 @@ describe('OrderHandler', () => {
           goodTilBlockTime: existingGoodTilBlockTime,
           orderFlags: ORDER_FLAG_LONG_TERM.toString(),
           clientMetadata: '0',
+          updatedAt: defaultDateTime.toISO(),
+          updatedAtHeight: defaultHeight.toString(),
         }),
       ]);
 
@@ -709,6 +717,8 @@ describe('OrderHandler', () => {
         goodTilBlock: protocolTranslations.getGoodTilBlock(makerOrderProto)?.toString(),
         goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(makerOrderProto),
         clientMetadata: makerOrderProto.clientMetadata.toString(),
+        updatedAt: defaultDateTime.toISO(),
+        updatedAtHeight: defaultHeight.toString(),
       });
 
       const takerOrderSize: string = '0.1002'; // quantums in human = (1e9 + 2e6) * 1e-10 = 0.1002
@@ -727,6 +737,8 @@ describe('OrderHandler', () => {
         goodTilBlock: protocolTranslations.getGoodTilBlock(takerOrderProto)?.toString(),
         goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(takerOrderProto),
         clientMetadata: takerOrderProto.clientMetadata.toString(),
+        updatedAt: defaultDateTime.toISO(),
+        updatedAtHeight: defaultHeight.toString(),
       });
 
       const eventId: Buffer = TendermintEventTable.createEventId(
@@ -947,6 +959,8 @@ describe('OrderHandler', () => {
       goodTilBlock: protocolTranslations.getGoodTilBlock(makerOrderProto)?.toString(),
       goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(makerOrderProto),
       clientMetadata: makerOrderProto.clientMetadata.toString(),
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
 
     // This size should be in fixed-point notation rather than exponential notation (1e-9)
@@ -966,6 +980,8 @@ describe('OrderHandler', () => {
       goodTilBlock: protocolTranslations.getGoodTilBlock(takerOrderProto)?.toString(),
       goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(takerOrderProto),
       clientMetadata: takerOrderProto.clientMetadata.toString(),
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
 
     const eventId: Buffer = TendermintEventTable.createEventId(
@@ -1154,6 +1170,8 @@ describe('OrderHandler', () => {
       goodTilBlock: protocolTranslations.getGoodTilBlock(makerOrderProto)?.toString(),
       goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(makerOrderProto),
       clientMetadata: makerOrderProto.clientMetadata.toString(),
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
 
     const takerOrderSize: string = '0.1'; // quantums in human = 1e1 * 1e-2 = 1e-1
@@ -1172,6 +1190,8 @@ describe('OrderHandler', () => {
       goodTilBlock: protocolTranslations.getGoodTilBlock(takerOrderProto)?.toString(),
       goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(takerOrderProto),
       clientMetadata: takerOrderProto.clientMetadata.toString(),
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
 
     const eventId: Buffer = TendermintEventTable.createEventId(

--- a/indexer/services/ender/__tests__/handlers/stateful-order/conditional-order-placement-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/conditional-order-placement-handler.test.ts
@@ -23,6 +23,8 @@ import { KafkaMessage } from 'kafkajs';
 import { onMessage } from '../../../src/lib/on-message';
 import { DydxIndexerSubtypes } from '../../../src/lib/types';
 import {
+  defaultDateTime,
+  defaultHeight,
   defaultMakerOrder,
   defaultPreviousHeight,
   defaultTime,
@@ -149,6 +151,8 @@ describe('conditionalOrderPlacementHandler', () => {
       createdAtHeight: '3',
       clientMetadata: '0',
       triggerPrice: getTriggerPrice(defaultOrder, testConstants.defaultPerpetualMarket),
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
     expectTimingStats();
     expectOrderSubaccountKafkaMessage(
@@ -180,6 +184,8 @@ describe('conditionalOrderPlacementHandler', () => {
       goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(defaultOrder),
       createdAtHeight: '1',
       clientMetadata: '0',
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
     const kafkaMessage: KafkaMessage = createKafkaMessageFromStatefulOrderEvent(
       defaultStatefulOrderEvent,
@@ -206,6 +212,8 @@ describe('conditionalOrderPlacementHandler', () => {
       createdAtHeight: '3',
       clientMetadata: '0',
       triggerPrice: getTriggerPrice(defaultOrder, testConstants.defaultPerpetualMarket),
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
     expectTimingStats();
     expectOrderSubaccountKafkaMessage(

--- a/indexer/services/ender/__tests__/handlers/stateful-order/conditional-order-triggered-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/conditional-order-triggered-handler.test.ts
@@ -21,6 +21,8 @@ import { KafkaMessage } from 'kafkajs';
 import { onMessage } from '../../../src/lib/on-message';
 import { DydxIndexerSubtypes } from '../../../src/lib/types';
 import {
+  defaultDateTime,
+  defaultHeight,
   defaultOrderId, defaultPreviousHeight, defaultTime, defaultTxHash,
 } from '../../helpers/constants';
 import { createKafkaMessageFromStatefulOrderEvent } from '../../helpers/kafka-helpers';
@@ -128,7 +130,11 @@ describe('statefulOrderRemovalHandler', () => {
     );
 
     expect(order).toBeDefined();
-    expect(order!.status).toEqual(OrderStatus.OPEN);
+    expect(order).toEqual(expect.objectContaining({
+      status: OrderStatus.OPEN,
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
+    }));
 
     const expectedOffchainUpdate: OffChainUpdateV1 = {
       orderPlace: {

--- a/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
@@ -24,6 +24,8 @@ import { KafkaMessage } from 'kafkajs';
 import { onMessage } from '../../../src/lib/on-message';
 import { DydxIndexerSubtypes } from '../../../src/lib/types';
 import {
+  defaultDateTime,
+  defaultHeight,
   defaultMakerOrder,
   defaultPreviousHeight,
   defaultTime,
@@ -167,6 +169,8 @@ describe('statefulOrderPlacementHandler', () => {
       createdAtHeight: '3',
       clientMetadata: '0',
       triggerPrice: null,
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
     expectTimingStats();
 
@@ -212,6 +216,8 @@ describe('statefulOrderPlacementHandler', () => {
       goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(defaultOrder),
       createdAtHeight: '1',
       clientMetadata: '0',
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: '0',
     });
     const kafkaMessage: KafkaMessage = createKafkaMessageFromStatefulOrderEvent(
       statefulOrderEvent,
@@ -238,6 +244,8 @@ describe('statefulOrderPlacementHandler', () => {
       createdAtHeight: '3',
       clientMetadata: '0',
       triggerPrice: null,
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
     });
     expectTimingStats();
     // TODO[IND-20]: Add tests for vulcan messages

--- a/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-removal-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-removal-handler.test.ts
@@ -19,6 +19,8 @@ import { KafkaMessage } from 'kafkajs';
 import { onMessage } from '../../../src/lib/on-message';
 import { DydxIndexerSubtypes } from '../../../src/lib/types';
 import {
+  defaultDateTime,
+  defaultHeight,
   defaultOrderId, defaultPreviousHeight, defaultTime, defaultTxHash,
 } from '../../helpers/constants';
 import { createKafkaMessageFromStatefulOrderEvent } from '../../helpers/kafka-helpers';
@@ -114,7 +116,11 @@ describe('statefulOrderRemovalHandler', () => {
     await onMessage(kafkaMessage);
     const order: OrderFromDatabase | undefined = await OrderTable.findById(orderId);
     expect(order).toBeDefined();
-    expect(order!.status).toEqual(OrderStatus.CANCELED);
+    expect(order).toEqual(expect.objectContaining({
+      status: OrderStatus.CANCELED,
+      updatedAt: defaultDateTime.toISO(),
+      updatedAtHeight: defaultHeight.toString(),
+    }));
     expectTimingStats();
 
     const expectedOffchainUpdate: OffChainUpdateV1 = {

--- a/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
@@ -28,6 +28,7 @@ import {
   PerpetualMarketStatus,
   PerpetualMarketFromDatabase,
   PerpetualMarketTable,
+  IsoString,
 } from '@dydxprotocol-indexer/postgres';
 import { getOrderIdHash } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
@@ -565,6 +566,8 @@ export async function expectOrderInDatabase({
   goodTilBlock,
   goodTilBlockTime,
   clientMetadata,
+  updatedAt,
+  updatedAtHeight,
 }: {
   subaccountId: string,
   clientId: string,
@@ -580,6 +583,8 @@ export async function expectOrderInDatabase({
   goodTilBlock?: string,
   goodTilBlockTime?: string,
   clientMetadata: string,
+  updatedAt: IsoString,
+  updatedAtHeight: string,
 }): Promise<void> {
   const orderId: string = OrderTable.uuid(subaccountId, clientId, clobPairId, orderFlags);
   const orderFromDatabase: OrderFromDatabase | undefined = await
@@ -602,6 +607,8 @@ export async function expectOrderInDatabase({
     goodTilBlock: goodTilBlock ?? null,
     goodTilBlockTime: goodTilBlockTime ?? null,
     clientMetadata,
+    updatedAt,
+    updatedAtHeight,
   }));
 }
 

--- a/indexer/services/ender/__tests__/scripts/scripts.test.ts
+++ b/indexer/services/ender/__tests__/scripts/scripts.test.ts
@@ -53,6 +53,10 @@ describe('SQL Function Tests', () => {
     await dbHelpers.clearData();
   });
 
+  afterEach(async () => {
+    await dbHelpers.clearData();
+  });
+
   afterAll(async () => {
     await dbHelpers.teardown();
     jest.resetAllMocks();

--- a/indexer/services/ender/src/handlers/abstract-stateful-order-handler.ts
+++ b/indexer/services/ender/src/handlers/abstract-stateful-order-handler.ts
@@ -5,6 +5,7 @@ import {
   PerpetualMarketFromDatabase,
 } from '@dydxprotocol-indexer/postgres';
 import { IndexerOrderId, IndexerOrder, IndexerOrder_Side } from '@dydxprotocol-indexer/v4-protos';
+import { DateTime } from 'luxon';
 
 import { STATEFUL_ORDER_ORDER_FILL_EVENT_TYPE } from '../constants';
 import { getPrice, getSize } from '../lib/helper';
@@ -28,6 +29,8 @@ export abstract class AbstractStatefulOrderHandler<T> extends Handler<T> {
     const orderUpdateObject: OrderUpdateObject = {
       id: orderId,
       status,
+      updatedAt: DateTime.fromJSDate(this.block.time!).toISO(),
+      updatedAtHeight: this.block.height.toString(),
     };
 
     const order: OrderFromDatabase | undefined = await OrderTable.update(
@@ -79,6 +82,8 @@ export abstract class AbstractStatefulOrderHandler<T> extends Handler<T> {
       createdAtHeight: this.block.height.toString(),
       clientMetadata: order.clientMetadata.toString(),
       triggerPrice,
+      updatedAt: DateTime.fromJSDate(this.block.time!).toISO(),
+      updatedAtHeight: this.block.height.toString(),
     };
 
     return OrderTable.upsert(orderToCreate, { txId: this.txId });

--- a/indexer/services/ender/src/handlers/order-fills/abstract-order-fill-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/abstract-order-fill-handler.ts
@@ -37,6 +37,7 @@ import {
 } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
 import Long from 'long';
+import { DateTime } from 'luxon';
 
 import {
   generateFillSubaccountMessage,
@@ -317,6 +318,8 @@ export abstract class AbstractOrderFillHandler<T> extends Handler<T> {
       goodTilBlock: protocolTranslations.getGoodTilBlock(order)?.toString(),
       goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(order),
       clientMetadata: order.clientMetadata.toString(),
+      updatedAt: DateTime.fromJSDate(this.block.time!).toISO(),
+      updatedAtHeight: this.block.height.toString(),
     };
 
     return OrderTable.upsert(orderToCreate, { txId: this.txId });

--- a/indexer/services/ender/src/scripts/dydx_order_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/dydx_order_fill_handler_per_order.sql
@@ -112,7 +112,9 @@ BEGIN
             "goodTilBlockTime" = order_record."goodTilBlockTime",
             "timeInForce" = order_record."timeInForce",
             "reduceOnly" = order_record."reduceOnly",
-            "clientMetadata" = order_record."clientMetadata"
+            "clientMetadata" = order_record."clientMetadata",
+            "updatedAt" = block_time,
+            "updatedAtHeight" = block_height
         WHERE id = order_uuid;
     ELSE
         order_record."id" = order_uuid;
@@ -125,9 +127,12 @@ BEGIN
         order_record."totalFilled" = fill_amount;
         order_record."status" = get_order_status(fill_amount, order_size, is_cancelled);
         order_record."createdAtHeight" = block_height;
+        order_record."updatedAt" = block_time;
+        order_record."updatedAtHeight" = block_height;
         INSERT INTO orders
             ("id", "subaccountId", "clientId", "clobPairId", "side", "size", "totalFilled", "price", "type",
-             "status", "timeInForce", "reduceOnly", "orderFlags", "goodTilBlock", "goodTilBlockTime", "createdAtHeight", "clientMetadata", "triggerPrice")
+            "status", "timeInForce", "reduceOnly", "orderFlags", "goodTilBlock", "goodTilBlockTime", "createdAtHeight",
+            "clientMetadata", "triggerPrice", "updatedAt", "updatedAtHeight")
         VALUES (order_record.*);
     END IF;
 


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added `updatedAt` and `updatedAtHeight` fields to the Order model, interfaces, and database schema. These fields represent the timestamp and height at which an order was last updated.
- Updated the JSON schema for the `orders` endpoint and the `OrderSubaccountMessageContents` interface to include these new fields in the request payload and response body.
- Enhanced test cases to validate the correct handling of these new fields.

**Refactor:**
- Improved test isolation by clearing data between tests using an `afterEach` hook.

These changes provide more detailed tracking of order updates, improving data accuracy and enabling more precise analysis and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->