### PR TITLE
Release v0.3.4: Bound the number of attempted liquidations by `MaxLiquidationOrdersPerBlock`. Revert breaking change for selecting perpetual position when liquidating.  Randomly select position to deleverage.

### DIFF
--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -31,7 +31,7 @@ const (
 
 // Default values.
 const (
-	DefaultMaxLiquidationOrdersPerBlock    = 100
+	DefaultMaxLiquidationOrdersPerBlock    = 20
 	DefaultMaxDeleveragingAttemptsPerBlock = 5
 
 	DefaultMevTelemetryEnabled    = false

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -604,15 +604,10 @@ func (k Keeper) GetPerpetualPositionToLiquidate(
 
 	var perpetualPosition *satypes.PerpetualPosition
 
-	// Randomly (with deterministic seeding) select a perpetual position. This is done by iterating through
-	// the slice at-most-once starting at a random index.
-	// Note that this could run in O(n^2) time. This is fine for now because we have less than a hundred
-	// perpetuals and only liquidate once per subaccount per block.
-	numPositions := len(subaccount.PerpetualPositions)
-	indexOffset := k.GetPseudoRand(ctx).Intn(numPositions)
-	for i := 0; i < numPositions; i++ {
-		ppi := (i + indexOffset) % numPositions
-		position := subaccount.PerpetualPositions[ppi]
+	for _, position := range subaccount.PerpetualPositions {
+		// Note that this could run in O(n^2) time. This is fine for now because we have less than a hundred
+		// perpetuals and only liquidate once per subaccount per block. This means that the position with smallest
+		// id will be liquidated first.
 		if !subaccountLiquidationInfo.HasPerpetualBeenLiquidatedForSubaccount(position.PerpetualId) {
 			perpetualPosition = position
 			break

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -37,7 +37,10 @@ func (k Keeper) LiquidateSubaccountsAgainstOrderbook(
 	liquidationOrdersForSorting := make([]types.LiquidationOrder, 0)
 	numSubaccounts := len(subaccountIds)
 	numLiqOrders := lib.Min(numSubaccounts, int(k.MaxLiquidationOrdersPerBlock))
-	indexOffset := pseudoRand.Intn(numSubaccounts)
+	indexOffset := 0
+	if numSubaccounts > 0 {
+		indexOffset = pseudoRand.Intn(numSubaccounts)
+	}
 	for i := 0; i < numLiqOrders; i++ {
 		index := (i + indexOffset) % numSubaccounts
 		subaccountId := subaccountIds[index]


### PR DESCRIPTION
### Changelist
- Bound the number of _attempted_ liquidations by `MaxLiquidationOrdersPerBlock`, not just the number of successful liquidations
- Decrease the default value of `MaxLiquidationOrdersPerBlock` to 20 to attempt to reduce the liquidation flow (triggered at the end of each block) to a maximum of low-double-digit milliseconds in duration
- Given that every possible liquidated account may not be attempted, pseudorandomly select the subset of accounts to try and liquidate
- Revert part of https://github.com/dydxprotocol/v4-chain/pull/535 which was unintentionally breaking `ProcessProposal` and `DeliverTx` when liquidations occurred in the block
- However, keep the pseudorandom selection for deleveraged positions which is necessary for making deleveragable accounts "unstuck" and does not seem to be validated in the same way as liquidations (the previous change does not seem to be breaking for deleveraging)

### Test Plan
N/A
