### PR TITLE
Use new binance endpoint

### DIFF
--- a/protocol/CHANGELOG.md
+++ b/protocol/CHANGELOG.md
@@ -9,7 +9,9 @@
 ### Improvements
 
 * [#479](https://github.com/dydxprotocol/v4-chain/pull/479) Ensure that rate limiting of short term order placements/cancellations is guarded against replay attacks.
-  
+
+* [#532](https://github.com/dydxprotocol/v4-chain/pull/532) Use updated `data-api.binance.vision` endpoint for Binance price data.
+
 ### Bug Fixes
 * [#449](https://github.com/dydxprotocol/v4-chain/pull/449) Removes possible undesirable panics in x/rewards `EndBlocker`.
 

--- a/protocol/daemons/pricefeed/client/price_function/binance/exchange_query_details.go
+++ b/protocol/daemons/pricefeed/client/price_function/binance/exchange_query_details.go
@@ -8,7 +8,7 @@ import (
 var (
 	BinanceDetails = types.ExchangeQueryDetails{
 		Exchange:      exchange_common.EXCHANGE_ID_BINANCE,
-		Url:           "https://data.binance.com/api/v3/ticker/24hr",
+		Url:           "https://data-api.binance.vision/api/v3/ticker/24hr",
 		PriceFunction: BinancePriceFunction,
 		IsMultiMarket: true,
 	}

--- a/protocol/daemons/pricefeed/client/price_function/binance/exchange_query_details_test.go
+++ b/protocol/daemons/pricefeed/client/price_function/binance/exchange_query_details_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBinanceUrl(t *testing.T) {
-	require.Equal(t, "https://data.binance.com/api/v3/ticker/24hr", binance.BinanceDetails.Url)
+	require.Equal(t, "https://data-api.binance.vision/api/v3/ticker/24hr", binance.BinanceDetails.Url)
 }
 
 func TestBinanceUsUrl(t *testing.T) {


### PR DESCRIPTION
### Changelist
Use `data-api.binance.vision` instead of `data.binance.com`
https://binance-docs.github.io/apidocs/spot/en/#change-log:~:text=API%20Market%20data%20from%20data.binance.com%20can%20now%20be%20accessed%20from%20data%2Dapi.binance.vision.

Even though this technically can affect `PrepareProposal` and `ProcessProposal`, I would consider it non-breaking since prices from exchanges are already medianized and very similar to each other

### Test Plan
Tested locally and in internal `funder` service

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.