### PR TITLE
Handle undefined / null values in bulk queries correctly.

### DIFF
--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -10,6 +10,8 @@
 * [#469](https://github.com/dydxprotocol/v4-chain/pull/469) Added a reason field to `/screen` endpoint to display a reason for blocking an address.
   
 ### Bug Fixes
+* [#528](https://github.com/dydxprotocol/v4-chain/pull/528) Fixed bug with bulk SQL queries with nullable numeric / string / boolean values.
+
 * [#496](https://github.com/dydxprotocol/v4-chain/pull/496) Don't geo-block requests made to `comlink` if it's from an internal ip.
 
 * [#460](https://github.com/dydxprotocol/v4-chain/pull/460/files) Fixed track lag timing to output positive numbers.

--- a/indexer/packages/postgres/__tests__/stores/compliance-data-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/compliance-data-table.test.ts
@@ -243,9 +243,13 @@ describe('Compliance data store', () => {
     );
     expect(complianceData.length).toEqual(1);
 
-    const updatedTime: string = DateTime.fromISO(
+    const updatedTime1: string = DateTime.fromISO(
       nonBlockedComplianceData.updatedAt!,
     ).plus(10).toUTC().toISO();
+    const updatedTime2: string = DateTime.fromISO(
+      nonBlockedComplianceData.updatedAt!,
+    ).plus(20).toUTC().toISO();
+    const otherAddress: string = 'dydx1scu097p2sstqzupe6t687kpc2w4sv665fedctf';
 
     await ComplianceDataTable.bulkUpsert(
       [
@@ -254,7 +258,14 @@ describe('Compliance data store', () => {
           ...nonBlockedComplianceData,
           riskScore: '30.00',
           blocked: true,
-          updatedAt: updatedTime,
+          updatedAt: updatedTime1,
+        },
+        {
+          ...nonBlockedComplianceData,
+          address: otherAddress,
+          riskScore: undefined,
+          blocked: false,
+          updatedAt: updatedTime2,
         },
       ],
     );
@@ -264,13 +275,20 @@ describe('Compliance data store', () => {
       [],
       { readReplica: true },
     );
-    expect(complianceData.length).toEqual(2);
+    expect(complianceData.length).toEqual(3);
     expect(complianceData[0]).toEqual(blockedComplianceData);
     expect(complianceData[1]).toEqual({
       ...nonBlockedComplianceData,
       riskScore: '30.00',
       blocked: true,
-      updatedAt: updatedTime,
+      updatedAt: updatedTime1,
+    });
+    expect(complianceData[2]).toEqual({
+      ...nonBlockedComplianceData,
+      address: otherAddress,
+      riskScore: null,
+      blocked: false,
+      updatedAt: updatedTime2,
     });
   });
 });

--- a/indexer/packages/postgres/src/helpers/stores-helpers.ts
+++ b/indexer/packages/postgres/src/helpers/stores-helpers.ts
@@ -110,10 +110,10 @@ export function setBulkRowsForUpdate<T extends string>({
 }): string[] {
   return objectArray.map((object) => columns.map((col) => {
     if (stringColumns && stringColumns.includes(col)) {
-      return `'${object[col]}'`;
+      return `'${castNull(object[col])}'`;
     }
     if (numericColumns && numericColumns.includes(col)) {
-      return `${_.get(object, col)}`;
+      return `${castNull(_.get(object, col))}`;
     }
     if (bigintColumns && bigintColumns.includes(col)) {
       return castValue(object[col] as number | undefined | null, 'bigint');
@@ -128,10 +128,22 @@ export function setBulkRowsForUpdate<T extends string>({
       return castBinaryValue(object[col] as Buffer | null | undefined);
     }
     if (booleanColumns && booleanColumns.includes(col)) {
-      return `${object[col]}`;
+      return `${castNull(object[col])}`;
     }
     throw new Error(`Unsupported column for bulk update: ${col}`);
   }).join(', '));
+}
+
+/**
+ * If the value is null || undefined, return 'NULL'
+ */
+function castNull(
+  value: Buffer | string | number | boolean | null | undefined,
+): string {
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+  return `${value}`;
 }
 
 /**


### PR DESCRIPTION
### Changelist
Update the bulk query generation functions to correctly handle `undefined` or `null` numeric / string / boolean values by converting them to `NULL`.

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes:**

- **Bug Fix**: Resolved an issue with bulk SQL queries handling nullable numeric, string, or boolean values (#528).
- **Bug Fix**: Prevented geo-blocking requests made to `comlink` from internal IPs (#496).
- **New Feature**: Enhanced the `/screen` endpoint by adding a 'reason' field to display the reason for blocking an address (#469).
- **Test**: Added new test cases and interfaces to handle undefined or null risk scores in the compliance data update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->