### PR TITLE
[CORE-621] - Add unit tests to confirm that gas is accepted in usdc and native token

### DIFF
--- a/protocol/app/ante/gas_test.go
+++ b/protocol/app/ante/gas_test.go
@@ -144,6 +144,7 @@ func TestSubmitTxnWithGas(t *testing.T) {
 	tests := map[string]struct {
 		gasFee       sdk.Coins
 		responseCode uint32
+		logMessage   string
 	}{
 		"Success - 5 cents usdc gas fee": {
 			gasFee:       constants.TestFeeCoins_5Cents,
@@ -156,6 +157,8 @@ func TestSubmitTxnWithGas(t *testing.T) {
 		"Failure: 0 gas fee": {
 			gasFee:       sdk.Coins{},
 			responseCode: sdkerrors.ErrInsufficientFee.ABCICode(),
+			logMessage: "insufficient fees; got:  required: 25000000000000000adv4tnt," +
+				"25000ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5: insufficient fee",
 		},
 		"Failure: unsupported gas fee denom": {
 			gasFee: sdk.Coins{
@@ -163,6 +166,8 @@ func TestSubmitTxnWithGas(t *testing.T) {
 				sdk.NewCoin(constants.BtcUsd.Denom, sdkmath.NewInt(100_000_000)),
 			},
 			responseCode: sdkerrors.ErrInsufficientFee.ABCICode(),
+			logMessage: "insufficient fees; got: 100000000btc-denom required: 25000000000000000adv4tnt," +
+				"25000ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5: insufficient fee",
 		},
 	}
 	for name, tc := range tests {
@@ -199,6 +204,9 @@ func TestSubmitTxnWithGas(t *testing.T) {
 			// Sanity check that gas was used.
 			require.Greater(t, checkTx.GasUsed, int64(0))
 			require.Equal(t, tc.responseCode, checkTx.Code)
+			if tc.responseCode != errors.SuccessABCICode {
+				require.Equal(t, tc.logMessage, checkTx.Log)
+			}
 		})
 	}
 }

--- a/protocol/app/ante/gas_test.go
+++ b/protocol/app/ante/gas_test.go
@@ -175,12 +175,11 @@ func TestSubmitTxnWithGas(t *testing.T) {
 				},
 			}
 
-			tApp := testapp.NewTestAppBuilder().
+			tApp := testapp.NewTestAppBuilder(t).
 				WithAppCreatorFn(
 					testapp.DefaultTestAppCreatorFn(map[string]interface{}{},
 						baseapp.SetMinGasPrices(cmd.MinGasPrice),
 					)).
-				WithTesting(t).
 				Build()
 			ctx := tApp.InitChain()
 

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -103,9 +103,9 @@ type AdvanceToBlockOptions struct {
 	ValidateDeliverTxs  ValidateDeliverTxsFn
 }
 
-// Create an instance of app.App with default settings, suitable for unit testing,
-// with the option to override specific flags.
-func DefaultTestApp(customFlags map[string]interface{}) *app.App {
+// DefaultTestApp creates an instance of app.App with default settings, suitable for unit testing. The app will be
+// initialized with any specified flags as overrides, and with any specified base app options.
+func DefaultTestApp(customFlags map[string]interface{}, baseAppOptions ...func(*baseapp.BaseApp)) *app.App {
 	appOptions := appoptions.GetDefaultTestAppOptionsFromTempDirectory("", customFlags)
 	logger, ok := appOptions.Get(testlog.LoggerInstanceForTest).(log.Logger)
 	if !ok {
@@ -118,14 +118,19 @@ func DefaultTestApp(customFlags map[string]interface{}) *app.App {
 		nil,
 		true,
 		appOptions,
+		baseAppOptions...,
 	)
 	return dydxApp
 }
 
-// DefaultTestAppCreatorFn is a wrapper function around DefaultTestApp using the specified custom flags.
-func DefaultTestAppCreatorFn(customFlags map[string]interface{}) AppCreatorFn {
+// DefaultTestAppCreatorFn is a wrapper function around DefaultTestApp using the specified custom flags, and allowing
+// for optional base app options.
+func DefaultTestAppCreatorFn(
+	customFlags map[string]interface{},
+	baseAppOptions ...func(*baseapp.BaseApp),
+) AppCreatorFn {
 	return func() *app.App {
-		return DefaultTestApp(customFlags)
+		return DefaultTestApp(customFlags, baseAppOptions...)
 	}
 }
 

--- a/protocol/testutil/constants/assets.go
+++ b/protocol/testutil/constants/assets.go
@@ -11,6 +11,8 @@ import (
 const (
 	// TestFee is the gas fee offered for test transactions.
 	TestFee = "50000" + asstypes.UusdcDenom // 5 cents
+	// TestFeeNativeTokens is the gas fee offered for test transactions specified in native tokens.
+	TestFeeNativeTokens = "50000000000000000adv4tnt" // .05 of native token in adv4tnt denom
 	// TestGasLimit is the gas limit used for test transactions.
 	// It's set to a larger amount such that the transaction never runs out of gas.
 	TestGasLimit = 1_000_000
@@ -20,7 +22,8 @@ const (
 
 var (
 	// TestFeeCoins_5Cents is the gas fee offered for test transactions.
-	TestFeeCoins_5Cents = lib.MustParseCoinsNormalized(TestFee)
+	TestFeeCoins_5Cents             = lib.MustParseCoinsNormalized(TestFee)
+	TestFeeCoins_5Cents_NativeToken = lib.MustParseCoinsNormalized(TestFeeNativeTokens)
 )
 
 // BigNegMaxUint64 returns a `big.Int` that is set to -math.MaxUint64.

--- a/protocol/testutil/constants/assets.go
+++ b/protocol/testutil/constants/assets.go
@@ -12,7 +12,8 @@ const (
 	// TestFee is the gas fee offered for test transactions.
 	TestFee = "50000" + asstypes.UusdcDenom // 5 cents
 	// TestFeeNativeTokens is the gas fee offered for test transactions specified in native tokens.
-	TestFeeNativeTokens = "50000000000000000adv4tnt" // .05 of native token in adv4tnt denom
+	// Value is .05 of native token in adv4tnt denom.
+	TestFeeNativeTokens = "50000000000000000" + lib.DefaultBaseDenom
 	// TestGasLimit is the gas limit used for test transactions.
 	// It's set to a larger amount such that the transaction never runs out of gas.
 	TestGasLimit = 1_000_000

--- a/protocol/testutil/constants/assets.go
+++ b/protocol/testutil/constants/assets.go
@@ -22,7 +22,8 @@ const (
 
 var (
 	// TestFeeCoins_5Cents is the gas fee offered for test transactions.
-	TestFeeCoins_5Cents             = lib.MustParseCoinsNormalized(TestFee)
+	TestFeeCoins_5Cents = lib.MustParseCoinsNormalized(TestFee)
+	// TestFeeCoins_5Cents_NativeToken is the gas fee offered for test transactions specified in native tokens.
 	TestFeeCoins_5Cents_NativeToken = lib.MustParseCoinsNormalized(TestFeeNativeTokens)
 )
 


### PR DESCRIPTION
### Changelist
Add unit test to confirm that gas fees are permitted in either usdc or native token denominations.

Additionally, update test app library to allow for specifying additional BaseAppOptions in order to configure the app with MinGasPrices.

### Test Plan
Via the added unit tests! No new features added.

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for gas fees in native tokens. This allows transactions to be submitted with gas fees specified in the native token denomination.
- Test: Enhanced unit tests to validate transaction submission with various gas fee amounts, including zero and unsupported denominations. This ensures robust handling of different gas fee scenarios.
- Refactor: Updated `DefaultTestApp` function to accept optional base app options, enhancing flexibility during unit testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->