### PR TITLE
Select a pseudorandom positionId when liquidating

### DIFF
--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"fmt"
-	"math"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/spf13/cobra"
@@ -32,8 +31,8 @@ const (
 
 // Default values.
 const (
-	DefaultMaxLiquidationOrdersPerBlock    = math.MaxUint32
-	DefaultMaxDeleveragingAttemptsPerBlock = 35
+	DefaultMaxLiquidationOrdersPerBlock    = 100
+	DefaultMaxDeleveragingAttemptsPerBlock = 5
 
 	DefaultMevTelemetryEnabled    = false
 	DefaultMevTelemetryHost       = ""

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
@@ -164,9 +163,6 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 	deltaQuantumsRemaining = new(big.Int).Set(deltaQuantumsTotal)
 	fills = make([]types.MatchPerpetualDeleveraging_Fill, 0)
 
-	s := rand.NewSource(k.blockTimeKeeper.GetPreviousBlockInfo(ctx).Timestamp.Unix())
-	rand := rand.New(s)
-
 	k.subaccountsKeeper.ForEachSubaccountRandomStart(
 		ctx,
 		func(offsettingSubaccount satypes.Subaccount) (finished bool) {
@@ -300,7 +296,7 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 			}
 			return deltaQuantumsRemaining.Sign() == 0
 		},
-		rand,
+		k.GetPseudoRand(ctx),
 	)
 
 	telemetry.SetGauge(float32(numSubaccountsIterated), metrics.NumSubaccountsIterated, metrics.Count)

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -604,10 +604,15 @@ func (k Keeper) GetPerpetualPositionToLiquidate(
 
 	var perpetualPosition *satypes.PerpetualPosition
 
-	for _, position := range subaccount.PerpetualPositions {
-		// Note that this could run in O(n^2) time. This is fine for now because we have less than a hundred
-		// perpetuals and only liquidate once per subaccount per block. This means that the position with smallest
-		// id will be liquidated first.
+	// Randomly (with deterministic seeding) select a perpetual position. This is done by iterating through
+	// the slice at-most-once starting at a random index.
+	// Note that this could run in O(n^2) time. This is fine for now because we have less than a hundred
+	// perpetuals and only liquidate once per subaccount per block.
+	numPositions := len(subaccount.PerpetualPositions)
+	indexOffset := k.GetPseudoRand(ctx).Intn(numPositions)
+	for i := 0; i < numPositions; i++ {
+		ppi := (i + indexOffset) % numPositions
+		position := subaccount.PerpetualPositions[ppi]
 		if !subaccountLiquidationInfo.HasPerpetualBeenLiquidatedForSubaccount(position.PerpetualId) {
 			perpetualPosition = position
 			break

--- a/protocol/x/clob/keeper/random.go
+++ b/protocol/x/clob/keeper/random.go
@@ -1,0 +1,16 @@
+package keeper
+
+import (
+	"math/rand"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// GetPseudoRand returns a random number generator seeded with a pseudorandom seed.
+// The seed is based on the previous block timestamp.
+func (k *Keeper) GetPseudoRand(ctx sdk.Context) *rand.Rand {
+	s := rand.NewSource(
+		k.blockTimeKeeper.GetPreviousBlockInfo(ctx).Timestamp.Unix(),
+	)
+	return rand.New(s)
+}


### PR DESCRIPTION
### Changelist
- Select a pseudorandom positionId when liquidating
- This also affects the positionId to deleverage
- Decrease the maximum number of accounts to liquidate or deleverage per block to levels that can easily be processed in the span of a single block

### Test Plan
For testnet-3

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added `exponent` property to the `MarketUpdateObject` and `MarketModifyEventV1` interfaces, allowing for more precise price calculations.
- New Feature: Introduced a new upgrade handler for version 0.3.0 of the application, which includes updates to various market parameters and state data structures.
- Refactor: Simplified code in `protocol/x/clob/keeper/deleveraging.go` by removing unnecessary randomness and unused variables.
- Performance: Improved selection process in `protocol/x/clob/keeper/liquidations.go` by using deterministic seeding for random position selection.
- New Feature: Added new functions `UnsafeSetClobPair`, `UnsafeSetPerpetual`, `UnsafeDeleteNumLiquidityTiersKey`, `UnsafeModifyMarketParam`, and `UnsafeSetMarketPrice` for direct manipulation of store data.
- Test: Updated test cases to accommodate the new `exponent` property and other changes.
- Chore: Adjusted default values for `DefaultMaxLiquidationOrdersPerBlock` and `DefaultMaxDeleveragingAttemptsPerBlock` constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->