### PR TITLE
[DEC-2081] Audit app/prepare/full_node_prepare_proposal.go

### DIFF
--- a/protocol/app/prepare/full_node_prepare_proposal_test.go
+++ b/protocol/app/prepare/full_node_prepare_proposal_test.go
@@ -1,220 +1,62 @@
 package prepare_test
 
 import (
+	"bytes"
 	"testing"
+	"time"
 
+	gometrics "github.com/armon/go-metrics"
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/log"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	"github.com/dydxprotocol/v4-chain/protocol/app/prepare"
-	"github.com/dydxprotocol/v4-chain/protocol/mocks"
-	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
-	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	perpetualtypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
-	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
-	"github.com/stretchr/testify/mock"
+	"github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	testApp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/stretchr/testify/require"
 )
 
 // TestFullNodePrepareProposalHandler test that the full-node PrepareProposal handler always returns
 // an empty result.
 func TestFullNodePrepareProposalHandler(t *testing.T) {
-	tests := map[string]struct {
-		txs      [][]byte
-		maxBytes int64
+	defer gometrics.Shutdown()
 
-		pricesResp    *pricestypes.MsgUpdateMarketPrices
-		pricesEncoder sdktypes.TxEncoder
+	conf := gometrics.DefaultConfig("testService")
+	sink := gometrics.NewInmemSink(time.Hour, time.Hour)
+	_, err := gometrics.NewGlobal(conf, sink)
+	require.NoError(t, err)
 
-		fundingResp    *perpetualtypes.MsgAddPremiumVotes
-		fundingEncoder sdktypes.TxEncoder
-
-		clobResp    *clobtypes.MsgProposedOperations
-		clobEncoder sdktypes.TxEncoder
-	}{
-		"Error: newPrepareProposalTransactions fails": {
-			maxBytes: 0, // <= 0 value throws error.
-		},
-
-		// Prices related.
-		"Error: GetPricesTx returns err": {
-			maxBytes: 1,
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: failingTxEncoder, // encoder fails and returns err.
-		},
-		"Error: GetPricesTx returns empty": {
-			maxBytes: 1,
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: emptyTxEncoder, // encoder returns empty.
-		},
-		"Error: SetPricesTx returns err": {
-			maxBytes: 1,
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderTwo, // encoder returns two bytes, which exceeds max.
-		},
-
-		// Funding related.
-		"Error: GetFundingTx returns err": {
-			maxBytes: 2,
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderOne,
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: failingTxEncoder, // encoder fails and returns err.
-		},
-		"Error: GetFundingTx returns empty": {
-			maxBytes: 2,
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderOne,
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: emptyTxEncoder, // encoder returns empty.
-		},
-		"Error: SetFundingTx returns err": {
-			maxBytes: 1, // only upto 1 byte, not enough space for funding tx bytes.
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderOne, // takes up 1 byte.
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderOne, // takes up another 1 byte, so exceeds max.
-		},
-
-		// Operations related.
-		"Error: GetOperationsTx returns err": {
-			maxBytes: 3,
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderOne,
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderOne,
-
-			clobResp:    &clobtypes.MsgProposedOperations{},
-			clobEncoder: failingTxEncoder, // encoder fails and returns err.
-		},
-		"Error: GetOperationsTx returns empty": {
-			maxBytes: 3,
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderOne,
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderOne,
-
-			clobResp:    &clobtypes.MsgProposedOperations{},
-			clobEncoder: emptyTxEncoder, // encoder returns empty.
-		},
-		"Error: SetOperationsTx returns err": {
-			maxBytes: 2, // only upto 2 bytes, not enough space for the operation tx.
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderOne, // takes up 1 byte.
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderOne, // takes up another 1 byte.
-
-			clobResp:    &clobtypes.MsgProposedOperations{},
-			clobEncoder: passingTxEncoderOne, // takes up another 1, so exceeds max.
-		},
-
-		// "Others" related.
-		"Error: Others takes up all space, no space for order tx": {
-			maxBytes: 12,
-			txs:      [][]byte{{9}}, // "Other" order takes up 1 byte.
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderFour, // takes up 4 byte.
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderFour, // takes up 4 bytes
-
-			clobResp:    &clobtypes.MsgProposedOperations{},
-			clobEncoder: passingTxEncoderFour, // takes another 4 bytes, but exceeds max.
-		},
-		"Error: AddOtherTxs return error": {
-			maxBytes: 13,
-			txs:      [][]byte{{}},
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderFour,
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderFour,
-
-			clobResp:    &clobtypes.MsgProposedOperations{},
-			clobEncoder: passingTxEncoderFour,
-		},
-		"Error: AddOtherTxs (additional) return error": {
-			maxBytes: 15,
-			txs:      [][]byte{{9, 8}, {9}, {}, {}},
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderFour,
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderFour,
-
-			clobResp:    &clobtypes.MsgProposedOperations{},
-			clobEncoder: passingTxEncoderFour,
-		},
-		"Valid: Not all Others than can fit": {
-			maxBytes: 13,
-			txs:      [][]byte{{9}, {9}, {9}},
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderFour,
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderFour,
-
-			clobResp:    &clobtypes.MsgProposedOperations{},
-			clobEncoder: passingTxEncoderFour,
-		},
-		"Valid: Additional Others fit": {
-			maxBytes: 15,
-			txs:      [][]byte{{9}, {9, 8}, {9, 8, 7}},
-
-			pricesResp:    &pricestypes.MsgUpdateMarketPrices{},
-			pricesEncoder: passingTxEncoderFour,
-
-			fundingResp:    &perpetualtypes.MsgAddPremiumVotes{},
-			fundingEncoder: passingTxEncoderFour,
-
-			clobResp:    &clobtypes.MsgProposedOperations{},
-			clobEncoder: passingTxEncoderFour,
-		},
+	var logBuffer bytes.Buffer
+	appOpts := map[string]interface{}{
+		flags.NonValidatingFullNodeFlag: true,
+		testApp.LoggerInstanceForTest:   log.TestingLoggerWithOutput(&logBuffer),
 	}
+	tApp := testApp.NewTestAppBuilder().WithTesting(t).WithAppCreatorFn(testApp.DefaultTestAppCreatorFn(appOpts)).Build()
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			mockPricesKeeper := mocks.PreparePricesKeeper{}
-			mockPricesKeeper.On("GetValidMarketPriceUpdates", mock.Anything).
-				Return(tc.pricesResp)
+	found := false
+	tApp.AdvanceToBlock(2, testApp.AdvanceToBlockOptions{
+		BlockTime:                         time.Time{},
+		RequestPrepareProposalTxsOverride: [][]byte{{9}, {9, 8}, {9, 8, 7}},
+		ValidateRespPrepare: func(context sdktypes.Context, proposal abci.ResponsePrepareProposal) (haltChain bool) {
+			require.Empty(t, proposal.Txs)
+			return true
+		},
+	})
 
-			mockPerpKeeper := mocks.PreparePerpetualsKeeper{}
-			mockPerpKeeper.On("GetAddPremiumVotes", mock.Anything, mock.Anything).
-				Return(tc.fundingResp)
+	for _, metrics := range sink.Data() {
+		metrics.RLock()
+		defer metrics.RUnlock()
 
-			mockClobKeeper := mocks.PrepareClobKeeper{}
-			mockClobKeeper.On("GetOperations", mock.Anything, mock.Anything).
-				Return(tc.clobResp)
-
-			ctx, _, _, _, _, _ := keepertest.PricesKeepers(t)
-
-			handler := prepare.FullNodePrepareProposalHandler()
-
-			req := abci.RequestPrepareProposal{
-				Txs:        tc.txs,
-				MaxTxBytes: tc.maxBytes,
-			}
-
-			response := handler(ctx, req)
-			require.Equal(t, [][]byte{}, response.Txs)
-		})
+		if metric, ok := metrics.Counters["testService.prepare_proposal.handler.error.count;detail=prepare_proposal_txs"]; ok {
+			require.Equal(t,
+				[]gometrics.Label{{
+					Name:  "detail",
+					Value: "prepare_proposal_txs",
+				}},
+				metric.Labels)
+			require.Equal(t, 1, metric.Count)
+			require.Equal(t, float64(1), metric.Sum)
+			found = true
+		}
 	}
+	require.True(t, found)
+	require.Contains(t, logBuffer.String(), "This validator may be incorrectly running in full-node mode!")
 }

--- a/protocol/app/prepare/full_node_prepare_proposal_test.go
+++ b/protocol/app/prepare/full_node_prepare_proposal_test.go
@@ -17,7 +17,7 @@ import (
 // TestFullNodePrepareProposalHandler test that the full-node PrepareProposal handler always returns
 // an empty result.
 func TestFullNodePrepareProposalHandler(t *testing.T) {
-	defer gometrics.Shutdown()
+	t.Cleanup(gometrics.Shutdown)
 
 	conf := gometrics.DefaultConfig("testService")
 	sink := gometrics.NewInmemSink(time.Hour, time.Hour)
@@ -57,6 +57,11 @@ func TestFullNodePrepareProposalHandler(t *testing.T) {
 			found = true
 		}
 	}
-	require.True(t, found)
-	require.Contains(t, logBuffer.String(), "This validator may be incorrectly running in full-node mode!")
+	require.True(t, found, "Expected metric not found")
+	require.Contains(
+		t,
+		logBuffer.String(),
+		"This validator may be incorrectly running in full-node mode!",
+		"Expected log message not found",
+	)
 }

--- a/protocol/lib/metrics/util_test.go
+++ b/protocol/lib/metrics/util_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestIncrCountMetricWithLabels(t *testing.T) {
-	defer gometrics.Shutdown()
+	t.Cleanup(gometrics.Shutdown)
 
 	conf := gometrics.DefaultConfig("testService")
 	sink := gometrics.NewInmemSink(time.Hour, time.Hour)
@@ -220,7 +220,7 @@ func TestGetMetricValueFromBigInt(t *testing.T) {
 }
 
 func TestModuleMeasureSinceWithLabels(t *testing.T) {
-	defer gometrics.Shutdown()
+	t.Cleanup(gometrics.Shutdown)
 
 	conf := gometrics.DefaultConfig("testService")
 	sink := gometrics.NewInmemSink(time.Hour, time.Hour)

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -112,8 +112,8 @@ type AdvanceToBlockOptions struct {
 // with the option to override specific flags.
 func DefaultTestApp(customFlags map[string]interface{}) *app.App {
 	appOptions := appoptions.GetDefaultTestAppOptionsFromTempDirectory("", customFlags)
-	logger := appOptions.Get(LoggerInstanceForTest).(log.Logger)
-	if logger == nil {
+	logger, ok := appOptions.Get(LoggerInstanceForTest).(log.Logger)
+	if !ok {
 		logger = log.TestingLogger()
 	}
 	db := dbm.NewMemDB()

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -52,6 +52,10 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+const (
+	LoggerInstanceForTest = "logger-instance-for-test"
+)
+
 // MustMakeCheckTxOptions is a struct containing options for MustMakeCheckTx.* functions.
 type MustMakeCheckTxOptions struct {
 	// AccAddressForSigning is the account that's used to sign the transaction.
@@ -108,7 +112,10 @@ type AdvanceToBlockOptions struct {
 // with the option to override specific flags.
 func DefaultTestApp(customFlags map[string]interface{}) *app.App {
 	appOptions := appoptions.GetDefaultTestAppOptionsFromTempDirectory("", customFlags)
-	logger := log.TestingLogger()
+	logger := appOptions.Get(LoggerInstanceForTest).(log.Logger)
+	if logger == nil {
+		logger = log.TestingLogger()
+	}
 	db := dbm.NewMemDB()
 	dydxApp := app.New(
 		logger,

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -18,20 +18,19 @@ import (
 	"github.com/cometbft/cometbft/mempool"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cometbft/cometbft/types"
-
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	sdkproto "github.com/cosmos/gogoproto/proto"
-
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	sdkproto "github.com/cosmos/gogoproto/proto"
 	"github.com/dydxprotocol/v4-chain/protocol/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/appoptions"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	testlog "github.com/dydxprotocol/v4-chain/protocol/testutil/logger"
 	testtx "github.com/dydxprotocol/v4-chain/protocol/testutil/tx"
 	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	blocktimetypes "github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
@@ -47,13 +46,8 @@ import (
 	stattypes "github.com/dydxprotocol/v4-chain/protocol/x/stats/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	vesttypes "github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
-
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
-)
-
-const (
-	LoggerInstanceForTest = "logger-instance-for-test"
 )
 
 // MustMakeCheckTxOptions is a struct containing options for MustMakeCheckTx.* functions.
@@ -112,9 +106,9 @@ type AdvanceToBlockOptions struct {
 // with the option to override specific flags.
 func DefaultTestApp(customFlags map[string]interface{}) *app.App {
 	appOptions := appoptions.GetDefaultTestAppOptionsFromTempDirectory("", customFlags)
-	logger, ok := appOptions.Get(LoggerInstanceForTest).(log.Logger)
+	logger, ok := appOptions.Get(testlog.LoggerInstanceForTest).(log.Logger)
 	if !ok {
-		logger = log.TestingLogger()
+		logger, _ = testlog.TestLogger()
 	}
 	db := dbm.NewMemDB()
 	dydxApp := app.New(

--- a/protocol/testutil/logger/logger.go
+++ b/protocol/testutil/logger/logger.go
@@ -1,0 +1,16 @@
+package logger
+
+import (
+	"bytes"
+	"github.com/cometbft/cometbft/libs/log"
+)
+
+const (
+	LoggerInstanceForTest = "logger-instance-for-test"
+)
+
+// TestLogger returns a logger instance and a buffer where all logs are written to.
+func TestLogger() (log.Logger, *bytes.Buffer) {
+	var logBuffer bytes.Buffer
+	return log.NewTMLogger(log.NewSyncWriter(&logBuffer)), &logBuffer
+}


### PR DESCRIPTION
### Changelist
* Swap tests to be more faithful with how a full node starts.
* Add the ability to capture logs for test apps.
* Validate full nodes metric and log is produced.

### Test Plan
These are test only changes.

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Test: Enhanced `TestFullNodePrepareProposalHandler` in `full_node_prepare_proposal_test.go` with metrics and logging integration, and improved test setup with a test application builder.
- Refactor: Introduced a new constant `LoggerInstanceForTest` in `app.go` for retrieving the logger instance from the `appOptions` map, allowing for more flexible logger customization in tests.
- Test: Updated `TestIncrCountMetricWithLabels` and `TestModuleMeasureSinceWithLabels` in `util_test.go` to ensure `gometrics.Shutdown` is called at the end of each test case, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->