### PR TITLE
[DEC-2143] use cast to parse command line flags

### DIFF
--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -2,8 +2,10 @@ package flags
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
 
@@ -85,24 +87,34 @@ func GetFlagValuesFromOptions(
 	}
 
 	// Populate the flags if they exist.
-	if v, ok := appOpts.Get(NonValidatingFullNodeFlag).(bool); ok {
-		result.NonValidatingFullNode = v
+	if option := appOpts.Get(NonValidatingFullNodeFlag); option != nil {
+		if v, err := cast.ToBoolE(option); err == nil {
+			result.NonValidatingFullNode = v
+		}
 	}
 
-	if v, ok := appOpts.Get(DdAgentHost).(string); ok {
-		result.DdAgentHost = v
+	if option := appOpts.Get(DdAgentHost); option != nil {
+		if v, err := cast.ToStringE(option); err == nil {
+			result.DdAgentHost = v
+		}
 	}
 
-	if v, ok := appOpts.Get(DdTraceAgentPort).(uint16); ok {
-		result.DdTraceAgentPort = v
+	if option := appOpts.Get(DdTraceAgentPort); option != nil {
+		if v, err := cast.ToUint16E(option); err == nil {
+			result.DdTraceAgentPort = v
+		}
 	}
 
-	if v, ok := appOpts.Get(GrpcAddress).(string); ok {
-		result.GrpcAddress = v
+	if option := appOpts.Get(GrpcAddress); option != nil {
+		if v, err := cast.ToStringE(option); err == nil {
+			result.GrpcAddress = v
+		}
 	}
 
-	if v, ok := appOpts.Get(GrpcEnable).(bool); ok {
-		result.GrpcEnable = v
+	if option := appOpts.Get(GrpcEnable); option != nil {
+		if v, err := cast.ToBoolE(option); err == nil {
+			result.GrpcEnable = v
+		}
 	}
 
 	return result

--- a/protocol/daemons/flags/flags.go
+++ b/protocol/daemons/flags/flags.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
 
@@ -172,41 +173,61 @@ func GetDaemonFlagValuesFromOptions(
 	result := GetDefaultDaemonFlags()
 
 	// Shared Flags
-	if v, ok := appOpts.Get(FlagUnixSocketAddress).(string); ok {
-		result.Shared.SocketAddress = v
+	if option := appOpts.Get(FlagUnixSocketAddress); option != nil {
+		if v, err := cast.ToStringE(option); err == nil {
+			result.Shared.SocketAddress = v
+		}
 	}
 
 	// Bridge Daemon.
-	if v, ok := appOpts.Get(FlagBridgeDaemonEnabled).(bool); ok {
-		result.Bridge.Enabled = v
+	if option := appOpts.Get(FlagBridgeDaemonEnabled); option != nil {
+		if v, err := cast.ToBoolE(option); err == nil {
+			result.Bridge.Enabled = v
+		}
 	}
-	if v, ok := appOpts.Get(FlagBridgeDaemonLoopDelayMs).(uint32); ok {
-		result.Bridge.LoopDelayMs = v
+	if option := appOpts.Get(FlagBridgeDaemonLoopDelayMs); option != nil {
+		if v, err := cast.ToUint32E(option); err == nil {
+			result.Bridge.LoopDelayMs = v
+		}
 	}
-	if v, ok := appOpts.Get(FlagBridgeDaemonEthRpcEndpoint).(string); ok {
-		result.Bridge.EthRpcEndpoint = v
+	if option := appOpts.Get(FlagBridgeDaemonEthRpcEndpoint); option != nil {
+		if v, err := cast.ToStringE(option); err == nil {
+			result.Bridge.EthRpcEndpoint = v
+		}
 	}
 
 	// Liquidation Daemon.
-	if v, ok := appOpts.Get(FlagLiquidationDaemonEnabled).(bool); ok {
-		result.Liquidation.Enabled = v
+	if option := appOpts.Get(FlagLiquidationDaemonEnabled); option != nil {
+		if v, err := cast.ToBoolE(option); err == nil {
+			result.Liquidation.Enabled = v
+		}
 	}
-	if v, ok := appOpts.Get(FlagLiquidationDaemonLoopDelayMs).(uint32); ok {
-		result.Liquidation.LoopDelayMs = v
+	if option := appOpts.Get(FlagLiquidationDaemonLoopDelayMs); option != nil {
+		if v, err := cast.ToUint32E(option); err == nil {
+			result.Liquidation.LoopDelayMs = v
+		}
 	}
-	if v, ok := appOpts.Get(FlagLiquidationDaemonSubaccountPageLimit).(uint64); ok {
-		result.Liquidation.SubaccountPageLimit = v
+	if option := appOpts.Get(FlagLiquidationDaemonSubaccountPageLimit); option != nil {
+		if v, err := cast.ToUint64E(option); err == nil {
+			result.Liquidation.SubaccountPageLimit = v
+		}
 	}
-	if v, ok := appOpts.Get(FlagLiquidationDaemonRequestChunkSize).(uint64); ok {
-		result.Liquidation.RequestChunkSize = v
+	if option := appOpts.Get(FlagLiquidationDaemonRequestChunkSize); option != nil {
+		if v, err := cast.ToUint64E(option); err == nil {
+			result.Liquidation.RequestChunkSize = v
+		}
 	}
 
 	// Price Daemon.
-	if v, ok := appOpts.Get(FlagPriceDaemonEnabled).(bool); ok {
-		result.Price.Enabled = v
+	if option := appOpts.Get(FlagPriceDaemonEnabled); option != nil {
+		if v, err := cast.ToBoolE(option); err == nil {
+			result.Price.Enabled = v
+		}
 	}
-	if v, ok := appOpts.Get(FlagPriceDaemonLoopDelayMs).(uint32); ok {
-		result.Price.LoopDelayMs = v
+	if option := appOpts.Get(FlagPriceDaemonLoopDelayMs); option != nil {
+		if v, err := cast.ToUint32E(option); err == nil {
+			result.Price.LoopDelayMs = v
+		}
 	}
 
 	return result

--- a/protocol/indexer/flags.go
+++ b/protocol/indexer/flags.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
 
@@ -63,8 +64,9 @@ func AddIndexerFlagsToCmd(cmd *cobra.Command) {
 func GetIndexerFlagValuesFromOptions(
 	appOpts servertypes.AppOptions,
 ) IndexerFlags {
-	kafkaConnStr, ok := appOpts.Get(FlagKafkaConnStr).(string)
-	if !ok {
+	option := appOpts.Get(FlagKafkaConnStr)
+	kafkaConnStr, err := cast.ToStringE(option)
+	if option == nil || err != nil {
 		return IndexerFlags{
 			KafkaAddrs:       []string{},
 			MaxRetries:       DefaultMaxRetries,
@@ -72,8 +74,8 @@ func GetIndexerFlagValuesFromOptions(
 		}
 	}
 
-	maxRetries := appOpts.Get(FlagKafkaMaxRetry).(int)
-	sendOffchainData := appOpts.Get(FlagSendOffchainData).(bool)
+	maxRetries := cast.ToInt(appOpts.Get(FlagKafkaMaxRetry))
+	sendOffchainData := cast.ToBool(appOpts.Get(FlagSendOffchainData))
 
 	var kafkaAddrs []string
 	if kafkaConnStr == "" {

--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
 
@@ -96,24 +97,34 @@ func GetClobFlagValuesFromOptions(
 	result := GetDefaultClobFlags()
 
 	// Populate the flags if they exist.
-	if v, ok := appOpts.Get(MevTelemetryEnabled).(bool); ok {
-		result.MevTelemetryEnabled = v
+	if option := appOpts.Get(MevTelemetryEnabled); option != nil {
+		if v, err := cast.ToBoolE(option); err == nil {
+			result.MevTelemetryEnabled = v
+		}
 	}
 
-	if v, ok := appOpts.Get(MevTelemetryHost).(string); ok {
-		result.MevTelemetryHost = v
+	if option := appOpts.Get(MevTelemetryHost); option != nil {
+		if v, err := cast.ToStringE(option); err == nil {
+			result.MevTelemetryHost = v
+		}
 	}
 
-	if v, ok := appOpts.Get(MevTelemetryIdentifier).(string); ok {
-		result.MevTelemetryIdentifier = v
+	if option := appOpts.Get(MevTelemetryIdentifier); option != nil {
+		if v, err := cast.ToStringE(option); err == nil {
+			result.MevTelemetryIdentifier = v
+		}
 	}
 
-	if v, ok := appOpts.Get(MaxLiquidationOrdersPerBlock).(uint32); ok {
-		result.MaxLiquidationOrdersPerBlock = v
+	if option := appOpts.Get(MaxLiquidationOrdersPerBlock); option != nil {
+		if v, err := cast.ToUint32E(option); err == nil {
+			result.MaxLiquidationOrdersPerBlock = v
+		}
 	}
 
-	if v, ok := appOpts.Get(MaxDeleveragingAttemptsPerBlock).(uint32); ok {
-		result.MaxDeleveragingAttemptsPerBlock = v
+	if option := appOpts.Get(MaxDeleveragingAttemptsPerBlock); option != nil {
+		if v, err := cast.ToUint32E(option); err == nil {
+			result.MaxDeleveragingAttemptsPerBlock = v
+		}
 	}
 
 	return result


### PR DESCRIPTION
### Changelist
Use cast to parse command line flags.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Enhanced type safety in the `flags` package across multiple modules (`protocol/app`, `protocol/daemons`, `protocol/indexer`, `protocol/x/clob`). The `GetFlagValuesFromOptions` and similar functions now use the `cast` package for type conversion, ensuring that option values are correctly converted to their expected types. This change improves error handling and reduces the risk of runtime type assertion errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->