### PR TITLE
[DEC-2065] - Unit tests for SetDelayedMessage.

### DIFF
--- a/protocol/x/delaymsg/keeper/delayed_message.go
+++ b/protocol/x/delaymsg/keeper/delayed_message.go
@@ -129,6 +129,16 @@ func (k Keeper) SetDelayedMessage(
 
 	// Add message to the store.
 	store := k.newDelayedMessageStore(ctx)
+
+	// Check for duplicate message id.
+	if store.Get(lib.Uint32ToKey(msg.Id)) != nil {
+		return errorsmod.Wrapf(
+			types.ErrInvalidInput,
+			"failed to delay message: message with id %d already exists",
+			msg.Id,
+		)
+	}
+
 	store.Set(lib.Uint32ToKey(msg.Id), k.cdc.MustMarshal(msg))
 
 	// Add message id to the list of message ids for the block.


### PR DESCRIPTION
### Changelist
Add unit tests for SetDelayedMessage. Additionally, add a guard to prevent duplicate id inserts. (This duplicate id behavior is  currently prevented by existing validation everywhere `SetDelayedMessage` is called, but this change should help to future-proof against anyone using the method to put the keeper into an invalid state.)

### Test Plan
With included unit tests.

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Added a check in the `SetDelayedMessage` function to prevent storing duplicate message IDs. If a message with the same ID already exists, an error is now returned.
- Test: Introduced a new test function `TestSetDelayedMessage` to validate the functionality of `SetDelayedMessage`. The tests cover various scenarios including successful execution, invalid block height, and duplicate ID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->