### PR TITLE
audit lib/bytes.go

### DIFF
--- a/protocol/lib/bytes.go
+++ b/protocol/lib/bytes.go
@@ -5,45 +5,38 @@ import (
 	"strconv"
 )
 
-func Uint32ToBytes(i uint32) []byte {
-	bytes := make([]byte, 4)
-	binary.LittleEndian.PutUint32(bytes, i)
-	return bytes
-}
-
-func Int32ToBytes(i int32) []byte {
+// Bit32ToBytes converts 32-bit types into a 4-byte slice in little-endian format.
+func Bit32ToBytes[T uint32 | int32](i T) []byte {
 	bytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(bytes, uint32(i))
 	return bytes
 }
 
-func Int64ToBytes(i int64) []byte {
+// Bit64ToBytes converts 64-bit types into an 8-byte slice in little-endian format.
+func Bit64ToBytes[T uint64 | int64](i T) []byte {
 	bytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(bytes, uint64(i))
 	return bytes
 }
 
+// BytesToUint32 converts a byte slice (of length at least 4) into a uint32.
+// The first 4 bytes of the slice are interpreted as little-endian format.
 func BytesToUint32(b []byte) uint32 {
 	return binary.LittleEndian.Uint32(b)
 }
 
+// BytesToUint32 converts a byte slice (of length at least 4) into an int32.
+// The first 4 bytes of the slice are interpreted as little-endian format.
 func BytesToInt32(b []byte) int32 {
 	return int32(binary.LittleEndian.Uint32(b))
 }
 
-func Int32ToString(i int32) string {
+// IntToString converts any int type to a base-10 string.
+func IntToString[T int | int32 | int64](i T) string {
 	return strconv.FormatInt(int64(i), 10)
 }
 
-func Uint32ToString(i uint32) string {
+// UintToString converts any uint type to a base-10 string.
+func UintToString[T uint | uint32 | uint64](i T) string {
 	return strconv.FormatUint(uint64(i), 10)
-}
-
-func StringToUint32(s string) (uint32, error) {
-	result, err := strconv.ParseUint(s, 10, 32)
-	if err != nil {
-		return uint32(0), err
-	}
-
-	return uint32(result), nil
 }

--- a/protocol/lib/bytes.go
+++ b/protocol/lib/bytes.go
@@ -25,7 +25,7 @@ func BytesToUint32(b []byte) uint32 {
 	return binary.LittleEndian.Uint32(b)
 }
 
-// BytesToUint32 converts a byte slice (of length at least 4) into an int32.
+// BytesToInt32 converts a byte slice (of length at least 4) into an int32.
 // The first 4 bytes of the slice are interpreted as little-endian format.
 func BytesToInt32(b []byte) int32 {
 	return int32(binary.LittleEndian.Uint32(b))

--- a/protocol/lib/bytes_test.go
+++ b/protocol/lib/bytes_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUint32ToBytes(t *testing.T) {
+func TestBit32ToBytes_Uint32(t *testing.T) {
 	tests := map[string]struct {
 		value    uint32
 		expected []byte
@@ -30,14 +30,14 @@ func TestUint32ToBytes(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := Uint32ToBytes(tc.value)
+			result := Bit32ToBytes(tc.value)
 			require.Equal(t, tc.expected, result)
 			require.Equal(t, BytesToUint32(result), tc.value)
 		})
 	}
 }
 
-func TestInt32ToBytes(t *testing.T) {
+func TestBit32ToBytes_Int32(t *testing.T) {
 	tests := map[string]struct {
 		value    int32
 		expected []byte
@@ -68,14 +68,14 @@ func TestInt32ToBytes(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := Int32ToBytes(tc.value)
+			result := Bit32ToBytes(tc.value)
 			require.Equal(t, tc.expected, result)
 			require.Equal(t, BytesToInt32(result), tc.value)
 		})
 	}
 }
 
-func TestInt64ToBytes(t *testing.T) {
+func TestBit64ToBytes(t *testing.T) {
 	tests := map[string]struct {
 		value    int64
 		expected []byte
@@ -104,66 +104,27 @@ func TestInt64ToBytes(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := Int64ToBytes(tc.value)
+			result := Bit64ToBytes(tc.value)
 			require.Equal(t, tc.expected, result)
 			require.Equal(t, int64(binary.LittleEndian.Uint64(result)), tc.value)
 		})
 	}
 }
 
-func TestInt32ToString(t *testing.T) {
-	i := int32(15)
-	require.Equal(t, "15", Int32ToString(i))
+func TestIntToString(t *testing.T) {
+	require.Equal(t, "15", IntToString(int(15)))
+	require.Equal(t, "15", IntToString(int32(15)))
+	require.Equal(t, "15", IntToString(int64(15)))
+	require.Equal(t, "-15", IntToString(int(-15)))
+	require.Equal(t, "-15", IntToString(int32(-15)))
+	require.Equal(t, "-15", IntToString(int64(-15)))
+	require.Equal(t, "9223372036854775807", IntToString(math.MaxInt64))
+	require.Equal(t, "-9223372036854775808", IntToString(math.MinInt64))
 }
 
-func TestUint32ToString(t *testing.T) {
-	i := uint32(15)
-	require.Equal(t, "15", Uint32ToString(i))
-}
-
-func TestStringToUint32(t *testing.T) {
-	tests := map[string]struct {
-		value         string
-		expected      uint32
-		expectedError string
-	}{
-		"value of zero": {
-			value:    "0",
-			expected: uint32(0),
-		},
-		"value of 100": {
-			value:    "100",
-			expected: uint32(100),
-		},
-		"max uint": {
-			// Max uint32 = 4294967295.
-			value:    "4294967295",
-			expected: math.MaxUint32,
-		},
-		"max uint + 1": {
-			// Max uint32 = 4294967295.
-			value:         "4294967296",
-			expectedError: "value out of range",
-		},
-		"empty value": {
-			value:         "",
-			expectedError: "invalid syntax",
-		},
-		"garbage value": {
-			value:         "ffff",
-			expectedError: "invalid syntax",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			res, err := StringToUint32(tc.value)
-			if tc.expectedError != "" {
-				require.ErrorContains(t, err, tc.expectedError)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tc.expected, res)
-			}
-		})
-	}
+func TestUintToString(t *testing.T) {
+	require.Equal(t, "15", UintToString(uint(15)))
+	require.Equal(t, "15", UintToString(uint32(15)))
+	require.Equal(t, "15", UintToString(uint64(15)))
+	require.Equal(t, "18446744073709551615", UintToString(uint64(math.MaxUint64)))
 }

--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -115,7 +115,7 @@ func (k Keeper) ModifyAsset(
 	// Get asset
 	asset, exists := k.GetAsset(ctx, id)
 	if !exists {
-		return asset, errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.Uint32ToString(id))
+		return asset, errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.UintToString(id))
 	}
 
 	// Validate market
@@ -142,12 +142,12 @@ func (k Keeper) ModifyLongInterest(
 	// Get asset
 	asset, exists := k.GetAsset(ctx, id)
 	if !exists {
-		return asset, errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.Uint32ToString(id))
+		return asset, errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.UintToString(id))
 	}
 
 	// Validate delta
 	if !isIncrease && delta > asset.LongInterest {
-		return asset, errorsmod.Wrap(types.ErrNegativeLongInterest, lib.Uint32ToString(id))
+		return asset, errorsmod.Wrap(types.ErrNegativeLongInterest, lib.UintToString(id))
 	}
 
 	// Modify asset
@@ -168,7 +168,7 @@ func (k Keeper) setAsset(
 ) {
 	b := k.cdc.MustMarshal(&asset)
 	assetStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.AssetKeyPrefix))
-	assetStore.Set(lib.Uint32ToBytes(asset.Id), b)
+	assetStore.Set(lib.Bit32ToBytes(asset.Id), b)
 }
 
 func (k Keeper) GetAsset(
@@ -177,7 +177,7 @@ func (k Keeper) GetAsset(
 ) (val types.Asset, exists bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.AssetKeyPrefix))
 
-	b := store.Get(lib.Uint32ToBytes(id))
+	b := store.Get(lib.Bit32ToBytes(id))
 	if b == nil {
 		return val, false
 	}
@@ -224,7 +224,7 @@ func (k Keeper) GetNetCollateral(
 	// Get asset
 	_, exists := k.GetAsset(ctx, id)
 	if !exists {
-		return big.NewInt(0), errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.Uint32ToString(id))
+		return big.NewInt(0), errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.UintToString(id))
 	}
 
 	// Balance is zero.
@@ -263,7 +263,7 @@ func (k Keeper) GetMarginRequirements(
 	_, exists := k.GetAsset(ctx, id)
 	if !exists {
 		return big.NewInt(0), big.NewInt(0), errorsmod.Wrap(
-			types.ErrAssetDoesNotExist, lib.Uint32ToString(id))
+			types.ErrAssetDoesNotExist, lib.UintToString(id))
 	}
 
 	// Balance is zero or positive.
@@ -305,7 +305,7 @@ func (k Keeper) ConvertAssetToCoin(
 	asset, exists := k.GetAsset(ctx, assetId)
 	if !exists {
 		return nil, sdk.Coin{}, errorsmod.Wrap(
-			types.ErrAssetDoesNotExist, lib.Uint32ToString(assetId))
+			types.ErrAssetDoesNotExist, lib.UintToString(assetId))
 	}
 
 	if lib.AbsInt32(asset.AtomicResolution) > types.MaxAssetUnitExponentAbs {
@@ -352,7 +352,7 @@ func (k Keeper) IsPositionUpdatable(
 ) {
 	_, exists := k.GetAsset(ctx, id)
 	if !exists {
-		return false, errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.Uint32ToString(id))
+		return false, errorsmod.Wrap(types.ErrAssetDoesNotExist, lib.UintToString(id))
 	}
 	// All existing assets are by default updatable.
 	return true, nil

--- a/protocol/x/clob/abci_test.go
+++ b/protocol/x/clob/abci_test.go
@@ -77,7 +77,7 @@ func assertFillAmountAndPruneState(
 		)
 
 		potentiallyPrunableOrdersBytes := blockHeightToPotentiallyPrunableOrdersStore.Get(
-			lib.Uint32ToBytes(blockHeight),
+			lib.Bit32ToBytes(blockHeight),
 		)
 
 		var potentiallyPrunableOrders = &types.PotentiallyPrunableOrders{}

--- a/protocol/x/clob/client/cli/query_clob_pair.go
+++ b/protocol/x/clob/client/cli/query_clob_pair.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +53,7 @@ func CmdShowClobPair() *cobra.Command {
 
 			queryClient := types.NewQueryClient(clientCtx)
 
-			argId, err := lib.StringToUint32(args[0])
+			argId, err := cast.ToUint32E(args[0])
 			if err != nil {
 				return err
 			}

--- a/protocol/x/clob/client/cli/query_clob_pair_test.go
+++ b/protocol/x/clob/client/cli/query_clob_pair_test.go
@@ -4,9 +4,10 @@ package cli_test
 
 import (
 	"fmt"
-	"github.com/dydxprotocol/v4-chain/protocol/app/stoppable"
 	"strconv"
 	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/app/stoppable"
 
 	tmcli "github.com/cometbft/cometbft/libs/cli"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -121,7 +122,7 @@ func TestShowClobPair(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			args := []string{
-				lib.Uint32ToString(tc.id),
+				lib.UintToString(tc.id),
 			}
 			args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowClobPair(), args)

--- a/protocol/x/clob/keeper/clob_pair.go
+++ b/protocol/x/clob/keeper/clob_pair.go
@@ -26,7 +26,7 @@ func (k Keeper) getClobPairStore(
 func clobPairKey(
 	id types.ClobPairId,
 ) []byte {
-	return lib.Uint32ToBytes(id.ToUint32())
+	return lib.Bit32ToBytes(id.ToUint32())
 }
 
 // CreatePerpetualClobPair creates a new perpetual CLOB pair in the store.

--- a/protocol/x/clob/keeper/clob_pair_test.go
+++ b/protocol/x/clob/keeper/clob_pair_test.go
@@ -179,7 +179,7 @@ func TestCreatePerpetualClobPair_FailsWithDuplicateClobPairId(t *testing.T) {
 
 	// Write clob pair to state with clob pair id 0.
 	b := cdc.MustMarshal(&constants.ClobPair_Btc)
-	store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+	store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 
 	clobPair := *clobtest.GenerateClobPair()
 
@@ -537,10 +537,10 @@ func TestInitMemClobOrderbooks(t *testing.T) {
 	cdc := codec.NewProtoCodec(registry)
 
 	b := cdc.MustMarshal(&constants.ClobPair_Eth)
-	store.Set(lib.Uint32ToBytes(constants.ClobPair_Eth.Id), b)
+	store.Set(lib.Bit32ToBytes(constants.ClobPair_Eth.Id), b)
 
 	b = cdc.MustMarshal(&constants.ClobPair_Btc)
-	store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+	store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 
 	// Read the new `ClobPairs` and make sure they do not exist.
 	_, err = ks.ClobKeeper.GetClobPairIdForPerpetual(ks.Ctx, 1)
@@ -569,10 +569,10 @@ func TestHydrateClobPairAndPerpetualMapping(t *testing.T) {
 	cdc := codec.NewProtoCodec(registry)
 
 	b := cdc.MustMarshal(&constants.ClobPair_Eth)
-	store.Set(lib.Uint32ToBytes(constants.ClobPair_Eth.Id), b)
+	store.Set(lib.Bit32ToBytes(constants.ClobPair_Eth.Id), b)
 
 	b = cdc.MustMarshal(&constants.ClobPair_Btc)
-	store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+	store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 
 	// Read the new `ClobPairs` and make sure they do not exist.
 	_, err = ks.ClobKeeper.GetClobPairIdForPerpetual(ks.Ctx, 1)
@@ -1050,7 +1050,7 @@ func TestIsPerpetualClobPairActive(t *testing.T) {
 				store := prefix.NewStore(ks.Ctx.KVStore(ks.StoreKey), []byte(types.ClobPairKeyPrefix))
 
 				b := cdc.MustMarshal(tc.clobPair)
-				store.Set(lib.Uint32ToBytes(tc.clobPair.Id), b)
+				store.Set(lib.Bit32ToBytes(tc.clobPair.Id), b)
 			}
 
 			ks.ClobKeeper.PerpetualIdToClobPairId = tc.perpetualIdToClobPairId

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair_test.go
@@ -56,7 +56,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 				clobPair := constants.ClobPair_Btc
 				clobPair.Status = types.ClobPair_STATUS_INITIALIZING
 				b := cdc.MustMarshal(&clobPair)
-				store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+				store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 
 				mockIndexerEventManager.On("AddTxnEvent",
 					ks.Ctx,
@@ -108,7 +108,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 				clobPair := constants.ClobPair_Btc
 				clobPair.Status = types.ClobPair_STATUS_ACTIVE
 				b := cdc.MustMarshal(&clobPair)
-				store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+				store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 			},
 			expectedErr: types.ErrInvalidClobPairStatusTransition,
 		},
@@ -153,7 +153,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 				store := prefix.NewStore(ks.Ctx.KVStore(ks.StoreKey), []byte(types.ClobPairKeyPrefix))
 				// Write clob pair to state with clob pair id 0 and status initializing.
 				b := cdc.MustMarshal(&constants.ClobPair_Btc)
-				store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+				store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 			},
 			expectedErr: govtypes.ErrInvalidSigner,
 		},
@@ -180,7 +180,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 				store := prefix.NewStore(ks.Ctx.KVStore(ks.StoreKey), []byte(types.ClobPairKeyPrefix))
 				// Write clob pair to state with clob pair id 0 and status initializing.
 				b := cdc.MustMarshal(&constants.ClobPair_Btc)
-				store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+				store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 			},
 			expectedErr: types.ErrInvalidClobPairUpdate,
 		},
@@ -207,7 +207,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 				store := prefix.NewStore(ks.Ctx.KVStore(ks.StoreKey), []byte(types.ClobPairKeyPrefix))
 				// Write clob pair to state with clob pair id 0 and status initializing.
 				b := cdc.MustMarshal(&constants.ClobPair_Btc)
-				store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+				store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 			},
 			expectedErr: types.ErrInvalidClobPairUpdate,
 		},
@@ -234,7 +234,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 				store := prefix.NewStore(ks.Ctx.KVStore(ks.StoreKey), []byte(types.ClobPairKeyPrefix))
 				// Write clob pair to state with clob pair id 0 and status initializing.
 				b := cdc.MustMarshal(&constants.ClobPair_Btc)
-				store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+				store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 			},
 			expectedErr: types.ErrInvalidClobPairUpdate,
 		},
@@ -261,7 +261,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 				store := prefix.NewStore(ks.Ctx.KVStore(ks.StoreKey), []byte(types.ClobPairKeyPrefix))
 				// Write clob pair to state with clob pair id 0 and status initializing.
 				b := cdc.MustMarshal(&constants.ClobPair_Btc)
-				store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc.Id), b)
+				store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc.Id), b)
 			},
 			expectedErr: types.ErrInvalidClobPairUpdate,
 		},

--- a/protocol/x/clob/keeper/order_state.go
+++ b/protocol/x/clob/keeper/order_state.go
@@ -157,7 +157,7 @@ func (k Keeper) AddOrdersForPruning(ctx sdk.Context, orderIds []types.OrderId, p
 
 	// Retrieve the `PotentiallyPrunableOrders` bytes from the store.
 	potentiallyPrunableOrdersBytes := store.Get(
-		lib.Uint32ToBytes(prunableBlockHeight),
+		lib.Bit32ToBytes(prunableBlockHeight),
 	)
 
 	var potentiallyPrunableOrdersSet = make(map[types.OrderId]bool)
@@ -197,7 +197,7 @@ func (k Keeper) AddOrdersForPruning(ctx sdk.Context, orderIds []types.OrderId, p
 
 	// Write `prunableOrders` to state for the appropriate block height.
 	store.Set(
-		lib.Uint32ToBytes(prunableBlockHeight),
+		lib.Bit32ToBytes(prunableBlockHeight),
 		potentiallyPrunableOrdersBytes,
 	)
 }
@@ -215,7 +215,7 @@ func (k Keeper) PruneOrdersForBlockHeight(ctx sdk.Context, blockHeight uint32) (
 
 	// Retrieve the raw bytes of the `prunableOrders`.
 	potentiallyPrunableOrderBytes := blockHeightToPotentiallyPrunableOrdersStore.Get(
-		lib.Uint32ToBytes(blockHeight),
+		lib.Bit32ToBytes(blockHeight),
 	)
 
 	// If there are no prunable orders for this block, then there is nothing to do. Early return.
@@ -245,7 +245,7 @@ func (k Keeper) PruneOrdersForBlockHeight(ctx sdk.Context, blockHeight uint32) (
 
 	// Delete the key for prunable orders at this block height.
 	blockHeightToPotentiallyPrunableOrdersStore.Delete(
-		lib.Uint32ToBytes(blockHeight),
+		lib.Bit32ToBytes(blockHeight),
 	)
 
 	return prunedOrderIds

--- a/protocol/x/clob/keeper/order_state_test.go
+++ b/protocol/x/clob/keeper/order_state_test.go
@@ -302,7 +302,7 @@ func TestAddOrdersForPruning_Determinism(t *testing.T) {
 		)
 
 		potentiallyPrunableOrdersBytes := store.Get(
-			lib.Uint32ToBytes(blockHeight),
+			lib.Bit32ToBytes(blockHeight),
 		)
 
 		var potentiallyPrunableOrders = &types.PotentiallyPrunableOrders{}
@@ -345,7 +345,7 @@ func TestAddOrdersForPruning_DuplicateOrderIds(t *testing.T) {
 	)
 
 	potentiallyPrunableOrdersBytes := store.Get(
-		lib.Uint32ToBytes(blockHeight),
+		lib.Bit32ToBytes(blockHeight),
 	)
 
 	var potentiallyPrunableOrders = &types.PotentiallyPrunableOrders{}
@@ -579,7 +579,7 @@ func TestPruning(t *testing.T) {
 
 			for _, blockHeight := range tc.expectedEmptyPotentiallyPrunableOrderBlockHeights {
 				has := blockHeightToPotentiallyPrunableOrdersStore.Has(
-					lib.Uint32ToBytes(blockHeight),
+					lib.Bit32ToBytes(blockHeight),
 				)
 				require.False(t, has)
 			}

--- a/protocol/x/clob/keeper/process_operations_test.go
+++ b/protocol/x/clob/keeper/process_operations_test.go
@@ -1392,7 +1392,7 @@ func TestProcessProposerOperations(t *testing.T) {
 				cdc := codec.NewProtoCodec(registry)
 				store := prefix.NewStore(ks.Ctx.KVStore(ks.StoreKey), []byte(types.ClobPairKeyPrefix))
 				b := cdc.MustMarshal(&constants.ClobPair_Btc_Paused)
-				store.Set(lib.Uint32ToBytes(constants.ClobPair_Btc_Paused.Id), b)
+				store.Set(lib.Bit32ToBytes(constants.ClobPair_Btc_Paused.Id), b)
 			},
 			expectedPanics: "validateInternalOperationAgainstClobPairStatus: ClobPair's status is not supported",
 		},

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -197,7 +197,7 @@ func (k Keeper) GetNextStatefulOrderTransactionIndex(ctx sdk.Context) (
 	// index, to ensure that transaction indexes are monotonically increasing.
 	nextTransactionIndexTransientStore.Set(
 		[]byte(types.NextStatefulOrderBlockTransactionIndexKey),
-		lib.Uint32ToBytes(nextStatefulOrderTransactionIndex+1),
+		lib.Bit32ToBytes(nextStatefulOrderTransactionIndex+1),
 	)
 	return nextStatefulOrderTransactionIndex
 }

--- a/protocol/x/clob/keeper/to_be_committed_stateful_order_state.go
+++ b/protocol/x/clob/keeper/to_be_committed_stateful_order_state.go
@@ -48,6 +48,6 @@ func (k Keeper) SetToBeCommittedStatefulOrderCount(
 	store := k.GetToBeCommittedStatefulOrderCountTransientStore(ctx)
 	store.Set(
 		orderId.SubaccountId.MustMarshal(),
-		lib.Int32ToBytes(count),
+		lib.Bit32ToBytes(count),
 	)
 }

--- a/protocol/x/clob/keeper/uncommitted_stateful_order_state.go
+++ b/protocol/x/clob/keeper/uncommitted_stateful_order_state.go
@@ -93,7 +93,7 @@ func (k Keeper) SetUncommittedStatefulOrderCount(
 	store := k.GetUncommittedStatefulOrderCountTransientStore(ctx)
 	store.Set(
 		orderId.SubaccountId.MustMarshal(),
-		lib.Int32ToBytes(count),
+		lib.Bit32ToBytes(count),
 	)
 }
 

--- a/protocol/x/delaymsg/keeper/block_message_ids.go
+++ b/protocol/x/delaymsg/keeper/block_message_ids.go
@@ -26,7 +26,7 @@ func (k Keeper) GetBlockMessageIds(
 	}
 
 	store := k.newBlockMessageIdsStore(ctx)
-	b := store.Get(lib.Int64ToBytes(blockHeight))
+	b := store.Get(lib.Bit64ToBytes(blockHeight))
 
 	if b == nil {
 		return types.BlockMessageIds{}, false
@@ -47,7 +47,7 @@ func (k Keeper) addMessageIdToBlock(
 ) {
 	store := k.newBlockMessageIdsStore(ctx)
 	var blockMessageIds types.BlockMessageIds
-	key := lib.Int64ToBytes(blockHeight)
+	key := lib.Bit64ToBytes(blockHeight)
 	if b := store.Get(key); b != nil {
 		k.cdc.MustUnmarshal(b, &blockMessageIds)
 		blockMessageIds.Ids = append(blockMessageIds.Ids, id)
@@ -91,11 +91,11 @@ func (k Keeper) deleteMessageIdFromBlock(
 
 		// If the remaining list of ids is empty, go ahead and delete the BlockMessageIds from the store.
 		if len(blockMessageIds.Ids) == 0 {
-			k.newBlockMessageIdsStore(ctx).Delete(lib.Int64ToBytes(blockHeight))
+			k.newBlockMessageIdsStore(ctx).Delete(lib.Bit64ToBytes(blockHeight))
 		} else {
 			// Otherwise, update the BlockMessageIds to have the id of this delayed message removed.
 			k.newBlockMessageIdsStore(ctx).Set(
-				lib.Int64ToBytes(blockHeight),
+				lib.Bit64ToBytes(blockHeight),
 				k.cdc.MustMarshal(&blockMessageIds),
 			)
 		}

--- a/protocol/x/delaymsg/keeper/delayed_message.go
+++ b/protocol/x/delaymsg/keeper/delayed_message.go
@@ -33,7 +33,7 @@ func (k Keeper) SetNumMessages(
 	numMessages uint32,
 ) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set([]byte(types.NumDelayedMessagesKey), lib.Uint32ToBytes(numMessages))
+	store.Set([]byte(types.NumDelayedMessagesKey), lib.Bit32ToBytes(numMessages))
 }
 
 // GetMessage returns a message from its id.
@@ -45,7 +45,7 @@ func (k Keeper) GetMessage(
 	found bool,
 ) {
 	store := k.newDelayedMessageStore(ctx)
-	b := store.Get(lib.Uint32ToBytes(id))
+	b := store.Get(lib.Bit32ToBytes(id))
 	if b == nil {
 		return types.DelayedMessage{}, false
 	}
@@ -94,7 +94,7 @@ func (k Keeper) DeleteMessage(
 		)
 	}
 	store := k.newDelayedMessageStore(ctx)
-	store.Delete(lib.Uint32ToBytes(id))
+	store.Delete(lib.Bit32ToBytes(id))
 
 	// Remove message id from block message ids.
 	if err := k.deleteMessageIdFromBlock(ctx, id, delayedMsg.BlockHeight); err != nil {
@@ -125,7 +125,7 @@ func (k Keeper) SetDelayedMessage(
 
 	// Add message to the store.
 	store := k.newDelayedMessageStore(ctx)
-	store.Set(lib.Uint32ToBytes(msg.Id), k.cdc.MustMarshal(msg))
+	store.Set(lib.Bit32ToBytes(msg.Id), k.cdc.MustMarshal(msg))
 
 	// Add message id to the list of message ids for the block.
 	k.addMessageIdToBlock(ctx, msg.Id, msg.BlockHeight)

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -39,7 +39,7 @@ func (k Keeper) CreatePerpetual(
 	if k.HasPerpetual(ctx, id) {
 		return types.Perpetual{}, errorsmod.Wrap(
 			types.ErrPerpetualAlreadyExists,
-			lib.Uint32ToString(id),
+			lib.UintToString(id),
 		)
 	}
 
@@ -79,7 +79,7 @@ func (k Keeper) HasPerpetual(
 	id uint32,
 ) (found bool) {
 	perpetualStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.PerpetualKeyPrefix))
-	return perpetualStore.Has(lib.Uint32ToBytes(id))
+	return perpetualStore.Has(lib.Bit32ToBytes(id))
 }
 
 func (k Keeper) HasAuthority(authority string) bool {
@@ -153,9 +153,9 @@ func (k Keeper) GetPerpetual(
 ) (val types.Perpetual, err error) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.PerpetualKeyPrefix))
 
-	b := store.Get(lib.Uint32ToBytes(id))
+	b := store.Get(lib.Bit32ToBytes(id))
 	if b == nil {
-		return val, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, lib.Uint32ToString(id))
+		return val, errorsmod.Wrap(types.ErrPerpetualDoesNotExist, lib.UintToString(id))
 	}
 
 	k.cdc.MustUnmarshal(b, &val)
@@ -1100,7 +1100,7 @@ func (k Keeper) setPerpetual(
 ) {
 	b := k.cdc.MustMarshal(&perpetual)
 	perpetualStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.PerpetualKeyPrefix))
-	perpetualStore.Set(lib.Uint32ToBytes(perpetual.Params.Id), b)
+	perpetualStore.Set(lib.Bit32ToBytes(perpetual.Params.Id), b)
 }
 
 // GetPerpetualAndMarketPrice retrieves a Perpetual by its id and its corresponding MarketPrice.
@@ -1161,7 +1161,7 @@ func (k Keeper) validatePerpetual(
 
 	// Validate `liquidityTier` exists.
 	if !k.HasLiquidityTier(ctx, perpetual.Params.LiquidityTier) {
-		return errorsmod.Wrap(types.ErrLiquidityTierDoesNotExist, lib.Uint32ToString(perpetual.Params.LiquidityTier))
+		return errorsmod.Wrap(types.ErrLiquidityTierDoesNotExist, lib.UintToString(perpetual.Params.LiquidityTier))
 	}
 
 	return nil
@@ -1272,7 +1272,7 @@ func (k Keeper) HasLiquidityTier(
 	id uint32,
 ) (found bool) {
 	ltStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.LiquidityTierKeyPrefix))
-	return ltStore.Has(lib.Uint32ToBytes(id))
+	return ltStore.Has(lib.Bit32ToBytes(id))
 }
 
 // `SetLiquidityTier` sets a liquidity tier in the store (i.e. updates if `id` exists and creates otherwise).
@@ -1342,9 +1342,9 @@ func (k Keeper) GetLiquidityTier(ctx sdk.Context, id uint32) (
 ) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.LiquidityTierKeyPrefix))
 
-	b := store.Get(lib.Uint32ToBytes(id))
+	b := store.Get(lib.Bit32ToBytes(id))
 	if b == nil {
-		return liquidityTier, errorsmod.Wrap(types.ErrLiquidityTierDoesNotExist, lib.Uint32ToString(id))
+		return liquidityTier, errorsmod.Wrap(types.ErrLiquidityTierDoesNotExist, lib.UintToString(id))
 	}
 
 	k.cdc.MustUnmarshal(b, &liquidityTier)
@@ -1378,7 +1378,7 @@ func (k Keeper) setLiquidityTier(
 ) {
 	b := k.cdc.MustMarshal(&liquidityTier)
 	liquidityTierStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.LiquidityTierKeyPrefix))
-	liquidityTierStore.Set(lib.Uint32ToBytes(liquidityTier.Id), b)
+	liquidityTierStore.Set(lib.Bit32ToBytes(liquidityTier.Id), b)
 }
 
 /* === PARAMETERS FUNCTIONS === */

--- a/protocol/x/perpetuals/keeper/perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/perpetual_test.go
@@ -766,7 +766,7 @@ func TestGetMarginRequirements_MarketNotFound(t *testing.T) {
 	cdc := codec.NewProtoCodec(registry)
 	b := cdc.MustMarshal(&perpetual)
 	perpetualStore := prefix.NewStore(pc.Ctx.KVStore(pc.StoreKey), []byte(types.PerpetualKeyPrefix))
-	perpetualStore.Set(lib.Uint32ToBytes(
+	perpetualStore.Set(lib.Bit32ToBytes(
 		perpetual.Params.Id,
 	), b)
 
@@ -800,7 +800,7 @@ func TestGetMarginRequirements_LiquidityTierNotFound(t *testing.T) {
 	cdc := codec.NewProtoCodec(registry)
 	b := cdc.MustMarshal(&perpetual)
 	perpetualStore := prefix.NewStore(pc.Ctx.KVStore(pc.StoreKey), []byte(types.PerpetualKeyPrefix))
-	perpetualStore.Set(lib.Uint32ToBytes(
+	perpetualStore.Set(lib.Bit32ToBytes(
 		perpetual.Params.Id,
 	), b)
 
@@ -965,7 +965,7 @@ func TestGetNetNotional_MarketNotFound(t *testing.T) {
 	cdc := codec.NewProtoCodec(registry)
 	b := cdc.MustMarshal(&perpetual)
 	perpetualStore := prefix.NewStore(pc.Ctx.KVStore(pc.StoreKey), []byte(types.PerpetualKeyPrefix))
-	perpetualStore.Set(lib.Uint32ToBytes(
+	perpetualStore.Set(lib.Bit32ToBytes(
 		perpetual.Params.Id,
 	), b)
 
@@ -1129,7 +1129,7 @@ func TestGetNotionalInBaseQuantums_MarketNotFound(t *testing.T) {
 	cdc := codec.NewProtoCodec(registry)
 	b := cdc.MustMarshal(&perpetual)
 	perpetualStore := prefix.NewStore(pc.Ctx.KVStore(pc.StoreKey), []byte(types.PerpetualKeyPrefix))
-	perpetualStore.Set(lib.Uint32ToBytes(
+	perpetualStore.Set(lib.Bit32ToBytes(
 		perpetual.Params.Id,
 	), b)
 
@@ -1294,7 +1294,7 @@ func TestGetNetCollateral_MarketNotFound(t *testing.T) {
 	cdc := codec.NewProtoCodec(registry)
 	b := cdc.MustMarshal(&perpetual)
 	perpetualStore := prefix.NewStore(pc.Ctx.KVStore(pc.StoreKey), []byte(types.PerpetualKeyPrefix))
-	perpetualStore.Set(lib.Uint32ToBytes(
+	perpetualStore.Set(lib.Bit32ToBytes(
 		perpetual.Params.Id,
 	), b)
 
@@ -2974,7 +2974,7 @@ func TestSetLiquidityTier_New_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion,
 			basePositionNotional:   uint64(0),
 			impactNotional:         uint64(lib.OneMillion),
-			expectedError:          errorsmod.Wrap(types.ErrBasePositionNotionalIsZero, fmt.Sprint(0)),
+			expectedError:          types.ErrBasePositionNotionalIsZero,
 		},
 		"Impact Notional is zero": {
 			id:                     1,
@@ -2983,7 +2983,7 @@ func TestSetLiquidityTier_New_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion,
 			basePositionNotional:   uint64(lib.OneMillion),
 			impactNotional:         uint64(0),
-			expectedError:          errorsmod.Wrap(types.ErrImpactNotionalIsZero, fmt.Sprint(0)),
+			expectedError:          types.ErrImpactNotionalIsZero,
 		},
 	}
 
@@ -3114,7 +3114,7 @@ func TestSetLiquidityTier_Existing_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion,
 			basePositionNotional:   uint64(0),
 			impactNotional:         uint64(lib.OneMillion),
-			expectedError:          errorsmod.Wrap(types.ErrBasePositionNotionalIsZero, fmt.Sprint(0)),
+			expectedError:          types.ErrBasePositionNotionalIsZero,
 		},
 		"Impact Notional is zero": {
 			id:                     1,
@@ -3123,7 +3123,7 @@ func TestSetLiquidityTier_Existing_Failure(t *testing.T) {
 			maintenanceFractionPpm: lib.OneMillion,
 			basePositionNotional:   uint64(lib.OneMillion),
 			impactNotional:         uint64(0),
-			expectedError:          errorsmod.Wrap(types.ErrImpactNotionalIsZero, fmt.Sprint(0)),
+			expectedError:          types.ErrImpactNotionalIsZero,
 		},
 	}
 

--- a/protocol/x/perpetuals/types/liquidity_tier.go
+++ b/protocol/x/perpetuals/types/liquidity_tier.go
@@ -13,20 +13,20 @@ import (
 // - Base position notional is not 0.
 func (liquidityTier LiquidityTier) Validate() error {
 	if liquidityTier.InitialMarginPpm > MaxInitialMarginPpm {
-		return errorsmod.Wrap(ErrInitialMarginPpmExceedsMax, lib.Uint32ToString(liquidityTier.InitialMarginPpm))
+		return errorsmod.Wrap(ErrInitialMarginPpmExceedsMax, lib.UintToString(liquidityTier.InitialMarginPpm))
 	}
 
 	if liquidityTier.MaintenanceFractionPpm > MaxMaintenanceFractionPpm {
 		return errorsmod.Wrap(ErrMaintenanceFractionPpmExceedsMax,
-			lib.Uint32ToString(liquidityTier.MaintenanceFractionPpm))
+			lib.UintToString(liquidityTier.MaintenanceFractionPpm))
 	}
 
 	if liquidityTier.BasePositionNotional == 0 {
-		return errorsmod.Wrap(ErrBasePositionNotionalIsZero, lib.Uint32ToString(0))
+		return ErrBasePositionNotionalIsZero
 	}
 
 	if liquidityTier.ImpactNotional == 0 {
-		return errorsmod.Wrap(ErrImpactNotionalIsZero, lib.Uint32ToString(0))
+		return ErrImpactNotionalIsZero
 	}
 
 	return nil

--- a/protocol/x/perpetuals/types/perpetual.go
+++ b/protocol/x/perpetuals/types/perpetual.go
@@ -22,7 +22,7 @@ func (p *PerpetualParams) Validate() error {
 	if defaultFundingPpm > MaxDefaultFundingPpmAbs {
 		return errorsmod.Wrap(
 			ErrDefaultFundingPpmMagnitudeExceedsMax,
-			lib.Int32ToString(p.DefaultFundingPpm))
+			lib.IntToString(p.DefaultFundingPpm))
 	}
 
 	return nil

--- a/protocol/x/prices/keeper/market.go
+++ b/protocol/x/prices/keeper/market.go
@@ -41,10 +41,10 @@ func (k Keeper) CreateMarket(
 	priceBytes := k.cdc.MustMarshal(&marketPrice)
 
 	marketParamStore := k.newMarketParamStore(ctx)
-	marketParamStore.Set(lib.Uint32ToBytes(marketParam.Id), paramBytes)
+	marketParamStore.Set(lib.Bit32ToBytes(marketParam.Id), paramBytes)
 
 	marketPriceStore := k.newMarketPriceStore(ctx)
-	marketPriceStore.Set(lib.Uint32ToBytes(marketPrice.Id), priceBytes)
+	marketPriceStore.Set(lib.Bit32ToBytes(marketPrice.Id), priceBytes)
 
 	k.GetIndexerEventManager().AddTxnEvent(
 		ctx,

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -34,20 +34,20 @@ func (k Keeper) ModifyMarketParam(
 	if !exists {
 		return types.MarketParam{}, errorsmod.Wrap(
 			types.ErrMarketParamDoesNotExist,
-			lib.Uint32ToString(marketParam.Id),
+			lib.UintToString(marketParam.Id),
 		)
 	}
 
 	// Validate update is permitted.
 	if marketParam.Exponent != existingParam.Exponent {
 		return types.MarketParam{},
-			errorsmod.Wrapf(types.ErrMarketExponentCannotBeUpdated, lib.Uint32ToString(marketParam.Id))
+			errorsmod.Wrapf(types.ErrMarketExponentCannotBeUpdated, lib.UintToString(marketParam.Id))
 	}
 
 	// Store the modified market param.
 	marketParamStore := k.newMarketParamStore(ctx)
 	b := k.cdc.MustMarshal(&marketParam)
-	marketParamStore.Set(lib.Uint32ToBytes(marketParam.Id), b)
+	marketParamStore.Set(lib.Bit32ToBytes(marketParam.Id), b)
 
 	k.GetIndexerEventManager().AddTxnEvent(
 		ctx,
@@ -84,7 +84,7 @@ func (k Keeper) GetMarketParam(
 	exists bool,
 ) {
 	marketParamStore := k.newMarketParamStore(ctx)
-	b := marketParamStore.Get(lib.Uint32ToBytes(id))
+	b := marketParamStore.Get(lib.Bit32ToBytes(id))
 	if b == nil {
 		return types.MarketParam{}, false
 	}

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -82,7 +82,7 @@ func (k Keeper) UpdateMarketPrices(
 	for _, marketPrice := range updatedMarketPrices {
 		// Store the modified market price.
 		b := k.cdc.MustMarshal(&marketPrice)
-		marketPriceStore.Set(lib.Uint32ToBytes(marketPrice.Id), b)
+		marketPriceStore.Set(lib.Bit32ToBytes(marketPrice.Id), b)
 
 		// Monitor the last block a market price is updated.
 		telemetry.SetGaugeWithLabels(
@@ -118,9 +118,9 @@ func (k Keeper) GetMarketPrice(
 	id uint32,
 ) (types.MarketPrice, error) {
 	store := k.newMarketPriceStore(ctx)
-	b := store.Get(lib.Uint32ToBytes(id))
+	b := store.Get(lib.Bit32ToBytes(id))
 	if b == nil {
-		return types.MarketPrice{}, errorsmod.Wrap(types.ErrMarketPriceDoesNotExist, lib.Uint32ToString(id))
+		return types.MarketPrice{}, errorsmod.Wrap(types.ErrMarketPriceDoesNotExist, lib.UintToString(id))
 	}
 
 	var marketPrice = types.MarketPrice{}

--- a/protocol/x/prices/keeper/market_test.go
+++ b/protocol/x/prices/keeper/market_test.go
@@ -212,7 +212,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 			require.EqualError(
 				t,
 				err,
-				errorsmod.Wrap(types.ErrMarketPriceDoesNotExist, lib.Uint32ToString(0)).Error(),
+				errorsmod.Wrap(types.ErrMarketPriceDoesNotExist, lib.UintToString(uint32(0))).Error(),
 			)
 
 			// Verify no new market event.

--- a/protocol/x/stats/keeper/keeper.go
+++ b/protocol/x/stats/keeper/keeper.go
@@ -110,7 +110,7 @@ func (k Keeper) SetStatsMetadata(ctx sdk.Context, metadata *types.StatsMetadata)
 // if epoch stats aren't found.
 func (k Keeper) GetEpochStatsOrNil(ctx sdk.Context, epoch uint32) *types.EpochStats {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.EpochStatsKeyPrefix))
-	bytes := store.Get(lib.Uint32ToBytes(epoch))
+	bytes := store.Get(lib.Bit32ToBytes(epoch))
 
 	if bytes == nil {
 		return nil
@@ -124,12 +124,12 @@ func (k Keeper) GetEpochStatsOrNil(ctx sdk.Context, epoch uint32) *types.EpochSt
 func (k Keeper) SetEpochStats(ctx sdk.Context, epoch uint32, epochStats *types.EpochStats) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.EpochStatsKeyPrefix))
 	b := k.cdc.MustMarshal(epochStats)
-	store.Set(lib.Uint32ToBytes(epoch), b)
+	store.Set(lib.Bit32ToBytes(epoch), b)
 }
 
 func (k Keeper) deleteEpochStats(ctx sdk.Context, epoch uint32) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.EpochStatsKeyPrefix))
-	store.Delete(lib.Uint32ToBytes(epoch))
+	store.Delete(lib.Bit32ToBytes(epoch))
 }
 
 func (k Keeper) GetUserStats(ctx sdk.Context, address string) *types.UserStats {

--- a/protocol/x/subaccounts/client/cli/query_subaccount.go
+++ b/protocol/x/subaccounts/client/cli/query_subaccount.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +54,7 @@ func CmdShowSubaccount() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			argOwner := args[0]
-			argNumber, err := lib.StringToUint32(args[1])
+			argNumber, err := cast.ToUint32E(args[1])
 			if err != nil {
 				return err
 			}

--- a/protocol/x/subaccounts/keeper/transfer.go
+++ b/protocol/x/subaccounts/keeper/transfer.go
@@ -1,9 +1,10 @@
 package keeper
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math/big"
+
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -97,7 +98,7 @@ func (k Keeper) TransferFundsFromSubaccountToModule(
 	}
 
 	if quantums.Sign() <= 0 {
-		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
+		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.UintToString(assetId))
 	}
 
 	convertedQuantums, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
@@ -158,7 +159,7 @@ func (k Keeper) TransferFundsFromModuleToSubaccount(
 	}
 
 	if quantums.Sign() <= 0 {
-		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
+		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.UintToString(assetId))
 	}
 
 	convertedQuantums, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
@@ -217,7 +218,7 @@ func (k Keeper) DepositFundsFromAccountToSubaccount(
 	}
 
 	if quantums.Sign() <= 0 {
-		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
+		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.UintToString(assetId))
 	}
 
 	convertedQuantums, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
@@ -274,7 +275,7 @@ func (k Keeper) WithdrawFundsFromSubaccountToAccount(
 	}
 
 	if quantums.Sign() <= 0 {
-		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.Uint32ToString(assetId))
+		return errorsmod.Wrap(types.ErrAssetTransferQuantumsNotPositive, lib.UintToString(assetId))
 	}
 
 	convertedQuantums, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -1035,7 +1035,7 @@ func TestTransferInsuranceFundPayments(t *testing.T) {
 			skipSetUpUsdc:                       true,
 			subaccountModuleAccBalance:          500,
 			quantums:                            big.NewInt(500),
-			expectedErr:                         errorsmod.Wrap(asstypes.ErrAssetDoesNotExist, lib.Uint32ToString(0)),
+			expectedErr:                         errorsmod.Wrap(asstypes.ErrAssetDoesNotExist, lib.UintToString(uint32(0))),
 			expectedSubaccountsModuleAccBalance: 500,
 			expectedInsuranceFundBalance:        1500,
 			panics:                              true,


### PR DESCRIPTION
`BytesToInt32/BytesToUint32` tested by `Bit32ToBytes` tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated various functions across multiple modules to use more generic byte conversion functions, improving flexibility and consistency in handling different integer types.
- Bug Fix: Fixed several test cases by updating the function calls for converting integers to bytes or strings, ensuring accurate test results.
- Chore: Replaced usage of `lib.StringToUint32` with `cast.ToUint32E` in CLI queries for better error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->