### PR TITLE
[DEC-2117] - Adding authority validation to MsgCompleteBridge

### DIFF
--- a/protocol/x/bridge/types/msg_complete_bridge.go
+++ b/protocol/x/bridge/types/msg_complete_bridge.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -10,5 +12,15 @@ func (msg *MsgCompleteBridge) GetSigners() []sdk.AccAddress {
 }
 
 func (msg *MsgCompleteBridge) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrap(
+			ErrInvalidAuthority,
+			fmt.Sprintf(
+				"authority '%s' must be a valid bech32 address, but got error '%v'",
+				msg.Authority,
+				err.Error(),
+			),
+		)
+	}
 	return nil
 }

--- a/protocol/x/bridge/types/msg_complete_bridge_test.go
+++ b/protocol/x/bridge/types/msg_complete_bridge_test.go
@@ -1,0 +1,44 @@
+package types_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMsgCompleteBridge_GetSigners(t *testing.T) {
+	msg := types.MsgCompleteBridge{
+		Authority: constants.CarlAccAddress.String(),
+	}
+	require.Equal(t, []sdk.AccAddress{constants.CarlAccAddress}, msg.GetSigners())
+}
+
+func TestMsgCompleteBridge_ValidateBasic(t *testing.T) {
+	tests := map[string]struct {
+		msg         types.MsgCompleteBridge
+		expectedErr error
+	}{
+		"Success": {
+			msg: *constants.TestMsg1,
+		},
+		"Failure: Invalid authority": {
+			msg: types.MsgCompleteBridge{
+				Authority: "",
+			},
+			expectedErr: types.ErrInvalidAuthority,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/protocol/x/bridge/types/msg_complete_bridge_test.go
+++ b/protocol/x/bridge/types/msg_complete_bridge_test.go
@@ -23,9 +23,15 @@ func TestMsgCompleteBridge_ValidateBasic(t *testing.T) {
 		"Success": {
 			msg: *constants.TestMsg1,
 		},
-		"Failure: Invalid authority": {
+		"Failure: Empty authority": {
 			msg: types.MsgCompleteBridge{
 				Authority: "",
+			},
+			expectedErr: types.ErrInvalidAuthority,
+		},
+		"Failure: Not an address": {
+			msg: types.MsgCompleteBridge{
+				Authority: "invalid",
 			},
 			expectedErr: types.ErrInvalidAuthority,
 		},


### PR DESCRIPTION
### Changelist
Adding missing authority validation to MsgCompleteBridge.

### Test Plan
Updated with unit tests.

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `MsgCompleteBridge` type in the `bridge` package by adding validation for the `Authority` field. This ensures that the `Authority` field contains a valid Bech32 address, improving the robustness of the system.
- Test: Added comprehensive test cases for the `MsgCompleteBridge` type. These tests cover the `GetSigners` and `ValidateBasic` functions, ensuring they behave as expected under various scenarios. This contributes to the overall reliability of the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->