### PR TITLE
Revert "Empty delay msg in prod genesisdefault"

### DIFF
--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -6,7 +6,6 @@ set -eo pipefail
 # The script must be run from the root of the `v4-chain` repo.
 #
 # example usage:
-# $ make build
 # $ ./scripts/genesis/prod_pregenesis.sh ./build/dydxprotocold
 
 # Check for missing required arguments
@@ -132,9 +131,15 @@ function overwrite_genesis_production() {
 	dasel put -t string -f "$GENESIS" '.app_state.vest.vest_entries.[1].end_time' -v "$REWARDS_VEST_END_TIME"
 
 	# Delayed message params
-	# By default, no delayed messages at genesis.
-	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.num_messages' -v '0'
+	# Schedule a delayed message to swap fee tiers to the standard schedule after ~120 days of blocks.
+	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.num_messages' -v '1'
 	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages' -v "[]"
+	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[]' -v "{}"
+	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].id' -v '0'
+	delaymsg=$(cat "$DELAY_MSG_JSON_DIR/perpetual_fee_params_msg.json" | jq -c '.')
+	dasel put -t json -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].msg' -v "$delaymsg"
+	# Schedule the message to execute in ~120 days (at 1.5s per block)
+	dasel put -t int -f "$GENESIS" '.app_state.delaymsg.delayed_messages.[0].block_height' -v '6912000'
 
 	# Bridge module params.
 	dasel put -t string -f "$GENESIS" '.app_state.bridge.event_params.denom' -v "$NATIVE_TOKEN"

--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -6,6 +6,7 @@ set -eo pipefail
 # The script must be run from the root of the `v4-chain` repo.
 #
 # example usage:
+# $ make build
 # $ ./scripts/genesis/prod_pregenesis.sh ./build/dydxprotocold
 
 # Check for missing required arguments

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -530,8 +530,93 @@
       }
     },
     "delaymsg": {
-      "delayed_messages": [],
-      "num_messages": 0
+      "delayed_messages": [
+        {
+          "block_height": 6912000,
+          "id": 0,
+          "msg": {
+            "@type": "/dydxprotocol.feetiers.MsgUpdatePerpetualFeeParams",
+            "authority": "dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr",
+            "params": {
+              "tiers": [
+                {
+                  "absolute_volume_requirement": "0",
+                  "maker_fee_ppm": 100,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "1",
+                  "taker_fee_ppm": 500,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "1000000000000",
+                  "maker_fee_ppm": 100,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "2",
+                  "taker_fee_ppm": 450,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "5000000000000",
+                  "maker_fee_ppm": 50,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "3",
+                  "taker_fee_ppm": 400,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "25000000000000",
+                  "maker_fee_ppm": 0,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "4",
+                  "taker_fee_ppm": 350,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": 0,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "5",
+                  "taker_fee_ppm": 300,
+                  "total_volume_share_requirement_ppm": 0
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": -50,
+                  "maker_volume_share_requirement_ppm": 0,
+                  "name": "6",
+                  "taker_fee_ppm": 250,
+                  "total_volume_share_requirement_ppm": 5000
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": -70,
+                  "maker_volume_share_requirement_ppm": 10000,
+                  "name": "7",
+                  "taker_fee_ppm": 250,
+                  "total_volume_share_requirement_ppm": 5000
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": -90,
+                  "maker_volume_share_requirement_ppm": 20000,
+                  "name": "8",
+                  "taker_fee_ppm": 250,
+                  "total_volume_share_requirement_ppm": 5000
+                },
+                {
+                  "absolute_volume_requirement": "125000000000000",
+                  "maker_fee_ppm": -110,
+                  "maker_volume_share_requirement_ppm": 40000,
+                  "name": "9",
+                  "taker_fee_ppm": 250,
+                  "total_volume_share_requirement_ppm": 5000
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "num_messages": 1
     },
     "distribution": {
       "delegator_starting_infos": [],


### PR DESCRIPTION
Reverting per this [thread](https://dydx-team.slack.com/archives/C05FB5XECHZ/p1696544525042179?thread_ts=1696513383.433089&cid=C05FB5XECHZ)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Implemented a delayed message functionality in the `overwrite_genesis_production` function. This feature will automatically swap fee tiers to the standard schedule after approximately 120 days of blocks. The change aims to enhance the predictability and stability of fee structures for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->