### PR TITLE
Include .pyi files in v4-proto-py build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,6 @@ v4-proto-py-gen: proto-export-deps
 		--grpc_python_out=./v4-proto-py/v4_proto \
 		$$(find ./$${dir} -type f -name '*.proto'); \
 	done;
-	perl -i -pe 's/^from (?!google\.protobuf)([^ ]*) import ([^ ]*)_pb2 as ([^ ]*)$$/from v4_proto.\1 import \2_pb2 as \3/' $$(find ./v4-proto-py/v4_proto -type f \( -name '*_pb2.py' -o -name '*_pb2_grpc.py' \))
+	perl -i -pe 's/^from (?!google\.protobuf)([^ ]*) import ([^ ]*)_pb2 as ([^ ]*)$$/from v4_proto.\1 import \2_pb2 as \3/' $$(find ./v4-proto-py/v4_proto -type f \( -name '*_pb2.py' -o -name '*_pb2_grpc.py' -o -name '*_pb2.pyi' -o -name '*_pb2_grpc.pyi' \))
 
 .PHONY: proto-format proto-lint proto-check-bc-breaking proto-export proto-export-deps v4-proto-py-gen

--- a/v4-proto-py/MANIFEST.in
+++ b/v4-proto-py/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include * *.pyi

--- a/v4-proto-py/setup.py
+++ b/v4-proto-py/setup.py
@@ -10,6 +10,7 @@ setup(
     author_email="contact@dydx.exchange",
     description="Protos for dYdX v4 protocol",
     packages = find_namespace_packages(),
+    include_package_data=True,  # Include files specified in MANIFEST.in
     install_requires=required,
     license_files = ("LICENSE"),
     python_requires=">=3.8",


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated Makefile to handle additional protobuf-generated file patterns (`*_pb2.pyi` and `*_pb2_grpc.pyi`). This ensures correct import statements in these files.
- New Feature: Modified `v4-proto-py/MANIFEST.in` to include all `*.pyi` files recursively, ensuring they are packaged during distribution.
- New Feature: Adjusted `v4-proto-py/setup.py` to include package data during installation. This guarantees that all necessary files specified in the MANIFEST.in file are included when the package is installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->