### PR TITLE
Add reason to screen API, move constants into compliance package.

### DIFF
--- a/indexer/packages/compliance/src/constants.ts
+++ b/indexer/packages/compliance/src/constants.ts
@@ -1,0 +1,2 @@
+export const INDEXER_GEOBLOCKED_PAYLOAD = 'Because you appear to be a resident of, or trading from, a jurisdiction that violates our terms of use, or have engaged in activity that violates our terms of use, you have been blocked. You may withdraw your funds from the protocol at any time.';
+export const INDEXER_COMPLIANCE_BLOCKED_PAYLOAD = 'Because this address appears to be a resident of, or trading from, a jurisdiction that violates our terms of use, or has engaged in activity that violates our terms of use, this address has been blocked.';

--- a/indexer/packages/compliance/src/index.ts
+++ b/indexer/packages/compliance/src/index.ts
@@ -4,3 +4,4 @@ export * from './geoblocking/restrict-countries';
 export * from './geoblocking/util';
 export * from './types';
 export * from './config';
+export * from './constants';

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@dydxprotocol-indexer/postgres';
 import { stats } from '@dydxprotocol-indexer/base';
 import { complianceProvider } from '../../../../src/helpers/compliance/compliance-clients';
-import { ComplianceClientResponse } from '@dydxprotocol-indexer/compliance';
+import { ComplianceClientResponse, INDEXER_COMPLIANCE_BLOCKED_PAYLOAD } from '@dydxprotocol-indexer/compliance';
 import { ratelimitRedis } from '../../../../src/caches/rate-limiters';
 import { redis } from '@dydxprotocol-indexer/redis';
 import { DateTime } from 'luxon';
@@ -68,6 +68,7 @@ describe('compliance-controller#V4', () => {
       });
 
       expect(response.body.restricted).toEqual(false);
+      expect(response.reason).toBeUndefined();
       expect(stats.timing).toHaveBeenCalledTimes(1);
       expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(1);
 
@@ -95,6 +96,7 @@ describe('compliance-controller#V4', () => {
         });
 
         expect(response.body.restricted).toEqual(false);
+        expect(response.reason).toBeUndefined();
         expect(stats.timing).toHaveBeenCalledTimes(1);
         expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
 
@@ -117,6 +119,7 @@ describe('compliance-controller#V4', () => {
         });
 
         expect(response.body.restricted).toEqual(true);
+        expect(response.body.reason).toEqual(INDEXER_COMPLIANCE_BLOCKED_PAYLOAD);
         expect(stats.timing).toHaveBeenCalledTimes(1);
         expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
 
@@ -144,6 +147,7 @@ describe('compliance-controller#V4', () => {
         });
 
         expect(response.body.restricted).toEqual(false);
+        expect(response.body.reason).toBeUndefined();
         expect(stats.timing).toHaveBeenCalledTimes(1);
         expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(1);
 
@@ -177,6 +181,7 @@ describe('compliance-controller#V4', () => {
         });
 
         expect(response.body.restricted).toEqual(true);
+        expect(response.body.reason).toEqual(INDEXER_COMPLIANCE_BLOCKED_PAYLOAD);
         expect(stats.timing).toHaveBeenCalledTimes(1);
         expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
 

--- a/indexer/services/comlink/__tests__/lib/compliance-check.test.ts
+++ b/indexer/services/comlink/__tests__/lib/compliance-check.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@dydxprotocol-indexer/postgres';
 import { blockedComplianceData, nonBlockedComplianceData } from '@dydxprotocol-indexer/postgres/build/__tests__/helpers/constants';
 import request from 'supertest';
-import { INDEXER_COMPLIANCE_BLOCKED_PAYLOAD } from '../../src/constants';
+import { INDEXER_COMPLIANCE_BLOCKED_PAYLOAD } from '@dydxprotocol-indexer/compliance';
 
 // Create a router to test the middleware with
 const router: express.Router = express.Router();

--- a/indexer/services/comlink/__tests__/lib/restrict-countries.test.ts
+++ b/indexer/services/comlink/__tests__/lib/restrict-countries.test.ts
@@ -1,7 +1,6 @@
-import { INDEXER_GEOBLOCKED_PAYLOAD } from '../../src/constants';
+import { INDEXER_GEOBLOCKED_PAYLOAD, isRestrictedCountryHeaders } from '@dydxprotocol-indexer/compliance';
 import config from '../../src/config';
 import { rejectRestrictedCountries } from '../../src/lib/restrict-countries';
-import { isRestrictedCountryHeaders } from '@dydxprotocol-indexer/compliance';
 import { BlockedCode } from '../../src/types';
 
 jest.mock('@dydxprotocol-indexer/compliance');

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -531,7 +531,8 @@ fetch('https://indexer.v4testnet.dydx.exchange/v4/screen?address=string',
 
 ```json
 {
-  "restricted": true
+  "restricted": true,
+  "reason": "string"
 }
 ```
 
@@ -2191,7 +2192,8 @@ This operation does not require authentication
 
 ```json
 {
-  "restricted": true
+  "restricted": true,
+  "reason": "string"
 }
 
 ```
@@ -2201,6 +2203,7 @@ This operation does not require authentication
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |restricted|boolean|true|none|none|
+|reason|string|false|none|none|
 
 ## OrderSide
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -274,6 +274,9 @@
         "properties": {
           "restricted": {
             "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
           }
         },
         "required": [

--- a/indexer/services/comlink/src/constants.ts
+++ b/indexer/services/comlink/src/constants.ts
@@ -1,5 +1,2 @@
 // Maximum subaccount number.
 export const MAX_SUBACCOUNT_NUMBER: number = 127;
-
-export const INDEXER_GEOBLOCKED_PAYLOAD = 'Because you appear to be a resident of, or trading from, a jurisdiction that violates our terms of use, or have engaged in activity that violates our terms of use, you have been blocked. You may withdraw your funds from the protocol at any time.';
-export const INDEXER_COMPLIANCE_BLOCKED_PAYLOAD = 'Because this address appears to be a resident of, or trading from, a jurisdiction that violates our terms of use, or has engaged in activity that violates our terms of use, this address has been blocked.';

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -1,5 +1,5 @@
 import { logger, stats, TooManyRequestsError } from '@dydxprotocol-indexer/base';
-import { ComplianceClientResponse } from '@dydxprotocol-indexer/compliance';
+import { ComplianceClientResponse, INDEXER_COMPLIANCE_BLOCKED_PAYLOAD } from '@dydxprotocol-indexer/compliance';
 import { ComplianceDataFromDatabase, ComplianceTable } from '@dydxprotocol-indexer/postgres';
 import express from 'express';
 import { checkSchema, matchedData } from 'express-validator';
@@ -54,6 +54,7 @@ class ComplianceController extends Controller {
     if (complianceData?.blocked) {
       return {
         restricted: true,
+        reason: INDEXER_COMPLIANCE_BLOCKED_PAYLOAD,
       };
     }
 
@@ -73,6 +74,7 @@ class ComplianceController extends Controller {
 
     return {
       restricted: complianceData.blocked,
+      reason: complianceData.blocked ? INDEXER_COMPLIANCE_BLOCKED_PAYLOAD : undefined,
     };
   }
 }

--- a/indexer/services/comlink/src/lib/compliance-check.ts
+++ b/indexer/services/comlink/src/lib/compliance-check.ts
@@ -1,8 +1,8 @@
+import { INDEXER_COMPLIANCE_BLOCKED_PAYLOAD } from '@dydxprotocol-indexer/compliance';
 import { ComplianceDataFromDatabase, ComplianceTable } from '@dydxprotocol-indexer/postgres';
 import express from 'express';
 import { matchedData } from 'express-validator';
 
-import { INDEXER_COMPLIANCE_BLOCKED_PAYLOAD } from '../constants';
 import { AddressRequest, BlockedCode } from '../types';
 import { create4xxResponse } from './helpers';
 

--- a/indexer/services/comlink/src/lib/restrict-countries.ts
+++ b/indexer/services/comlink/src/lib/restrict-countries.ts
@@ -1,10 +1,10 @@
 import {
   CountryHeaders,
   isRestrictedCountryHeaders,
+  INDEXER_GEOBLOCKED_PAYLOAD,
 } from '@dydxprotocol-indexer/compliance';
 import express from 'express';
 
-import { INDEXER_GEOBLOCKED_PAYLOAD } from '../constants';
 import { BlockedCode } from '../types';
 import { create4xxResponse } from './helpers';
 

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -385,6 +385,7 @@ export interface Risk {
 
 export interface ComplianceResponse {
   restricted: boolean;
+  reason?: string;
 }
 
 export interface ComplianceRequest extends AddressRequest {}


### PR DESCRIPTION
Add reason so that `/screen` can return the legal message as well for blocked addreses.
Move constants out of `comlink` and into `compliance` so they can be re-used later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added a new optional `reason` field to the `ComplianceResponse` interface. This field provides additional context when a user is blocked due to compliance issues.

**Refactor:**
- Moved constants `INDEXER_GEOBLOCKED_PAYLOAD` and `INDEXER_COMPLIANCE_BLOCKED_PAYLOAD` to the `@dydxprotocol-indexer/compliance` module for better modularity and maintainability.
  
**Test:**
- Updated test cases to include assertions for the new `reason` property in the response object.

**Documentation:**
- Updated API documentation to reflect the addition of the `reason` field in the JSON response objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->