### PR TITLE
[CLOB-914] Increase the mempool cache size to prevent replay attacks for short-term placements/cancellations.

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/config.go
+++ b/protocol/cmd/dydxprotocold/cmd/config.go
@@ -6,6 +6,7 @@ import (
 	tmcfg "github.com/cometbft/cometbft/config"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
 const (
@@ -84,7 +85,11 @@ func initTendermintConfig() *tmcfg.Config {
 
 	// Mempool config.
 	cfg.Mempool.Version = "v1"
-	cfg.Mempool.CacheSize = 20000
+	// We specifically are using a number greater than max QPS (currently set at 5000) * ShortBlockWindow to prevent
+	// a replay attack that is possible with short-term order placements and cancellations. The attack would consume
+	// a users rate limit if the entry is evicted from the mempool cache as it would be possible for the transaction
+	// to go through `CheckTx` again causing it to hit rate limit code against the users account.
+	cfg.Mempool.CacheSize = 5000 * int(clobtypes.ShortBlockWindow)
 	cfg.Mempool.Size = 50000
 	cfg.Mempool.TTLNumBlocks = 20 //nolint:staticcheck
 	cfg.Mempool.KeepInvalidTxsInCache = true


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the mempool cache size in the dYdX protocol configuration to mitigate potential replay attacks. The cache size is now dynamically set based on the `ShortBlockWindow` constant from the `clobtypes` package, ensuring efficient handling of short-term order placements and cancellations without premature eviction of entries. This change improves the security and reliability of transaction processing within the protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->