### PR TITLE
[DEC-2081] Audit app/prepare/other_msgs.go and app/prepare/transactions.go

### DIFF
--- a/protocol/app/prepare/other_msgs.go
+++ b/protocol/app/prepare/other_msgs.go
@@ -16,15 +16,15 @@ import (
 // GetGroupMsgOther returns two separate slices of byte txs given a single slice of byte txs and max bytes.
 // The first slice contains the first N txs where the total bytes of the N txs is <= max bytes.
 // The second slice contains the rest of txs, if any.
-func GetGroupMsgOther(availableTxs [][]byte, maxBytes int64) ([][]byte, [][]byte) {
+func GetGroupMsgOther(availableTxs [][]byte, maxBytes uint64) ([][]byte, [][]byte) {
 	var (
 		txsToInclude [][]byte
 		txsRemainder [][]byte
-		byteCount    int64
+		byteCount    uint64
 	)
 
 	for _, tx := range availableTxs {
-		byteCount += int64(len(tx))
+		byteCount += uint64(len(tx))
 		if byteCount <= maxBytes {
 			txsToInclude = append(txsToInclude, tx)
 		} else {

--- a/protocol/app/prepare/other_msgs_test.go
+++ b/protocol/app/prepare/other_msgs_test.go
@@ -29,7 +29,7 @@ var (
 func TestGetGroupMsgOther(t *testing.T) {
 	tests := map[string]struct {
 		txs      [][]byte
-		maxBytes int64
+		maxBytes uint64
 
 		expectedTxsInclude   [][]byte
 		expectedTxsRemainder [][]byte

--- a/protocol/app/prepare/other_msgs_test.go
+++ b/protocol/app/prepare/other_msgs_test.go
@@ -1,12 +1,12 @@
 package prepare_test
 
 import (
+	testApp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/app/prepare"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/encoding"
-	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,7 +162,8 @@ func TestRemoveDisallowMsgs(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, _, _, _, _, _ := keepertest.PricesKeepers(t)
+			tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+			ctx := tApp.InitChain()
 			txs := prepare.RemoveDisallowMsgs(ctx, encodingCfg.TxConfig.TxDecoder(), tc.txs)
 			require.Equal(t, tc.expectedTxs, txs)
 		})

--- a/protocol/app/prepare/prepare_proposal.go
+++ b/protocol/app/prepare/prepare_proposal.go
@@ -118,7 +118,7 @@ func PrepareProposalHandler(
 		}
 
 		// Gather "Other" group messages.
-		otherBytesAllocated := txs.GetAvailableBytes() / int64(4) // ~25% of the remainder.
+		otherBytesAllocated := txs.GetAvailableBytes() / 4 // ~25% of the remainder.
 		// filter out txs that have disallow messages.
 		txsWithoutDisallowMsgs := RemoveDisallowMsgs(ctx, txConfig.TxDecoder(), req.Txs)
 		otherTxsToInclude, otherTxsRemainder := GetGroupMsgOther(txsWithoutDisallowMsgs, otherBytesAllocated)

--- a/protocol/app/prepare/transactions.go
+++ b/protocol/app/prepare/transactions.go
@@ -33,7 +33,8 @@ func NewPrepareProposalTxs(
 	}
 
 	return PrepareProposalTxs{
-		MaxBytes: uint64(req.MaxTxBytes),
+		MaxBytes:  uint64(req.MaxTxBytes),
+		UsedBytes: 0,
 	}, nil
 }
 

--- a/protocol/app/prepare/transactions.go
+++ b/protocol/app/prepare/transactions.go
@@ -41,7 +41,7 @@ func NewPrepareProposalTxs(
 func (t *PrepareProposalTxs) SetUpdateMarketPricesTx(tx []byte) error {
 	oldBytes := uint64(len(t.UpdateMarketPricesTx))
 	newBytes := uint64(len(tx))
-	if err := t.updateUsedBytes(oldBytes, newBytes); err != nil {
+	if err := t.UpdateUsedBytes(oldBytes, newBytes); err != nil {
 		return err
 	}
 	t.UpdateMarketPricesTx = tx
@@ -52,7 +52,7 @@ func (t *PrepareProposalTxs) SetUpdateMarketPricesTx(tx []byte) error {
 func (t *PrepareProposalTxs) SetAddPremiumVotesTx(tx []byte) error {
 	oldBytes := uint64(len(t.AddPremiumVotesTx))
 	newBytes := uint64(len(tx))
-	if err := t.updateUsedBytes(oldBytes, newBytes); err != nil {
+	if err := t.UpdateUsedBytes(oldBytes, newBytes); err != nil {
 		return err
 	}
 	t.AddPremiumVotesTx = tx
@@ -63,7 +63,7 @@ func (t *PrepareProposalTxs) SetAddPremiumVotesTx(tx []byte) error {
 func (t *PrepareProposalTxs) SetProposedOperationsTx(tx []byte) error {
 	oldBytes := uint64(len(t.ProposedOperationsTx))
 	newBytes := uint64(len(tx))
-	if err := t.updateUsedBytes(oldBytes, newBytes); err != nil {
+	if err := t.UpdateUsedBytes(oldBytes, newBytes); err != nil {
 		return err
 	}
 	t.ProposedOperationsTx = tx
@@ -74,7 +74,7 @@ func (t *PrepareProposalTxs) SetProposedOperationsTx(tx []byte) error {
 func (t *PrepareProposalTxs) SetAcknowledgeBridgesTx(tx []byte) error {
 	oldBytes := uint64(len(t.AcknowledgeBridgesTx))
 	newBytes := uint64(len(tx))
-	if err := t.updateUsedBytes(oldBytes, newBytes); err != nil {
+	if err := t.UpdateUsedBytes(oldBytes, newBytes); err != nil {
 		return err
 	}
 	t.AcknowledgeBridgesTx = tx
@@ -96,7 +96,7 @@ func (t *PrepareProposalTxs) AddOtherTxs(allTxs [][]byte) error {
 		return errors.New("No txs to add.")
 	}
 
-	if err := t.updateUsedBytes(0, bytesToAdd); err != nil {
+	if err := t.UpdateUsedBytes(0, bytesToAdd); err != nil {
 		return err
 	}
 
@@ -104,9 +104,9 @@ func (t *PrepareProposalTxs) AddOtherTxs(allTxs [][]byte) error {
 	return nil
 }
 
-// updateUsedBytes updates the used bytes field. This returns an error if the num used bytes
+// UpdateUsedBytes updates the used bytes field. This returns an error if the num used bytes
 // exceeds the max byte limit.
-func (t *PrepareProposalTxs) updateUsedBytes(
+func (t *PrepareProposalTxs) UpdateUsedBytes(
 	bytesToRemove uint64,
 	bytesToAdd uint64,
 ) error {

--- a/protocol/app/prepare/transactions_test.go
+++ b/protocol/app/prepare/transactions_test.go
@@ -277,8 +277,8 @@ func Test_UpdateUsedBytes(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, int64(10), ppt.MaxBytes)
-			require.Equal(t, int64(0), ppt.UsedBytes)
+			require.Equal(t, uint64(10), ppt.MaxBytes)
+			require.Equal(t, uint64(0), ppt.UsedBytes)
 
 			ppt.UsedBytes = tc.usedBytes
 

--- a/protocol/app/prepare/transactions_test.go
+++ b/protocol/app/prepare/transactions_test.go
@@ -25,8 +25,8 @@ func Test_NewPrepareProposalTransactions_Success(t *testing.T) {
 	ppt, err := prepare.NewPrepareProposalTxs(req)
 
 	require.NoError(t, err)
-	require.Equal(t, int64(123), ppt.MaxBytes)
-	require.Equal(t, int64(0), ppt.UsedBytes)
+	require.Equal(t, uint64(123), ppt.MaxBytes)
+	require.Equal(t, uint64(0), ppt.UsedBytes)
 
 	require.Nil(t, ppt.UpdateMarketPricesTx)
 	require.Nil(t, ppt.AddPremiumVotesTx)
@@ -66,7 +66,7 @@ func setterTestCases(t *testing.T, tFunc TestFunction) {
 		tx []byte
 
 		expectedTx        []byte
-		expectedUsedBytes int64
+		expectedUsedBytes uint64
 		expectedErr       error
 	}{
 		"input is nil": {
@@ -100,8 +100,8 @@ func setterTestCases(t *testing.T, tFunc TestFunction) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, int64(4), ppt.MaxBytes)
-			require.Equal(t, int64(0), ppt.UsedBytes)
+			require.Equal(t, uint64(4), ppt.MaxBytes)
+			require.Equal(t, uint64(0), ppt.UsedBytes)
 
 			err = setterTestHelper(tFunc, &ppt, tc.tx)
 
@@ -153,7 +153,7 @@ func Test_AddOtherTxs(t *testing.T) {
 		additionalTxs [][]byte
 
 		expectedTxs           [][]byte
-		expectedUsedBytes     int64
+		expectedUsedBytes     uint64
 		expectedErr           error
 		expectedAdditionalErr error
 	}{
@@ -207,8 +207,8 @@ func Test_AddOtherTxs(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, int64(4), ppt.MaxBytes)
-			require.Equal(t, int64(0), ppt.UsedBytes)
+			require.Equal(t, uint64(4), ppt.MaxBytes)
+			require.Equal(t, uint64(0), ppt.UsedBytes)
 
 			// initial txs.
 			err = ppt.AddOtherTxs(tc.txs)
@@ -232,78 +232,6 @@ func Test_AddOtherTxs(t *testing.T) {
 	}
 }
 
-func Test_UpdateUsedBytes(t *testing.T) {
-	tests := map[string]struct {
-		usedBytes     int64
-		bytesToRemove int64
-		bytesToAdd    int64
-
-		expectedErr error
-	}{
-		"Valid: replaced > add": {
-			usedBytes:     4,
-			bytesToRemove: 4,
-			bytesToAdd:    2,
-		},
-		"Valid: replaced = add": {
-			usedBytes:     5,
-			bytesToRemove: 3,
-			bytesToAdd:    3,
-		},
-		"Valid: replaced < add": {
-			usedBytes:     5,
-			bytesToRemove: 3,
-			bytesToAdd:    5,
-		},
-		"Neg: bytes to remove": {
-			usedBytes:     5,
-			bytesToRemove: -1,
-			bytesToAdd:    1,
-			expectedErr:   errors.New("Invalid bytes to remove/add"),
-		},
-		"Neg: bytes to add": {
-			usedBytes:     5,
-			bytesToRemove: 1,
-			bytesToAdd:    -1,
-			expectedErr:   errors.New("Invalid bytes to remove/add"),
-		},
-		"Cannot be Negative": {
-			usedBytes:     0,
-			bytesToRemove: 3,
-			bytesToAdd:    2,
-			expectedErr:   errors.New("Result cannot be negative"),
-		},
-		"Exceeds max": {
-			usedBytes:     0,
-			bytesToRemove: 0,
-			bytesToAdd:    11,
-			expectedErr:   errors.New("Exceeds max: max=10, used=0, adding=11"),
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			ppt, err := prepare.NewPrepareProposalTxs(
-				abci.RequestPrepareProposal{
-					MaxTxBytes: 10,
-				},
-			)
-			require.NoError(t, err)
-			require.Equal(t, int64(10), ppt.MaxBytes)
-			require.Equal(t, int64(0), ppt.UsedBytes)
-
-			ppt.UsedBytes = tc.usedBytes
-
-			err = ppt.UpdateUsedBytes(tc.bytesToRemove, tc.bytesToAdd)
-			if tc.expectedErr != nil {
-				require.ErrorContains(t, err, tc.expectedErr.Error())
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func Test_GetAvailableBytes(t *testing.T) {
 	tests := map[string]struct {
 		pricesTx           []byte
@@ -312,11 +240,10 @@ func Test_GetAvailableBytes(t *testing.T) {
 		otherTxs           [][]byte
 		otherAdditionalTxs [][]byte
 
-		expectedUsedBytes  int64
-		expectedAvailBytes int64
+		expectedUsedBytes  uint64
+		expectedAvailBytes uint64
 	}{
 		"inputs are nil": {
-			expectedUsedBytes:  0,
 			expectedAvailBytes: 10,
 		},
 		"inputs are empty": {
@@ -359,8 +286,8 @@ func Test_GetAvailableBytes(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, int64(10), ppt.MaxBytes)
-			require.Equal(t, int64(0), ppt.UsedBytes)
+			require.Equal(t, uint64(10), ppt.MaxBytes)
+			require.Equal(t, uint64(0), ppt.UsedBytes)
 
 			err = ppt.SetUpdateMarketPricesTx(tc.pricesTx)
 			require.NoError(t, err)
@@ -503,8 +430,8 @@ func Test_GetTxsInOrder(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, int64(11), ppt.MaxBytes)
-			require.Equal(t, int64(0), ppt.UsedBytes)
+			require.Equal(t, uint64(11), ppt.MaxBytes)
+			require.Equal(t, uint64(0), ppt.UsedBytes)
 
 			err = ppt.SetUpdateMarketPricesTx(tc.pricesTx)
 			require.NoError(t, err)


### PR DESCRIPTION
Note that the testing of what is and isn't allowed should be covered by lib/ante/disallow_msg.go audit.

### Changelist
Minor test clean-up and swap to use uint value type for values that are never meant to be negative and hid visibility of `UpdateUsedBytes`.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated data types from `int64` to `uint64` in `other_msgs.go`, `prepare_proposal.go`, and `transactions.go` for better handling of unsigned integer values.
- Test: Modified test setup in `other_msgs_test.go` and `transactions_test.go` to align with the refactored code.
- Chore: Renamed `UpdateUsedBytes` to `updateUsedBytes` in `transactions.go` for better code readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->