### PR TITLE
[DEC-2071] - Add input validation to exposed method on the keeper to maintain expected invariants

### DIFF
--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -141,22 +141,26 @@ func (k Keeper) AddRewardSharesForFill(
 	)
 	if takerWeight.Cmp(lib.BigInt0()) > 0 {
 		// We aren't concerned with errors here because we've already validated the weight is positive.
-		_ = k.AddRewardShareToAddress(
+		if err := k.AddRewardShareToAddress(
 			ctx,
 			takerAddress,
 			takerWeight,
-		)
+		); err != nil {
+			k.Logger(ctx).Error("Failed to add rewards share to address", constants.ErrorLogKey, err)
+		}
 	}
 
 	// Process reward weight for maker.
 	makerWeight := new(big.Int).Set(bigMakerFeeQuoteQuantums)
 	if makerWeight.Cmp(lib.BigInt0()) > 0 {
 		// We aren't concerned with errors here because we've already validated the weight is positive.
-		_ = k.AddRewardShareToAddress(
+		if err := k.AddRewardShareToAddress(
 			ctx,
 			makerAddress,
 			makerWeight,
-		)
+		); err != nil {
+			k.Logger(ctx).Error("Failed to add rewards share to address", constants.ErrorLogKey, err)
+		}
 	}
 }
 

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -168,7 +169,11 @@ func (k Keeper) AddRewardShareToAddress(
 	weight *big.Int,
 ) error {
 	if weight.Cmp(lib.BigInt0()) <= 0 {
-		return fmt.Errorf("reward share weight must be positive")
+		return errorsmod.Wrapf(
+			types.ErrNonpositiveWeight,
+			"Invalid weight %v",
+			weight.String(),
+		)
 	}
 
 	// Get existing reward share. If no previous reward share, 0 weight is returned.
@@ -191,7 +196,11 @@ func (k Keeper) SetRewardShare(
 	rewardShare types.RewardShare,
 ) error {
 	if rewardShare.Weight.BigInt().Cmp(lib.BigInt0()) <= 0 {
-		return fmt.Errorf("reward share weight must be positive")
+		return errorsmod.Wrapf(
+			types.ErrNonpositiveWeight,
+			"Invalid weight %v",
+			rewardShare.Weight.String(),
+		)
 	}
 
 	store := prefix.NewStore(ctx.KVStore(k.transientStoreKey), []byte(types.RewardShareKeyPrefix))

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -139,7 +139,8 @@ func (k Keeper) AddRewardSharesForFill(
 		makerRebateMulTakerVolume,
 	)
 	if takerWeight.Cmp(lib.BigInt0()) > 0 {
-		k.AddRewardShareToAddress(
+		// We aren't concerned with errors here because we've already validated the weight is positive.
+		_ = k.AddRewardShareToAddress(
 			ctx,
 			takerAddress,
 			takerWeight,
@@ -149,7 +150,8 @@ func (k Keeper) AddRewardSharesForFill(
 	// Process reward weight for maker.
 	makerWeight := new(big.Int).Set(bigMakerFeeQuoteQuantums)
 	if makerWeight.Cmp(lib.BigInt0()) > 0 {
-		k.AddRewardShareToAddress(
+		// We aren't concerned with errors here because we've already validated the weight is positive.
+		_ = k.AddRewardShareToAddress(
 			ctx,
 			makerAddress,
 			makerWeight,
@@ -164,7 +166,11 @@ func (k Keeper) AddRewardShareToAddress(
 	ctx sdk.Context,
 	address string,
 	weight *big.Int,
-) {
+) error {
+	if weight.Cmp(lib.BigInt0()) <= 0 {
+		return fmt.Errorf("reward share weight must be positive")
+	}
+
 	// Get existing reward share. If no previous reward share, 0 weight is returned.
 	rewardShare := k.GetRewardShare(ctx, address)
 	newWeight := new(big.Int).Add(
@@ -173,7 +179,7 @@ func (k Keeper) AddRewardShareToAddress(
 	)
 
 	// Set the new reward share.
-	k.SetRewardShare(ctx, types.RewardShare{
+	return k.SetRewardShare(ctx, types.RewardShare{
 		Address: address,
 		Weight:  dtypes.NewIntFromBigInt(newWeight),
 	})
@@ -183,11 +189,16 @@ func (k Keeper) AddRewardShareToAddress(
 func (k Keeper) SetRewardShare(
 	ctx sdk.Context,
 	rewardShare types.RewardShare,
-) {
+) error {
+	if rewardShare.Weight.BigInt().Cmp(lib.BigInt0()) <= 0 {
+		return fmt.Errorf("reward share weight must be positive")
+	}
+
 	store := prefix.NewStore(ctx.KVStore(k.transientStoreKey), []byte(types.RewardShareKeyPrefix))
 	b := k.cdc.MustMarshal(&rewardShare)
 
 	store.Set([]byte(rewardShare.Address), b)
+	return nil
 }
 
 func (k Keeper) getAllRewardSharesAndTotalWeight(ctx sdk.Context) (

--- a/protocol/x/rewards/keeper/keeper_test.go
+++ b/protocol/x/rewards/keeper/keeper_test.go
@@ -58,7 +58,8 @@ func TestRewardShareStorage_Exists(t *testing.T) {
 		Weight:  dtypes.NewInt(12_345_678),
 	}
 
-	k.SetRewardShare(ctx, val)
+	err := k.SetRewardShare(ctx, val)
+	require.NoError(t, err)
 	require.Equal(t, val, k.GetRewardShare(ctx, TestAddress1))
 }
 
@@ -99,10 +100,12 @@ func TestAddRewardShareToAddress(t *testing.T) {
 			k := tApp.App.RewardsKeeper
 
 			if tc.prevRewardShare != nil {
-				k.SetRewardShare(ctx, *tc.prevRewardShare)
+				err := k.SetRewardShare(ctx, *tc.prevRewardShare)
+				require.NoError(t, err)
 			}
 
-			k.AddRewardShareToAddress(ctx, TestAddress1, tc.newWeight)
+			err := k.AddRewardShareToAddress(ctx, TestAddress1, tc.newWeight)
+			require.NoError(t, err)
 
 			// Check the new reward share.
 			require.Equal(t, tc.expectedRewardShare, k.GetRewardShare(ctx, TestAddress1))
@@ -247,10 +250,12 @@ func TestAddRewardSharesForFill(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.prevTakerRewardShare != nil {
-				k.SetRewardShare(ctx, *tc.prevTakerRewardShare)
+				err := k.SetRewardShare(ctx, *tc.prevTakerRewardShare)
+				require.NoError(t, err)
 			}
 			if tc.prevMakerRewardShare != nil {
-				k.SetRewardShare(ctx, *tc.prevMakerRewardShare)
+				err := k.SetRewardShare(ctx, *tc.prevMakerRewardShare)
+				require.NoError(t, err)
 			}
 
 			k.AddRewardSharesForFill(
@@ -648,7 +653,8 @@ func TestProcessRewardsForBlock(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, rewardShare := range tc.rewardShares {
-				k.AddRewardShareToAddress(ctx, rewardShare.Address, rewardShare.Weight.BigInt())
+				err := k.AddRewardShareToAddress(ctx, rewardShare.Address, rewardShare.Weight.BigInt())
+				require.NoError(t, err)
 			}
 
 			err = k.ProcessRewardsForBlock(ctx)

--- a/protocol/x/rewards/types/errors.go
+++ b/protocol/x/rewards/types/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrInvalidTreasuryAccount  = errorsmod.Register(ModuleName, 1001, "invalid treasury account")
 	ErrInvalidFeeMultiplierPpm = errorsmod.Register(ModuleName, 1002, "invalid FeeMultiplierPpm")
 	ErrInvalidAuthority        = errorsmod.Register(ModuleName, 1003, "Authority is invalid")
+	ErrNonpositiveWeight       = errorsmod.Register(ModuleName, 1004, "weight must be positive")
 )


### PR DESCRIPTION
### Changelist
Incoming rewards weights should always be positive, but some methods exposed by the keeper don't do this validation. Add validation to these methods.

This shouldn't affect existing code because these error conditions are already checked for higher up in the chain. I don't handle errors where this is already called, either, for that reason. This is really about future-proofing the module.

### Test Plan

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enhanced error handling in the `protocol/x/rewards/keeper` package. Functions `AddRewardSharesForFill`, `AddRewardShareToAddress`, and `SetRewardShare` now return an error when the reward share weight is non-positive, improving the robustness of the rewards system.
- Test: Added and updated tests in `protocol/x/rewards/keeper/keeper_test.go` to cover the new error handling scenarios, ensuring the system behaves as expected when encountering non-positive weights.
- Chore: Introduced a new error code `ErrNonpositiveWeight` in `protocol/x/rewards/types/errors.go` for better error identification and handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->