### PR TITLE
Move `consensus_params` to `genesis.sh` from `prod_genesis.sh`

### DIFF
--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -113,10 +113,6 @@ function overwrite_genesis_production() {
 	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_vote_quorum' -v 'false' 
 	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_vote_veto' -v 'true'
 
-	# Consensus params
-	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_bytes' -v '4194304'
-	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_gas' -v '-1'
-
 	# Rewards params
 	dasel put -t string -f "$GENESIS" '.app_state.rewards.params.denom' -v "$NATIVE_TOKEN"
 	dasel put -t int -f "$GENESIS" '.app_state.rewards.params.fee_multiplier_ppm' -v '0'

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -58,6 +58,10 @@ function edit_genesis() {
 		INITIAL_CLOB_PAIR_STATUS='STATUS_ACTIVE'
 	fi
 
+	# Consensus params
+	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_bytes' -v '4194304'
+	dasel put -t string -f "$GENESIS" '.consensus_params.block.max_gas' -v '-1'
+
 	# Update crisis module.
 	dasel put -t string -f "$GENESIS" '.app_state.crisis.constant_fee.denom' -v "$NATIVE_TOKEN"
 


### PR DESCRIPTION
Prefer to have network-generic parameters live in `genesis.sh` so testing environments are as realistic as possible