### PR TITLE
add flag to limit the number of subaccounts iterated for deleveraging

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -282,6 +282,7 @@ const (
 	NumSubaccountsIterated         = "num_subaccounts_iterated"
 	NotEnoughPositionToFullyOffset = "not_enough_position_to_fully_offset"
 	NonOverlappingBankruptcyPrices = "non_overlapping_bankruptcy_prices"
+	NoOpenPositionOnOppositeSide   = "no_open_position_on_opposite_side"
 
 	// Pricefeed Daemon.
 	Exchange                                = "exchange"

--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -9,8 +9,9 @@ import (
 
 // A struct containing the values of all flags.
 type ClobFlags struct {
-	MaxLiquidationOrdersPerBlock    uint32
-	MaxDeleveragingAttemptsPerBlock uint32
+	MaxLiquidationOrdersPerBlock        uint32
+	MaxDeleveragingAttemptsPerBlock     uint32
+	MaxDeleveragingSubaccountsToIterate uint32
 
 	MevTelemetryEnabled    bool
 	MevTelemetryHost       string
@@ -20,8 +21,9 @@ type ClobFlags struct {
 // List of CLI flags.
 const (
 	// Liquidations and deleveraging.
-	MaxLiquidationOrdersPerBlock    = "max-liquidation-orders-per-block"
-	MaxDeleveragingAttemptsPerBlock = "max-deleveraging-attempts-per-block"
+	MaxLiquidationOrdersPerBlock        = "max-liquidation-orders-per-block"
+	MaxDeleveragingAttemptsPerBlock     = "max-deleveraging-attempts-per-block"
+	MaxDeleveragingSubaccountsToIterate = "max-deleveraging-subaccounts-to-iterate"
 
 	// Mev.
 	MevTelemetryEnabled    = "mev-telemetry-enabled"
@@ -31,8 +33,9 @@ const (
 
 // Default values.
 const (
-	DefaultMaxLiquidationOrdersPerBlock    = 20
-	DefaultMaxDeleveragingAttemptsPerBlock = 5
+	DefaultMaxLiquidationOrdersPerBlock        = 20
+	DefaultMaxDeleveragingAttemptsPerBlock     = 5
+	DefaultMaxDeleveragingSubaccountsToIterate = 500
 
 	DefaultMevTelemetryEnabled    = false
 	DefaultMevTelemetryHost       = ""
@@ -59,6 +62,14 @@ func AddClobFlagsToCmd(cmd *cobra.Command) {
 			DefaultMaxDeleveragingAttemptsPerBlock,
 		),
 	)
+	cmd.Flags().Uint32(
+		MaxDeleveragingSubaccountsToIterate,
+		DefaultMaxDeleveragingSubaccountsToIterate,
+		fmt.Sprintf(
+			"Sets the maximum number of subaccounts iterated for each deleveraging event. Default = %d",
+			DefaultMaxDeleveragingSubaccountsToIterate,
+		),
+	)
 	cmd.Flags().Bool(
 		MevTelemetryEnabled,
 		DefaultMevTelemetryEnabled,
@@ -78,11 +89,12 @@ func AddClobFlagsToCmd(cmd *cobra.Command) {
 
 func GetDefaultClobFlags() ClobFlags {
 	return ClobFlags{
-		MaxLiquidationOrdersPerBlock:    DefaultMaxLiquidationOrdersPerBlock,
-		MaxDeleveragingAttemptsPerBlock: DefaultMaxDeleveragingAttemptsPerBlock,
-		MevTelemetryEnabled:             DefaultMevTelemetryEnabled,
-		MevTelemetryHost:                DefaultMevTelemetryHost,
-		MevTelemetryIdentifier:          DefaultMevTelemetryIdentifier,
+		MaxLiquidationOrdersPerBlock:        DefaultMaxLiquidationOrdersPerBlock,
+		MaxDeleveragingAttemptsPerBlock:     DefaultMaxDeleveragingAttemptsPerBlock,
+		MaxDeleveragingSubaccountsToIterate: DefaultMaxDeleveragingSubaccountsToIterate,
+		MevTelemetryEnabled:                 DefaultMevTelemetryEnabled,
+		MevTelemetryHost:                    DefaultMevTelemetryHost,
+		MevTelemetryIdentifier:              DefaultMevTelemetryIdentifier,
 	}
 }
 
@@ -113,6 +125,10 @@ func GetClobFlagValuesFromOptions(
 
 	if v, ok := appOpts.Get(MaxDeleveragingAttemptsPerBlock).(uint32); ok {
 		result.MaxDeleveragingAttemptsPerBlock = v
+	}
+
+	if v, ok := appOpts.Get(MaxDeleveragingSubaccountsToIterate).(uint32); ok {
+		result.MaxDeleveragingSubaccountsToIterate = v
 	}
 
 	return result

--- a/protocol/x/clob/flags/flags_test.go
+++ b/protocol/x/clob/flags/flags_test.go
@@ -44,28 +44,32 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 		optsMap map[string]any
 
 		// Expectations.
-		expectedMaxLiquidationOrdersPerBlock    uint32
-		expectedMaxDeleveragingAttemptsPerBlock uint32
-		expectedMevTelemetryHost                string
-		expectedMevTelemetryIdentifier          string
+		expectedMaxLiquidationOrdersPerBlock        uint32
+		expectedMaxDeleveragingAttemptsPerBlock     uint32
+		expectedMaxDeleveragingSubaccountsToIterate uint32
+		expectedMevTelemetryHost                    string
+		expectedMevTelemetryIdentifier              string
 	}{
 		"Sets to default if unset": {
-			expectedMaxLiquidationOrdersPerBlock:    flags.DefaultMaxLiquidationOrdersPerBlock,
-			expectedMaxDeleveragingAttemptsPerBlock: flags.DefaultMaxDeleveragingAttemptsPerBlock,
-			expectedMevTelemetryHost:                flags.DefaultMevTelemetryHost,
-			expectedMevTelemetryIdentifier:          flags.DefaultMevTelemetryIdentifier,
+			expectedMaxLiquidationOrdersPerBlock:        flags.DefaultMaxLiquidationOrdersPerBlock,
+			expectedMaxDeleveragingAttemptsPerBlock:     flags.DefaultMaxDeleveragingAttemptsPerBlock,
+			expectedMaxDeleveragingSubaccountsToIterate: flags.DefaultMaxDeleveragingSubaccountsToIterate,
+			expectedMevTelemetryHost:                    flags.DefaultMevTelemetryHost,
+			expectedMevTelemetryIdentifier:              flags.DefaultMevTelemetryIdentifier,
 		},
 		"Sets values from options": {
 			optsMap: map[string]any{
-				flags.MaxLiquidationOrdersPerBlock:    uint32(50),
-				flags.MaxDeleveragingAttemptsPerBlock: uint32(25),
-				flags.MevTelemetryHost:                "https://localhost:13137",
-				flags.MevTelemetryIdentifier:          "node-agent-01",
+				flags.MaxLiquidationOrdersPerBlock:        uint32(50),
+				flags.MaxDeleveragingAttemptsPerBlock:     uint32(25),
+				flags.MaxDeleveragingSubaccountsToIterate: uint32(100),
+				flags.MevTelemetryHost:                    "https://localhost:13137",
+				flags.MevTelemetryIdentifier:              "node-agent-01",
 			},
-			expectedMaxLiquidationOrdersPerBlock:    uint32(50),
-			expectedMaxDeleveragingAttemptsPerBlock: uint32(25),
-			expectedMevTelemetryHost:                "https://localhost:13137",
-			expectedMevTelemetryIdentifier:          "node-agent-01",
+			expectedMaxLiquidationOrdersPerBlock:        uint32(50),
+			expectedMaxDeleveragingAttemptsPerBlock:     uint32(25),
+			expectedMaxDeleveragingSubaccountsToIterate: uint32(100),
+			expectedMevTelemetryHost:                    "https://localhost:13137",
+			expectedMevTelemetryIdentifier:              "node-agent-01",
 		},
 	}
 
@@ -97,6 +101,11 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 				t,
 				tc.expectedMaxDeleveragingAttemptsPerBlock,
 				flags.MaxDeleveragingAttemptsPerBlock,
+			)
+			require.Equal(
+				t,
+				tc.expectedMaxDeleveragingSubaccountsToIterate,
+				flags.MaxDeleveragingSubaccountsToIterate,
 			)
 		})
 	}

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -166,6 +166,11 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 	k.subaccountsKeeper.ForEachSubaccountRandomStart(
 		ctx,
 		func(offsettingSubaccount satypes.Subaccount) (finished bool) {
+			// Iterate at most `MaxDeleveragingSubaccountsToIterate` subaccounts.
+			if numSubaccountsIterated >= int(k.MaxDeleveragingSubaccountsToIterate) {
+				return true
+			}
+
 			numSubaccountsIterated++
 			offsettingPosition, _ := offsettingSubaccount.GetPerpetualPositionForId(perpetualId)
 			bigOffsettingPositionQuantums := offsettingPosition.GetBigQuantums()
@@ -209,86 +214,86 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 				)
 			} else {
 				// If an error is returned, it's likely because the subaccounts' bankruptcy prices do not overlap.
-				liquidatedSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, liquidatedSubaccountId)
-				liquidatedBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
-					ctx,
-					liquidatedSubaccountId,
-					perpetualId,
-					deltaQuantums,
-				)
-				if bankruptcyPriceError != nil {
-					k.Logger(ctx).Error(
-						"error when getting bankruptcy price for liquidated subaccount",
-						"error", bankruptcyPriceError,
-						"blockHeight", ctx.BlockHeight(),
-						"checkTx", ctx.IsCheckTx(),
-						"perpetualId", perpetualId,
-						"deltaQuantums", deltaQuantums,
-					)
-					return false
-				}
-				liquidatedTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
-					ctx, satypes.Update{SubaccountId: *liquidatedSubaccount.Id},
-				)
-				if tncErr != nil {
-					k.Logger(ctx).Error(
-						"error when getting TNC for liquidated subaccount",
-						"error", tncErr,
-						"blockHeight", ctx.BlockHeight(),
-						"checkTx", ctx.IsCheckTx(),
-						"perpetualId", perpetualId,
-						"deltaQuantums", deltaQuantums,
-					)
-					return false
-				}
+				// liquidatedSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, liquidatedSubaccountId)
+				// liquidatedBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
+				// 	ctx,
+				// 	liquidatedSubaccountId,
+				// 	perpetualId,
+				// 	deltaQuantums,
+				// )
+				// if bankruptcyPriceError != nil {
+				// 	k.Logger(ctx).Error(
+				// 		"error when getting bankruptcy price for liquidated subaccount",
+				// 		"error", bankruptcyPriceError,
+				// 		"blockHeight", ctx.BlockHeight(),
+				// 		"checkTx", ctx.IsCheckTx(),
+				// 		"perpetualId", perpetualId,
+				// 		"deltaQuantums", deltaQuantums,
+				// 	)
+				// 	return false
+				// }
+				// liquidatedTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
+				// 	ctx, satypes.Update{SubaccountId: *liquidatedSubaccount.Id},
+				// )
+				// if tncErr != nil {
+				// 	k.Logger(ctx).Error(
+				// 		"error when getting TNC for liquidated subaccount",
+				// 		"error", tncErr,
+				// 		"blockHeight", ctx.BlockHeight(),
+				// 		"checkTx", ctx.IsCheckTx(),
+				// 		"perpetualId", perpetualId,
+				// 		"deltaQuantums", deltaQuantums,
+				// 	)
+				// 	return false
+				// }
 
-				offsettingSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, *offsettingSubaccount.Id)
-				offsettingBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
-					ctx,
-					*offsettingSubaccount.Id,
-					perpetualId,
-					new(big.Int).Neg(deltaQuantums),
-				)
-				if bankruptcyPriceError != nil {
-					k.Logger(ctx).Error(
-						"error when getting bankruptcy price for offsetting subaccount",
-						"error", bankruptcyPriceError,
-						"blockHeight", ctx.BlockHeight(),
-						"checkTx", ctx.IsCheckTx(),
-						"perpetualId", perpetualId,
-						"deltaQuantums", deltaQuantums,
-					)
-					return false
-				}
-				offsettingTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
-					ctx, satypes.Update{SubaccountId: *offsettingSubaccount.Id},
-				)
-				if tncErr != nil {
-					k.Logger(ctx).Error(
-						"error when getting TNC for offsetting subaccount",
-						"error", tncErr,
-						"blockHeight", ctx.BlockHeight(),
-						"checkTx", ctx.IsCheckTx(),
-						"perpetualId", perpetualId,
-						"deltaQuantums", deltaQuantums,
-					)
-					return false
-				}
+				// offsettingSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, *offsettingSubaccount.Id)
+				// offsettingBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
+				// 	ctx,
+				// 	*offsettingSubaccount.Id,
+				// 	perpetualId,
+				// 	new(big.Int).Neg(deltaQuantums),
+				// )
+				// if bankruptcyPriceError != nil {
+				// 	k.Logger(ctx).Error(
+				// 		"error when getting bankruptcy price for offsetting subaccount",
+				// 		"error", bankruptcyPriceError,
+				// 		"blockHeight", ctx.BlockHeight(),
+				// 		"checkTx", ctx.IsCheckTx(),
+				// 		"perpetualId", perpetualId,
+				// 		"deltaQuantums", deltaQuantums,
+				// 	)
+				// 	return false
+				// }
+				// offsettingTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
+				// 	ctx, satypes.Update{SubaccountId: *offsettingSubaccount.Id},
+				// )
+				// if tncErr != nil {
+				// 	k.Logger(ctx).Error(
+				// 		"error when getting TNC for offsetting subaccount",
+				// 		"error", tncErr,
+				// 		"blockHeight", ctx.BlockHeight(),
+				// 		"checkTx", ctx.IsCheckTx(),
+				// 		"perpetualId", perpetualId,
+				// 		"deltaQuantums", deltaQuantums,
+				// 	)
+				// 	return false
+				// }
 
-				k.Logger(ctx).Info(
-					"Encountered error when processing deleveraging",
-					"error", err,
-					"blockHeight", ctx.BlockHeight(),
-					"checkTx", ctx.IsCheckTx(),
-					"perpetualId", perpetualId,
-					"deltaQuantums", deltaQuantums,
-					"liquidatedSubaccount", fmt.Sprintf("%+v", liquidatedSubaccount),
-					"liquidatedBankruptcyPriceQuoteQuantums", liquidatedBankruptcyPrice,
-					"liquidatedTnc", liquidatedTnc,
-					"offsettingSubaccount", fmt.Sprintf("%+v", offsettingSubaccount),
-					"offsettingBankruptcyPriceQuoteQuantums", offsettingBankruptcyPrice,
-					"offsettingTnc", offsettingTnc,
-				)
+				// k.Logger(ctx).Info(
+				// 	"Encountered error when processing deleveraging",
+				// 	"error", err,
+				// 	"blockHeight", ctx.BlockHeight(),
+				// 	"checkTx", ctx.IsCheckTx(),
+				// 	"perpetualId", perpetualId,
+				// 	"deltaQuantums", deltaQuantums,
+				// 	"liquidatedSubaccount", fmt.Sprintf("%+v", liquidatedSubaccount),
+				// 	"liquidatedBankruptcyPriceQuoteQuantums", liquidatedBankruptcyPrice,
+				// 	"liquidatedTnc", liquidatedTnc,
+				// 	"offsettingSubaccount", fmt.Sprintf("%+v", offsettingSubaccount),
+				// 	"offsettingBankruptcyPriceQuoteQuantums", offsettingBankruptcyPrice,
+				// 	"offsettingTnc", offsettingTnc,
+				// )
 				telemetry.IncrCounter(
 					1,
 					types.ModuleName, metrics.Deleveraging, metrics.NonOverlappingBankruptcyPrices, metrics.Count,
@@ -299,7 +304,10 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 		k.GetPseudoRand(ctx),
 	)
 
-	telemetry.SetGauge(float32(numSubaccountsIterated), metrics.NumSubaccountsIterated, metrics.Count)
+	telemetry.IncrCounter(
+		float32(numSubaccountsIterated),
+		types.ModuleName, metrics.Deleveraging, metrics.NumSubaccountsIterated, metrics.Count,
+	)
 
 	if deltaQuantumsRemaining.Sign() == 0 {
 		// Deleveraging was successful.

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -44,8 +44,9 @@ type (
 
 		memStoreInitialized *atomic.Bool
 
-		MaxLiquidationOrdersPerBlock    uint32
-		MaxDeleveragingAttemptsPerBlock uint32
+		MaxLiquidationOrdersPerBlock        uint32
+		MaxDeleveragingAttemptsPerBlock     uint32
+		MaxDeleveragingSubaccountsToIterate uint32
 
 		mevTelemetryConfig MevTelemetryConfig
 
@@ -108,10 +109,11 @@ func NewKeeper(
 			Host:       clobFlags.MevTelemetryHost,
 			Identifier: clobFlags.MevTelemetryIdentifier,
 		},
-		MaxLiquidationOrdersPerBlock:    clobFlags.MaxLiquidationOrdersPerBlock,
-		MaxDeleveragingAttemptsPerBlock: clobFlags.MaxDeleveragingAttemptsPerBlock,
-		placeOrderRateLimiter:           placeOrderRateLimiter,
-		cancelOrderRateLimiter:          cancelOrderRateLimiter,
+		MaxLiquidationOrdersPerBlock:        clobFlags.MaxLiquidationOrdersPerBlock,
+		MaxDeleveragingAttemptsPerBlock:     clobFlags.MaxDeleveragingAttemptsPerBlock,
+		MaxDeleveragingSubaccountsToIterate: clobFlags.MaxDeleveragingSubaccountsToIterate,
+		placeOrderRateLimiter:               placeOrderRateLimiter,
+		cancelOrderRateLimiter:              cancelOrderRateLimiter,
 	}
 
 	// Provide the keeper to the MemClob.

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -979,7 +979,7 @@ func (k Keeper) validateMatchedLiquidation(
 	// Validate that processing the liquidation fill does not leave insufficient funds
 	// in the insurance fund (such that the liquidation couldn't have possibly continued).
 	if !k.IsValidInsuranceFundDelta(ctx, insuranceFundDelta) {
-		k.Logger(ctx).Info("ProcessMatches: insurance fund has insufficient balance to process the liquidation.")
+		// k.Logger(ctx).Info("ProcessMatches: insurance fund has insufficient balance to process the liquidation.")
 		return nil, errorsmod.Wrapf(
 			types.ErrInsuranceFundHasInsufficientFunds,
 			"Liquidation order %v, insurance fund delta %v",

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -979,7 +979,7 @@ func (k Keeper) validateMatchedLiquidation(
 	// Validate that processing the liquidation fill does not leave insufficient funds
 	// in the insurance fund (such that the liquidation couldn't have possibly continued).
 	if !k.IsValidInsuranceFundDelta(ctx, insuranceFundDelta) {
-		// k.Logger(ctx).Info("ProcessMatches: insurance fund has insufficient balance to process the liquidation.")
+		k.Logger(ctx).Debug("ProcessMatches: insurance fund has insufficient balance to process the liquidation.")
 		return nil, errorsmod.Wrapf(
 			types.ErrInsuranceFundHasInsufficientFunds,
 			"Liquidation order %v, insurance fund delta %v",


### PR DESCRIPTION
### Changelist
- Add a commandline flag to control the number of subaccounts iterated per deleveraging event.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
