### PR TITLE
remove unused functions in x/assets

### DIFF
--- a/protocol/x/assets/keeper/asset_test.go
+++ b/protocol/x/assets/keeper/asset_test.go
@@ -267,64 +267,6 @@ func TestModifyAsset_MarketNotFound(t *testing.T) {
 	require.EqualError(t, err, errorsmod.Wrap(pricestypes.ErrMarketPriceDoesNotExist, "999").Error())
 }
 
-func TestGetDenomById_Success(t *testing.T) {
-	ctx, keeper, pricesKeeper, _, _, _ := keepertest.AssetsKeepers(t, true)
-	items, err := createNAssets(t, ctx, keeper, pricesKeeper, 10)
-	require.NoError(t, err)
-
-	for _, item := range items {
-		denom, err := keeper.GetDenomById(
-			ctx,
-			item.Id,
-		)
-		require.NoError(t, err)
-		require.Equal(t,
-			item.Denom,
-			denom,
-		)
-	}
-}
-
-func TestGetDenomById_NotFound(t *testing.T) {
-	ctx, keeper, _, _, _, _ := keepertest.AssetsKeepers(t, true)
-
-	_, err := keeper.GetDenomById(
-		ctx,
-		0,
-	)
-	require.EqualError(t, err, errorsmod.Wrap(types.ErrAssetDoesNotExist, "0").Error())
-}
-
-func TestGetIdByDenom_Success(t *testing.T) {
-	ctx, keeper, pricesKeeper, _, _, _ := keepertest.AssetsKeepers(t, true)
-	items, err := createNAssets(t, ctx, keeper, pricesKeeper, 10)
-	require.NoError(t, err)
-
-	for _, item := range items {
-		id, err := keeper.GetIdByDenom(ctx,
-			item.Denom,
-		)
-		require.NoError(t, err)
-		require.Equal(t,
-			item.Id,
-			id,
-		)
-	}
-}
-
-func TestGetIdByDenom_NotFound(t *testing.T) {
-	ctx, keeper, pricesKeeper, _, _, _ := keepertest.AssetsKeepers(t, true)
-	_, err := createNAssets(t, ctx, keeper, pricesKeeper, 10)
-	require.NoError(t, err)
-
-	nonExistingDenom := "non-existent-denom"
-
-	_, err = keeper.GetIdByDenom(ctx,
-		nonExistingDenom,
-	)
-	require.EqualError(t, err, errorsmod.Wrap(types.ErrNoAssetWithDenom, nonExistingDenom).Error())
-}
-
 func TestGetAsset_Success(t *testing.T) {
 	ctx, keeper, pricesKeeper, _, _, _ := keepertest.AssetsKeepers(t, true)
 	items, err := createNAssets(t, ctx, keeper, pricesKeeper, 10)

--- a/protocol/x/assets/types/keys.go
+++ b/protocol/x/assets/types/keys.go
@@ -11,9 +11,6 @@ const (
 
 // State
 const (
-	// DenomToIdKeyPrefix is the prefix to retrieve denom-to-asset-id mappings
-	DenomToIdKeyPrefix = "denom_to_id/"
-
 	// AssetKeyPrefix is the prefix to retrieve all Assets
 	AssetKeyPrefix = "asset/"
 )

--- a/protocol/x/subaccounts/types/expected_keepers.go
+++ b/protocol/x/subaccounts/types/expected_keepers.go
@@ -39,13 +39,6 @@ type ProductKeeper interface {
 
 type AssetsKeeper interface {
 	ProductKeeper
-	GetDenomById(
-		ctx sdk.Context,
-		id uint32,
-	) (
-		denom string,
-		err error,
-	)
 	ConvertAssetToCoin(
 		ctx sdk.Context,
 		assetId uint32,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Simplified the asset creation process in `protocol/x/assets/keeper/asset.go` by removing redundant checks for duplicate denominations (`denom`). The new approach ensures uniqueness of `denom` among existing assets.
- Test: Removed tests related to getting asset denominations and IDs in `protocol/x/assets/keeper/asset_test.go`, aligning with the updated codebase.
- Chore: Cleaned up unused constants in `protocol/x/assets/types/keys.go`, improving code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->