### PR TITLE
[DEC-2110] Check usdc asset exponent on creation

### DIFF
--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -39,6 +39,9 @@ func (k Keeper) CreateAsset(
 			return types.Asset{}, types.ErrUsdcMustBeAssetZero
 		}
 
+		// Confirm that USDC asset has the expected denom exponent (-6).
+		// This is an important invariant before coin-to-quote-quantum conversion
+		// is correctly implemented (CLOB-871).
 		if denomExponent != types.AssetUsdc.DenomExponent {
 			return types.Asset{}, errorsmod.Wrapf(
 				types.ErrUnexpectedUsdcDenomExponent,

--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -33,9 +33,20 @@ func (k Keeper) CreateAsset(
 		)
 	}
 
-	// Ensure assetId zero is always USDC. This is a protocol-wide invariant.
-	if assetId == types.AssetUsdc.Id && denom != types.AssetUsdc.Denom {
-		return types.Asset{}, types.ErrUsdcMustBeAssetZero
+	if assetId == types.AssetUsdc.Id {
+		// Ensure assetId zero is always USDC. This is a protocol-wide invariant.
+		if denom != types.AssetUsdc.Denom {
+			return types.Asset{}, types.ErrUsdcMustBeAssetZero
+		}
+
+		if denomExponent != types.AssetUsdc.DenomExponent {
+			return types.Asset{}, errorsmod.Wrapf(
+				types.ErrUnexpectedUsdcDenomExponent,
+				"expected = %v, actual = %v",
+				types.AssetUsdc.DenomExponent,
+				denomExponent,
+			)
+		}
 	}
 
 	// Ensure USDC is not created with a non-zero assetId. This is a protocol-wide invariant.

--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -41,7 +41,7 @@ func (k Keeper) CreateAsset(
 
 		// Confirm that USDC asset has the expected denom exponent (-6).
 		// This is an important invariant before coin-to-quote-quantum conversion
-		// is correctly implemented (CLOB-871).
+		// is correctly implemented. See CLOB-871 for details.
 		if denomExponent != types.AssetUsdc.DenomExponent {
 			return types.Asset{}, errorsmod.Wrapf(
 				types.ErrUnexpectedUsdcDenomExponent,

--- a/protocol/x/assets/keeper/asset_test.go
+++ b/protocol/x/assets/keeper/asset_test.go
@@ -83,7 +83,7 @@ func TestCreateAsset_MarketNotFound(t *testing.T) {
 	require.Len(t, keeper.GetAllAssets(ctx), 0)
 }
 
-func TestCreateAsset_UsdcMustBeAssetZero(t *testing.T) {
+func TestCreateAsset_InvalidUsdcAsset(t *testing.T) {
 	ctx, keeper, _, _, _, _ := keepertest.AssetsKeepers(t, true)
 
 	// Throws error when creating an asset with id 0 that's not USDC.
@@ -114,6 +114,22 @@ func TestCreateAsset_UsdcMustBeAssetZero(t *testing.T) {
 		int32(-1),
 	)
 	require.ErrorIs(t, err, types.ErrUsdcMustBeAssetZero)
+
+	// Does not create an asset.
+	require.Len(t, keeper.GetAllAssets(ctx), 0)
+
+	// Throws error when creating asset USDC with id other than 0.
+	_, err = keeper.CreateAsset(
+		ctx,
+		0,
+		constants.Usdc.Symbol, // symbol
+		constants.Usdc.Denom,  // denom
+		-9,                    // denomExponent
+		true,
+		uint32(999),
+		int32(-1),
+	)
+	require.ErrorIs(t, err, types.ErrUnexpectedUsdcDenomExponent)
 
 	// Does not create an asset.
 	require.Len(t, keeper.GetAllAssets(ctx), 0)

--- a/protocol/x/assets/keeper/asset_test.go
+++ b/protocol/x/assets/keeper/asset_test.go
@@ -118,7 +118,7 @@ func TestCreateAsset_InvalidUsdcAsset(t *testing.T) {
 	// Does not create an asset.
 	require.Len(t, keeper.GetAllAssets(ctx), 0)
 
-	// Throws error when creating asset USDC with id other than 0.
+	// Throws error when creating asset USDC with unexpected denom exponent.
 	_, err = keeper.CreateAsset(
 		ctx,
 		0,

--- a/protocol/x/assets/types/errors.go
+++ b/protocol/x/assets/types/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrInvalidAssetAtomicResolution = errorsmod.Register(ModuleName, 10, "Invalid asset atomic resolution")
 	ErrInvalidDenomExponent         = errorsmod.Register(ModuleName, 11, "Invalid denom exponent")
 	ErrAssetAlreadyExists           = errorsmod.Register(ModuleName, 12, "Asset already exists")
+	ErrUnexpectedUsdcDenomExponent  = errorsmod.Register(ModuleName, 13, "USDC denom exponent is unexpected")
 
 	// Errors for Not Implemented
 	ErrNotImplementedMulticollateral = errorsmod.Register(ModuleName, 401, "Not Implemented: Multi-Collateral")

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -62,20 +62,20 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 				Id:               0,
 				Symbol:           "USDC",
 				Denom:            asstypes.AssetUsdc.Denom,
-				DenomExponent:    int32(-3), // $1 = 1_000 coin unit.
+				DenomExponent:    int32(-6), // $1 = 1_000_000 coin unit.
 				HasMarket:        false,
 				MarketId:         uint32(0),
-				AtomicResolution: int32(-4), // $1 = 10_000 quantums
+				AtomicResolution: int32(-7), // $1 = 10_000_000 quantums
 			},
-			accAddressBalance:          big.NewInt(2_500),  // $2.5
-			subaccountModuleAccBalance: big.NewInt(10_000), // $10
-			quantums:                   big.NewInt(20_001), // $2.0001, only $2 transfered.
+			accAddressBalance:          big.NewInt(2_500_000),  // $2.5
+			subaccountModuleAccBalance: big.NewInt(10_000_000), // $10
+			quantums:                   big.NewInt(20_000_001), // $2.0000001, only $2 transfered.
 			assetPositions: keepertest.CreateUsdcAssetPosition(
-				big.NewInt(30_001),
+				big.NewInt(30_000_001),
 			), // $3.0001
-			expectedQuoteBalance:                big.NewInt(10_001), // $1.0001, untransfered $0.0001 remains.
-			expectedSubaccountsModuleAccBalance: big.NewInt(8_000),  // $8
-			expectedAccAddressBalance:           big.NewInt(4_500),  // $2.5 + $2
+			expectedQuoteBalance:                big.NewInt(10_000_001), // $1.0001, untransfered $0.0001 remains.
+			expectedSubaccountsModuleAccBalance: big.NewInt(8_000_000),  // $8
+			expectedAccAddressBalance:           big.NewInt(4_500_000),  // $2.5 + $2
 		},
 		"DepositFundsFromAccountToSubaccount: send from account to subaccount": {
 			testTransferFundToAccount:           false,
@@ -94,18 +94,18 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 				Id:               0,
 				Symbol:           "USDC",
 				Denom:            asstypes.AssetUsdc.Denom,
-				DenomExponent:    int32(-4), // $1 = 10_000 coin unit.
+				DenomExponent:    int32(-6), // $1 = 1000_000 coin unit.
 				HasMarket:        false,
 				MarketId:         uint32(0),
-				AtomicResolution: int32(-3), // $1 = 1_000 quantums
+				AtomicResolution: int32(-5), // $1 = 100_000 quantums
 			},
-			subaccountModuleAccBalance:          big.NewInt(20_000),                                    // $2
-			accAddressBalance:                   big.NewInt(90_000),                                    // $9
-			quantums:                            big.NewInt(5_021),                                     // $5.021
-			assetPositions:                      keepertest.CreateUsdcAssetPosition(big.NewInt(1_050)), // $1.05
-			expectedQuoteBalance:                big.NewInt(6_071),                                     // $1.05 + $5.021
-			expectedSubaccountsModuleAccBalance: big.NewInt(70_210),                                    // $2 + $5.021
-			expectedAccAddressBalance:           big.NewInt(39_790),                                    // $9 - $5.021
+			subaccountModuleAccBalance:          big.NewInt(2_000_000),                                   // $2
+			accAddressBalance:                   big.NewInt(9_000_000),                                   // $9
+			quantums:                            big.NewInt(502_100),                                     // $5.021
+			assetPositions:                      keepertest.CreateUsdcAssetPosition(big.NewInt(105_000)), // $1.05
+			expectedQuoteBalance:                big.NewInt(607_100),                                     // $1.05 + $5.021
+			expectedSubaccountsModuleAccBalance: big.NewInt(7_021_000),                                   // $2 + $5.021
+			expectedAccAddressBalance:           big.NewInt(3_979_000),                                   // $9 - $5.021
 		},
 		"DepositFundsFromAccountToSubaccount: new balance reaches max int64": {
 			testTransferFundToAccount:  false,


### PR DESCRIPTION
Original [context](https://dydx-team.slack.com/archives/C03SLFHC3L7/p1694708788214889?thread_ts=1693875473.553399&cid=C03SLFHC3L7)

Asset creation is currently the only path that touches `asset.DenomExponent`, so added a check there


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enforced strict rules for the creation of `USDC` asset in the `CreateAsset` function. The asset ID must be zero and the denom exponent must match the expected value. This prevents incorrect or fraudulent creation of `USDC`.
- Test: Enhanced test coverage in `TestCreateAsset_InvalidUsdcAsset` to validate the new checks introduced for `USDC` asset creation.
- Chore: Adjusted denominations, atomic resolutions, and balance values in various tests to reflect more accurate asset and balance values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->