### PR TITLE
[CLOB-914] Ensure that rate limiting of short term order placements/cancellations is guarded against replay attacks.

### DIFF
--- a/protocol/x/clob/e2e/app_test.go
+++ b/protocol/x/clob/e2e/app_test.go
@@ -32,7 +32,17 @@ import (
 )
 
 var (
-	Clob_0                                             = MustGetClobPairsFromGenesis(testapp.DefaultGenesis())[0]
+	Clob_0                                            = MustGetClobPairsFromGenesis(testapp.DefaultGenesis())[0]
+	PlaceOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB5 = *clobtypes.NewMsgPlaceOrder(MustScaleOrder(
+		clobtypes.Order{
+			OrderId:      clobtypes.OrderId{SubaccountId: constants.Alice_Num0, ClientId: 0, ClobPairId: 0},
+			Side:         clobtypes.Order_SIDE_BUY,
+			Quantums:     5,
+			Subticks:     10,
+			GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 5},
+		},
+		testapp.DefaultGenesis(),
+	))
 	PlaceOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20 = *clobtypes.NewMsgPlaceOrder(MustScaleOrder(
 		clobtypes.Order{
 			OrderId:      clobtypes.OrderId{SubaccountId: constants.Alice_Num0, ClientId: 0, ClobPairId: 0},
@@ -40,6 +50,16 @@ var (
 			Quantums:     5,
 			Subticks:     10,
 			GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 20},
+		},
+		testapp.DefaultGenesis(),
+	))
+	PlaceOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB27 = *clobtypes.NewMsgPlaceOrder(MustScaleOrder(
+		clobtypes.Order{
+			OrderId:      clobtypes.OrderId{SubaccountId: constants.Alice_Num0, ClientId: 0, ClobPairId: 0},
+			Side:         clobtypes.Order_SIDE_BUY,
+			Quantums:     5,
+			Subticks:     10,
+			GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 27},
 		},
 		testapp.DefaultGenesis(),
 	))
@@ -96,6 +116,14 @@ var (
 			ClobPairId:   0,
 		},
 		20,
+	)
+	CancelOrder_Alice_Num0_Id0_Clob0_GTB27 = *clobtypes.NewMsgCancelOrderShortTerm(
+		clobtypes.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     0,
+			ClobPairId:   0,
+		},
+		27,
 	)
 	CancelOrder_Alice_Num1_Id0_Clob0_GTB20 = *clobtypes.NewMsgCancelOrderShortTerm(
 		clobtypes.OrderId{


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added validation for the "GoodTilBlock" (GTB) field in order placement and cancellation to prevent replay attacks.
- Refactor: Extracted GTB validation logic into a separate function `validateGoodTilBlock` for better code modularity and reuse.
- Test: Enhanced test coverage for rate limiting short-term orders and guarding against replay attacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->