### PR TITLE
Use Elliptic API secret, update threshold.

### DIFF
--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -7,9 +7,13 @@
 * [#143](https://github.com/dydxprotocol/v4-chain/pull/143) Add websocket events for perpetual markets.
 
 ### Improvements
+* [#552](https://github.com/dydxprotocol/v4-chain/pull/552) Updated Elliptic compliance client block addresses with risk scores equal to the threshold in addition to risk score greater than the threshold.
+
 * [#469](https://github.com/dydxprotocol/v4-chain/pull/469) Added a reason field to `/screen` endpoint to display a reason for blocking an address.
   
 ### Bug Fixes
+* [#552](https://github.com/dydxprotocol/v4-chain/pull/552) Fixed bug with Elliptic compliance client where the API key was incorrectly used instead of the API secret to generate the auth headers for the Elliptic request.
+
 * [#528](https://github.com/dydxprotocol/v4-chain/pull/528) Fixed bug with bulk SQL queries with nullable numeric / string / boolean values.
 
 * [#496](https://github.com/dydxprotocol/v4-chain/pull/496) Don't geo-block requests made to `comlink` if it's from an internal ip.

--- a/indexer/packages/compliance/__tests__/clients/elliptic-provider.test.ts
+++ b/indexer/packages/compliance/__tests__/clients/elliptic-provider.test.ts
@@ -40,7 +40,7 @@ describe('elliptic-provider', () => {
     expect(headers).toEqual({
       headers: {
         'x-access-key': 'default_elliptic_api_key',
-        'x-access-sign': 'R4UGA98pd6XaA6rsrmPhNefg9cm9QSBjzFj+KNQJrZE=',
+        'x-access-sign': 'ihaI6NUlY4QZ3co7fV0jLH4XYCHELKQ/nt1Q5XRN2no=',
         'x-access-timestamp': 1698192000000,
       },
     });
@@ -96,7 +96,7 @@ describe('elliptic-provider', () => {
 
   describe('getComplianceResponse', () => {
     it('gets compliance response for blocked user', async () => {
-      axiosMock.mockResolvedValueOnce(getMockResponse(config.ELLIPTIC_RISK_SCORE_THRESHOLD + 1));
+      axiosMock.mockResolvedValueOnce(getMockResponse(config.ELLIPTIC_RISK_SCORE_THRESHOLD));
       const complianceData: ComplianceClientResponse = await provider.getComplianceResponse(
         defaultAddress,
       );

--- a/indexer/packages/compliance/__tests__/clients/elliptic-provider.test.ts
+++ b/indexer/packages/compliance/__tests__/clients/elliptic-provider.test.ts
@@ -102,7 +102,7 @@ describe('elliptic-provider', () => {
       );
       expect(complianceData).toEqual({
         address: defaultAddress,
-        riskScore: (config.ELLIPTIC_RISK_SCORE_THRESHOLD + 1).toFixed(),
+        riskScore: (config.ELLIPTIC_RISK_SCORE_THRESHOLD).toFixed(),
         blocked: true,
       });
     });

--- a/indexer/packages/compliance/src/clients/elliptic-provider.ts
+++ b/indexer/packages/compliance/src/clients/elliptic-provider.ts
@@ -29,16 +29,18 @@ export const NO_RULES_TRIGGERED_RISK_SCORE: number = -1;
 
 export class EllipticProviderClient extends ComplianceClient {
   private apiKey: string;
+  private apiSecret: string;
 
   public constructor() {
     super();
     this.apiKey = config.ELLIPTIC_API_KEY;
+    this.apiSecret = config.ELLIPTIC_API_SECRET;
   }
 
   public async getComplianceResponse(address: string): Promise<ComplianceClientResponse> {
     const riskScore: number | null = await this.getRiskScore(address);
 
-    if (riskScore !== null && riskScore > config.ELLIPTIC_RISK_SCORE_THRESHOLD) {
+    if (riskScore !== null && riskScore >= config.ELLIPTIC_RISK_SCORE_THRESHOLD) {
       return {
         address,
         blocked: true,
@@ -147,7 +149,7 @@ export class EllipticProviderClient extends ComplianceClient {
   */
   getApiSignature(timeOfRequest: number, payload: string): string {
     // create a SHA256 HMAC using the supplied secret, decoded from base64
-    const secret: string = this.apiKey;
+    const secret: string = this.apiSecret;
     const hmac = crypto.createHmac('sha256', Buffer.from(secret, 'base64'));
 
     // concatenate the request text to be signed


### PR DESCRIPTION
### Changelist
Use the elliptic API secret to generate the signature headers instead of the API key as specified [here](https://developers.elliptic.co/docs/authentication).
Update logic to use `>=` instead of `>` when comparing a risk score and the threshold, so that scores equal to the threshold result in a blocked address.

### Test Plan
Unit tests for the threshold logic. Tested on `dev` with an Elliptic API key / secret for the API secret logic.

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added websocket events for perpetual markets, enhancing real-time data availability.
- New Feature: Introduced a 'reason' field to the `/screen` endpoint, providing more context for blocked addresses.
- Bug Fix: Updated Elliptic compliance client to block addresses with risk scores equal to the threshold, improving security measures.
- Bug Fix: Corrected an issue in the Elliptic compliance client where the API key was incorrectly used instead of the API secret, enhancing security.
- Bug Fix: Fixed a bug with bulk SQL queries handling nullable numeric/string/boolean values, improving data integrity.
- Refactor: Internal IP requests to `comlink` are no longer geo-blocked, improving internal communication efficiency.
- Test: Updated test cases in 'elliptic-provider' to align with new 'config' values, ensuring accurate testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->