### PR TITLE
[DEC-2147] - De-escalate unresponsive daemon panics to errors

### DIFF
--- a/protocol/daemons/server/server.go
+++ b/protocol/daemons/server/server.go
@@ -49,7 +49,7 @@ func NewServer(
 		gsrv:          grpcServer,
 		fileHandler:   fileHandler,
 		socketAddress: socketAddress,
-		updateMonitor: types.NewUpdateFrequencyMonitor(),
+		updateMonitor: types.NewUpdateFrequencyMonitor(types.DaemonStartupGracePeriod, logger),
 	}
 	stoppable.RegisterServiceForTestCleanup(uniqueTestIdentifier, srv)
 	return srv

--- a/protocol/daemons/server/types/constants.go
+++ b/protocol/daemons/server/types/constants.go
@@ -10,8 +10,9 @@ const (
 	DaemonStartupGracePeriod = 60 * time.Second
 
 	// MaximumLoopDelayMultiple defines the maximum acceptable update delay for a daemon as a multiple of the
-	// daemon's loop delay.
-	MaximumLoopDelayMultiple = 3
+	// daemon's loop delay. This is set to 8 to have generous headroom to ignore errors from the liquidations daemon,
+	// which we have sometimes seen to take up to ~10s to respond.
+	MaximumLoopDelayMultiple = 8
 
 	LiquidationsDaemonServiceName = "liquidations-daemon"
 	PricefeedDaemonServiceName    = "pricefeed-daemon"

--- a/protocol/daemons/server/types/update_monitor.go
+++ b/protocol/daemons/server/types/update_monitor.go
@@ -13,7 +13,7 @@ type updateMetadata struct {
 }
 
 // UpdateMonitor monitors the update frequency of daemon services. If a daemon service does not respond within
-// the maximum acceptable update delay set when the daemon is registered, the monitor will panic and halt the
+// the maximum acceptable update delay set when the daemon is registered, the monitor will log an error and halt the
 // protocol. This was judged to be the best solution for network performance because it prevents any validator from
 // participating in the network at all if a daemon service is not responding.
 type UpdateMonitor struct {
@@ -113,7 +113,7 @@ func LogErrorServiceNotResponding(service string, logger log.Logger) func() {
 }
 
 // RegisterDaemonService registers a new daemon service with the update frequency monitor. If the daemon service
-// fails to respond within the maximum acceptable update delay, the monitor will execute a panic and halt the protocol.
+// fails to respond within the maximum acceptable update delay, the monitor will log an error.
 // This method is synchronized. The method an error if the daemon service was already registered or the monitor has
 // already been stopped.
 func (ufm *UpdateMonitor) RegisterDaemonService(

--- a/protocol/daemons/server/types/util_test.go
+++ b/protocol/daemons/server/types/util_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMaximumAcceptableUpdateDelay(t *testing.T) {
 	loopDelayMs := uint32(1000)
-	expected := time.Duration(MaximumLoopDelayMultiple * loopDelayMs * 1000000)
+	expected := time.Duration(MaximumLoopDelayMultiple*loopDelayMs) * time.Millisecond
 	actual := MaximumAcceptableUpdateDelay(loopDelayMs)
 	require.Equal(t, expected, actual)
 }


### PR DESCRIPTION
### Changelist
As a P0 follow-up over this weekend's outage, remove panics on apparently unresponsive daemons and log errors instead.
Additionally, I upped the maximum acceptable update delay to not be triggered based on the liquidations daemon response latencies we saw this weekend.

### Test Plan
- updated unit tests
- added new test that explicitly checks for error

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Enhanced the `NewServer` function in `server.go` to initialize the `updateMonitor` parameter with `types.NewUpdateFrequencyMonitor(types.DaemonStartupGracePeriod, logger)`, improving error handling and logging capabilities.
- Chore: Adjusted the `MaximumLoopDelayMultiple` constant in `constants.go` from 3 to 8, providing more tolerance for the liquidations daemon response time.
- New Feature: Updated `update_monitor.go` to include a logger for better error tracking and a grace period for daemon startup, improving system resilience and debuggability.
- Test: Revised tests in `update_monitor_test.go` and `util_test.go` to accommodate the new logger and grace period, ensuring the changes are properly validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->