### PR TITLE
Revert change to orderbook instrumentation loop interval.

### DIFF
--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -56,7 +56,7 @@ export const configSchema = {
     default: 2 * ONE_MINUTE_IN_MILLISECONDS,
   }),
   LOOPS_INTERVAL_MS_ORDERBOOK_INSTRUMENTATION: parseInteger({
-    default: FIVE_MINUTES_IN_MILLISECONDS,
+    default: 5 * ONE_SECOND_IN_MILLISECONDS,
   }),
   LOOPS_INTERVAL_MS_CANCEL_STALE_ORDERS: parseInteger({
     default: THIRTY_SECONDS_IN_MILLISECONDS,


### PR DESCRIPTION
### Changelist
Revert change erroneously made to the loop interval of the orderbook instrumentation task. It was changed to 5 minutes, when originally was 5 seconds.

### Test Plan
Not tested.

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately. [N/A]
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label. [N/A]
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`. [N/A]
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`. [N/A]
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`. [N/A]
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`. [chore]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Adjusted the interval duration for order book instrumentation. The default value of `LOOPS_INTERVAL_MS_ORDERBOOK_INSTRUMENTATION` in the configuration schema has been changed from `FIVE_MINUTES_IN_MILLISECONDS` to `5 * ONE_SECOND_IN_MILLISECONDS`. This change will result in more frequent updates, providing users with more current data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->