### PR TITLE
Add additional stats for /screen endpoint.

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
@@ -70,6 +70,10 @@ describe('compliance-controller#V4', () => {
       expect(response.body.restricted).toEqual(false);
       expect(response.reason).toBeUndefined();
       expect(stats.timing).toHaveBeenCalledTimes(1);
+      expect(stats.increment).toHaveBeenCalledWith(
+        'comlink.compliance-controller.compliance_data_cache_miss',
+        { provider: complianceProvider.provider },
+      );
       expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(1);
 
       data = await ComplianceTable.findAll({}, [], {});

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
@@ -227,6 +227,10 @@ describe('compliance-controller#V4', () => {
         errorMsg: 'Too many requests',
         expectedStatus: 429,
       });
+      expect(stats.increment).toHaveBeenCalledWith(
+        'comlink.compliance-controller.compliance_screen_rate_limited_attempts',
+        { provider: complianceProvider.provider },
+      );
     });
 
     it('Get /screen with multiple new address globally gets rate-limited', async () => {
@@ -244,6 +248,10 @@ describe('compliance-controller#V4', () => {
         errorMsg: 'Too many requests',
         expectedStatus: 429,
       });
+      expect(stats.increment).toHaveBeenCalledWith(
+        'comlink.compliance-controller.compliance_screen_rate_limited_attempts',
+        { provider: complianceProvider.provider },
+      );
     });
   });
 });

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-controller.test.ts
@@ -98,6 +98,10 @@ describe('compliance-controller#V4', () => {
         expect(response.body.restricted).toEqual(false);
         expect(response.reason).toBeUndefined();
         expect(stats.timing).toHaveBeenCalledTimes(1);
+        expect(stats.increment).toHaveBeenCalledWith(
+          'comlink.compliance-controller.compliance_data_cache_hit',
+          { provider: complianceProvider.provider },
+        );
         expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
 
         data = await ComplianceTable.findAll({}, [], {});
@@ -121,6 +125,10 @@ describe('compliance-controller#V4', () => {
         expect(response.body.restricted).toEqual(true);
         expect(response.body.reason).toEqual(INDEXER_COMPLIANCE_BLOCKED_PAYLOAD);
         expect(stats.timing).toHaveBeenCalledTimes(1);
+        expect(stats.increment).toHaveBeenCalledWith(
+          'comlink.compliance-controller.compliance_data_cache_hit',
+          { provider: complianceProvider.provider },
+        );
         expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
 
         data = await ComplianceTable.findAll({}, [], {});
@@ -149,6 +157,14 @@ describe('compliance-controller#V4', () => {
         expect(response.body.restricted).toEqual(false);
         expect(response.body.reason).toBeUndefined();
         expect(stats.timing).toHaveBeenCalledTimes(1);
+        expect(stats.increment).toHaveBeenCalledWith(
+          'comlink.compliance-controller.compliance_data_cache_hit',
+          { provider: complianceProvider.provider },
+        );
+        expect(stats.increment).toHaveBeenCalledWith(
+          'comlink.compliance-controller.refresh_compliance_data_cache',
+          { provider: complianceProvider.provider },
+        );
         expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(1);
 
         data = await ComplianceTable.findAll({}, [], {});
@@ -183,6 +199,10 @@ describe('compliance-controller#V4', () => {
         expect(response.body.restricted).toEqual(true);
         expect(response.body.reason).toEqual(INDEXER_COMPLIANCE_BLOCKED_PAYLOAD);
         expect(stats.timing).toHaveBeenCalledTimes(1);
+        expect(stats.increment).toHaveBeenCalledWith(
+          'comlink.compliance-controller.compliance_data_cache_hit',
+          { provider: complianceProvider.provider },
+        );
         expect(complianceProvider.client.getComplianceResponse).toHaveBeenCalledTimes(0);
 
         data = await ComplianceTable.findAll({}, [], {});

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -72,7 +72,7 @@ class ComplianceController extends Controller {
       if (complianceData === undefined) {
         stats.increment(
           `${config.SERVICE_NAME}.${controllerName}.compliance_data_cache_miss`,
-          { provder: complianceProvider.provider },
+          { provider: complianceProvider.provider },
         );
       } else {
         stats.increment(


### PR DESCRIPTION
### Changelist
Add additional stats to measure the number of cache hits/misses and refreshes of compliance data. Also measures the attempts that were rate-limited.

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label. [N/A]
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`. [N/A]
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the compliance-controller module with additional tracking for cache hits and misses related to compliance data. This will provide better insights into system performance and efficiency.
- New Feature: Added monitoring for rate-limited attempts during the compliance screening process, improving visibility into potential bottlenecks or issues in the system.
- Test: Expanded test coverage in the `compliance-controller#V4` module to ensure the new statistics tracking functions as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->