### PR TITLE
[CORE-638] Set testnet default unbonding time to 12 days

### DIFF
--- a/protocol/testing/testnet-external/pregenesis.sh
+++ b/protocol/testing/testnet-external/pregenesis.sh
@@ -147,7 +147,7 @@ function overwrite_genesis_public_testnet() {
 	dasel put -t string -f "$GENESIS" '.app_state.staking.params.bond_denom' -v "$NATIVE_TOKEN"
 	dasel put -t int -f "$GENESIS" '.app_state.staking.params.max_validators' -v '100'
 	dasel put -t string -f "$GENESIS" '.app_state.staking.params.min_commission_rate' -v '0.05' # 5%
-	dasel put -t string -f "$GENESIS" '.app_state.staking.params.unbonding_time' -v '259200s' # 3 days
+	dasel put -t string -f "$GENESIS" '.app_state.staking.params.unbonding_time' -v '1814400s' # 21 days
 	dasel put -t int -f "$GENESIS" '.app_state.staking.params.max_entries' -v '7'
 	dasel put -t int -f "$GENESIS" '.app_state.staking.params.historical_entries' -v '10000'
 

--- a/protocol/testing/testnet-external/pregenesis.sh
+++ b/protocol/testing/testnet-external/pregenesis.sh
@@ -147,7 +147,7 @@ function overwrite_genesis_public_testnet() {
 	dasel put -t string -f "$GENESIS" '.app_state.staking.params.bond_denom' -v "$NATIVE_TOKEN"
 	dasel put -t int -f "$GENESIS" '.app_state.staking.params.max_validators' -v '100'
 	dasel put -t string -f "$GENESIS" '.app_state.staking.params.min_commission_rate' -v '0.05' # 5%
-	dasel put -t string -f "$GENESIS" '.app_state.staking.params.unbonding_time' -v '1814400s' # 21 days
+	dasel put -t string -f "$GENESIS" '.app_state.staking.params.unbonding_time' -v '1036800s' # 12 days
 	dasel put -t int -f "$GENESIS" '.app_state.staking.params.max_entries' -v '7'
 	dasel put -t int -f "$GENESIS" '.app_state.staking.params.historical_entries' -v '10000'
 


### PR DESCRIPTION
AI for clob `AppHash` mismatch 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Configuration Update":
- Updated the `unbonding_time` parameter in the staking configuration of the Genesis file for external testnet environments. The unbonding period has been extended from 3 days to 21 days in one environment, and to 12 days in another. This change will affect the time it takes for staked tokens to become available after they have been unbonded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->