### PR TITLE
[DEC-2134] - Final market config changes to pregenesis, including addition of dydx token

### DIFF
--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config.go
@@ -16,7 +16,7 @@ const (
 	// compute an index price for a market, given exchange unavailability due to exchange geo-fencing,
 	// downtime, etc.
 	// Ok to drop this to 5 for some markets if needed, but 6 is better.
-	MinimumRequiredExchangesPerMarket = 6
+	MinimumRequiredExchangesPerMarket = 5
 )
 
 // GenerateExchangeConfigJson generates human-readable exchange config json for each market based on the contents

--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
@@ -155,6 +155,10 @@ func TestGenerateExchangeConfigJson(t *testing.T) {
 			id:                             exchange_config.MARKET_USDT_USD,
 			expectedExchangeConfigJsonFile: "usdt_exchange_config.json",
 		},
+		"DYDX exchange config": {
+			id:                             exchange_config.MARKET_DYDX_USD,
+			expectedExchangeConfigJsonFile: "dydx_exchange_config.json",
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/protocol/daemons/pricefeed/client/constants/testdata/ada_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/ada_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "ADA/USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "ADAUSDT",
       "adjustByMarket": "USDT-USD"
@@ -17,10 +13,6 @@
     {
       "exchangeName": "CoinbasePro",
       "ticker": "ADA-USD"
-    },
-    {
-      "exchangeName": "CryptoCom",
-      "ticker": "ADA_USD"
     },
     {
       "exchangeName": "Gate",
@@ -44,6 +36,11 @@
     {
       "exchangeName": "Mexc",
       "ticker": "ADA_USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Okx",
+      "ticker": "ADA-USDT",
       "adjustByMarket": "USDT-USD"
     }
   ]

--- a/protocol/daemons/pricefeed/client/constants/testdata/ape_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/ape_exchange_config.json
@@ -10,11 +10,6 @@
       "ticker": "APE-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "APE_USDT",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
       "exchangeName": "Gate",
       "ticker": "APE_USDT",
       "adjustByMarket": "USDT-USD"
@@ -22,6 +17,11 @@
     {
       "exchangeName": "Kraken",
       "ticker": "APEUSD"
+    },
+    {
+      "exchangeName": "Kucoin",
+      "ticker": "APE-USDT",
+      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Mexc",

--- a/protocol/daemons/pricefeed/client/constants/testdata/apt_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/apt_exchange_config.json
@@ -25,6 +25,11 @@
       "adjustByMarket": "USDT-USD"
     },
     {
+      "exchangeName": "Kucoin",
+      "ticker": "APT-USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
       "exchangeName": "Mexc",
       "ticker": "APT_USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/arb_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/arb_exchange_config.json
@@ -25,10 +25,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Kraken",
-      "ticker": "ARBUSD"
-    },
-    {
       "exchangeName": "Kucoin",
       "ticker": "ARB-USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/atom_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/atom_exchange_config.json
@@ -29,6 +29,11 @@
       "adjustByMarket": "USDT-USD"
     },
     {
+      "exchangeName": "Mexc",
+      "ticker": "ATOM_USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
       "exchangeName": "Okx",
       "ticker": "ATOM-USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/avax_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/avax_exchange_config.json
@@ -6,6 +6,11 @@
       "adjustByMarket": "USDT-USD"
     },
     {
+      "exchangeName": "Bybit",
+      "ticker": "AVAXUSDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
       "exchangeName": "CoinbasePro",
       "ticker": "AVAX-USD"
     },

--- a/protocol/daemons/pricefeed/client/constants/testdata/bch_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/bch_exchange_config.json
@@ -6,17 +6,13 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "BCH/USD"
+      "exchangeName": "Bybit",
+      "ticker": "BCHUSDT",
+      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "CoinbasePro",
       "ticker": "BCH-USD"
-    },
-    {
-      "exchangeName": "CryptoCom",
-      "ticker": "BCH_USD",
-      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Gate",
@@ -35,6 +31,11 @@
     {
       "exchangeName": "Kucoin",
       "ticker": "BCH-USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Mexc",
+      "ticker": "BCH_USDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/btc_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/btc_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "BTC/USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "BTCUSDT",
       "adjustByMarket": "USDT-USD"
@@ -19,12 +15,18 @@
       "ticker": "BTC-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "BTC_USD"
+      "exchangeName": "Huobi",
+      "ticker": "btcusdt",
+      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Kraken",
       "ticker": "XXBTZUSD"
+    },
+    {
+      "exchangeName": "Kucoin",
+      "ticker": "BTC-USDT",
+      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Mexc",

--- a/protocol/daemons/pricefeed/client/constants/testdata/comp_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/comp_exchange_config.json
@@ -10,11 +10,6 @@
       "ticker": "COMP-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "COMP_USDT",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
       "exchangeName": "Gate",
       "ticker": "COMP_USDT",
       "adjustByMarket": "USDT-USD"
@@ -22,6 +17,11 @@
     {
       "exchangeName": "Kraken",
       "ticker": "COMPUSD"
+    },
+    {
+      "exchangeName": "Mexc",
+      "ticker": "COMP_USDT",
+      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Okx",

--- a/protocol/daemons/pricefeed/client/constants/testdata/crv_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/crv_exchange_config.json
@@ -15,17 +15,17 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Huobi",
-      "ticker": "crvusdt",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
       "exchangeName": "Kraken",
       "ticker": "CRVUSD"
     },
     {
       "exchangeName": "Kucoin",
       "ticker": "CRV-USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Mexc",
+      "ticker": "CRV_USDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/doge_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/doge_exchange_config.json
@@ -15,10 +15,6 @@
       "ticker": "DOGE-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "DOGE_USD"
-    },
-    {
       "exchangeName": "Gate",
       "ticker": "DOGE_USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/dot_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/dot_exchange_config.json
@@ -6,12 +6,13 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "CoinbasePro",
-      "ticker": "DOT-USD"
+      "exchangeName": "Bybit",
+      "ticker": "DOTUSDT",
+      "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "DOT_USD"
+      "exchangeName": "CoinbasePro",
+      "ticker": "DOT-USD"
     },
     {
       "exchangeName": "Gate",
@@ -25,6 +26,11 @@
     {
       "exchangeName": "Kucoin",
       "ticker": "DOT-USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Mexc",
+      "ticker": "DOT_USDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/dydx_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/dydx_exchange_config.json
@@ -1,37 +1,28 @@
 {
   "exchanges": [
     {
-      "exchangeName": "Binance",
-      "ticker": "ETCUSDT",
+      "exchangeName": "Bybit",
+      "ticker": "DYDXUSDT",
       "adjustByMarket": "USDT-USD"
-    },
-    {
-      "exchangeName": "CoinbasePro",
-      "ticker": "ETC-USD"
     },
     {
       "exchangeName": "Gate",
-      "ticker": "ETC_USDT",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
-      "exchangeName": "Huobi",
-      "ticker": "etcusdt",
+      "ticker": "DYDX_USDT",
       "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Kucoin",
-      "ticker": "ETC-USDT",
+      "ticker": "DYDX-USDT",
       "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Mexc",
-      "ticker": "ETC_USDT",
+      "ticker": "DYDX_USDT",
       "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Okx",
-      "ticker": "ETC-USDT",
+      "ticker": "DYDX-USDT",
       "adjustByMarket": "USDT-USD"
     }
   ]

--- a/protocol/daemons/pricefeed/client/constants/testdata/dydx_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/dydx_exchange_config.json
@@ -1,6 +1,11 @@
 {
   "exchanges": [
     {
+      "exchangeName": "Binance",
+      "ticker": "DYDXUSDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
       "exchangeName": "Bybit",
       "ticker": "DYDXUSDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/eth_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/eth_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "ETH/USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "ETHUSDT",
       "adjustByMarket": "USDT-USD"
@@ -19,12 +15,18 @@
       "ticker": "ETH-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "ETH_USD"
+      "exchangeName": "Huobi",
+      "ticker": "ethusdt",
+      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Kraken",
       "ticker": "XETHZUSD"
+    },
+    {
+      "exchangeName": "Kucoin",
+      "ticker": "ETH-USDT",
+      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Mexc",

--- a/protocol/daemons/pricefeed/client/constants/testdata/fil_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/fil_exchange_config.json
@@ -24,11 +24,6 @@
       "ticker": "FILUSD"
     },
     {
-      "exchangeName": "Kucoin",
-      "ticker": "FIL-USDT",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
       "exchangeName": "Mexc",
       "ticker": "FIL_USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/link_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/link_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "LINK/USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "LINKUSDT",
       "adjustByMarket": "USDT-USD"
@@ -17,10 +13,6 @@
     {
       "exchangeName": "CoinbasePro",
       "ticker": "LINK-USD"
-    },
-    {
-      "exchangeName": "CryptoCom",
-      "ticker": "LINK_USD"
     },
     {
       "exchangeName": "Kraken",

--- a/protocol/daemons/pricefeed/client/constants/testdata/ltc_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/ltc_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "LTC/USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "LTCUSDT",
       "adjustByMarket": "USDT-USD"
@@ -17,10 +13,6 @@
     {
       "exchangeName": "CoinbasePro",
       "ticker": "LTC-USD"
-    },
-    {
-      "exchangeName": "CryptoCom",
-      "ticker": "LTC_USD"
     },
     {
       "exchangeName": "Huobi",

--- a/protocol/daemons/pricefeed/client/constants/testdata/matic_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/matic_exchange_config.json
@@ -6,12 +6,13 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "CoinbasePro",
-      "ticker": "MATIC-USD"
+      "exchangeName": "Bybit",
+      "ticker": "MATICUSDT",
+      "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "MATIC_USD"
+      "exchangeName": "CoinbasePro",
+      "ticker": "MATIC-USD"
     },
     {
       "exchangeName": "Gate",
@@ -24,8 +25,17 @@
       "adjustByMarket": "USDT-USD"
     },
     {
+      "exchangeName": "Kraken",
+      "ticker": "MATICUSD"
+    },
+    {
       "exchangeName": "Kucoin",
       "ticker": "MATIC-USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Mexc",
+      "ticker": "MATIC_USDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/mkr_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/mkr_exchange_config.json
@@ -10,8 +10,8 @@
       "ticker": "MKR-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "MKR_USD"
+      "exchangeName": "Kraken",
+      "ticker": "MKRUSD"
     },
     {
       "exchangeName": "Kucoin",

--- a/protocol/daemons/pricefeed/client/constants/testdata/near_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/near_exchange_config.json
@@ -10,11 +10,6 @@
       "ticker": "NEAR-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "NEAR_USDT",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
       "exchangeName": "Gate",
       "ticker": "NEAR_USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/op_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/op_exchange_config.json
@@ -6,11 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bybit",
-      "ticker": "OPUSDT",
-      "adjustByMarket": "USDT-USD"
-    },
-    {
       "exchangeName": "CoinbasePro",
       "ticker": "OP-USD"
     },

--- a/protocol/daemons/pricefeed/client/constants/testdata/shib_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/shib_exchange_config.json
@@ -15,10 +15,6 @@
       "ticker": "SHIB-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "SHIB_USD"
-    },
-    {
       "exchangeName": "Gate",
       "ticker": "SHIB_USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/sol_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/sol_exchange_config.json
@@ -15,10 +15,6 @@
       "ticker": "SOL-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "SOL_USD"
-    },
-    {
       "exchangeName": "Huobi",
       "ticker": "solusdt",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/sui_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/sui_exchange_config.json
@@ -15,10 +15,6 @@
       "ticker": "SUI-USD"
     },
     {
-      "exchangeName": "CryptoCom",
-      "ticker": "SUI_USD"
-    },
-    {
       "exchangeName": "Gate",
       "ticker": "SUI_USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/trx_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/trx_exchange_config.json
@@ -21,6 +21,10 @@
       "adjustByMarket": "USDT-USD"
     },
     {
+      "exchangeName": "Kraken",
+      "ticker": "TRXUSD"
+    },
+    {
       "exchangeName": "Kucoin",
       "ticker": "TRX-USDT",
       "adjustByMarket": "USDT-USD"

--- a/protocol/daemons/pricefeed/client/constants/testdata/uni_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/uni_exchange_config.json
@@ -24,8 +24,8 @@
       "ticker": "UNIUSD"
     },
     {
-      "exchangeName": "Mexc",
-      "ticker": "UNI_USDT",
+      "exchangeName": "Kucoin",
+      "ticker": "UNI-USDT",
       "adjustByMarket": "USDT-USD"
     },
     {

--- a/protocol/daemons/pricefeed/client/constants/testdata/usdt_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/usdt_exchange_config.json
@@ -6,10 +6,6 @@
       "invert": true
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "USDT/USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "USDCUSDT",
       "invert": true
@@ -17,10 +13,6 @@
     {
       "exchangeName": "CoinbasePro",
       "ticker": "USDT-USD"
-    },
-    {
-      "exchangeName": "CryptoCom",
-      "ticker": "USDT_USD"
     },
     {
       "exchangeName": "Huobi",
@@ -40,9 +32,7 @@
     },
     {
       "exchangeName": "Okx",
-      "ticker": "BTC-USDT",
-      "adjustByMarket": "BTC-USD",
-      "invert": true
+      "ticker": "USDT-USDC"
     }
   ]
 }

--- a/protocol/daemons/pricefeed/client/constants/testdata/xlm_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/xlm_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "XLM/USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "XLMUSDT",
       "adjustByMarket": "USDT-USD"
@@ -17,11 +13,6 @@
     {
       "exchangeName": "CoinbasePro",
       "ticker": "XLM-USD"
-    },
-    {
-      "exchangeName": "CryptoCom",
-      "ticker": "XLM_USDT",
-      "adjustByMarket": "USDT-USD"
     },
     {
       "exchangeName": "Kraken",
@@ -35,6 +26,11 @@
     {
       "exchangeName": "Mexc",
       "ticker": "XLM_USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Okx",
+      "ticker": "XLM-USDT",
       "adjustByMarket": "USDT-USD"
     }
   ]

--- a/protocol/daemons/pricefeed/client/constants/testdata/xrp_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/xrp_exchange_config.json
@@ -6,10 +6,6 @@
       "adjustByMarket": "USDT-USD"
     },
     {
-      "exchangeName": "Bitstamp",
-      "ticker": "XRP/USD"
-    },
-    {
       "exchangeName": "Bybit",
       "ticker": "XRPUSDT",
       "adjustByMarket": "USDT-USD"
@@ -17,10 +13,6 @@
     {
       "exchangeName": "CoinbasePro",
       "ticker": "XRP-USD"
-    },
-    {
-      "exchangeName": "CryptoCom",
-      "ticker": "XRP_USD"
     },
     {
       "exchangeName": "Gate",

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -939,6 +939,22 @@ function edit_genesis() {
 	usdt_exchange_config_json=$(cat "$EXCHANGE_CONFIG_JSON_DIR/usdt_exchange_config.json" | jq -c '.')
 	dasel put -t string -f "$GENESIS" '.app_state.prices.market_params.[33].exchange_config_json' -v "$usdt_exchange_config_json"
 
+	# Market: DYDX-USD
+	dasel put -t json -f "$GENESIS" '.app_state.prices.market_params.[]' -v "{}"
+	dasel put -t string -f "$GENESIS" '.app_state.prices.market_params.[34].pair' -v 'DYDX-USD'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[34].id' -v '1000001'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[34].exponent' -v '-9'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[34].min_exchanges' -v '3'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[34].min_price_change_ppm' -v '2500'  # 0.25%
+	dasel put -t json -f "$GENESIS" '.app_state.prices.market_prices.[]' -v "{}"
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].id' -v '1000001'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].exponent' -v '-9'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].price' -v '25000000000'          # $2.5 = 1 DYDX.
+	# DYDX Exchange Config
+	dydx_exchange_config_json=$(cat "$EXCHANGE_CONFIG_JSON_DIR/dydx_exchange_config.json" | jq -c '.')
+	dasel put -t string -f "$GENESIS" '.app_state.prices.market_params.[34].exchange_config_json' -v "$dydx_exchange_config_json"
+
+
 	total_accounts_quote_balance=0
 	acct_idx=0
 	# Update subaccounts module for load testing accounts.
@@ -1453,16 +1469,17 @@ function update_genesis_use_test_exchange() {
 # Modify the genesis file to add test volatile market. Market TEST-USD will be added as market 33.
 function update_genesis_use_test_volatile_market() {
 	GENESIS=$1/genesis.json
+	NEXT_MARKET_ID=33
 
 	# Market: TEST-USD
 	dasel put -t json -f "$GENESIS" '.app_state.prices.market_params.[]' -v "{}"
 	dasel put -t string -f "$GENESIS" '.app_state.prices.market_params.last().pair' -v 'TEST-USD'
-	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().id' -v '33'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().id' -v "${NEXT_MARKET_ID}"
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().exponent' -v '-5'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().min_exchanges' -v '1'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().min_price_change_ppm' -v '250' # 0.025%
 	dasel put -t json -f "$GENESIS" '.app_state.prices.market_prices.[]' -v "{}"
-	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().id' -v '33'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().id' -v '34'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().exponent' -v '-5'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().price' -v '10000000'          # $100 = 1 TEST.
 	# TEST Exchange Config
@@ -1475,7 +1492,7 @@ function update_genesis_use_test_volatile_market() {
 	dasel put -t json -f "$GENESIS" '.app_state.perpetuals.perpetuals.[]' -v "{}"
 	dasel put -t string -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.ticker' -v 'TEST-USD'
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.id' -v "${NUM_PERPETUALS}"
-	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.market_id' -v '33'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.market_id' -v "${NEXT_MARKET_ID}"
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.atomic_resolution' -v '-10'
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.default_funding_ppm' -v '0'
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.liquidity_tier' -v '0'

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -1479,7 +1479,7 @@ function update_genesis_use_test_volatile_market() {
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().min_exchanges' -v '1'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().min_price_change_ppm' -v '250' # 0.025%
 	dasel put -t json -f "$GENESIS" '.app_state.prices.market_prices.[]' -v "{}"
-	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().id' -v '34'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().id' -v "${NEXT_MARKET_ID}"
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().exponent' -v '-5'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().price' -v '10000000'          # $100 = 1 TEST.
 	# TEST Exchange Config

--- a/protocol/testutil/daemons/pricefeed/exchange_config/market_id.go
+++ b/protocol/testutil/daemons/pricefeed/exchange_config/market_id.go
@@ -75,7 +75,9 @@ const (
 	// MARKET_TEST_USD is the id used for the TEST-USD market pair.
 	MARKET_TEST_USD types.MarketId = 33
 
-	// Non-trading adjust-by markets.
+	// Non-trading markets.
 	// MARKET_USDT_USD is the id for the USDT-USD market pair.
 	MARKET_USDT_USD types.MarketId = 1_000_000
+	// MARKET_DYDX_USD is the id for the DYDX-USD market pair.
+	MARKET_DYDX_USD types.MarketId = 1_000_001
 )

--- a/protocol/testutil/daemons/pricefeed/exchange_config/testnet_exchange_market_config.go
+++ b/protocol/testutil/daemons/pricefeed/exchange_config/testnet_exchange_market_config.go
@@ -141,6 +141,10 @@ var (
 					Ticker:         "XRPUSDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDXUSDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_USDT_USD: {
 					Ticker: "USDCUSDT",
 					Invert: true,

--- a/protocol/testutil/daemons/pricefeed/exchange_config/testnet_exchange_market_config.go
+++ b/protocol/testutil/daemons/pricefeed/exchange_config/testnet_exchange_market_config.go
@@ -186,9 +186,6 @@ var (
 				MARKET_APE_USD: {
 					Ticker: "APEUSD",
 				},
-				MARKET_ARB_USD: {
-					Ticker: "ARBUSD",
-				},
 				MARKET_BLUR_USD: {
 					Ticker: "BLURUSD",
 				},
@@ -210,9 +207,6 @@ var (
 				MARKET_COMP_USD: {
 					Ticker: "COMPUSD",
 				},
-				MARKET_ETC_USD: {
-					Ticker: "XETCZUSD",
-				},
 				MARKET_AVAX_USD: {
 					Ticker: "AVAXUSD",
 				},
@@ -224,6 +218,15 @@ var (
 				},
 				MARKET_USDT_USD: {
 					Ticker: "USDTZUSD",
+				},
+				MARKET_MATIC_USD: {
+					Ticker: "MATICUSD",
+				},
+				MARKET_MKR_USD: {
+					Ticker: "MKRUSD",
+				},
+				MARKET_TRX_USD: {
+					Ticker: "TRXUSD",
 				},
 			},
 		},
@@ -330,39 +333,15 @@ var (
 					Ticker:         "COMP_USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDX_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 			},
 		},
 		exchange_common.EXCHANGE_ID_BITSTAMP: {
-			Id: exchange_common.EXCHANGE_ID_BITSTAMP,
-			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
-				MARKET_BTC_USD: {
-					Ticker: "BTC/USD",
-				},
-				MARKET_ETH_USD: {
-					Ticker: "ETH/USD",
-				},
-				MARKET_XRP_USD: {
-					Ticker: "XRP/USD",
-				},
-				MARKET_LTC_USD: {
-					Ticker: "LTC/USD",
-				},
-				MARKET_BCH_USD: {
-					Ticker: "BCH/USD",
-				},
-				MARKET_ADA_USD: {
-					Ticker: "ADA/USD",
-				},
-				MARKET_XLM_USD: {
-					Ticker: "XLM/USD",
-				},
-				MARKET_LINK_USD: {
-					Ticker: "LINK/USD",
-				},
-				MARKET_USDT_USD: {
-					Ticker: "USDT/USD",
-				},
-			},
+			Id:                   exchange_common.EXCHANGE_ID_BITSTAMP,
+			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{},
 		},
 		exchange_common.EXCHANGE_ID_BYBIT: {
 			Id: exchange_common.EXCHANGE_ID_BYBIT,
@@ -439,12 +418,28 @@ var (
 					Ticker:         "SEIUSDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
-				MARKET_OP_USD: {
-					Ticker:         "OPUSDT",
-					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
-				},
 				MARKET_PEPE_USD: {
 					Ticker:         "PEPEUSDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_AVAX_USD: {
+					Ticker:         "AVAXUSDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_BCH_USD: {
+					Ticker:         "BCHUSDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_DOT_USD: {
+					Ticker:         "DOTUSDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDXUSDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_MATIC_USD: {
+					Ticker:         "MATICUSDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
 				MARKET_USDT_USD: {
@@ -454,71 +449,8 @@ var (
 			},
 		},
 		exchange_common.EXCHANGE_ID_CRYPTO_COM: {
-			Id: exchange_common.EXCHANGE_ID_CRYPTO_COM,
-			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
-				MARKET_BTC_USD: {
-					Ticker: "BTC_USD",
-				},
-				MARKET_ETH_USD: {
-					Ticker: "ETH_USD",
-				},
-				MARKET_LINK_USD: {
-					Ticker: "LINK_USD",
-				},
-				MARKET_SHIB_USD: {
-					Ticker: "SHIB_USD",
-				},
-				MARKET_XRP_USD: {
-					Ticker: "XRP_USD",
-				},
-				MARKET_SOL_USD: {
-					Ticker: "SOL_USD",
-				},
-				MARKET_BCH_USD: {
-					Ticker:         "BCH_USD",
-					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
-				},
-				MARKET_LTC_USD: {
-					Ticker: "LTC_USD",
-				},
-				MARKET_ADA_USD: {
-					Ticker: "ADA_USD",
-				},
-				MARKET_DOT_USD: {
-					Ticker: "DOT_USD",
-				},
-				MARKET_DOGE_USD: {
-					Ticker: "DOGE_USD",
-				},
-				MARKET_MATIC_USD: {
-					Ticker: "MATIC_USD",
-				},
-				MARKET_SUI_USD: {
-					Ticker: "SUI_USD",
-				},
-				MARKET_APE_USD: {
-					Ticker:         "APE_USDT",
-					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
-				},
-				MARKET_XLM_USD: {
-					Ticker:         "XLM_USDT",
-					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
-				},
-				MARKET_COMP_USD: {
-					Ticker:         "COMP_USDT",
-					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
-				},
-				MARKET_MKR_USD: {
-					Ticker: "MKR_USD",
-				},
-				MARKET_NEAR_USD: {
-					Ticker:         "NEAR_USDT",
-					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
-				},
-				MARKET_USDT_USD: {
-					Ticker: "USDT_USD",
-				},
-			},
+			Id:                   exchange_common.EXCHANGE_ID_CRYPTO_COM,
+			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{},
 		},
 		exchange_common.EXCHANGE_ID_HUOBI: {
 			Id: exchange_common.EXCHANGE_ID_HUOBI,
@@ -579,10 +511,6 @@ var (
 					Ticker:         "xrpusdt",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
-				MARKET_CRV_USD: {
-					Ticker:         "crvusdt",
-					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
-				},
 				MARKET_AVAX_USD: {
 					Ticker:         "avaxusdt",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
@@ -593,6 +521,14 @@ var (
 				},
 				MARKET_ETC_USD: {
 					Ticker:         "etcusdt",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_BTC_USD: {
+					Ticker:         "btcusdt",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_ETH_USD: {
+					Ticker:         "ethusdt",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
 				MARKET_USDT_USD: {
@@ -627,10 +563,6 @@ var (
 				},
 				MARKET_AVAX_USD: {
 					Ticker:         "AVAX-USDT",
-					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
-				},
-				MARKET_FIL_USD: {
-					Ticker:         "FIL-USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
 				MARKET_LTC_USD: {
@@ -709,10 +641,38 @@ var (
 					Ticker:         "NEAR-USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
+				MARKET_APE_USD: {
+					Ticker:         "APE-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_APT_USD: {
+					Ticker:         "APT-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_USDT_USD: {
 					Ticker:         "BTC-USDT", // Adjusted with BTC index price.
 					AdjustByMarket: newMarketIdWithValue(MARKET_BTC_USD),
 					Invert:         true,
+				},
+				MARKET_BTC_USD: {
+					Ticker:         "BTC-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDX-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_ETC_USD: {
+					Ticker:         "ETC-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_ETH_USD: {
+					Ticker:         "ETH-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_UNI_USD: {
+					Ticker:         "UNI-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
 			},
 		},
@@ -831,13 +791,23 @@ var (
 					Ticker:         "ATOM-USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
+				MARKET_ADA_USD: {
+					Ticker:         "ADA-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_LDO_USD: {
 					Ticker: "LDO-USDT",
 				},
 				MARKET_USDT_USD: {
-					Ticker:         "BTC-USDT", // Adjusted with BTC index price.
-					AdjustByMarket: newMarketIdWithValue(MARKET_BTC_USD),
-					Invert:         true,
+					Ticker: "USDT-USDC",
+				},
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDX-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_XLM_USD: {
+					Ticker:         "XLM-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
 			},
 		},
@@ -939,8 +909,36 @@ var (
 					Ticker:         "NEAR_USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
-				MARKET_UNI_USD: {
-					Ticker:         "UNI_USDT",
+				MARKET_ATOM_USD: {
+					Ticker:         "ATOM_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_BCH_USD: {
+					Ticker:         "BCH_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_COMP_USD: {
+					Ticker:         "COMP_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_CRV_USD: {
+					Ticker:         "CRV_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_DOT_USD: {
+					Ticker:         "DOT_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDX_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_ETC_USD: {
+					Ticker:         "ETC_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
+				MARKET_MATIC_USD: {
+					Ticker:         "MATIC_USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
 				},
 			},


### PR DESCRIPTION
All changes in https://dydx-team.slack.com/files/U04R7L0FECX/F05PPPH7FJL/v4_markets_august implemented except where I note that the change was already made in the `price oracle diffs progress` page.

Tested this locally and saw price updates for all markets, including DYDX, except for USDT (expected, as we set the min change high to limit USDT market updates and the genesis price matches the market price.)

EDIT: PR changes here have been moved to two PRS: [DYDX token addition](https://github.com/dydxprotocol/v4-chain/pull/466), [existing market updates](https://github.com/dydxprotocol/v4-chain/pull/467)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for DYDX-USD and TEST-USD market pairs in the price feed daemon. This includes new market configurations, adjustments to tickers, and updated exchange configuration JSON files.
- Refactor: Reduced the minimum required exchanges per market from 6 to 5, enhancing flexibility in market data sourcing.
- Test: Introduced new test cases for the DYDX exchange configuration, improving coverage and reliability of the testing suite.
- Chore: Updated genesis file with new market configurations for DYDX-USD and TEST-USD, ensuring accurate initialization of these markets during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->