### PR TITLE
[DEC-2071] - x/rewards remove panics that can be invoked in EndBlocker

### DIFF
--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants"
 	"math/big"
 	"time"
 
@@ -290,7 +291,7 @@ func (k Keeper) ProcessRewardsForBlock(
 				share.Weight.BigInt(),
 			),
 			totalRewardWeight,
-		) // big.Div() rounds down, so sum of actual distributed tokens will not exeed `tokensToDistribute`
+		) // big.Div() rounds down, so sum of actual distributed tokens will not exceed `tokensToDistribute`
 
 		if rewardAmountForAddress.Sign() == 0 {
 			// Nothing to distribute to this address. This will only happen due to rounding.
@@ -311,11 +312,14 @@ func (k Keeper) ProcessRewardsForBlock(
 				},
 			},
 		); err != nil {
-			panic(
-				fmt.Errorf(
-					"failed to send reward tokens from treasury (%s) to address %s: %w",
-					params.TreasuryAccount, share.Address, err,
-				),
+			k.Logger(ctx).Error(
+				"Failed to send reward tokens from treasury account to address",
+				"treasury_account",
+				params.TreasuryAccount,
+				"address",
+				share.Address,
+				constants.ErrorLogKey,
+				err,
 			)
 		}
 	}

--- a/protocol/x/rewards/module.go
+++ b/protocol/x/rewards/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -152,7 +153,11 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	if err := am.keeper.ProcessRewardsForBlock(ctx); err != nil {
 		// Panicking here will only happen due to misconfiguration of the rewards module,
 		// and will lead to consensus failure.
-		panic(err)
+		am.keeper.Logger(ctx).Error(
+			"failed to process rewards for block",
+			constants.ErrorLogKey,
+			err,
+		)
 	}
 
 	return []abci.ValidatorUpdate{}


### PR DESCRIPTION
Log errors and continue operating instead.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes:**

- Bug Fix: Updated error handling in the `EndBlock` function within `protocol/x/rewards/module.go`. The application will now log errors during block reward processing instead of causing a panic, improving system stability.
- Refactor: Enhanced error logging in `protocol/x/rewards/keeper/keeper.go` to provide more detailed information, aiding in troubleshooting and issue resolution.
- Chore: Added import of the package `github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants` in both files for consistent usage of constants across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->