### PR TITLE
Add code to blocked error responses.

### DIFF
--- a/indexer/services/comlink/__tests__/lib/compliance-check.test.ts
+++ b/indexer/services/comlink/__tests__/lib/compliance-check.test.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import { RequestMethod } from '../../src/types';
+import { BlockedCode, RequestMethod } from '../../src/types';
 import Server from '../../src/request-helpers/server';
 import { sendRequestToApp } from '../helpers/helpers';
 import { complianceCheck } from '../../src/lib/compliance-check';
@@ -124,6 +124,7 @@ describe('compliance-check', () => {
     expect(response.body).toEqual(expect.objectContaining({
       errors: expect.arrayContaining([{
         msg: INDEXER_COMPLIANCE_BLOCKED_PAYLOAD,
+        code: BlockedCode.COMPLIANCE_BLOCKED,
       }]),
     }));
   });

--- a/indexer/services/comlink/__tests__/lib/restrict-countries.test.ts
+++ b/indexer/services/comlink/__tests__/lib/restrict-countries.test.ts
@@ -2,6 +2,7 @@ import { INDEXER_GEOBLOCKED_PAYLOAD } from '../../src/constants';
 import config from '../../src/config';
 import { rejectRestrictedCountries } from '../../src/lib/restrict-countries';
 import { isRestrictedCountryHeaders } from '@dydxprotocol-indexer/compliance';
+import { BlockedCode } from '../../src/types';
 
 jest.mock('@dydxprotocol-indexer/compliance');
 
@@ -65,7 +66,10 @@ describe('rejectRestrictedCountries', () => {
     expect(res.status).toHaveBeenCalledWith(403);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
       errors: expect.arrayContaining([
-        { msg: INDEXER_GEOBLOCKED_PAYLOAD },
+        {
+          msg: INDEXER_GEOBLOCKED_PAYLOAD,
+          code: BlockedCode.GEOBLOCKED,
+        },
       ]),
     }));
     expect(next).not.toHaveBeenCalled();

--- a/indexer/services/comlink/src/lib/compliance-check.ts
+++ b/indexer/services/comlink/src/lib/compliance-check.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import { matchedData } from 'express-validator';
 
 import { INDEXER_COMPLIANCE_BLOCKED_PAYLOAD } from '../constants';
-import { AddressRequest } from '../types';
+import { AddressRequest, BlockedCode } from '../types';
 import { create4xxResponse } from './helpers';
 
 /**
@@ -34,6 +34,7 @@ export async function complianceCheck(
       res,
       INDEXER_COMPLIANCE_BLOCKED_PAYLOAD,
       403,
+      { code: BlockedCode.COMPLIANCE_BLOCKED },
     );
   }
 

--- a/indexer/services/comlink/src/lib/helpers.ts
+++ b/indexer/services/comlink/src/lib/helpers.ts
@@ -105,9 +105,11 @@ export function create4xxResponse(
   res: express.Response,
   msg: string,
   status: number = 400,
+  additionalParams: object = {},
 ): express.Response {
   return res.status(status).json({
     errors: [{
+      ...additionalParams,
       msg,
     }],
   });

--- a/indexer/services/comlink/src/lib/restrict-countries.ts
+++ b/indexer/services/comlink/src/lib/restrict-countries.ts
@@ -5,6 +5,7 @@ import {
 import express from 'express';
 
 import { INDEXER_GEOBLOCKED_PAYLOAD } from '../constants';
+import { BlockedCode } from '../types';
 import { create4xxResponse } from './helpers';
 
 /**
@@ -20,6 +21,7 @@ export function rejectRestrictedCountries(
       res,
       INDEXER_GEOBLOCKED_PAYLOAD,
       403,
+      { code: BlockedCode.GEOBLOCKED },
     );
   }
 

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -388,3 +388,8 @@ export interface ComplianceResponse {
 }
 
 export interface ComplianceRequest extends AddressRequest {}
+
+export enum BlockedCode {
+  GEOBLOCKED = 'GEOBLOCKED',
+  COMPLIANCE_BLOCKED = 'COMPLIANCE_BLOCKED',
+}


### PR DESCRIPTION
Add string enum `code` property to the response payload for the blocked error responses so FE can distinguish w/o matching directly against the message.