### PR TITLE
[CORE-652] add bridge disabling to prepareProposal, processProposal, acknowledgeBridges, and completeBridge

### DIFF
--- a/protocol/app/process/acknowledge_bridges.go
+++ b/protocol/app/process/acknowledge_bridges.go
@@ -59,6 +59,7 @@ func DecodeAcknowledgeBridgesTx(
 
 // Validate returns an error if:
 // - msg fails `ValidateBasic`.
+// - bridge events are non empty and bridging is disabled.
 // - first bridge event ID is not the one to be next acknowledged.
 // - last bridge event ID has not been recognized.
 // - a bridge event's content is not the same as in server state.
@@ -78,9 +79,12 @@ func (abt *AcknowledgeBridgesTx) Validate() error {
 		return getValidateBasicError(abt.msg, err)
 	}
 
-	// If there is no bridge event, return nil.
 	if len(abt.msg.Events) == 0 {
+		// If there is no bridge event, return nil.
 		return nil
+	} else if abt.bridgeKeeper.GetSafetyParams(abt.ctx).IsDisabled {
+		// If there is any bridge event when bridging is disabled, return error.
+		return types.ErrBridgingDisabled
 	}
 
 	// Validate that first bridge event ID is the one to be next acknowledged.

--- a/protocol/app/process/expected_keepers.go
+++ b/protocol/app/process/expected_keepers.go
@@ -65,4 +65,5 @@ type ProcessBridgeKeeper interface {
 		ctx sdk.Context,
 	) (recognizedEventInfo bridgetypes.BridgeEventInfo)
 	GetBridgeEventFromServer(ctx sdk.Context, id uint32) (event bridgetypes.BridgeEvent, found bool)
+	GetSafetyParams(ctx sdk.Context) (safetyParams bridgetypes.SafetyParams)
 }

--- a/protocol/mocks/ProcessBridgeKeeper.go
+++ b/protocol/mocks/ProcessBridgeKeeper.go
@@ -63,6 +63,20 @@ func (_m *ProcessBridgeKeeper) GetRecognizedEventInfo(ctx types.Context) bridget
 	return r0
 }
 
+// GetSafetyParams provides a mock function with given fields: ctx
+func (_m *ProcessBridgeKeeper) GetSafetyParams(ctx types.Context) bridgetypes.SafetyParams {
+	ret := _m.Called(ctx)
+
+	var r0 bridgetypes.SafetyParams
+	if rf, ok := ret.Get(0).(func(types.Context) bridgetypes.SafetyParams); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(bridgetypes.SafetyParams)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewProcessBridgeKeeper interface {
 	mock.TestingT
 	Cleanup(func())

--- a/protocol/x/bridge/keeper/acknowledge_bridges.go
+++ b/protocol/x/bridge/keeper/acknowledge_bridges.go
@@ -21,8 +21,7 @@ func (k Keeper) GetAcknowledgeBridges(
 	blockTimestamp time.Time,
 ) (msg *types.MsgAcknowledgeBridges) {
 	// Do not propose bridge events if bridging is disabled.
-	safetyParams := k.GetSafetyParams(ctx)
-	if safetyParams.IsDisabled {
+	if k.GetSafetyParams(ctx).IsDisabled {
 		return &types.MsgAcknowledgeBridges{
 			Events: []types.BridgeEvent{},
 		}

--- a/protocol/x/bridge/keeper/acknowledge_bridges.go
+++ b/protocol/x/bridge/keeper/acknowledge_bridges.go
@@ -20,6 +20,14 @@ func (k Keeper) GetAcknowledgeBridges(
 	ctx sdk.Context,
 	blockTimestamp time.Time,
 ) (msg *types.MsgAcknowledgeBridges) {
+	// Do not propose bridge events if bridging is disabled.
+	safetyParams := k.GetSafetyParams(ctx)
+	if safetyParams.IsDisabled {
+		return &types.MsgAcknowledgeBridges{
+			Events: []types.BridgeEvent{},
+		}
+	}
+
 	wallClock := k.bridgeEventManager.GetNow()
 	proposeParams := k.GetProposeParams(ctx)
 
@@ -81,13 +89,16 @@ func (k Keeper) AcknowledgeBridges(
 		metrics.Latency,
 	)
 
+	safetyParams := k.GetSafetyParams(ctx)
 	if len(bridgeEvents) == 0 {
 		return nil
+	} else if safetyParams.IsDisabled {
+		// Do not acknowledge bridges if bridging is disabled.
+		return types.ErrBridgingDisabled
 	}
 
 	// For each bridge event, delay a `MsgCompleteBridge` to be executed `safetyParams.DelayBlocks`
 	// blocks in the future. Panic if fails to delay any of the messages.
-	safetyParams := k.GetSafetyParams(ctx)
 	delayMsgModuleAccAddrString := authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String()
 	for _, bridgeEvent := range bridgeEvents {
 		// delaymsg module should be the authority for completing bridges.

--- a/protocol/x/bridge/keeper/acknowledge_bridges_test.go
+++ b/protocol/x/bridge/keeper/acknowledge_bridges_test.go
@@ -85,7 +85,7 @@ func TestAcknowledgeBridges(t *testing.T) {
 
 				// Verify that AcknowledgedEventInfo was not updated.
 				require.Equal(t, initialAei, bridgeKeeper.GetAcknowledgedEventInfo(ctx))
-			} else { // briding is not disabled.
+			} else { // bridging is not disabled.
 				// Verify that AcknowledgeBridges returns no error.
 				require.NoError(t, err)
 
@@ -232,7 +232,7 @@ func TestGetAcknowledgeBridges(t *testing.T) {
 				Events: []types.BridgeEvent{},
 			},
 		},
-		"No event is proposed when bridging is diabled": {
+		"No event is proposed when bridging is disabled": {
 			blockTimestamp: timeNow,
 			eventTimestamp: timeNow.Add(-time.Second * 2),
 			proposeParams: types.ProposeParams{

--- a/protocol/x/bridge/keeper/complete_bridge.go
+++ b/protocol/x/bridge/keeper/complete_bridge.go
@@ -23,6 +23,12 @@ func (k Keeper) CompleteBridge(
 		metrics.Latency,
 	)
 
+	// Do not complete bridge if bridging is disabled.
+	safetyParams := k.GetSafetyParams(ctx)
+	if safetyParams.IsDisabled {
+		return types.ErrBridgingDisabled
+	}
+
 	// Convert bridge address string to sdk.AccAddress.
 	bridgeAccAddress, err := sdk.AccAddressFromBech32(bridge.Address)
 	if err != nil {

--- a/protocol/x/bridge/keeper/complete_bridge_test.go
+++ b/protocol/x/bridge/keeper/complete_bridge_test.go
@@ -19,6 +19,8 @@ func TestCompleteBridge(t *testing.T) {
 		initialBalance sdk.Coin
 		// Bridge event to complete.
 		bridgeEvent types.BridgeEvent
+		// Whether bridging is disabled.
+		bridgingDisabled bool
 
 		// Expected error, if any.
 		expectedError string
@@ -58,14 +60,26 @@ func TestCompleteBridge(t *testing.T) {
 			expectedError:   "insufficient funds",
 			expectedBalance: sdk.NewCoin("adv4tnt", sdkmath.NewInt(500)),
 		},
+		"Failure: bridging is disabled": {
+			initialBalance:   sdk.NewCoin("adv4tnt", sdkmath.NewInt(1_000)),
+			bridgeEvent:      constants.BridgeEvent_Id0_Height0, // bridges 888 tokens.
+			bridgingDisabled: true,
+			expectedError:    types.ErrBridgingDisabled.Error(),
+			expectedBalance:  sdk.NewCoin("adv4tnt", sdkmath.NewInt(1_000)), // same as initial.
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Initialize context and keeper.
 			ctx, bridgeKeeper, _, _, _, bankKeeper, _ := keepertest.BridgeKeepers(t)
+			err := bridgeKeeper.UpdateSafetyParams(ctx, types.SafetyParams{
+				IsDisabled:  tc.bridgingDisabled,
+				DelayBlocks: bridgeKeeper.GetSafetyParams(ctx).DelayBlocks,
+			})
+			require.NoError(t, err)
 			// Fund bridge module account with enought balance.
-			err := bankKeeper.MintCoins(
+			err = bankKeeper.MintCoins(
 				ctx,
 				types.ModuleName,
 				sdk.NewCoins(tc.initialBalance),

--- a/protocol/x/bridge/types/errors.go
+++ b/protocol/x/bridge/types/errors.go
@@ -52,4 +52,9 @@ var (
 		401,
 		"Rate is out of bounds",
 	)
+	ErrBridgingDisabled = errorsmod.Register(
+		ModuleName,
+		402,
+		"Bridging is disabled",
+	)
 )


### PR DESCRIPTION
### Changelist
If bridging is disabled
* do not propose bridge events (prepare)
* reject non-empty bridge events in process (process)
* do not acknowledge bridge events (deliverTx)
* do not complete bridge events

### Test Plan
unit testing and integration testing in this PR
local testing (through running localnet)

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a validation check to prevent bridging operations when bridging is disabled. This includes operations such as acknowledging bridges and completing bridges.
- New Feature: Introduced a new error `ErrBridgingDisabled` to indicate when bridging operations are attempted while bridging is disabled.
- Test: Enhanced test coverage to include scenarios where bridging is disabled. This includes tests for acknowledging bridges, processing proposals, and completing bridges.
- Refactor: Updated the `ProcessBridgeKeeper` interface and its mock to include a new method `GetSafetyParams` for retrieving safety parameters, including the bridging disabled status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->