### PR TITLE
Force public for v4-proto-js

### DIFF
--- a/v4-proto-js/package.json
+++ b/v4-proto-js/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dydxprotocol/v4-proto",
   "version": "0.0.0",
+  "access": "public",
   "description": "Protos for dYdX v4 protocol",
   "author": "dYdX Trading Inc.",
   "homepage": "https://github.com/dydxprotocol/v4-chain",


### PR DESCRIPTION
Package seems to be reverting to private every publish, so lets force it to public