### PR TITLE
[CLOB-920] assert check tx in memclob public methods

### DIFF
--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -935,7 +935,7 @@ func TestAddPreexistingStatefulOrder(t *testing.T) {
 				}
 
 				_, orderStatus, _, err := ks.ClobKeeper.AddPreexistingStatefulOrder(
-					ctx,
+					ctx.WithIsCheckTx(true),
 					&order,
 					blockHeight,
 					memClob,
@@ -966,7 +966,7 @@ func TestAddPreexistingStatefulOrder(t *testing.T) {
 			orderSizeOptimisticallyFilledFromMatching,
 				orderStatus,
 				_,
-				err := ks.ClobKeeper.AddPreexistingStatefulOrder(ctx, &tc.order, blockHeight, memClob)
+				err := ks.ClobKeeper.AddPreexistingStatefulOrder(ctx.WithIsCheckTx(true), &tc.order, blockHeight, memClob)
 
 			// Verify test expectations.
 			require.ErrorIs(t, err, tc.expectedErr)

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -85,6 +85,8 @@ func (m *MemClobPriceTimePriority) CancelOrder(
 	ctx sdk.Context,
 	msgCancelOrder *types.MsgCancelOrder,
 ) (offchainUpdates *types.OffchainUpdates, err error) {
+	lib.AssertCheckTxMode(ctx)
+
 	orderIdToCancel := msgCancelOrder.GetOrderId()
 
 	// Stateful orders are not expected here.
@@ -180,6 +182,7 @@ func (m *MemClobPriceTimePriority) GetCancelOrder(
 	ctx sdk.Context,
 	orderId types.OrderId,
 ) (tilBlock uint32, found bool) {
+	lib.AssertCheckTxMode(ctx)
 	return m.cancels.get(orderId)
 }
 
@@ -204,6 +207,7 @@ func (m *MemClobPriceTimePriority) GetSubaccountOrders(
 	subaccountId satypes.SubaccountId,
 	side types.Order_Side,
 ) (openOrders []types.Order, err error) {
+	lib.AssertCheckTxMode(ctx)
 	return m.openOrders.getSubaccountOrders(
 		ctx,
 		clobPairId,
@@ -404,6 +408,8 @@ func (m *MemClobPriceTimePriority) PlaceOrder(
 	offchainUpdates *types.OffchainUpdates,
 	err error,
 ) {
+	lib.AssertCheckTxMode(ctx)
+
 	// Perform invariant checks that the orderbook is not crossed after `PlaceOrder` finishes execution.
 	defer func() {
 		orderbook := m.openOrders.mustGetOrderbook(ctx, order.GetClobPairId())
@@ -668,6 +674,8 @@ func (m *MemClobPriceTimePriority) PlacePerpetualLiquidation(
 	offchainUpdates *types.OffchainUpdates,
 	err error,
 ) {
+	lib.AssertCheckTxMode(ctx)
+
 	// Attempt to match the liquidation order against the orderbook.
 	// TODO(DEC-1157): Update liquidations flow to send off-chain indexer messages.
 	liquidationOrderStatus, offchainUpdates, _, err := m.matchOrder(ctx, &liquidationOrder)
@@ -693,6 +701,8 @@ func (m *MemClobPriceTimePriority) DeleverageSubaccount(
 	quantumsDeleveraged *big.Int,
 	err error,
 ) {
+	lib.AssertCheckTxMode(ctx)
+
 	fills, deltaQuantumsRemaining := m.clobKeeper.OffsetSubaccountPerpetualPosition(
 		ctx,
 		subaccountId,
@@ -839,6 +849,8 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 	shortTermOrderTxBytes map[types.OrderHash][]byte,
 	existingOffchainUpdates *types.OffchainUpdates,
 ) *types.OffchainUpdates {
+	lib.AssertCheckTxMode(ctx)
+
 	// Recover from any panics that occur during replay operations.
 	// This could happen in cases where i.e. A subaccount balance overflowed
 	// during a match. We don't want to halt the entire chain in this case.
@@ -987,6 +999,8 @@ func (m *MemClobPriceTimePriority) GenerateOffchainUpdatesForReplayPlaceOrder(
 	placeOrderOffchainUpdates *types.OffchainUpdates,
 	existingOffchainUpdates *types.OffchainUpdates,
 ) *types.OffchainUpdates {
+	lib.AssertCheckTxMode(ctx)
+
 	orderId := order.OrderId
 	if err != nil {
 		var loggerString string
@@ -1038,6 +1052,8 @@ func (m *MemClobPriceTimePriority) RemoveAndClearOperationsQueue(
 	ctx sdk.Context,
 	localValidatorOperationsQueue []types.InternalOperation,
 ) {
+	lib.AssertCheckTxMode(ctx)
+
 	// Clear the OTP. This will also remove nonces for every operation in `operationsQueueCopy`.
 	m.operationsToPropose.ClearOperationsQueue()
 
@@ -1089,6 +1105,8 @@ func (m *MemClobPriceTimePriority) PurgeInvalidMemclobState(
 	removedStatefulOrderIds []types.OrderId,
 	existingOffchainUpdates *types.OffchainUpdates,
 ) *types.OffchainUpdates {
+	lib.AssertCheckTxMode(ctx)
+
 	blockHeight := lib.MustConvertIntegerToUint32(ctx.BlockHeight())
 
 	// Remove all fully-filled order IDs from the memclob if they exist.
@@ -1731,6 +1749,8 @@ func (m *MemClobPriceTimePriority) mustPerformTakerOrderMatching(
 func (m *MemClobPriceTimePriority) SetMemclobGauges(
 	ctx sdk.Context,
 ) {
+	lib.AssertCheckTxMode(ctx)
+
 	// Set gauges for each orderbook.
 	for clobPairId, orderbook := range m.openOrders.orderbooksMap {
 		// Set gauge for total open orders on each orderbook.

--- a/protocol/x/clob/memclob/memclob_cancel_order_test.go
+++ b/protocol/x/clob/memclob/memclob_cancel_order_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestShortTermCancelOrder_CancelAlreadyExists(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	memclob := NewMemClobPriceTimePriority(true)
 	memclob.SetClobKeeper(testutil_memclob.NewFakeMemClobKeeper())
 	order := constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15
@@ -44,6 +45,7 @@ func TestShortTermCancelOrder_CancelAlreadyExists(t *testing.T) {
 
 func TestShortTermCancelOrder_OrdersTilBlockExceedsCancels(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	memClobKeeper := testutil_memclob.NewFakeMemClobKeeper()
 	memclob := NewMemClobPriceTimePriority(true)
 	memclob.SetClobKeeper(memClobKeeper)
@@ -90,6 +92,7 @@ func TestCancelOrder_PanicsOnStatefulOrder(t *testing.T) {
 	memclob := NewMemClobPriceTimePriority(true)
 	orderId := constants.LongTermOrderId_Alice_Num0_ClientId0_Clob0
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 
 	expectedError := fmt.Sprintf(
 		"MustBeShortTermOrder: called with stateful order ID (%+v)",
@@ -104,6 +107,7 @@ func TestCancelOrder_PanicsOnStatefulOrder(t *testing.T) {
 
 func TestCancelOrder(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	tests := map[string]struct {
 		// State.
 		existingOrders  []types.Order
@@ -331,6 +335,7 @@ func TestCancelOrder_Telemetry(t *testing.T) {
 	require.NotNil(t, m)
 
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	memclob := NewMemClobPriceTimePriority(true)
 	memclob.SetClobKeeper(testutil_memclob.NewFakeMemClobKeeper())
 

--- a/protocol/x/clob/memclob/memclob_get_premium_price_test.go
+++ b/protocol/x/clob/memclob/memclob_get_premium_price_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestGetPremiumPrice(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	tests := map[string]struct {
 		// State.
 		placedMatchableOrders []types.MatchableOrder

--- a/protocol/x/clob/memclob/memclob_get_subaccount_orders_test.go
+++ b/protocol/x/clob/memclob/memclob_get_subaccount_orders_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestGetSubaccountOrders(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	tests := map[string]struct {
 		// State.
 		memclobOrders []types.Order
@@ -235,6 +236,7 @@ func TestGetSubaccountOrders(t *testing.T) {
 
 func TestGetSubaccountOrders_OrderNotFoundPanics(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	memclob := NewMemClobPriceTimePriority(false)
 	memclob.openOrders.orderbooksMap[0] = &types.Orderbook{
 		SubaccountOpenClobOrders: map[satypes.SubaccountId]map[types.Order_Side]map[types.OrderId]bool{

--- a/protocol/x/clob/memclob/memclob_place_order_long_term_test.go
+++ b/protocol/x/clob/memclob/memclob_place_order_long_term_test.go
@@ -704,6 +704,7 @@ func TestPlaceOrder_LongTerm(t *testing.T) {
 func TestPlaceOrder_PreexistingStatefulOrder(t *testing.T) {
 	// Setup memclob state and test expectations.
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	longTermOrder := constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15
 	collateralizationCheck := map[int]testutil_memclob.CollateralizationCheck{
 		0: {

--- a/protocol/x/clob/memclob/memclob_purge_invalid_memclob_state_test.go
+++ b/protocol/x/clob/memclob/memclob_purge_invalid_memclob_state_test.go
@@ -248,6 +248,7 @@ func TestPurgeInvalidMemclobState(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Setup memclob state.
 			ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+			ctx = ctx.WithIsCheckTx(true)
 			mockMemClobKeeper := &mocks.MemClobKeeper{}
 			memclob := NewMemClobPriceTimePriority(true)
 			memclob.SetClobKeeper(mockMemClobKeeper)
@@ -336,6 +337,7 @@ func TestPurgeInvalidMemclobState(t *testing.T) {
 func TestPurgeInvalidMemclobState_PanicsWhenCalledWithDuplicateCanceledStatefulOrderIds(t *testing.T) {
 	// Setup memclob state.
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	memclob := NewMemClobPriceTimePriority(true)
 	canceledStatefulOrderIds := []types.OrderId{
 		constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.OrderId,
@@ -364,6 +366,7 @@ func TestPurgeInvalidMemclobState_PanicsWhenCalledWithDuplicateCanceledStatefulO
 func TestPurgeInvalidMemclobState_PanicsWhenNonStatefulOrderIsCanceled(t *testing.T) {
 	// Setup memclob state.
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	memclob := NewMemClobPriceTimePriority(true)
 	shortTermOrderId := constants.Order_Alice_Num0_Id0_Clob2_Buy5_Price10_GTB15.OrderId
 
@@ -389,6 +392,8 @@ func TestPurgeInvalidMemclobState_PanicsWhenNonStatefulOrderIsCanceled(t *testin
 func TestPurgeInvalidMemclobState_PanicsWhenCalledWithDuplicateExpiredStatefulOrders(t *testing.T) {
 	// Setup memclob state.
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
+
 	memclob := NewMemClobPriceTimePriority(true)
 	expiredStatefulOrderIds := []types.OrderId{
 		constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.OrderId,
@@ -417,6 +422,8 @@ func TestPurgeInvalidMemclobState_PanicsWhenCalledWithDuplicateExpiredStatefulOr
 func TestPurgeInvalidMemclobState_PanicsWhenCalledWithShortTermExpiredStatefulOrders(t *testing.T) {
 	// Setup memclob state.
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
+
 	memclob := NewMemClobPriceTimePriority(true)
 	shortTermOrderId := constants.Order_Alice_Num0_Id0_Clob2_Buy5_Price10_GTB15.OrderId
 

--- a/protocol/x/clob/memclob/memclob_remove_order_test.go
+++ b/protocol/x/clob/memclob/memclob_remove_order_test.go
@@ -27,6 +27,7 @@ func TestRemoveOrder_PanicsIfNotExists(t *testing.T) {
 
 func TestRemoveOrderIfFilled(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	tests := map[string]struct {
 		// State.
 		existingOrders []types.Order
@@ -385,6 +386,7 @@ func TestRemoveOrderIfFilled(t *testing.T) {
 
 func TestRemoveOrder(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
+	ctx = ctx.WithIsCheckTx(true)
 	tests := map[string]struct {
 		// State.
 		existingOrders []types.Order


### PR DESCRIPTION
### Changelist
- Adding assert check tx to memclob public methods.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Test: Enhanced transaction testing in various functions by enabling checkTx mode. This change improves the robustness of our tests and ensures that code paths for check transactions are properly tested.
- Refactor: Added `lib.AssertCheckTxMode(ctx)` function calls in multiple functions to ensure correct execution context. This helps maintain consistency and correctness in the application's behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->