### PR TITLE
Adjust impact notional for `Safety` tier

### DIFF
--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -754,7 +754,7 @@
         {
           "base_position_notional": 1000000000,
           "id": 3,
-          "impact_notional": 500000000,
+          "impact_notional": 2500000000,
           "initial_margin_ppm": 1000000,
           "maintenance_fraction_ppm": 200000,
           "name": "Safety"

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -126,7 +126,7 @@ function edit_genesis() {
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.liquidity_tiers.[3].initial_margin_ppm' -v '1000000' # 100%
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.liquidity_tiers.[3].maintenance_fraction_ppm' -v '200000' # 20% of IM
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.liquidity_tiers.[3].base_position_notional' -v '1000000000' # 1_000 USDC
-	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.liquidity_tiers.[3].impact_notional' -v '500000000' # 500 USDC (500 / 100%)
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.liquidity_tiers.[3].impact_notional' -v '2500000000' # 2_500 USDC (2_500 USDC / 100%)
 
 	# Params.
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.params.funding_rate_clamp_factor_ppm' -v '6000000' # 600 % (same as 75% on hourly rate)


### PR DESCRIPTION
Recommended by [research](https://dydx-team.slack.com/archives/C03FY21CSF6/p1696522471545949?thread_ts=1696442532.183679&cid=C03FY21CSF6)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the liquidity tier configuration in the testing protocol. The `impact_notional` value for the fourth liquidity tier has been increased from 500,000 USDC to 2,500,000 USDC. This change will affect the testing environment and does not impact end users directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->