### PR TITLE
[DEC-2137] Replace `lib.UsdcAssetId` with `assettypes.Usdc.AssetId`

### DIFF
--- a/protocol/lib/constants.go
+++ b/protocol/lib/constants.go
@@ -14,7 +14,6 @@ const (
 	MaxPriceChangePpm = uint32(10_000)
 	// 10^6 quantums == 1 USD.
 	QuoteCurrencyAtomicResolution = int32(-6)
-	UsdcAssetId                   = uint32(0)
 
 	ZeroUint64 = uint64(0)
 

--- a/protocol/testutil/constants/messages.go
+++ b/protocol/testutil/constants/messages.go
@@ -5,7 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/dydxprotocol/v4-chain/protocol/app/config"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 )
@@ -64,7 +64,7 @@ var (
 		Transfer: &sendingtypes.Transfer{
 			Sender:    Carl_Num0,
 			Recipient: Dave_Num0,
-			AssetId:   lib.UsdcAssetId,
+			AssetId:   assettypes.AssetUsdc.Id,
 			Amount:    500_000_000, // $500
 		},
 	}

--- a/protocol/testutil/constants/transfers.go
+++ b/protocol/testutil/constants/transfers.go
@@ -1,7 +1,7 @@
 package constants
 
 import (
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 )
 
@@ -9,31 +9,31 @@ var (
 	Transfer_Carl_Num0_Dave_Num0_Quote_500 = types.Transfer{
 		Sender:    Carl_Num0,
 		Recipient: Dave_Num0,
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Amount:    500_000_000, // $500
 	}
 	Transfer_Carl_Num0_Dave_Num0_Quote_600 = types.Transfer{
 		Sender:    Carl_Num0,
 		Recipient: Dave_Num0,
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Amount:    600_000_000, // $600
 	}
 	Transfer_Carl_Num0_Dave_Num0_Asset_600 = types.Transfer{
 		Sender:    Carl_Num0,
 		Recipient: Dave_Num0,
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Amount:    600_000_000, // $600
 	}
 	Transfer_Dave_Num0_Carl_Num0_Asset_500 = types.Transfer{
 		Sender:    Dave_Num0,
 		Recipient: Carl_Num0,
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Amount:    500_000_000, // $500
 	}
 	Transfer_Dave_Num0_Carl_Num0_Asset_500_GTB_20 = types.Transfer{
 		Sender:    Dave_Num0,
 		Recipient: Carl_Num0,
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Amount:    500_000_000, // $500
 	}
 )
@@ -43,13 +43,13 @@ var (
 	MsgDepositToSubaccount_Alice_To_Alice_Num0_500 = types.MsgDepositToSubaccount{
 		Sender:    AliceAccAddress.String(),
 		Recipient: Alice_Num0,
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Quantums:  500_000_000, // $500
 	}
 	MsgDepositToSubaccount_Alice_To_Carl_Num0_750 = types.MsgDepositToSubaccount{
 		Sender:    AliceAccAddress.String(),
 		Recipient: Carl_Num0,
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Quantums:  750_000_000, // $750
 	}
 )
@@ -59,13 +59,13 @@ var (
 	MsgWithdrawFromSubaccount_Alice_Num0_To_Alice_500 = types.MsgWithdrawFromSubaccount{
 		Sender:    Alice_Num0,
 		Recipient: AliceAccAddress.String(),
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Quantums:  500_000_000, // $500
 	}
 	MsgWithdrawFromSubaccount_Carl_Num0_To_Alice_750 = types.MsgWithdrawFromSubaccount{
 		Sender:    Carl_Num0,
 		Recipient: AliceAccAddress.String(),
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assettypes.AssetUsdc.Id,
 		Quantums:  750_000_000, // $750
 	}
 )

--- a/protocol/testutil/keeper/subaccounts.go
+++ b/protocol/testutil/keeper/subaccounts.go
@@ -1,9 +1,10 @@
 package keeper
 
 import (
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"math/big"
 	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/common"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
@@ -18,8 +19,8 @@ import (
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	asskeeper "github.com/dydxprotocol/v4-chain/protocol/x/assets/keeper"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	perpskeeper "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/keeper"
 	priceskeeper "github.com/dydxprotocol/v4-chain/protocol/x/prices/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
@@ -111,7 +112,7 @@ func CreateUsdcAssetPosition(
 ) []*types.AssetPosition {
 	return []*types.AssetPosition{
 		{
-			AssetId:  lib.UsdcAssetId,
+			AssetId:  assettypes.AssetUsdc.Id,
 			Quantums: dtypes.NewIntFromBigInt(quoteBalance),
 		},
 	}
@@ -122,7 +123,7 @@ func CreateUsdcAssetUpdate(
 ) []types.AssetUpdate {
 	return []types.AssetUpdate{
 		{
-			AssetId:          lib.UsdcAssetId,
+			AssetId:          assettypes.AssetUsdc.Id,
 			BigQuantumsDelta: deltaQuoteBalance,
 		},
 	}

--- a/protocol/x/assets/keeper/asset.go
+++ b/protocol/x/assets/keeper/asset.go
@@ -201,7 +201,7 @@ func (k Keeper) GetNetCollateral(
 	bigNetCollateralQuoteQuantums *big.Int,
 	err error,
 ) {
-	if id == lib.UsdcAssetId {
+	if id == types.AssetUsdc.Id {
 		return new(big.Int).Set(bigQuantums), nil
 	}
 
@@ -239,7 +239,7 @@ func (k Keeper) GetMarginRequirements(
 	err error,
 ) {
 	// QuoteBalance does not contribute to any margin requirements.
-	if id == lib.UsdcAssetId {
+	if id == types.AssetUsdc.Id {
 		return big.NewInt(0), big.NewInt(0), nil
 	}
 

--- a/protocol/x/assets/keeper/asset_test.go
+++ b/protocol/x/assets/keeper/asset_test.go
@@ -9,7 +9,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/nullify"
@@ -326,7 +325,7 @@ func TestGetNetCollateral(t *testing.T) {
 
 	netCollateral, err := keeper.GetNetCollateral(
 		ctx,
-		lib.UsdcAssetId,
+		types.AssetUsdc.Id,
 		new(big.Int).SetInt64(100),
 	)
 	require.NoError(t, err)
@@ -354,7 +353,7 @@ func TestGetMarginRequirements(t *testing.T) {
 
 	initial, maintenance, err := keeper.GetMarginRequirements(
 		ctx,
-		lib.UsdcAssetId,
+		types.AssetUsdc.Id,
 		new(big.Int).SetInt64(100),
 	)
 	require.NoError(t, err)
@@ -558,7 +557,7 @@ func TestIsPositionUpdatable(t *testing.T) {
 	require.NoError(t, keepertest.CreateUsdcAsset(ctx, keeper))
 
 	// Check Usdc asset is updatable.
-	updatable, err := keeper.IsPositionUpdatable(ctx, lib.UsdcAssetId)
+	updatable, err := keeper.IsPositionUpdatable(ctx, types.AssetUsdc.Id)
 	require.NoError(t, err)
 	require.True(t, updatable)
 

--- a/protocol/x/clob/client/cli/liquidations_cli_test.go
+++ b/protocol/x/clob/client/cli/liquidations_cli_test.go
@@ -4,6 +4,7 @@ package cli_test
 
 import (
 	"fmt"
+
 	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/app/stoppable"
 
@@ -16,6 +17,7 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/client/testutil"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	epochstypes "github.com/dydxprotocol/v4-chain/protocol/x/epochs/types"
@@ -143,7 +145,7 @@ func (s *LiquidationsIntegrationTestSuite) SetupSuite() {
 			Id: &satypes.SubaccountId{Owner: s.validatorAddress.String(), Number: liqTestSubaccountNumberOne},
 			AssetPositions: []*satypes.AssetPosition{
 				{
-					AssetId:  lib.UsdcAssetId,
+					AssetId:  assettypes.AssetUsdc.Id,
 					Quantums: dtypes.NewInt(-45_001_000_000), // -$45,001
 				},
 			},

--- a/protocol/x/clob/e2e/short_term_orders_test.go
+++ b/protocol/x/clob/e2e/short_term_orders_test.go
@@ -18,6 +18,7 @@ import (
 	clobtestutils "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	testtx "github.com/dydxprotocol/v4-chain/protocol/testutil/tx"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
@@ -163,7 +164,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Maker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(bobSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -187,7 +188,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Maker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(bobSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -211,7 +212,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Taker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(aliceSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -235,7 +236,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Taker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(aliceSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -375,7 +376,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Maker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(bobSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -399,7 +400,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Maker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(bobSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -423,7 +424,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Taker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(aliceSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -447,7 +448,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Taker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(aliceSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -587,7 +588,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Taker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(aliceSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -611,7 +612,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Taker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(aliceSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -635,7 +636,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Maker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(bobSubaccount.GetUsdcPosition()),
 										},
 									},
@@ -659,7 +660,7 @@ func TestPlaceOrder(t *testing.T) {
 									// Maker fees calculate to 0 so asset position doesn't change.
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assettypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(bobSubaccount.GetUsdcPosition()),
 										},
 									},

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -14,6 +14,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
@@ -65,7 +66,7 @@ func (k Keeper) GetInsuranceFundBalance(
 ) (
 	balance *big.Int,
 ) {
-	usdcAsset, exists := k.assetsKeeper.GetAsset(ctx, lib.UsdcAssetId)
+	usdcAsset, exists := k.assetsKeeper.GetAsset(ctx, assettypes.AssetUsdc.Id)
 	if !exists {
 		panic("GetInsuranceFundBalance: Usdc asset not found in state")
 	}
@@ -399,7 +400,7 @@ func (k Keeper) ProcessDeleveraging(
 		{
 			AssetUpdates: []satypes.AssetUpdate{
 				{
-					AssetId:          lib.UsdcAssetId,
+					AssetId:          assettypes.AssetUsdc.Id,
 					BigQuantumsDelta: deleveragedSubaccountQuoteBalanceDelta,
 				},
 			},
@@ -415,7 +416,7 @@ func (k Keeper) ProcessDeleveraging(
 		{
 			AssetUpdates: []satypes.AssetUpdate{
 				{
-					AssetId:          lib.UsdcAssetId,
+					AssetId:          assettypes.AssetUsdc.Id,
 					BigQuantumsDelta: offsettingSubaccountQuoteBalanceDelta,
 				},
 			},

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
@@ -340,7 +341,7 @@ func (k Keeper) persistMatchedOrders(
 		{
 			AssetUpdates: []satypes.AssetUpdate{
 				{
-					AssetId:          lib.UsdcAssetId,
+					AssetId:          assettypes.AssetUsdc.Id,
 					BigQuantumsDelta: bigTakerQuoteBalanceDelta,
 				},
 			},
@@ -356,7 +357,7 @@ func (k Keeper) persistMatchedOrders(
 		{
 			AssetUpdates: []satypes.AssetUpdate{
 				{
-					AssetId:          lib.UsdcAssetId,
+					AssetId:          assettypes.AssetUsdc.Id,
 					BigQuantumsDelta: bigMakerQuoteBalanceDelta,
 				},
 			},
@@ -411,7 +412,7 @@ func (k Keeper) persistMatchedOrders(
 	bigTotalFeeQuoteQuantums := new(big.Int).Add(bigTakerFeeQuoteQuantums, bigMakerFeeQuoteQuantums)
 	if err := k.subaccountsKeeper.TransferFeesToFeeCollectorModule(
 		ctx,
-		lib.UsdcAssetId,
+		assettypes.AssetUsdc.Id,
 		bigTotalFeeQuoteQuantums,
 	); err != nil {
 		return takerUpdateResult, makerUpdateResult, errorsmod.Wrapf(

--- a/protocol/x/clob/types/pending_updates.go
+++ b/protocol/x/clob/types/pending_updates.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -55,13 +56,13 @@ func (p *PendingUpdates) ConvertToUpdates() []satypes.Update {
 			assetUpdates = append(assetUpdates, assetUpdate)
 		}
 
-		if _, exists := pendingAssetUpdates[lib.UsdcAssetId]; !exists {
-			pendingAssetUpdates[lib.UsdcAssetId] = new(big.Int)
+		if _, exists := pendingAssetUpdates[assettypes.AssetUsdc.Id]; !exists {
+			pendingAssetUpdates[assettypes.AssetUsdc.Id] = new(big.Int)
 		}
 
 		// Subtract quote balance delta with total fees paid by subaccount.
-		pendingAssetUpdates[lib.UsdcAssetId].Sub(
-			pendingAssetUpdates[lib.UsdcAssetId],
+		pendingAssetUpdates[assettypes.AssetUsdc.Id].Sub(
+			pendingAssetUpdates[assettypes.AssetUsdc.Id],
 			p.subaccountFee[subaccountId],
 		)
 
@@ -123,10 +124,10 @@ func (p *PendingUpdates) AddPerpetualFill(
 		subaccountAssetUpdates = make(map[uint32]*big.Int)
 		p.subaccountAssetUpdates[subaccountId] = subaccountAssetUpdates
 	}
-	quoteBalanceUpdate, exists = subaccountAssetUpdates[lib.UsdcAssetId]
+	quoteBalanceUpdate, exists = subaccountAssetUpdates[assettypes.AssetUsdc.Id]
 	if !exists {
 		quoteBalanceUpdate = big.NewInt(0)
-		subaccountAssetUpdates[lib.UsdcAssetId] = quoteBalanceUpdate
+		subaccountAssetUpdates[assettypes.AssetUsdc.Id] = quoteBalanceUpdate
 	}
 
 	subaccountPerpetualUpdates, exists = p.subaccountPerpetualUpdates[subaccountId]

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -2,9 +2,10 @@ package keeper
 
 import (
 	"fmt"
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants"
 	"math/big"
 	"time"
+
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants"
 
 	sdkmath "cosmossdk.io/math"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 )
@@ -234,7 +236,7 @@ func (k Keeper) ProcessRewardsForBlock(
 	params := k.GetParams(ctx)
 
 	// Calculate value of `F`.
-	usdcAsset, exists := k.assetsKeeper.GetAsset(ctx, lib.UsdcAssetId)
+	usdcAsset, exists := k.assetsKeeper.GetAsset(ctx, assettypes.AssetUsdc.Id)
 	if !exists {
 		return fmt.Errorf("failed to get USDC asset")
 	}

--- a/protocol/x/sending/app_test.go
+++ b/protocol/x/sending/app_test.go
@@ -167,7 +167,7 @@ func TestMsgDepositToSubaccount(t *testing.T) {
 									[]*satypes.PerpetualPosition{},
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assetstypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(subaccountQuantumsAfterDeposit),
 										},
 									},
@@ -183,7 +183,7 @@ func TestMsgDepositToSubaccount(t *testing.T) {
 									[]*satypes.PerpetualPosition{},
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assetstypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(subaccountQuantumsAfterDeposit),
 										},
 									},
@@ -233,7 +233,7 @@ func TestMsgDepositToSubaccount_NonExistentAccount(t *testing.T) {
 	msgDepositToSubaccount := sendingtypes.MsgDepositToSubaccount{
 		Sender:    randomAccount.Address.String(),
 		Recipient: constants.Alice_Num1,
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assetstypes.AssetUsdc.Id,
 		Quantums:  uint64(1_000_000),
 	}
 
@@ -377,7 +377,7 @@ func TestMsgWithdrawFromSubaccount(t *testing.T) {
 									[]*satypes.PerpetualPosition{},
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assetstypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(subaccountQuantumsAfterWithdraw),
 										},
 									},
@@ -393,7 +393,7 @@ func TestMsgWithdrawFromSubaccount(t *testing.T) {
 									[]*satypes.PerpetualPosition{},
 									[]*satypes.AssetPosition{
 										{
-											AssetId:  lib.UsdcAssetId,
+											AssetId:  assetstypes.AssetUsdc.Id,
 											Quantums: dtypes.NewIntFromBigInt(subaccountQuantumsAfterWithdraw),
 										},
 									},
@@ -446,7 +446,7 @@ func TestMsgWithdrawFromSubaccount_NonExistentSubaccount(t *testing.T) {
 			Number: 0,
 		},
 		Recipient: constants.AliceAccAddress.String(),
-		AssetId:   lib.UsdcAssetId,
+		AssetId:   assetstypes.AssetUsdc.Id,
 		Quantums:  uint64(1_000_000),
 	}
 

--- a/protocol/x/sending/client/cli/tx_create_transfer.go
+++ b/protocol/x/sending/client/cli/tx_create_transfer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/spf13/cast"
@@ -57,7 +57,7 @@ func CmdCreateTransfer() *cobra.Command {
 						Owner:  argRecipientOwner,
 						Number: argRecipientNumber,
 					},
-					AssetId: lib.UsdcAssetId,
+					AssetId: assettypes.AssetUsdc.Id,
 					Amount:  argAmount,
 				},
 			)

--- a/protocol/x/sending/client/cli/tx_deposit_to_subaccount.go
+++ b/protocol/x/sending/client/cli/tx_deposit_to_subaccount.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/spf13/cast"
@@ -53,7 +53,7 @@ Note, the '--from' flag is ignored as it is implied from [sender_key_or_address]
 					Owner:  argRecipientOwner,
 					Number: argRecipientNumber,
 				},
-				lib.UsdcAssetId,
+				assettypes.AssetUsdc.Id,
 				argAmount,
 			)
 

--- a/protocol/x/sending/client/cli/tx_withdraw_from_subaccount.go
+++ b/protocol/x/sending/client/cli/tx_withdraw_from_subaccount.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/spf13/cast"
@@ -53,7 +53,7 @@ Note, the '--from' flag is ignored as it is implied from [sender_key_or_address]
 					Number: argSenderNumber,
 				},
 				argRecipient,
-				lib.UsdcAssetId,
+				assettypes.AssetUsdc.Id,
 				argAmount,
 			)
 

--- a/protocol/x/sending/keeper/transfer_test.go
+++ b/protocol/x/sending/keeper/transfer_test.go
@@ -14,10 +14,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sample"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 
@@ -286,7 +286,7 @@ func TestProcessTransfer_CreateRecipientAccount(t *testing.T) {
 			Owner:  recipient,
 			Number: uint32(0),
 		},
-		AssetId: lib.UsdcAssetId,
+		AssetId: assettypes.AssetUsdc.Id,
 		Amount:  500_000_000, // $500
 	}
 	err = ks.SendingKeeper.ProcessTransfer(ks.Ctx, &transfer)
@@ -332,7 +332,7 @@ func TestProcessDepositToSubaccount(t *testing.T) {
 			msg: types.MsgDepositToSubaccount{
 				Sender:    "1234567", // bad address string
 				Recipient: constants.Alice_Num0,
-				AssetId:   lib.UsdcAssetId,
+				AssetId:   assettypes.AssetUsdc.Id,
 				Quantums:  750_000_000,
 			},
 			expectedErrContains: "decoding bech32 failed",
@@ -417,7 +417,7 @@ func TestProcessWithdrawFromSubaccount(t *testing.T) {
 			msg: types.MsgWithdrawFromSubaccount{
 				Sender:    constants.Alice_Num0,
 				Recipient: "1234567", // bad address string
-				AssetId:   lib.UsdcAssetId,
+				AssetId:   assettypes.AssetUsdc.Id,
 				Quantums:  750_000_000,
 			},
 			expectedErrContains: "decoding bech32 failed",

--- a/protocol/x/sending/simulation/operations.go
+++ b/protocol/x/sending/simulation/operations.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sim_helpers"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -133,7 +134,7 @@ func SimulateMsgCreateTransfer(
 			Transfer: &types.Transfer{
 				Sender:    *senderAccount.GetId(),
 				Recipient: *recipientAccount.GetId(),
-				AssetId:   lib.UsdcAssetId,
+				AssetId:   assettypes.AssetUsdc.Id,
 				Amount:    amountToSend.Uint64(),
 			},
 		}

--- a/protocol/x/sending/types/message_create_transfer.go
+++ b/protocol/x/sending/types/message_create_transfer.go
@@ -3,7 +3,7 @@ package types
 import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 )
 
 var _ sdk.Msg = &MsgCreateTransfer{}
@@ -37,7 +37,7 @@ func (msg *MsgCreateTransfer) ValidateBasic() error {
 		return errorsmod.Wrapf(ErrSenderSameAsRecipient, "Sender is the same as recipient (%s)", &msg.Transfer.Sender)
 	}
 
-	if msg.Transfer.AssetId != lib.UsdcAssetId {
+	if msg.Transfer.AssetId != assettypes.AssetUsdc.Id {
 		return ErrNonUsdcAssetTransferNotImplemented
 	}
 

--- a/protocol/x/sending/types/message_create_transfer_test.go
+++ b/protocol/x/sending/types/message_create_transfer_test.go
@@ -3,9 +3,9 @@ package types_test
 import (
 	"testing"
 
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sample"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
@@ -81,7 +81,7 @@ func TestMsgCreateTransfer_ValidateBasic(t *testing.T) {
 				Transfer: &types.Transfer{
 					Sender:    constants.Carl_Num0,
 					Recipient: constants.Carl_Num0,
-					AssetId:   lib.UsdcAssetId,
+					AssetId:   assettypes.AssetUsdc.Id,
 					Amount:    uint64(500_000_000),
 				},
 			},
@@ -105,7 +105,7 @@ func TestMsgCreateTransfer_ValidateBasic(t *testing.T) {
 				Transfer: &types.Transfer{
 					Sender:    constants.Carl_Num0,
 					Recipient: constants.Dave_Num0,
-					AssetId:   lib.UsdcAssetId,
+					AssetId:   assettypes.AssetUsdc.Id,
 					Amount:    uint64(0),
 				},
 			},

--- a/protocol/x/sending/types/message_deposit_to_subaccount.go
+++ b/protocol/x/sending/types/message_deposit_to_subaccount.go
@@ -3,6 +3,7 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -49,7 +50,7 @@ func (msg *MsgDepositToSubaccount) ValidateBasic() error {
 	}
 
 	// Validate that asset is USDC.
-	if msg.AssetId != lib.UsdcAssetId {
+	if msg.AssetId != assettypes.AssetUsdc.Id {
 		return ErrNonUsdcAssetTransferNotImplemented
 	}
 

--- a/protocol/x/sending/types/message_withdraw_from_subaccount.go
+++ b/protocol/x/sending/types/message_withdraw_from_subaccount.go
@@ -3,6 +3,7 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -49,7 +50,7 @@ func (msg *MsgWithdrawFromSubaccount) ValidateBasic() error {
 	}
 
 	// Validate that asset is USDC.
-	if msg.AssetId != lib.UsdcAssetId {
+	if msg.AssetId != assettypes.AssetUsdc.Id {
 		return ErrNonUsdcAssetTransferNotImplemented
 	}
 

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -10,7 +10,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	big_testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/big"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
@@ -866,7 +865,7 @@ func TestUpdateSubaccounts(t *testing.T) {
 				{
 					AssetUpdates: []types.AssetUpdate{
 						{
-							AssetId:          lib.UsdcAssetId,
+							AssetId:          asstypes.AssetUsdc.Id,
 							BigQuantumsDelta: big.NewInt(100_000_000_000),
 						},
 						{

--- a/protocol/x/subaccounts/keeper/transfer.go
+++ b/protocol/x/subaccounts/keeper/transfer.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
@@ -37,7 +38,7 @@ func (k Keeper) getValidSubaccountUpdatesForTransfer(
 				SubaccountId: subaccountId,
 				AssetUpdates: []types.AssetUpdate{
 					{
-						AssetId:          lib.UsdcAssetId,
+						AssetId:          assettypes.AssetUsdc.Id,
 						BigQuantumsDelta: bigBalanceDelta,
 					},
 				},
@@ -93,7 +94,7 @@ func (k Keeper) TransferFundsFromSubaccountToModule(
 	quantums *big.Int,
 ) error {
 	// TODO(DEC-715): Support non-USDC assets.
-	if assetId != lib.UsdcAssetId {
+	if assetId != assettypes.AssetUsdc.Id {
 		return types.ErrAssetTransferThroughBankNotImplemented
 	}
 
@@ -154,7 +155,7 @@ func (k Keeper) TransferFundsFromModuleToSubaccount(
 	quantums *big.Int,
 ) error {
 	// TODO(DEC-715): Support non-USDC assets.
-	if assetId != lib.UsdcAssetId {
+	if assetId != assettypes.AssetUsdc.Id {
 		return types.ErrAssetTransferThroughBankNotImplemented
 	}
 
@@ -213,7 +214,7 @@ func (k Keeper) DepositFundsFromAccountToSubaccount(
 	quantums *big.Int,
 ) error {
 	// TODO(DEC-715): Support non-USDC assets.
-	if assetId != lib.UsdcAssetId {
+	if assetId != assettypes.AssetUsdc.Id {
 		return types.ErrAssetTransferThroughBankNotImplemented
 	}
 
@@ -270,7 +271,7 @@ func (k Keeper) WithdrawFundsFromSubaccountToAccount(
 	quantums *big.Int,
 ) error {
 	// TODO(DEC-715): Support non-USDC assets.
-	if assetId != lib.UsdcAssetId {
+	if assetId != assettypes.AssetUsdc.Id {
 		return types.ErrAssetTransferThroughBankNotImplemented
 	}
 
@@ -325,7 +326,7 @@ func (k Keeper) TransferFeesToFeeCollectorModule(
 	quantums *big.Int,
 ) error {
 	// TODO(DEC-715): Support non-USDC assets.
-	if assetId != lib.UsdcAssetId {
+	if assetId != assettypes.AssetUsdc.Id {
 		return types.ErrAssetTransferThroughBankNotImplemented
 	}
 
@@ -382,7 +383,7 @@ func (k Keeper) TransferInsuranceFundPayments(
 
 	_, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
 		ctx,
-		lib.UsdcAssetId,
+		assettypes.AssetUsdc.Id,
 		new(big.Int).Abs(insuranceFundDelta),
 	)
 	if err != nil {

--- a/protocol/x/subaccounts/simulation/genesis.go
+++ b/protocol/x/subaccounts/simulation/genesis.go
@@ -10,7 +10,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sim_helpers"
 	asstypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -55,7 +54,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 				quantums := r.Uint64()
 				subacct.AssetPositions = []*types.AssetPosition{
 					{
-						AssetId:  lib.UsdcAssetId,
+						AssetId:  asstypes.AssetUsdc.Id,
 						Quantums: dtypes.NewIntFromUint64(quantums),
 					},
 				}

--- a/protocol/x/subaccounts/simulation/genesis_test.go
+++ b/protocol/x/subaccounts/simulation/genesis_test.go
@@ -12,7 +12,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banksim "github.com/cosmos/cosmos-sdk/x/bank/simulation"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	testutil_rand "github.com/dydxprotocol/v4-chain/protocol/testutil/rand"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sim_helpers"
 	asstypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
@@ -62,7 +61,7 @@ func TestRandomizedGenState(t *testing.T) {
 				require.Len(t, sa.GetAssetPositions(), 1)
 
 				onlyAssetPosition := sa.GetAssetPositions()[0]
-				require.True(t, onlyAssetPosition.AssetId == lib.UsdcAssetId)
+				require.True(t, onlyAssetPosition.AssetId == asstypes.AssetUsdc.Id)
 
 				bigQuantums := sdkmath.NewIntFromBigInt(onlyAssetPosition.GetBigQuantums())
 				totalUsdcSupply = totalUsdcSupply.Add(bigQuantums)

--- a/protocol/x/subaccounts/types/subaccount.go
+++ b/protocol/x/subaccounts/types/subaccount.go
@@ -1,12 +1,13 @@
 package types
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"math/big"
+
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 )
 
 const (
@@ -84,7 +85,7 @@ func (m *Subaccount) SetUsdcAssetPosition(newUsdcPosition *big.Int) error {
 		} else {
 			if usdcAssetPosition == nil {
 				usdcAssetPosition = &AssetPosition{
-					AssetId: lib.UsdcAssetId,
+					AssetId: assettypes.AssetUsdc.Id,
 				}
 				m.AssetPositions = append([]*AssetPosition{usdcAssetPosition}, m.AssetPositions...)
 			}
@@ -100,7 +101,7 @@ func (m *Subaccount) getUsdcAssetPosition() *AssetPosition {
 	}
 
 	firstAsset := m.AssetPositions[0]
-	if firstAsset.AssetId != lib.UsdcAssetId {
+	if firstAsset.AssetId != assettypes.AssetUsdc.Id {
 		return nil
 	}
 	return firstAsset

--- a/protocol/x/subaccounts/types/subaccount_test.go
+++ b/protocol/x/subaccounts/types/subaccount_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sample"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
 )
@@ -158,7 +158,7 @@ func TestGetSubaccountQuoteBalance(t *testing.T) {
 				Id: &constants.Carl_Num0,
 				AssetPositions: []*types.AssetPosition{
 					{
-						AssetId:  lib.UsdcAssetId,
+						AssetId:  assettypes.AssetUsdc.Id,
 						Quantums: dtypes.NewInt(-599_000_000), // $599
 					},
 				},
@@ -223,7 +223,7 @@ func TestSetSubaccountQuoteBalance(t *testing.T) {
 			newQuoteBalance: big.NewInt(-10_000_000_000),
 			expectedAssetPositions: []*types.AssetPosition{
 				{
-					AssetId:  lib.UsdcAssetId,
+					AssetId:  assettypes.AssetUsdc.Id,
 					Quantums: dtypes.NewInt(-10_000_000_000), // $10,000
 				},
 			},
@@ -233,7 +233,7 @@ func TestSetSubaccountQuoteBalance(t *testing.T) {
 			newQuoteBalance: new(big.Int).SetUint64(math.MaxUint64),
 			expectedAssetPositions: []*types.AssetPosition{
 				{
-					AssetId:  lib.UsdcAssetId,
+					AssetId:  assettypes.AssetUsdc.Id,
 					Quantums: dtypes.NewIntFromUint64(math.MaxUint64),
 				},
 			},
@@ -243,7 +243,7 @@ func TestSetSubaccountQuoteBalance(t *testing.T) {
 			newQuoteBalance: constants.BigNegMaxUint64(),
 			expectedAssetPositions: []*types.AssetPosition{
 				{
-					AssetId:  lib.UsdcAssetId,
+					AssetId:  assettypes.AssetUsdc.Id,
 					Quantums: dtypes.NewIntFromBigInt(constants.BigNegMaxUint64()),
 				},
 			},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Replaced the usage of `lib.UsdcAssetId` with `assettypes.AssetUsdc.Id` across multiple files, indicating a shift in how the USDC asset ID is accessed and used within the codebase.
- New Feature: Added error handling for unexpected USDC denom exponent in `protocol/x/assets/types/errors.go`.
- Test: Updated various test cases to reflect changes in asset ID referencing.
- Chore: Adjusted import statements to accommodate the new asset type structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->