### PR TITLE
Don't geoblock internal ips.

### DIFF
--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -10,6 +10,8 @@
 * [#469](https://github.com/dydxprotocol/v4-chain/pull/469) Added a reason field to `/screen` endpoint to display a reason for blocking an address.
   
 ### Bug Fixes
+* [#496](https://github.com/dydxprotocol/v4-chain/pull/496) Don't geo-block requests made to `comlink` if it's from an internal ip.
+
 * [#460](https://github.com/dydxprotocol/v4-chain/pull/460/files) Fixed track lag timing to output positive numbers.
 
 ### API Breaking Changes

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
@@ -14,7 +14,7 @@ import { ratelimitRedis } from '../../../../src/caches/rate-limiters';
 import { redis } from '@dydxprotocol-indexer/redis';
 import { DateTime } from 'luxon';
 import config from '../../../../src/config';
-import { getIpAddr } from '../../../../src/lib/rate-limit';
+import { getIpAddr } from '../../../../src/lib/utils';
 
 jest.mock('../../../../src/lib/rate-limit', () => ({
   ...jest.requireActual('../../../../src/lib/rate-limit'),

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
@@ -16,8 +16,8 @@ import { DateTime } from 'luxon';
 import config from '../../../../src/config';
 import { getIpAddr } from '../../../../src/lib/utils';
 
-jest.mock('../../../../src/lib/rate-limit', () => ({
-  ...jest.requireActual('../../../../src/lib/rate-limit'),
+jest.mock('../../../../src/lib/utils', () => ({
+  ...jest.requireActual('../../../../src/lib/utils'),
   getIpAddr: jest.fn(),
 }));
 

--- a/indexer/services/comlink/__tests__/lib/restrict-countries.test.ts
+++ b/indexer/services/comlink/__tests__/lib/restrict-countries.test.ts
@@ -2,6 +2,7 @@ import { INDEXER_GEOBLOCKED_PAYLOAD, isRestrictedCountryHeaders } from '@dydxpro
 import config from '../../src/config';
 import { rejectRestrictedCountries } from '../../src/lib/restrict-countries';
 import { BlockedCode } from '../../src/types';
+import * as utils from '../../src/lib/utils';
 
 jest.mock('@dydxprotocol-indexer/compliance');
 
@@ -12,6 +13,8 @@ const restrictedHeaders = {
 const nonRestrictedHeaders = {
   'cf-ipcountry': 'SA',
 };
+
+const internalIp: string = '3.125.3.24';
 
 describe('rejectRestrictedCountries', () => {
   let isRestrictedCountrySpy: jest.SpyInstance;
@@ -72,5 +75,17 @@ describe('rejectRestrictedCountries', () => {
       ]),
     }));
     expect(next).not.toHaveBeenCalled();
+  });
+
+  it('does not check headers for internal indexer ip address', () => {
+    // restricted ipcountry
+    req.headers = restrictedHeaders;
+    isRestrictedCountrySpy.mockReturnValueOnce(true);
+    jest.spyOn(utils, 'getIpAddr').mockReturnValue(internalIp);
+    jest.spyOn(utils, 'isIndexerIp').mockImplementation((ip: string): boolean => ip === internalIp);
+
+    rejectRestrictedCountries(req, res, next);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
   });
 });

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -16,8 +16,9 @@ import {
 import config from '../../../config';
 import { complianceProvider } from '../../../helpers/compliance/compliance-clients';
 import { create4xxResponse, handleControllerError } from '../../../lib/helpers';
-import { getIpAddr, rateLimiterMiddleware } from '../../../lib/rate-limit';
+import { rateLimiterMiddleware } from '../../../lib/rate-limit';
 import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
+import { getIpAddr } from '../../../lib/utils';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { ComplianceRequest, ComplianceResponse } from '../../../types';

--- a/indexer/services/comlink/src/lib/rate-limit.ts
+++ b/indexer/services/comlink/src/lib/rate-limit.ts
@@ -5,7 +5,7 @@ import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
 
 import config from '../config';
 import { create4xxResponse } from './helpers';
-import { isIndexerIp } from './utils';
+import { getIpAddr, isIndexerIp } from './utils';
 
 const INTERNAL_REQUEST_POINTS: number = 0;
 const EXTERNAL_REQUEST_POINTS: number = 1;
@@ -71,22 +71,6 @@ export function rateLimiterMiddleware(
 
     return next();
   };
-}
-
-export function getIpAddr(req: express.Request): string | undefined {
-  const {
-    'cf-connecting-ip': cloudflareIP,
-    'x-forwarded-for': loadBalancerHeader,
-  } = req.headers as {
-    'cf-connecting-ip'?: string,
-    'x-forwarded-for'?: string,
-  };
-
-  // get ip address
-  const loadBalancerIPs: string[] | undefined = loadBalancerHeader?.replace(/\s/g, '').split(',');
-  const firstLoadBalancerIP: string | undefined = loadBalancerIPs?.[0];
-
-  return cloudflareIP || firstLoadBalancerIP;
 }
 
 export function getPointCost(

--- a/indexer/services/comlink/src/lib/restrict-countries.ts
+++ b/indexer/services/comlink/src/lib/restrict-countries.ts
@@ -7,6 +7,7 @@ import express from 'express';
 
 import { BlockedCode } from '../types';
 import { create4xxResponse } from './helpers';
+import { getIpAddr, isIndexerIp } from './utils';
 
 /**
  * Return an error code for users that access the API from a restricted country
@@ -16,6 +17,13 @@ export function rejectRestrictedCountries(
   res: express.Response,
   next: express.NextFunction,
 ) {
+  const ipAddr: string | undefined = getIpAddr(req);
+
+  // Don't enforce geo-blocking for internal IPs as they don't go through a proxy
+  if (ipAddr !== undefined && isIndexerIp(ipAddr)) {
+    return next();
+  }
+
   if (isRestrictedCountryHeaders(req.headers as CountryHeaders)) {
     return create4xxResponse(
       res,

--- a/indexer/services/comlink/src/lib/utils.ts
+++ b/indexer/services/comlink/src/lib/utils.ts
@@ -1,12 +1,25 @@
+import express from 'express';
+
 import config from '../config';
 
 const indexerIps: string[] = config.INDEXER_INTERNAL_IPS.split(',').map((l) => l.toLowerCase());
-const RESTRICTED_COUNTRY_CODES: Set<string> = new Set(config.RESTRICTED_COUNTRIES.split(','));
 
 export function isIndexerIp(ipAddress: string): boolean {
   return indexerIps.includes(ipAddress);
 }
 
-export function isRestrictedCountry(ipCountry: string): boolean {
-  return RESTRICTED_COUNTRY_CODES.has(ipCountry);
+export function getIpAddr(req: express.Request): string | undefined {
+  const {
+    'cf-connecting-ip': cloudflareIP,
+    'x-forwarded-for': loadBalancerHeader,
+  } = req.headers as {
+    'cf-connecting-ip'?: string,
+    'x-forwarded-for'?: string,
+  };
+
+  // get ip address
+  const loadBalancerIPs: string[] | undefined = loadBalancerHeader?.replace(/\s/g, '').split(',');
+  const firstLoadBalancerIP: string | undefined = loadBalancerIPs?.[0];
+
+  return cloudflareIP || firstLoadBalancerIP;
 }


### PR DESCRIPTION
### Changelist
Update the `restrict-countries.ts` middleware to not run geo-blocking logic on the request if it's from an internal IP. As the websocket service (`socks`) uses the API service (`comlink`) to get initial data for a websocket subscription, it does not go through a proxy and will not have country specific headers for geo-blocking logic to run on.

### Test Plan
Unit tests updated to cover the behavior of the middleware if the the ip address in the request is an internal ip.

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label. [N/A]
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`. [N/A]
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes:**

- New Feature: Added a reason field to the `/screen` endpoint for displaying a reason for blocking an address.
- Bug Fix: Corrected track lag timing to output positive numbers.
- Refactor: Updated the geo-blocking logic to exclude requests made from internal IPs. This change improves the efficiency of internal communications by bypassing unnecessary checks.
- Test: Updated tests to reflect changes in the import location and functionality of `getIpAddr`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->