### PR TITLE
[DEC-2134] - Add DYDX token to genesis.sh

### DIFF
--- a/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
+++ b/protocol/daemons/pricefeed/client/constants/static_exchange_market_config_test.go
@@ -155,6 +155,10 @@ func TestGenerateExchangeConfigJson(t *testing.T) {
 			id:                             exchange_config.MARKET_USDT_USD,
 			expectedExchangeConfigJsonFile: "usdt_exchange_config.json",
 		},
+		"DYDX exchange config": {
+			id:                             exchange_config.MARKET_DYDX_USD,
+			expectedExchangeConfigJsonFile: "dydx_exchange_config.json",
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/protocol/daemons/pricefeed/client/constants/testdata/dydx_exchange_config.json
+++ b/protocol/daemons/pricefeed/client/constants/testdata/dydx_exchange_config.json
@@ -1,0 +1,34 @@
+{
+  "exchanges": [
+    {
+      "exchangeName": "Binance",
+      "ticker": "DYDXUSDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Bybit",
+      "ticker": "DYDXUSDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Gate",
+      "ticker": "DYDX_USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Kucoin",
+      "ticker": "DYDX-USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Mexc",
+      "ticker": "DYDX_USDT",
+      "adjustByMarket": "USDT-USD"
+    },
+    {
+      "exchangeName": "Okx",
+      "ticker": "DYDX-USDT",
+      "adjustByMarket": "USDT-USD"
+    }
+  ]
+}

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -22,16 +22,11 @@ DEFAULT_SUBACCOUNT_QUOTE_BALANCE_FAUCET=900000000000000000
 TESTNET_VALIDATOR_NATIVE_TOKEN_BALANCE=1000000000000000000000000 # 1e24
 # Each testnet validator self-delegates 500k whole coins of native token.
 TESTNET_VALIDATOR_SELF_DELEGATE_AMOUNT=500000000000000000000000 # 5e23
-# TODO(GENESIS): 11155111 is the chain ID for sepolia testnet.
 ETH_CHAIN_ID=11155111 # sepolia
-# TODO(GENESIS): below is the bridge contract on sepolia testnet.
 # https://sepolia.etherscan.io/address/0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0
 ETH_BRIDGE_ADDRESS="0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0"
-# TODO(GENESIS): verify below balance is desired amount.
 BRIDGE_MODACC_BALANCE=1000000000000000000000000000 # 1e27
-# TODO(GENESIS): determine bridge events to manually include in genesis.
 BRIDGE_GENESIS_ACKNOWLEDGED_NEXT_ID=0 # TODO(CORE-329)
-# TODO(GENESIS): determine bridge events to manually include in genesis.
 BRIDGE_GENESIS_ACKNOWLEDGED_ETH_BLOCK_HEIGHT=0 # TODO(CORE-329)
 
 function edit_genesis() {
@@ -1469,17 +1464,17 @@ function update_genesis_use_test_exchange() {
 # Modify the genesis file to add test volatile market. Market TEST-USD will be added as market 33.
 function update_genesis_use_test_volatile_market() {
 	GENESIS=$1/genesis.json
-	NEXT_MARKET_ID=33
+	TEST_USD_MARKET_ID=33
 
 	# Market: TEST-USD
 	dasel put -t json -f "$GENESIS" '.app_state.prices.market_params.[]' -v "{}"
 	dasel put -t string -f "$GENESIS" '.app_state.prices.market_params.last().pair' -v 'TEST-USD'
-	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().id' -v "${NEXT_MARKET_ID}"
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().id' -v "${TEST_USD_MARKET_ID}"
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().exponent' -v '-5'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().min_exchanges' -v '1'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.last().min_price_change_ppm' -v '250' # 0.025%
 	dasel put -t json -f "$GENESIS" '.app_state.prices.market_prices.[]' -v "{}"
-	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().id' -v "${NEXT_MARKET_ID}"
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().id' -v "${TEST_USD_MARKET_ID}"
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().exponent' -v '-5'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.last().price' -v '10000000'          # $100 = 1 TEST.
 	# TEST Exchange Config
@@ -1492,7 +1487,7 @@ function update_genesis_use_test_volatile_market() {
 	dasel put -t json -f "$GENESIS" '.app_state.perpetuals.perpetuals.[]' -v "{}"
 	dasel put -t string -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.ticker' -v 'TEST-USD'
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.id' -v "${NUM_PERPETUALS}"
-	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.market_id' -v "${NEXT_MARKET_ID}"
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.market_id' -v "${TEST_USD_MARKET_ID}"
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.atomic_resolution' -v '-10'
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.default_funding_ppm' -v '0'
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.last().params.liquidity_tier' -v '0'
@@ -1514,4 +1509,25 @@ update_genesis_complete_bridge_delay() {
 
 	# Reduce complete bridge delay to 600 blocks.
 	dasel put -t int -f "$GENESIS" '.app_state.bridge.safety_params.delay_blocks' -v "$2"
+}
+
+# Set the denom metadata, which is for human readability.
+set_denom_metadata() {
+	local BASE_DENOM=$1
+	local WHOLE_COIN_DENOM=$2
+	local COIN_NAME=$3
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata" -v "[]"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[]" -v "{}"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].description" -v "The native token of the network"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units" -v "[]"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[]" -v "{}"
+	# Base denom is the minimum unit of the a token and the denom used by `x/bank`.
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[0].denom" -v "$BASE_DENOM"
+	dasel put -t json -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[]" -v "{}"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[1].denom" -v "$WHOLE_COIN_DENOM"
+	dasel put -t int -f "$GENESIS" ".app_state.bank.denom_metadata.[0].denom_units.[1].exponent" -v 18
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].base" -v "$BASE_DENOM"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].name" -v "$COIN_NAME"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].display" -v "$WHOLE_COIN_DENOM"
+	dasel put -t string -f "$GENESIS" ".app_state.bank.denom_metadata.[0].symbol" -v "$WHOLE_COIN_DENOM"
 }

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -949,7 +949,7 @@ function edit_genesis() {
 	dasel put -t json -f "$GENESIS" '.app_state.prices.market_prices.[]' -v "{}"
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].id' -v '1000001'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].exponent' -v '-9'
-	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].price' -v '20500000000'          # $2.05 = 1 DYDX.
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].price' -v '2050000000'          # $2.05 = 1 DYDX.
 	# DYDX Exchange Config
 	dydx_exchange_config_json=$(cat "$EXCHANGE_CONFIG_JSON_DIR/dydx_exchange_config.json" | jq -c '.')
 	dasel put -t string -f "$GENESIS" '.app_state.prices.market_params.[34].exchange_config_json' -v "$dydx_exchange_config_json"

--- a/protocol/testutil/daemons/pricefeed/exchange_config/market_id.go
+++ b/protocol/testutil/daemons/pricefeed/exchange_config/market_id.go
@@ -75,7 +75,9 @@ const (
 	// MARKET_TEST_USD is the id used for the TEST-USD market pair.
 	MARKET_TEST_USD types.MarketId = 33
 
-	// Non-trading adjust-by markets.
+	// Non-trading markets.
 	// MARKET_USDT_USD is the id for the USDT-USD market pair.
 	MARKET_USDT_USD types.MarketId = 1_000_000
+	// MARKET_DYDX_USD is the id for the DYDX-USD market pair.
+	MARKET_DYDX_USD types.MarketId = 1_000_001
 )

--- a/protocol/testutil/daemons/pricefeed/exchange_config/testnet_exchange_market_config.go
+++ b/protocol/testutil/daemons/pricefeed/exchange_config/testnet_exchange_market_config.go
@@ -13,6 +13,10 @@ var (
 			Id: exchange_common.EXCHANGE_ID_BINANCE,
 			// example `symbols` parameter: ["BTCUSDT","BNBUSDT"]
 			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDXUSDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_BTC_USD: {
 					Ticker:         "BTCUSDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
@@ -230,6 +234,10 @@ var (
 		exchange_common.EXCHANGE_ID_GATE: {
 			Id: exchange_common.EXCHANGE_ID_GATE,
 			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDX_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_MATIC_USD: {
 					Ticker:         "MATIC_USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
@@ -367,6 +375,10 @@ var (
 		exchange_common.EXCHANGE_ID_BYBIT: {
 			Id: exchange_common.EXCHANGE_ID_BYBIT,
 			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDXUSDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_BTC_USD: {
 					Ticker:         "BTCUSDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
@@ -605,6 +617,10 @@ var (
 		exchange_common.EXCHANGE_ID_KUCOIN: {
 			Id: exchange_common.EXCHANGE_ID_KUCOIN,
 			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDX-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_LINK_USD: {
 					Ticker:         "LINK-USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
@@ -719,6 +735,10 @@ var (
 		exchange_common.EXCHANGE_ID_OKX: {
 			Id: exchange_common.EXCHANGE_ID_OKX,
 			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDX-USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_BTC_USD: {
 					Ticker:         "BTC-USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
@@ -843,6 +863,10 @@ var (
 		},
 		exchange_common.EXCHANGE_ID_MEXC: {
 			MarketToMarketConfig: map[types.MarketId]types.MarketConfig{
+				MARKET_DYDX_USD: {
+					Ticker:         "DYDX_USDT",
+					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),
+				},
 				MARKET_BTC_USD: {
 					Ticker:         "BTC_USDT",
 					AdjustByMarket: newMarketIdWithValue(MARKET_USDT_USD),


### PR DESCRIPTION
DYDX token config from [this sheet](https://docs.google.com/spreadsheets/d/1QmuwS0LljTrZmkFiYMhUR9MfFa4jhgfzhgDC9z0v2LQ/edit#gid=60914733). PR that updates other markets is [here](https://github.com/dydxprotocol/v4-chain/pull/467).

Deprecated PR that combines both is [here](https://github.com/dydxprotocol/v4-chain/pull/455).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Added support for two new markets, DYDX-USD and TEST-USD, in the blockchain project's genesis file. This allows users to trade with these new market pairs.
- Introduced new constants `MARKET_DYDX_USD` and `MARKET_TEST_USD` to represent non-trading markets for the DYDX-USD and TEST-USD market pairs.
- Updated the `MarketToMarketConfig` map to include configurations for the new markets across different exchanges.

**Chore:**
- Updated bridge parameters and set the Ethereum chain ID and bridge contract address in the genesis file.
- Added TODOs for areas that require further attention in future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->