### PR TITLE
[DO NOT MERGE] Setup staging to behave like prod genesis

### DIFF
--- a/.github/workflows/protocol-build-and-push-snapshot.yml
+++ b/.github/workflows/protocol-build-and-push-snapshot.yml
@@ -1,6 +1,9 @@
 name: Protocol Build & Push Image to AWS ECR
 
 on:  # yamllint disable-line rule:truthy
+  pull_request:
+    paths:
+      - 'protocol/**'
   push:
     branches:
       - main

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -997,12 +997,12 @@ function edit_genesis() {
 	fi
 
 	# Initialize bank balance for reward vester account.
-	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[]" -v "{}"
-	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[$next_bank_idx].address" -v "${REWARDS_VESTER_ACCOUNT_ADDR}"
-	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[$next_bank_idx].coins.[]" -v "{}"
-	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[$next_bank_idx].coins.[0].denom" -v "${REWARD_TOKEN}"
-	dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[$next_bank_idx].coins.[0].amount" -v "1000000000000" # 1e12
-	next_bank_idx=$(($next_bank_idx+1))
+	# dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[]" -v "{}"
+	# dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[$next_bank_idx].address" -v "${REWARDS_VESTER_ACCOUNT_ADDR}"
+	# dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[$next_bank_idx].coins.[]" -v "{}"
+	# dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[$next_bank_idx].coins.[0].denom" -v "${REWARD_TOKEN}"
+	# dasel put -t string -f "$GENESIS" ".app_state.bank.balances.[$next_bank_idx].coins.[0].amount" -v "1000000000000" # 1e12
+	# next_bank_idx=$(($next_bank_idx+1))
 
 	# Initialize bank balance of bridge module account.
 	dasel put -t json -f "$GENESIS" ".app_state.bank.balances.[]" -v "{}"

--- a/protocol/testing/testnet-staging/staging.sh
+++ b/protocol/testing/testnet-staging/staging.sh
@@ -188,9 +188,16 @@ create_validators() {
 		# Using "*" as a subscript results in a single arg: "dydx1... dydx1... dydx1..."
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
-		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" ""
-		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
+		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "STATUS_INITIALIZING"
+		# update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "600"
+
+		# no fee multiplier at launch
+		dasel put -t int -f "$GENESIS" '.app_state.rewards.params.fee_multiplier_ppm' -v '0'
+		# reduced deposit period
+		dasel put -t string -f "$GENESIS" '.app_state.gov.params.max_deposit_period' -v '300s'
+		# reduced voting period
+		dasel put -t string -f "$GENESIS" '.app_state.gov.params.voting_period' -v '300s' 
 
 		for acct in "${TEST_ACCOUNTS[@]}"; do
 			dydxprotocold add-genesis-account "$acct" 100000000000000000$USDC_DENOM,$TESTNET_VALIDATOR_NATIVE_TOKEN_BALANCE$NATIVE_TOKEN --home "$VAL_HOME_DIR"

--- a/protocol/testing/testnet-staging/staging.sh
+++ b/protocol/testing/testnet-staging/staging.sh
@@ -198,6 +198,8 @@ create_validators() {
 		dasel put -t string -f "$GENESIS" '.app_state.gov.params.max_deposit_period' -v '300s'
 		# reduced voting period
 		dasel put -t string -f "$GENESIS" '.app_state.gov.params.voting_period' -v '300s' 
+		# update oracle market for rewards
+		dasel put -t int -f "$GENESIS" '.app_state.rewards.params.market_id' -v '1000001'
 
 		for acct in "${TEST_ACCOUNTS[@]}"; do
 			dydxprotocold add-genesis-account "$acct" 100000000000000000$USDC_DENOM,$TESTNET_VALIDATOR_NATIVE_TOKEN_BALANCE$NATIVE_TOKEN --home "$VAL_HOME_DIR"


### PR DESCRIPTION
One-time set up for manual testing in staging. 

Make staging behave more like production genesis - this involves micmicing the “ramping up” period on a prod netwok genesis, including things like:

- Create clob pairs in INITIALIZING
- No balance in reward vester or community vester
- 0 fee constant in rewards module

Additionally, make durations easier to test:
- Voting period


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new event trigger in the GitHub workflow to automatically build and push snapshots whenever changes are made in the `protocol/` directory via pull requests.
- Test: Updated the `create_validators()` function in the staging script for the testnet. This includes initializing validators with a new status, adjusting parameters in the genesis file for testing purposes (fee multiplier, deposit period, voting period), and adding test accounts with specific balances.
- Chore: Commented out code in `genesis.sh` that initializes bank balances for certain accounts. This is preparatory work for future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->