### PR TITLE
[DEC-2082] add + clarify comments

### DIFF
--- a/protocol/lib/ante/app_injected_msg_ante_wrapper.go
+++ b/protocol/lib/ante/app_injected_msg_ante_wrapper.go
@@ -27,9 +27,10 @@ func (imaw AppInjectedMsgAnteWrapper) AnteHandle(
 	simulate bool,
 	next sdk.AnteHandler,
 ) (sdk.Context, error) {
-	// "App-injected message" tx is skipped, because such tx is not signed on purpose.
-	// If a tx is not signed, signature related functions like `GetSigners` will fail
-	// with "empty address string is not allowed" error.
+	// "App-injected message" tx must skip certain AnteHandlers.
+	// For example, "App-injected message" tx is not signed on purpose and if a tx is not signed,
+	// signature related functions like `GetSigners` will fail due to signer field being empty.
+	// Therefore, we skip the AnteHandlers that require the tx to be signed.
 	if IsSingleAppInjectedMsg(tx.GetMsgs()) {
 		return next(ctx, tx, simulate)
 	}


### PR DESCRIPTION
### Changelist
This PR updates comments for `lib/ante` and usages of it.

### Test Plan
N/A. No logic is changed.

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `newAnteDecoratorChain` function with additional decorators and wrappers for app-injected messages, improving functionality and security.
- Refactor: Adjusted the order of decorators in the chain to optimize their execution.
- Documentation: Updated comments in `AppInjectedMsgAnteWrapper`'s `AnteHandle` function for better clarity on handling app-injected message transactions.
- Bug Fix: Improved error handling in `AppInjectedMsgAnteWrapper` to prevent failures from unsigned transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->