### PR TITLE
Update TestVolatileExchange to have sharp price dislocations

### DIFF
--- a/protocol/daemons/pricefeed/client/price_function/test_volatile_exchange/exchange_query_details.go
+++ b/protocol/daemons/pricefeed/client/price_function/test_volatile_exchange/exchange_query_details.go
@@ -18,7 +18,7 @@ var (
 	TestVolatileExchangeParams = VolatileExchangeParams{
 		AveragePrice: 100,
 		Amplitude:    0.5,
-		Frequency:    2,
+		Frequency:    1,
 	}
 	TestVolatileExchangeDetails = types.ExchangeQueryDetails{
 		Exchange:      exchange_common.EXCHANGE_ID_TEST_VOLATILE_EXCHANGE,


### PR DESCRIPTION
### Changelist
- Modify TestVolatileExchange to not follow a simple Sin wave. Instead, follow [this function](https://www.wolframalpha.com/input?i=graph+Piecewise%5B%7B%7Bcos%28x*4*pi%29%2C+x+%3C+0.5%7D%2C+%7Bcos%28%28x*4-1%29*pi%29%2C+x+%3E+0.5%7D%7D%5D+from+0+to+1) over each period
- This creates price dislocations (large jumps) during each period from the peak to the trough (and vice versa)
- This only affects testing in test environments

### Test Plan
None
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the `TestVolatileExchangeParams` struct to modify the frequency parameter used for the volatile exchange from `2` to `1`. This change will affect the frequency of price updates in the test volatile exchange.
- New Feature: Enhanced the `VolatileExchangePriceFunction` in `volatile_price_function.go`. The function now calculates the price value based on a time-based cosine wave function instead of a sine wave. This change will result in a different pattern of price fluctuations, providing a more diverse testing environment for the price feed system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->