### PR TITLE
Don't return 403s for blocked addresses for /screen endpoint.

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
@@ -81,55 +81,112 @@ describe('compliance-controller#V4', () => {
       }));
     });
 
-    it('Get /screen with existing address retrieves compliance data from database', async () => {
-      // Seed the database with a compliance record
-      await ComplianceTable.create(testConstants.nonBlockedComplianceData);
-      let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
+    it(
+      'Get /screen with existing non-blocked address retrieves compliance data from database',
+      async () => {
+      // Seed the database with a non-blocked compliance record
+        await ComplianceTable.create(testConstants.nonBlockedComplianceData);
+        let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
+        expect(data).toHaveLength(1);
 
-      const response: any = await sendRequest({
-        type: RequestMethod.GET,
-        path: `/v4/screen?address=${testConstants.defaultAddress}`,
+        const response: any = await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/screen?address=${testConstants.defaultAddress}`,
+        });
+
+        expect(response.body.restricted).toEqual(false);
+        expect(stats.timing).toHaveBeenCalledTimes(1);
+        expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
+
+        data = await ComplianceTable.findAll({}, [], {});
+        expect(data).toHaveLength(1);
+        expect(data[0]).toEqual(testConstants.nonBlockedComplianceData);
       });
 
-      expect(response.body.restricted).toEqual(false);
-      expect(stats.timing).toHaveBeenCalledTimes(1);
-      expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
+    it(
+      'Get /screen with existing blocked address retrieves compliance data from database',
+      async () => {
+      // Seed the database with a blocked compliance record
+        await ComplianceTable.create(testConstants.blockedComplianceData);
+        let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
+        expect(data).toHaveLength(1);
 
-      data = await ComplianceTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).toEqual(testConstants.nonBlockedComplianceData);
-    });
+        const response: any = await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/screen?address=${testConstants.blockedAddress}`,
+        });
 
-    it('Get /screen with old existing address refreshes compliance data', async () => {
-      // Seed the database with an old compliance record
-      await ComplianceTable.create({
-        ...testConstants.nonBlockedComplianceData,
-        updatedAt: DateTime.utc().minus({
+        expect(response.body.restricted).toEqual(true);
+        expect(stats.timing).toHaveBeenCalledTimes(1);
+        expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
+
+        data = await ComplianceTable.findAll({}, [], {});
+        expect(data).toHaveLength(1);
+        expect(data[0]).toEqual(testConstants.blockedComplianceData);
+      });
+
+    it(
+      'Get /screen with old existing non-blocked address refreshes compliance data',
+      async () => {
+      // Seed the database with an old non-blocked compliance record
+        await ComplianceTable.create({
+          ...testConstants.nonBlockedComplianceData,
+          updatedAt: DateTime.utc().minus({
+            seconds: config.MAX_AGE_SCREENED_ADDRESS_COMPLIANCE_DATA_SECONDS * 2,
+          }).toISO(),
+        });
+        let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
+        expect(data).toHaveLength(1);
+
+        const response: any = await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/screen?address=${testConstants.defaultAddress}`,
+        });
+
+        expect(response.body.restricted).toEqual(false);
+        expect(stats.timing).toHaveBeenCalledTimes(1);
+        expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(1);
+
+        data = await ComplianceTable.findAll({}, [], {});
+        expect(data).toHaveLength(1);
+        expect(data[0]).not.toEqual({
+          address: testConstants.defaultAddress,
+          provider: complianceProvider.provider,
+          blocked,
+          riskScore,
+        });
+      });
+
+    it(
+      'Get /screen with old existing blocked addressdoes not refresh compliance data',
+      async () => {
+      // Seed the database with an old blocked compliance record
+        const oldUpdatedAt: string = DateTime.utc().minus({
           seconds: config.MAX_AGE_SCREENED_ADDRESS_COMPLIANCE_DATA_SECONDS * 2,
-        }).toISO(),
-      });
-      let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
+        }).toISO();
+        await ComplianceTable.create({
+          ...testConstants.blockedComplianceData,
+          updatedAt: oldUpdatedAt,
+        });
+        let data: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
+        expect(data).toHaveLength(1);
 
-      const response: any = await sendRequest({
-        type: RequestMethod.GET,
-        path: `/v4/screen?address=${testConstants.defaultAddress}`,
-      });
+        const response: any = await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/screen?address=${testConstants.blockedAddress}`,
+        });
 
-      expect(response.body.restricted).toEqual(false);
-      expect(stats.timing).toHaveBeenCalledTimes(1);
-      expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(1);
+        expect(response.body.restricted).toEqual(true);
+        expect(stats.timing).toHaveBeenCalledTimes(1);
+        expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
 
-      data = await ComplianceTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).not.toEqual({
-        address: testConstants.defaultAddress,
-        provider: complianceProvider.provider,
-        blocked,
-        riskScore,
+        data = await ComplianceTable.findAll({}, [], {});
+        expect(data).toHaveLength(1);
+        expect(data[0]).toEqual({
+          ...testConstants.blockedComplianceData,
+          updatedAt: oldUpdatedAt,
+        });
       });
-    });
 
     it('Get /screen with multiple new address from same IP gets rate-limited', async () => {
       for (let i: number = 0; i < config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_POINTS; i++) {

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -50,7 +50,7 @@ class ComplianceController extends Controller {
       complianceProvider.provider,
     );
 
-    // Immediately return for blocked addresses
+    // Immediately return for blocked addresses, do not refresh
     if (complianceData?.blocked) {
       return {
         restricted: true,


### PR DESCRIPTION
FE ask, the `/screen` endpoint now will not return a 403 for blocked addresses after the first call to the API, and instead will always return:
```
{
  "restricted":true
}
```
for blocked addresses.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a check for blocked addresses in the `compliance-controller#V4` module. If an address is blocked, the system will now return a response indicating that it's restricted.
- Refactor: Removed the import of the unused `complianceCheck` function.
- Test: Updated unit tests for the `compliance-controller#V4` module to include additional scenarios for retrieving compliance data based on different address conditions.
- Chore: Implemented changes related to rate limiting and compliance data retrieval to improve system performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->