### PR TITLE
revert GetSubaccountOrders check tx validation

### DIFF
--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -207,7 +207,6 @@ func (m *MemClobPriceTimePriority) GetSubaccountOrders(
 	subaccountId satypes.SubaccountId,
 	side types.Order_Side,
 ) (openOrders []types.Order, err error) {
-	lib.AssertCheckTxMode(ctx)
 	return m.openOrders.getSubaccountOrders(
 		ctx,
 		clobPairId,


### PR DESCRIPTION
### Changelist
Fix simulation tests.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Bug Fix":
- Removed a redundant check in the `GetSubaccountOrders` function of the `MemClobPriceTimePriority` struct. This change streamlines the process of retrieving subaccount orders, improving performance and reducing unnecessary operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->