### PR TITLE
[CLOB-919] log errors in clob DeliverTx handlers

### DIFF
--- a/protocol/lib/error/logging.go
+++ b/protocol/lib/error/logging.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 
 	errorsmod "cosmossdk.io/errors"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
@@ -41,13 +40,17 @@ func WrapErrorWithSourceModuleContext(err error, module string) error {
 		WithLogKeyValue(SourceModuleKey, fmt.Sprintf("x/%v", module))
 }
 
-// LogErrorWithBlockHeight logs an error using the cosmos sdk Context's logger, appending the block
-// height to the error message.
-func LogErrorWithBlockHeight(ctx sdk.Context, err error) {
-	err = errorsmod.Wrapf(
-		err,
-		"Block height: %d",
-		ctx.BlockHeight(),
-	)
-	ctx.Logger().Error(err.Error())
+// LogErrorWithBlockHeight logs an error, appending the block height and ABCI callback to the error message.
+func LogErrorWithBlockHeight(logger log.Logger, err error, blockHeight int64, callback string) {
+	if err != nil {
+		err = errorsmod.Wrapf(
+			err,
+			"Block height: %d, Callback: %s",
+			blockHeight,
+			callback,
+		)
+		logger.Error(err.Error())
+	} else {
+		logger.Error("LogErrorWithBlockHeight called with nil error")
+	}
 }

--- a/protocol/lib/error/logging.go
+++ b/protocol/lib/error/logging.go
@@ -3,7 +3,11 @@ package error
 import (
 	"errors"
 	"fmt"
+
 	"github.com/cometbft/cometbft/libs/log"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
@@ -35,4 +39,15 @@ func LogErrorWithOptionalContext(
 func WrapErrorWithSourceModuleContext(err error, module string) error {
 	return NewErrorWithLogContext(err).
 		WithLogKeyValue(SourceModuleKey, fmt.Sprintf("x/%v", module))
+}
+
+// LogErrorWithBlockHeight logs an error using the cosmos sdk Context's logger, appending the block
+// height to the error message.
+func LogErrorWithBlockHeight(ctx sdk.Context, err error) {
+	err = errorsmod.Wrapf(
+		err,
+		"Block height: %d",
+		ctx.BlockHeight(),
+	)
+	ctx.Logger().Error(err.Error())
 }

--- a/protocol/lib/error/logging_test.go
+++ b/protocol/lib/error/logging_test.go
@@ -2,9 +2,10 @@ package error_test
 
 import (
 	"fmt"
+	"testing"
+
 	liberror "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
-	"testing"
 )
 
 func TestWrapErrorWithSourceModuleContext_ErrorWithLogContext(t *testing.T) {
@@ -30,6 +31,29 @@ func TestLogErrorWithOptionalContext_PlainError(t *testing.T) {
 	logger.On("Error", "test message", "error", err).Return()
 
 	liberror.LogErrorWithOptionalContext(logger, "test message", err)
+
+	logger.AssertExpectations(t)
+}
+
+func TestLogErrorWithBlockHeight(t *testing.T) {
+	logger := &mocks.Logger{}
+	err := fmt.Errorf("test error")
+
+	// Expect that the block height will be appended to the error message.
+	logger.On("Error", "Block height: 123, Callback: foobar: test error").Return()
+
+	liberror.LogErrorWithBlockHeight(logger, err, 123, "foobar")
+
+	logger.AssertExpectations(t)
+}
+
+func TestLogErrorWithBlockHeight_NilError(t *testing.T) {
+	logger := &mocks.Logger{}
+
+	// Expect that the block height will be appended to the error message.
+	logger.On("Error", "LogErrorWithBlockHeight called with nil error").Return()
+
+	liberror.LogErrorWithBlockHeight(logger, nil, 123, "foobar")
 
 	logger.AssertExpectations(t)
 }

--- a/protocol/x/clob/keeper/msg_server_cancel_orders.go
+++ b/protocol/x/clob/keeper/msg_server_cancel_orders.go
@@ -8,6 +8,7 @@ import (
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	indexershared "github.com/dydxprotocol/v4-chain/protocol/indexer/shared"
+	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
@@ -16,8 +17,14 @@ import (
 func (m msgServer) CancelOrder(
 	goCtx context.Context,
 	msg *types.MsgCancelOrder,
-) (*types.MsgCancelOrderResponse, error) {
+) (resp *types.MsgCancelOrderResponse, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	defer func() {
+		if err != nil {
+			errorlib.LogErrorWithBlockHeight(ctx, err)
+		}
+	}()
 
 	// 1. If this is a Short-Term order, panic.
 	msg.OrderId.MustBeStatefulOrder()

--- a/protocol/x/clob/keeper/msg_server_cancel_orders.go
+++ b/protocol/x/clob/keeper/msg_server_cancel_orders.go
@@ -22,7 +22,7 @@ func (m msgServer) CancelOrder(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx, err)
+			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_create_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_create_clob_pair.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
@@ -21,7 +22,7 @@ func (k msgServer) CreateClobPair(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx, err)
+			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_create_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_create_clob_pair.go
@@ -22,7 +22,7 @@ func (k msgServer) CreateClobPair(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
+			errorlib.LogErrorWithBlockHeight(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_create_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_create_clob_pair.go
@@ -2,10 +2,12 @@ package keeper
 
 import (
 	"context"
+
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
@@ -14,7 +16,15 @@ import (
 func (k msgServer) CreateClobPair(
 	goCtx context.Context,
 	msg *types.MsgCreateClobPair,
-) (*types.MsgCreateClobPairResponse, error) {
+) (resp *types.MsgCreateClobPairResponse, err error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	defer func() {
+		if err != nil {
+			errorlib.LogErrorWithBlockHeight(ctx, err)
+		}
+	}()
+
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
@@ -22,8 +32,6 @@ func (k msgServer) CreateClobPair(
 			msg.Authority,
 		)
 	}
-
-	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// TODO(DEC-1535): update this when additional clob pair types are supported.
 	if _, err := k.Keeper.CreatePerpetualClobPair(

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -23,7 +23,7 @@ func (k msgServer) PlaceOrder(goCtx context.Context, msg *types.MsgPlaceOrder) (
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx, err)
+			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -9,6 +10,7 @@ import (
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
@@ -16,8 +18,14 @@ import (
 // PlaceOrder is the entry point for stateful `MsgPlaceOrder` messages executed in `runMsgs` during `DeliverTx`.
 // This handler is only invoked for stateful orders due to the filtering logic in the mempool in our CometBFT fork.
 // TODO (CLOB-646) - Support stateful order replacements.
-func (k msgServer) PlaceOrder(goCtx context.Context, msg *types.MsgPlaceOrder) (*types.MsgPlaceOrderResponse, error) {
+func (k msgServer) PlaceOrder(goCtx context.Context, msg *types.MsgPlaceOrder) (resp *types.MsgPlaceOrderResponse, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	defer func() {
+		if err != nil {
+			errorlib.LogErrorWithBlockHeight(ctx, err)
+		}
+	}()
 
 	// 1. Ensure the order is not a Short-Term order.
 	order := msg.GetOrder()

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -18,12 +18,15 @@ import (
 // PlaceOrder is the entry point for stateful `MsgPlaceOrder` messages executed in `runMsgs` during `DeliverTx`.
 // This handler is only invoked for stateful orders due to the filtering logic in the mempool in our CometBFT fork.
 // TODO (CLOB-646) - Support stateful order replacements.
-func (k msgServer) PlaceOrder(goCtx context.Context, msg *types.MsgPlaceOrder) (resp *types.MsgPlaceOrderResponse, err error) {
+func (k msgServer) PlaceOrder(goCtx context.Context, msg *types.MsgPlaceOrder) (
+	resp *types.MsgPlaceOrderResponse,
+	err error,
+) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
+			errorlib.LogErrorWithBlockHeight(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_proposed_operations.go
+++ b/protocol/x/clob/keeper/msg_server_proposed_operations.go
@@ -17,7 +17,7 @@ func (k msgServer) ProposedOperations(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
+			errorlib.LogErrorWithBlockHeight(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_proposed_operations.go
+++ b/protocol/x/clob/keeper/msg_server_proposed_operations.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -16,7 +17,7 @@ func (k msgServer) ProposedOperations(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx, err)
+			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_proposed_operations.go
+++ b/protocol/x/clob/keeper/msg_server_proposed_operations.go
@@ -3,28 +3,27 @@ package keeper
 import (
 	"context"
 
-	errorsmod "cosmossdk.io/errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
 func (k msgServer) ProposedOperations(
 	goCtx context.Context,
 	msg *types.MsgProposedOperations,
-) (*types.MsgProposedOperationsResponse, error) {
+) (resp *types.MsgProposedOperationsResponse, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	defer func() {
+		if err != nil {
+			errorlib.LogErrorWithBlockHeight(ctx, err)
+		}
+	}()
 
 	if err := k.Keeper.ProcessProposerOperations(
 		ctx,
 		msg.GetOperationsQueue(),
 	); err != nil {
-		err = errorsmod.Wrapf(
-			err,
-			"Block height: %d",
-			ctx.BlockHeight(),
-		)
-		ctx.Logger().Error(err.Error())
 		return nil, err
 	}
 

--- a/protocol/x/clob/keeper/msg_server_proposed_operations_test.go
+++ b/protocol/x/clob/keeper/msg_server_proposed_operations_test.go
@@ -29,6 +29,9 @@ func TestProposedOperations(t *testing.T) {
 		"Propagate Process Error": {
 			setupMocks: func(ctx sdk.Context, mck *mocks.ClobKeeper) {
 				mck.On("ProcessProposerOperations", ctx, operationsQueue).Return(testError)
+				mockLogger := &mocks.Logger{}
+				mockLogger.On("Error", "Block height: 20, Callback: deliver_tx: error").Return()
+				mck.On("Logger", ctx).Return(mockLogger)
 			},
 			expectedErr: testError,
 		},

--- a/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
@@ -2,9 +2,11 @@ package keeper
 
 import (
 	"context"
+
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -13,7 +15,15 @@ import (
 func (k msgServer) UpdateBlockRateLimitConfiguration(
 	goCtx context.Context,
 	msg *types.MsgUpdateBlockRateLimitConfiguration,
-) (*types.MsgUpdateBlockRateLimitConfigurationResponse, error) {
+) (resp *types.MsgUpdateBlockRateLimitConfigurationResponse, err error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	defer func() {
+		if err != nil {
+			errorlib.LogErrorWithBlockHeight(ctx, err)
+		}
+	}()
+
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
@@ -22,7 +32,6 @@ func (k msgServer) UpdateBlockRateLimitConfiguration(
 		)
 	}
 
-	ctx := sdk.UnwrapSDKContext(goCtx)
 	if err := k.Keeper.InitializeBlockRateLimit(ctx, msg.BlockRateLimitConfig); err != nil {
 		return nil, err
 	}

--- a/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
@@ -21,7 +21,7 @@ func (k msgServer) UpdateBlockRateLimitConfiguration(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
+			errorlib.LogErrorWithBlockHeight(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -20,7 +21,7 @@ func (k msgServer) UpdateBlockRateLimitConfiguration(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx, err)
+			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -19,7 +20,7 @@ func (k msgServer) UpdateClobPair(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx, err)
+			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair.go
@@ -2,17 +2,27 @@ package keeper
 
 import (
 	"context"
+
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
 func (k msgServer) UpdateClobPair(
 	goCtx context.Context,
 	msg *types.MsgUpdateClobPair,
-) (*types.MsgUpdateClobPairResponse, error) {
+) (resp *types.MsgUpdateClobPairResponse, err error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	defer func() {
+		if err != nil {
+			errorlib.LogErrorWithBlockHeight(ctx, err)
+		}
+	}()
+
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
@@ -21,7 +31,6 @@ func (k msgServer) UpdateClobPair(
 		)
 	}
 
-	ctx := sdk.UnwrapSDKContext(goCtx)
 	if err := k.Keeper.UpdateClobPair(
 		ctx,
 		msg.GetClobPair(),

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair.go
@@ -20,7 +20,7 @@ func (k msgServer) UpdateClobPair(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
+			errorlib.LogErrorWithBlockHeight(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -20,7 +21,7 @@ func (k msgServer) UpdateEquityTierLimitConfiguration(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx, err)
+			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
@@ -2,9 +2,11 @@ package keeper
 
 import (
 	"context"
+
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -13,7 +15,15 @@ import (
 func (k msgServer) UpdateEquityTierLimitConfiguration(
 	goCtx context.Context,
 	msg *types.MsgUpdateEquityTierLimitConfiguration,
-) (*types.MsgUpdateEquityTierLimitConfigurationResponse, error) {
+) (resp *types.MsgUpdateEquityTierLimitConfigurationResponse, err error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	defer func() {
+		if err != nil {
+			errorlib.LogErrorWithBlockHeight(ctx, err)
+		}
+	}()
+
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
@@ -22,7 +32,6 @@ func (k msgServer) UpdateEquityTierLimitConfiguration(
 		)
 	}
 
-	ctx := sdk.UnwrapSDKContext(goCtx)
 	if err := k.Keeper.InitializeEquityTierLimit(ctx, msg.EquityTierLimitConfig); err != nil {
 		return nil, err
 	}

--- a/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
@@ -21,7 +21,7 @@ func (k msgServer) UpdateEquityTierLimitConfiguration(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
+			errorlib.LogErrorWithBlockHeight(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
@@ -2,10 +2,12 @@ package keeper
 
 import (
 	"context"
+
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -13,7 +15,15 @@ import (
 func (k msgServer) UpdateLiquidationsConfig(
 	goCtx context.Context,
 	msg *types.MsgUpdateLiquidationsConfig,
-) (*types.MsgUpdateLiquidationsConfigResponse, error) {
+) (resp *types.MsgUpdateLiquidationsConfigResponse, err error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	defer func() {
+		if err != nil {
+			errorlib.LogErrorWithBlockHeight(ctx, err)
+		}
+	}()
+
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
@@ -21,8 +31,6 @@ func (k msgServer) UpdateLiquidationsConfig(
 			msg.Authority,
 		)
 	}
-
-	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	if err := k.Keeper.UpdateLiquidationsConfig(ctx, msg.LiquidationsConfig); err != nil {
 		return nil, err

--- a/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -20,7 +21,7 @@ func (k msgServer) UpdateLiquidationsConfig(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx, err)
+			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 

--- a/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
@@ -21,7 +21,7 @@ func (k msgServer) UpdateLiquidationsConfig(
 
 	defer func() {
 		if err != nil {
-			errorlib.LogErrorWithBlockHeight(ctx.Logger(), err, ctx.BlockHeight(), metrics.DeliverTx)
+			errorlib.LogErrorWithBlockHeight(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), metrics.DeliverTx)
 		}
 	}()
 


### PR DESCRIPTION
- adds error logging for any errors returned from DeliverTx handlers for CLOB msgs. Wraps the errors with block height




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new function `LogErrorWithBlockHeight` in the `errorlib` package to log errors with additional block height information.
- Refactor: Updated various functions across the `clob` keeper to use the new `LogErrorWithBlockHeight` for error logging, improving error visibility and debugging capabilities.
- Test: Added tests for the new `LogErrorWithBlockHeight` function to ensure correct functionality.
- Chore: Modified several function signatures to return named variables for better readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->