### PR TITLE
[DEC-2065] - Delay msg validation until SetDelayedMessage

### DIFF
--- a/protocol/x/delaymsg/keeper/delayed_message.go
+++ b/protocol/x/delaymsg/keeper/delayed_message.go
@@ -119,6 +119,26 @@ func (k Keeper) SetDelayedMessage(
 ) (
 	err error,
 ) {
+	// Unpack the message and validate it.
+	// For messages that are being set from genesis state, we need to unpack the Any type to hydrate the cached value.
+	msg.UnpackInterfaces(k.cdc)
+	sdkMsg, err := msg.GetMessage()
+	if err != nil {
+		return errorsmod.Wrapf(
+			types.ErrInvalidInput,
+			"failed to delay message: %v",
+			err,
+		)
+	}
+
+	if err := k.ValidateMsg(sdkMsg); err != nil {
+		return errorsmod.Wrapf(
+			types.ErrInvalidInput,
+			"failed to delay message: %v",
+			err,
+		)
+	}
+
 	if msg.BlockHeight < lib.MustConvertIntegerToUint32(ctx.BlockHeight()) {
 		return errorsmod.Wrapf(
 			types.ErrInvalidInput,
@@ -166,6 +186,32 @@ func validateSigners(msg sdk.Msg) error {
 	return nil
 }
 
+// ValidateMsg validates that a message is routable, passes ValidateBasic, and has the expected signer.
+func (k Keeper) ValidateMsg(msg sdk.Msg) error {
+	handler := k.router.Handler(msg)
+	// If the message type is not routable, return an error.
+	if handler == nil {
+		return errorsmod.Wrapf(
+			types.ErrMsgIsUnroutable,
+			sdk.MsgTypeURL(msg),
+		)
+	}
+
+	if err := msg.ValidateBasic(); err != nil {
+		return errorsmod.Wrapf(
+			types.ErrInvalidInput,
+			"message failed basic validation: %v",
+			err,
+		)
+	}
+
+	if err := validateSigners(msg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // DelayMessageByBlocks registers an sdk.Msg to be executed after blockDelay blocks.
 func (k Keeper) DelayMessageByBlocks(
 	ctx sdk.Context,
@@ -175,27 +221,6 @@ func (k Keeper) DelayMessageByBlocks(
 	id uint32,
 	err error,
 ) {
-	handler := k.router.Handler(msg)
-	// If the message type is not routable, return an error.
-	if handler == nil {
-		return 0, errorsmod.Wrapf(
-			types.ErrMsgIsUnroutable,
-			sdk.MsgTypeURL(msg),
-		)
-	}
-
-	if err := msg.ValidateBasic(); err != nil {
-		return 0, errorsmod.Wrapf(
-			types.ErrInvalidInput,
-			"message failed basic validation: %v",
-			err,
-		)
-	}
-
-	if err := validateSigners(msg); err != nil {
-		return 0, err
-	}
-
 	nextId := k.GetNumMessages(ctx)
 	blockHeight, err := lib.AddUint32(ctx.BlockHeight(), blockDelay)
 	if err != nil {


### PR DESCRIPTION
### Changelist
The message validation that happened in the keeper entrypoint DelayMessageByBlocks was moved into the SetDelayedMessage method for the following reasons:
- DelayMessageByBlocks calls SetDelayedMessage, so we don't lose any validation in this code path
- genesis state calls SetDelayedMessage directly, so there was a risk that invalid genesis state with unexecutable messages could be loaded into the module that would only surface after the delay passed
- SetDelayedMessage is a public entrypoint into the module, so putting the guards here enforces that all additions of delayed messages to module state are validated the same way.

Message validation is factored out of DelayMessageByBlocks and copy-pasted into a ValidateMsg method that is now tested explicitly using test cases taken from DelayMessageByBlocks. Additionally SetDelayedMessage unit tests are extended to show errors pass through from ValidateMsg.

### Test Plan
Included unit tests.

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Enhanced the `SetDelayedMessage` and `DelayMessageByBlocks` functions in the `protocol/x/delaymsg/keeper` package. The changes improve message validation, type and signers verification, and error handling.
- Test: Expanded test coverage in `protocol/x/delaymsg/keeper`. Added new scenarios to `TestValidateMsg` and `TestSetDelayedMessage`, and updated expected outcomes in `TestDelayMessageByBlocks_Failures`.
- New Feature: Introduced a `ValidateMsg` function for comprehensive message validation. This addition strengthens the robustness of the message processing system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->