### PR TITLE
[CLOB-953] port over changes from v0.3.x release branch to main

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -299,6 +299,7 @@ const (
 	NumSubaccountsIterated         = "num_subaccounts_iterated"
 	NotEnoughPositionToFullyOffset = "not_enough_position_to_fully_offset"
 	NonOverlappingBankruptcyPrices = "non_overlapping_bankruptcy_prices"
+	NoOpenPositionOnOppositeSide   = "no_open_position_on_opposite_side"
 
 	// Pricefeed Daemon.
 	Exchange                                = "exchange"

--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -32,7 +32,7 @@ const (
 
 // Default values.
 const (
-	DefaultMaxLiquidationOrdersPerBlock    = 100
+	DefaultMaxLiquidationOrdersPerBlock    = 20
 	DefaultMaxDeleveragingAttemptsPerBlock = 5
 
 	DefaultMevTelemetryEnabled    = false

--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -138,8 +138,10 @@ func GetClobFlagValuesFromOptions(
 		}
 	}
 
-	if v, ok := appOpts.Get(MaxDeleveragingSubaccountsToIterate).(uint32); ok {
-		result.MaxDeleveragingSubaccountsToIterate = v
+	if option := appOpts.Get(MaxDeleveragingSubaccountsToIterate); option != nil {
+		if v, err := cast.ToUint32E(option); err == nil {
+			result.MaxDeleveragingSubaccountsToIterate = v
+		}
 	}
 
 	return result

--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -10,7 +10,7 @@ import (
 
 // A struct containing the values of all flags.
 type ClobFlags struct {
-	MaxLiquidationOrdersPerBlock        uint32
+	MaxLiquidationAttemptsPerBlock      uint32
 	MaxDeleveragingAttemptsPerBlock     uint32
 	MaxDeleveragingSubaccountsToIterate uint32
 
@@ -22,7 +22,7 @@ type ClobFlags struct {
 // List of CLI flags.
 const (
 	// Liquidations and deleveraging.
-	MaxLiquidationOrdersPerBlock        = "max-liquidation-orders-per-block"
+	MaxLiquidationAttemptsPerBlock      = "max-liquidation-attempts-per-block"
 	MaxDeleveragingAttemptsPerBlock     = "max-deleveraging-attempts-per-block"
 	MaxDeleveragingSubaccountsToIterate = "max-deleveraging-subaccounts-to-iterate"
 
@@ -34,8 +34,8 @@ const (
 
 // Default values.
 const (
-	DefaultMaxLiquidationOrdersPerBlock        = 20
-	DefaultMaxDeleveragingAttemptsPerBlock     = 5
+	DefaultMaxLiquidationAttemptsPerBlock      = 50
+	DefaultMaxDeleveragingAttemptsPerBlock     = 10
 	DefaultMaxDeleveragingSubaccountsToIterate = 500
 
 	DefaultMevTelemetryEnabled    = false
@@ -48,11 +48,11 @@ const (
 // E.g. `dydxprotocold start --non-validating-full-node true`.
 func AddClobFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().Uint32(
-		MaxLiquidationOrdersPerBlock,
-		DefaultMaxLiquidationOrdersPerBlock,
+		MaxLiquidationAttemptsPerBlock,
+		DefaultMaxLiquidationAttemptsPerBlock,
 		fmt.Sprintf(
 			"Sets the maximum number of liquidation orders to process per block. Default = %d",
-			DefaultMaxLiquidationOrdersPerBlock,
+			DefaultMaxLiquidationAttemptsPerBlock,
 		),
 	)
 	cmd.Flags().Uint32(
@@ -90,7 +90,7 @@ func AddClobFlagsToCmd(cmd *cobra.Command) {
 
 func GetDefaultClobFlags() ClobFlags {
 	return ClobFlags{
-		MaxLiquidationOrdersPerBlock:        DefaultMaxLiquidationOrdersPerBlock,
+		MaxLiquidationAttemptsPerBlock:      DefaultMaxLiquidationAttemptsPerBlock,
 		MaxDeleveragingAttemptsPerBlock:     DefaultMaxDeleveragingAttemptsPerBlock,
 		MaxDeleveragingSubaccountsToIterate: DefaultMaxDeleveragingSubaccountsToIterate,
 		MevTelemetryEnabled:                 DefaultMevTelemetryEnabled,
@@ -126,9 +126,9 @@ func GetClobFlagValuesFromOptions(
 		}
 	}
 
-	if option := appOpts.Get(MaxLiquidationOrdersPerBlock); option != nil {
+	if option := appOpts.Get(MaxLiquidationAttemptsPerBlock); option != nil {
 		if v, err := cast.ToUint32E(option); err == nil {
-			result.MaxLiquidationOrdersPerBlock = v
+			result.MaxLiquidationAttemptsPerBlock = v
 		}
 	}
 

--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -10,8 +10,9 @@ import (
 
 // A struct containing the values of all flags.
 type ClobFlags struct {
-	MaxLiquidationOrdersPerBlock    uint32
-	MaxDeleveragingAttemptsPerBlock uint32
+	MaxLiquidationOrdersPerBlock        uint32
+	MaxDeleveragingAttemptsPerBlock     uint32
+	MaxDeleveragingSubaccountsToIterate uint32
 
 	MevTelemetryEnabled    bool
 	MevTelemetryHost       string
@@ -21,8 +22,9 @@ type ClobFlags struct {
 // List of CLI flags.
 const (
 	// Liquidations and deleveraging.
-	MaxLiquidationOrdersPerBlock    = "max-liquidation-orders-per-block"
-	MaxDeleveragingAttemptsPerBlock = "max-deleveraging-attempts-per-block"
+	MaxLiquidationOrdersPerBlock        = "max-liquidation-orders-per-block"
+	MaxDeleveragingAttemptsPerBlock     = "max-deleveraging-attempts-per-block"
+	MaxDeleveragingSubaccountsToIterate = "max-deleveraging-subaccounts-to-iterate"
 
 	// Mev.
 	MevTelemetryEnabled    = "mev-telemetry-enabled"
@@ -32,8 +34,9 @@ const (
 
 // Default values.
 const (
-	DefaultMaxLiquidationOrdersPerBlock    = 20
-	DefaultMaxDeleveragingAttemptsPerBlock = 5
+	DefaultMaxLiquidationOrdersPerBlock        = 20
+	DefaultMaxDeleveragingAttemptsPerBlock     = 5
+	DefaultMaxDeleveragingSubaccountsToIterate = 500
 
 	DefaultMevTelemetryEnabled    = false
 	DefaultMevTelemetryHost       = ""
@@ -60,6 +63,14 @@ func AddClobFlagsToCmd(cmd *cobra.Command) {
 			DefaultMaxDeleveragingAttemptsPerBlock,
 		),
 	)
+	cmd.Flags().Uint32(
+		MaxDeleveragingSubaccountsToIterate,
+		DefaultMaxDeleveragingSubaccountsToIterate,
+		fmt.Sprintf(
+			"Sets the maximum number of subaccounts iterated for each deleveraging event. Default = %d",
+			DefaultMaxDeleveragingSubaccountsToIterate,
+		),
+	)
 	cmd.Flags().Bool(
 		MevTelemetryEnabled,
 		DefaultMevTelemetryEnabled,
@@ -79,11 +90,12 @@ func AddClobFlagsToCmd(cmd *cobra.Command) {
 
 func GetDefaultClobFlags() ClobFlags {
 	return ClobFlags{
-		MaxLiquidationOrdersPerBlock:    DefaultMaxLiquidationOrdersPerBlock,
-		MaxDeleveragingAttemptsPerBlock: DefaultMaxDeleveragingAttemptsPerBlock,
-		MevTelemetryEnabled:             DefaultMevTelemetryEnabled,
-		MevTelemetryHost:                DefaultMevTelemetryHost,
-		MevTelemetryIdentifier:          DefaultMevTelemetryIdentifier,
+		MaxLiquidationOrdersPerBlock:        DefaultMaxLiquidationOrdersPerBlock,
+		MaxDeleveragingAttemptsPerBlock:     DefaultMaxDeleveragingAttemptsPerBlock,
+		MaxDeleveragingSubaccountsToIterate: DefaultMaxDeleveragingSubaccountsToIterate,
+		MevTelemetryEnabled:                 DefaultMevTelemetryEnabled,
+		MevTelemetryHost:                    DefaultMevTelemetryHost,
+		MevTelemetryIdentifier:              DefaultMevTelemetryIdentifier,
 	}
 }
 
@@ -124,6 +136,10 @@ func GetClobFlagValuesFromOptions(
 		if v, err := cast.ToUint32E(option); err == nil {
 			result.MaxDeleveragingAttemptsPerBlock = v
 		}
+	}
+
+	if v, ok := appOpts.Get(MaxDeleveragingSubaccountsToIterate).(uint32); ok {
+		result.MaxDeleveragingSubaccountsToIterate = v
 	}
 
 	return result

--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"fmt"
-	"math"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/spf13/cast"
@@ -33,8 +32,8 @@ const (
 
 // Default values.
 const (
-	DefaultMaxLiquidationOrdersPerBlock    = math.MaxUint32
-	DefaultMaxDeleveragingAttemptsPerBlock = 35
+	DefaultMaxLiquidationOrdersPerBlock    = 100
+	DefaultMaxDeleveragingAttemptsPerBlock = 5
 
 	DefaultMevTelemetryEnabled    = false
 	DefaultMevTelemetryHost       = ""

--- a/protocol/x/clob/flags/flags_test.go
+++ b/protocol/x/clob/flags/flags_test.go
@@ -18,8 +18,8 @@ func TestAddFlagsToCommand(t *testing.T) {
 	tests := map[string]struct {
 		flagName string
 	}{
-		fmt.Sprintf("Has %s flag", flags.MaxLiquidationOrdersPerBlock): {
-			flagName: flags.MaxLiquidationOrdersPerBlock,
+		fmt.Sprintf("Has %s flag", flags.MaxLiquidationAttemptsPerBlock): {
+			flagName: flags.MaxLiquidationAttemptsPerBlock,
 		},
 		fmt.Sprintf("Has %s flag", flags.MaxDeleveragingAttemptsPerBlock): {
 			flagName: flags.MaxDeleveragingAttemptsPerBlock,
@@ -44,14 +44,14 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 		optsMap map[string]any
 
 		// Expectations.
-		expectedMaxLiquidationOrdersPerBlock        uint32
+		expectedMaxLiquidationAttemptsPerBlock      uint32
 		expectedMaxDeleveragingAttemptsPerBlock     uint32
 		expectedMaxDeleveragingSubaccountsToIterate uint32
 		expectedMevTelemetryHost                    string
 		expectedMevTelemetryIdentifier              string
 	}{
 		"Sets to default if unset": {
-			expectedMaxLiquidationOrdersPerBlock:        flags.DefaultMaxLiquidationOrdersPerBlock,
+			expectedMaxLiquidationAttemptsPerBlock:      flags.DefaultMaxLiquidationAttemptsPerBlock,
 			expectedMaxDeleveragingAttemptsPerBlock:     flags.DefaultMaxDeleveragingAttemptsPerBlock,
 			expectedMaxDeleveragingSubaccountsToIterate: flags.DefaultMaxDeleveragingSubaccountsToIterate,
 			expectedMevTelemetryHost:                    flags.DefaultMevTelemetryHost,
@@ -59,13 +59,13 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 		},
 		"Sets values from options": {
 			optsMap: map[string]any{
-				flags.MaxLiquidationOrdersPerBlock:        uint32(50),
+				flags.MaxLiquidationAttemptsPerBlock:      uint32(50),
 				flags.MaxDeleveragingAttemptsPerBlock:     uint32(25),
 				flags.MaxDeleveragingSubaccountsToIterate: uint32(100),
 				flags.MevTelemetryHost:                    "https://localhost:13137",
 				flags.MevTelemetryIdentifier:              "node-agent-01",
 			},
-			expectedMaxLiquidationOrdersPerBlock:        uint32(50),
+			expectedMaxLiquidationAttemptsPerBlock:      uint32(50),
 			expectedMaxDeleveragingAttemptsPerBlock:     uint32(25),
 			expectedMaxDeleveragingSubaccountsToIterate: uint32(100),
 			expectedMevTelemetryHost:                    "https://localhost:13137",
@@ -94,8 +94,8 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 			)
 			require.Equal(
 				t,
-				tc.expectedMaxLiquidationOrdersPerBlock,
-				flags.MaxLiquidationOrdersPerBlock,
+				tc.expectedMaxLiquidationAttemptsPerBlock,
+				flags.MaxLiquidationAttemptsPerBlock,
 			)
 			require.Equal(
 				t,

--- a/protocol/x/clob/flags/flags_test.go
+++ b/protocol/x/clob/flags/flags_test.go
@@ -44,28 +44,32 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 		optsMap map[string]any
 
 		// Expectations.
-		expectedMaxLiquidationOrdersPerBlock    uint32
-		expectedMaxDeleveragingAttemptsPerBlock uint32
-		expectedMevTelemetryHost                string
-		expectedMevTelemetryIdentifier          string
+		expectedMaxLiquidationOrdersPerBlock        uint32
+		expectedMaxDeleveragingAttemptsPerBlock     uint32
+		expectedMaxDeleveragingSubaccountsToIterate uint32
+		expectedMevTelemetryHost                    string
+		expectedMevTelemetryIdentifier              string
 	}{
 		"Sets to default if unset": {
-			expectedMaxLiquidationOrdersPerBlock:    flags.DefaultMaxLiquidationOrdersPerBlock,
-			expectedMaxDeleveragingAttemptsPerBlock: flags.DefaultMaxDeleveragingAttemptsPerBlock,
-			expectedMevTelemetryHost:                flags.DefaultMevTelemetryHost,
-			expectedMevTelemetryIdentifier:          flags.DefaultMevTelemetryIdentifier,
+			expectedMaxLiquidationOrdersPerBlock:        flags.DefaultMaxLiquidationOrdersPerBlock,
+			expectedMaxDeleveragingAttemptsPerBlock:     flags.DefaultMaxDeleveragingAttemptsPerBlock,
+			expectedMaxDeleveragingSubaccountsToIterate: flags.DefaultMaxDeleveragingSubaccountsToIterate,
+			expectedMevTelemetryHost:                    flags.DefaultMevTelemetryHost,
+			expectedMevTelemetryIdentifier:              flags.DefaultMevTelemetryIdentifier,
 		},
 		"Sets values from options": {
 			optsMap: map[string]any{
-				flags.MaxLiquidationOrdersPerBlock:    uint32(50),
-				flags.MaxDeleveragingAttemptsPerBlock: uint32(25),
-				flags.MevTelemetryHost:                "https://localhost:13137",
-				flags.MevTelemetryIdentifier:          "node-agent-01",
+				flags.MaxLiquidationOrdersPerBlock:        uint32(50),
+				flags.MaxDeleveragingAttemptsPerBlock:     uint32(25),
+				flags.MaxDeleveragingSubaccountsToIterate: uint32(100),
+				flags.MevTelemetryHost:                    "https://localhost:13137",
+				flags.MevTelemetryIdentifier:              "node-agent-01",
 			},
-			expectedMaxLiquidationOrdersPerBlock:    uint32(50),
-			expectedMaxDeleveragingAttemptsPerBlock: uint32(25),
-			expectedMevTelemetryHost:                "https://localhost:13137",
-			expectedMevTelemetryIdentifier:          "node-agent-01",
+			expectedMaxLiquidationOrdersPerBlock:        uint32(50),
+			expectedMaxDeleveragingAttemptsPerBlock:     uint32(25),
+			expectedMaxDeleveragingSubaccountsToIterate: uint32(100),
+			expectedMevTelemetryHost:                    "https://localhost:13137",
+			expectedMevTelemetryIdentifier:              "node-agent-01",
 		},
 	}
 
@@ -97,6 +101,11 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 				t,
 				tc.expectedMaxDeleveragingAttemptsPerBlock,
 				flags.MaxDeleveragingAttemptsPerBlock,
+			)
+			require.Equal(
+				t,
+				tc.expectedMaxDeleveragingSubaccountsToIterate,
+				flags.MaxDeleveragingSubaccountsToIterate,
 			)
 		})
 	}

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -8,6 +8,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 
+	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -219,70 +220,70 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 			} else {
 				// If an error is returned, it's likely because the subaccounts' bankruptcy prices do not overlap.
 				liquidatedSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, liquidatedSubaccountId)
-				liquidatedBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
-					ctx,
-					liquidatedSubaccountId,
-					perpetualId,
-					deltaQuantums,
-				)
-				if bankruptcyPriceError != nil {
-					k.Logger(ctx).Error(
-						"error when getting bankruptcy price for liquidated subaccount",
-						"error", bankruptcyPriceError,
-						"blockHeight", ctx.BlockHeight(),
-						"checkTx", ctx.IsCheckTx(),
-						"perpetualId", perpetualId,
-						"deltaQuantums", deltaQuantums,
-					)
-					return false
-				}
-				liquidatedTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
-					ctx, satypes.Update{SubaccountId: *liquidatedSubaccount.Id},
-				)
-				if tncErr != nil {
-					k.Logger(ctx).Error(
-						"error when getting TNC for liquidated subaccount",
-						"error", tncErr,
-						"blockHeight", ctx.BlockHeight(),
-						"checkTx", ctx.IsCheckTx(),
-						"perpetualId", perpetualId,
-						"deltaQuantums", deltaQuantums,
-					)
-					return false
-				}
+				// liquidatedBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
+				// 	ctx,
+				// 	liquidatedSubaccountId,
+				// 	perpetualId,
+				// 	deltaQuantums,
+				// )
+				// if bankruptcyPriceError != nil {
+				// 	k.Logger(ctx).Error(
+				// 		"error when getting bankruptcy price for liquidated subaccount",
+				// 		"error", bankruptcyPriceError,
+				// 		"blockHeight", ctx.BlockHeight(),
+				// 		"checkTx", ctx.IsCheckTx(),
+				// 		"perpetualId", perpetualId,
+				// 		"deltaQuantums", deltaQuantums,
+				// 	)
+				// 	return false
+				// }
+				// liquidatedTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
+				// 	ctx, satypes.Update{SubaccountId: *liquidatedSubaccount.Id},
+				// )
+				// if tncErr != nil {
+				// 	k.Logger(ctx).Error(
+				// 		"error when getting TNC for liquidated subaccount",
+				// 		"error", tncErr,
+				// 		"blockHeight", ctx.BlockHeight(),
+				// 		"checkTx", ctx.IsCheckTx(),
+				// 		"perpetualId", perpetualId,
+				// 		"deltaQuantums", deltaQuantums,
+				// 	)
+				// 	return false
+				// }
 
 				offsettingSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, *offsettingSubaccount.Id)
-				offsettingBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
-					ctx,
-					*offsettingSubaccount.Id,
-					perpetualId,
-					new(big.Int).Neg(deltaQuantums),
-				)
-				if bankruptcyPriceError != nil {
-					k.Logger(ctx).Error(
-						"error when getting bankruptcy price for offsetting subaccount",
-						"error", bankruptcyPriceError,
-						"blockHeight", ctx.BlockHeight(),
-						"checkTx", ctx.IsCheckTx(),
-						"perpetualId", perpetualId,
-						"deltaQuantums", deltaQuantums,
-					)
-					return false
-				}
-				offsettingTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
-					ctx, satypes.Update{SubaccountId: *offsettingSubaccount.Id},
-				)
-				if tncErr != nil {
-					k.Logger(ctx).Error(
-						"error when getting TNC for offsetting subaccount",
-						"error", tncErr,
-						"blockHeight", ctx.BlockHeight(),
-						"checkTx", ctx.IsCheckTx(),
-						"perpetualId", perpetualId,
-						"deltaQuantums", deltaQuantums,
-					)
-					return false
-				}
+				// offsettingBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
+				// 	ctx,
+				// 	*offsettingSubaccount.Id,
+				// 	perpetualId,
+				// 	new(big.Int).Neg(deltaQuantums),
+				// )
+				// if bankruptcyPriceError != nil {
+				// 	k.Logger(ctx).Error(
+				// 		"error when getting bankruptcy price for offsetting subaccount",
+				// 		"error", bankruptcyPriceError,
+				// 		"blockHeight", ctx.BlockHeight(),
+				// 		"checkTx", ctx.IsCheckTx(),
+				// 		"perpetualId", perpetualId,
+				// 		"deltaQuantums", deltaQuantums,
+				// 	)
+				// 	return false
+				// }
+				// offsettingTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
+				// 	ctx, satypes.Update{SubaccountId: *offsettingSubaccount.Id},
+				// )
+				// if tncErr != nil {
+				// 	k.Logger(ctx).Error(
+				// 		"error when getting TNC for offsetting subaccount",
+				// 		"error", tncErr,
+				// 		"blockHeight", ctx.BlockHeight(),
+				// 		"checkTx", ctx.IsCheckTx(),
+				// 		"perpetualId", perpetualId,
+				// 		"deltaQuantums", deltaQuantums,
+				// 	)
+				// 	return false
+				// }
 
 				k.Logger(ctx).Debug(
 					"Encountered error when processing deleveraging",
@@ -291,12 +292,12 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 					"checkTx", ctx.IsCheckTx(),
 					"perpetualId", perpetualId,
 					"deltaQuantums", deltaQuantums,
-					"liquidatedSubaccount", fmt.Sprintf("%+v", liquidatedSubaccount),
-					"liquidatedBankruptcyPriceQuoteQuantums", liquidatedBankruptcyPrice,
-					"liquidatedTnc", liquidatedTnc,
-					"offsettingSubaccount", fmt.Sprintf("%+v", offsettingSubaccount),
-					"offsettingBankruptcyPriceQuoteQuantums", offsettingBankruptcyPrice,
-					"offsettingTnc", offsettingTnc,
+					"liquidatedSubaccount", log.NewLazySprintf("%+v", liquidatedSubaccount),
+					// "liquidatedBankruptcyPriceQuoteQuantums", liquidatedBankruptcyPrice,
+					// "liquidatedTnc", liquidatedTnc,
+					"offsettingSubaccount", log.NewLazySprintf("%+v", offsettingSubaccount),
+					// "offsettingBankruptcyPriceQuoteQuantums", offsettingBankruptcyPrice,
+					// "offsettingTnc", offsettingTnc,
 				)
 				numSubaccountsWithNonOverlappingBankruptcyPrices++
 			}
@@ -327,15 +328,12 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 			1,
 			types.ModuleName, metrics.CheckTx, metrics.Deleveraging, metrics.NotEnoughPositionToFullyOffset, metrics.Count,
 		)
-		k.Logger(ctx).Error(
-			errorsmod.Wrapf(
-				types.ErrPositionCannotBeFullyOffset,
-				"OffsetSubaccountPerpetualPosition: Not enough position to fully offset position, "+
-					"subaccount = (%+v), perpetual = (%d), quantums remaining = (%+v)",
-				liquidatedSubaccountId,
-				perpetualId,
-				deltaQuantumsRemaining.String(),
-			).Error(),
+		k.Logger(ctx).Debug(
+			"OffsetSubaccountPerpetualPosition: Not enough positions to fully offset position",
+			"subaccount", liquidatedSubaccountId,
+			"perpetual", perpetualId,
+			"deltaQuantumsTotal", deltaQuantumsTotal.String(),
+			"deltaQuantumsRemaining", deltaQuantumsRemaining.String(),
 		)
 		// TODO(CLOB-75): Support deleveraging subaccounts with non overlapping bankruptcy prices.
 	}

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -161,9 +161,9 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 		metrics.OffsettingSubaccountPerpetualPosition,
 	)
 
-	numSubaccountsIterated := 0
-	numSubaccountsWithNonOverlappingBankruptcyPrices := 0
-	numSubaccountsWithNoOpenPositionOnOppositeSide := 0
+	numSubaccountsIterated := uint32(0)
+	numSubaccountsWithNonOverlappingBankruptcyPrices := uint32(0)
+	numSubaccountsWithNoOpenPositionOnOppositeSide := uint32(0)
 	deltaQuantumsRemaining = new(big.Int).Set(deltaQuantumsTotal)
 	fills = make([]types.MatchPerpetualDeleveraging_Fill, 0)
 
@@ -171,7 +171,7 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 		ctx,
 		func(offsettingSubaccount satypes.Subaccount) (finished bool) {
 			// Iterate at most `MaxDeleveragingSubaccountsToIterate` subaccounts.
-			if numSubaccountsIterated >= int(k.MaxDeleveragingSubaccountsToIterate) {
+			if numSubaccountsIterated >= k.Flags.MaxDeleveragingSubaccountsToIterate {
 				return true
 			}
 

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
@@ -165,9 +164,6 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 	deltaQuantumsRemaining = new(big.Int).Set(deltaQuantumsTotal)
 	fills = make([]types.MatchPerpetualDeleveraging_Fill, 0)
 
-	s := rand.NewSource(k.blockTimeKeeper.GetPreviousBlockInfo(ctx).Timestamp.Unix())
-	rand := rand.New(s)
-
 	k.subaccountsKeeper.ForEachSubaccountRandomStart(
 		ctx,
 		func(offsettingSubaccount satypes.Subaccount) (finished bool) {
@@ -301,7 +297,7 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 			}
 			return deltaQuantumsRemaining.Sign() == 0
 		},
-		rand,
+		k.GetPseudoRand(ctx),
 	)
 
 	telemetry.SetGauge(float32(numSubaccountsIterated), metrics.NumSubaccountsIterated, metrics.Count)

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -220,71 +220,7 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 			} else {
 				// If an error is returned, it's likely because the subaccounts' bankruptcy prices do not overlap.
 				liquidatedSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, liquidatedSubaccountId)
-				// liquidatedBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
-				// 	ctx,
-				// 	liquidatedSubaccountId,
-				// 	perpetualId,
-				// 	deltaQuantums,
-				// )
-				// if bankruptcyPriceError != nil {
-				// 	k.Logger(ctx).Error(
-				// 		"error when getting bankruptcy price for liquidated subaccount",
-				// 		"error", bankruptcyPriceError,
-				// 		"blockHeight", ctx.BlockHeight(),
-				// 		"checkTx", ctx.IsCheckTx(),
-				// 		"perpetualId", perpetualId,
-				// 		"deltaQuantums", deltaQuantums,
-				// 	)
-				// 	return false
-				// }
-				// liquidatedTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
-				// 	ctx, satypes.Update{SubaccountId: *liquidatedSubaccount.Id},
-				// )
-				// if tncErr != nil {
-				// 	k.Logger(ctx).Error(
-				// 		"error when getting TNC for liquidated subaccount",
-				// 		"error", tncErr,
-				// 		"blockHeight", ctx.BlockHeight(),
-				// 		"checkTx", ctx.IsCheckTx(),
-				// 		"perpetualId", perpetualId,
-				// 		"deltaQuantums", deltaQuantums,
-				// 	)
-				// 	return false
-				// }
-
 				offsettingSubaccount := k.subaccountsKeeper.GetSubaccount(ctx, *offsettingSubaccount.Id)
-				// offsettingBankruptcyPrice, bankruptcyPriceError := k.GetBankruptcyPriceInQuoteQuantums(
-				// 	ctx,
-				// 	*offsettingSubaccount.Id,
-				// 	perpetualId,
-				// 	new(big.Int).Neg(deltaQuantums),
-				// )
-				// if bankruptcyPriceError != nil {
-				// 	k.Logger(ctx).Error(
-				// 		"error when getting bankruptcy price for offsetting subaccount",
-				// 		"error", bankruptcyPriceError,
-				// 		"blockHeight", ctx.BlockHeight(),
-				// 		"checkTx", ctx.IsCheckTx(),
-				// 		"perpetualId", perpetualId,
-				// 		"deltaQuantums", deltaQuantums,
-				// 	)
-				// 	return false
-				// }
-				// offsettingTnc, _, _, tncErr := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
-				// 	ctx, satypes.Update{SubaccountId: *offsettingSubaccount.Id},
-				// )
-				// if tncErr != nil {
-				// 	k.Logger(ctx).Error(
-				// 		"error when getting TNC for offsetting subaccount",
-				// 		"error", tncErr,
-				// 		"blockHeight", ctx.BlockHeight(),
-				// 		"checkTx", ctx.IsCheckTx(),
-				// 		"perpetualId", perpetualId,
-				// 		"deltaQuantums", deltaQuantums,
-				// 	)
-				// 	return false
-				// }
-
 				k.Logger(ctx).Debug(
 					"Encountered error when processing deleveraging",
 					"error", err,
@@ -293,11 +229,7 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 					"perpetualId", perpetualId,
 					"deltaQuantums", deltaQuantums,
 					"liquidatedSubaccount", log.NewLazySprintf("%+v", liquidatedSubaccount),
-					// "liquidatedBankruptcyPriceQuoteQuantums", liquidatedBankruptcyPrice,
-					// "liquidatedTnc", liquidatedTnc,
 					"offsettingSubaccount", log.NewLazySprintf("%+v", offsettingSubaccount),
-					// "offsettingBankruptcyPriceQuoteQuantums", offsettingBankruptcyPrice,
-					// "offsettingTnc", offsettingTnc,
 				)
 				numSubaccountsWithNonOverlappingBankruptcyPrices++
 			}

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -44,8 +44,9 @@ type (
 
 		memStoreInitialized *atomic.Bool
 
-		MaxLiquidationOrdersPerBlock    uint32
-		MaxDeleveragingAttemptsPerBlock uint32
+		MaxLiquidationOrdersPerBlock        uint32
+		MaxDeleveragingAttemptsPerBlock     uint32
+		MaxDeleveragingSubaccountsToIterate uint32
 
 		mevTelemetryConfig MevTelemetryConfig
 
@@ -108,10 +109,11 @@ func NewKeeper(
 			Host:       clobFlags.MevTelemetryHost,
 			Identifier: clobFlags.MevTelemetryIdentifier,
 		},
-		MaxLiquidationOrdersPerBlock:    clobFlags.MaxLiquidationOrdersPerBlock,
-		MaxDeleveragingAttemptsPerBlock: clobFlags.MaxDeleveragingAttemptsPerBlock,
-		placeOrderRateLimiter:           placeOrderRateLimiter,
-		cancelOrderRateLimiter:          cancelOrderRateLimiter,
+		MaxLiquidationOrdersPerBlock:        clobFlags.MaxLiquidationOrdersPerBlock,
+		MaxDeleveragingAttemptsPerBlock:     clobFlags.MaxDeleveragingAttemptsPerBlock,
+		MaxDeleveragingSubaccountsToIterate: clobFlags.MaxDeleveragingSubaccountsToIterate,
+		placeOrderRateLimiter:               placeOrderRateLimiter,
+		cancelOrderRateLimiter:              cancelOrderRateLimiter,
 	}
 
 	// Provide the keeper to the MemClob.

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -44,9 +44,7 @@ type (
 
 		memStoreInitialized *atomic.Bool
 
-		MaxLiquidationOrdersPerBlock        uint32
-		MaxDeleveragingAttemptsPerBlock     uint32
-		MaxDeleveragingSubaccountsToIterate uint32
+		Flags flags.ClobFlags
 
 		mevTelemetryConfig MevTelemetryConfig
 
@@ -109,11 +107,9 @@ func NewKeeper(
 			Host:       clobFlags.MevTelemetryHost,
 			Identifier: clobFlags.MevTelemetryIdentifier,
 		},
-		MaxLiquidationOrdersPerBlock:        clobFlags.MaxLiquidationOrdersPerBlock,
-		MaxDeleveragingAttemptsPerBlock:     clobFlags.MaxDeleveragingAttemptsPerBlock,
-		MaxDeleveragingSubaccountsToIterate: clobFlags.MaxDeleveragingSubaccountsToIterate,
-		placeOrderRateLimiter:               placeOrderRateLimiter,
-		cancelOrderRateLimiter:              cancelOrderRateLimiter,
+		Flags:                  clobFlags,
+		placeOrderRateLimiter:  placeOrderRateLimiter,
+		cancelOrderRateLimiter: cancelOrderRateLimiter,
 	}
 
 	// Provide the keeper to the MemClob.

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -1007,7 +1007,7 @@ func (k Keeper) validateMatchedLiquidation(
 	// Validate that processing the liquidation fill does not leave insufficient funds
 	// in the insurance fund (such that the liquidation couldn't have possibly continued).
 	if !k.IsValidInsuranceFundDelta(ctx, insuranceFundDelta) {
-		k.Logger(ctx).Info("ProcessMatches: insurance fund has insufficient balance to process the liquidation.")
+		k.Logger(ctx).Debug("ProcessMatches: insurance fund has insufficient balance to process the liquidation.")
 		return nil, errorsmod.Wrapf(
 			types.ErrInsuranceFundHasInsufficientFunds,
 			"Liquidation order %v, insurance fund delta %v",

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -29,9 +29,21 @@ func (k Keeper) LiquidateSubaccountsAgainstOrderbook(
 ) error {
 	lib.AssertCheckTxMode(ctx)
 
+	pseudoRand := k.GetPseudoRand(ctx)
+
 	// Get the liquidation order for each subaccount.
+	// Process at-most `MaxLiquidationOrdersPerBlock` subaccounts, starting from a pseudorandom location
+	// in the slice.
 	liquidationOrdersForSorting := make([]types.LiquidationOrder, 0)
-	for _, subaccountId := range subaccountIds {
+	numSubaccounts := len(subaccountIds)
+	numLiqOrders := lib.Min(numSubaccounts, int(k.MaxLiquidationOrdersPerBlock))
+	indexOffset := 0
+	if numSubaccounts > 0 {
+		indexOffset = pseudoRand.Intn(numSubaccounts)
+	}
+	for i := 0; i < numLiqOrders; i++ {
+		index := (i + indexOffset) % numSubaccounts
+		subaccountId := subaccountIds[index]
 		// If attempting to liquidate a subaccount returns an error, panic.
 		liquidationOrder, err := k.MaybeGetLiquidationOrder(ctx, subaccountId)
 		if err != nil {
@@ -60,7 +72,7 @@ func (k Keeper) LiquidateSubaccountsAgainstOrderbook(
 	// Attempt to place each liquidation order and perform deleveraging if necessary.
 	numFilledLiquidations := uint32(0)
 	numAttemptedDeleveraging := uint32(0)
-	for i := 0; numFilledLiquidations < k.MaxLiquidationOrdersPerBlock && i < len(liquidationOrdersForSorting); i++ {
+	for i := 0; i < len(liquidationOrdersForSorting); i++ {
 		liquidationOrderSubaccountId := liquidationOrdersForSorting[i].GetSubaccountId()
 
 		// Generate a new liquidation order with the appropriate order size from the sorted subaccount ids.
@@ -99,8 +111,12 @@ func (k Keeper) LiquidateSubaccountsAgainstOrderbook(
 			if numAttemptedDeleveraging < k.MaxDeleveragingAttemptsPerBlock {
 				// The liquidation order was unfilled. Try to deleverage the subaccount.
 				subaccountId := liquidationOrder.GetSubaccountId()
-				perpetualId := liquidationOrder.MustGetLiquidatedPerpetualId()
 				deltaQuantums := liquidationOrder.GetDeltaQuantums()
+
+				// Get a pseudorandom perpetualId from the list of open positions.
+				subaccount := k.subaccountsKeeper.GetSubaccount(ctx, subaccountId)
+				positions := subaccount.GetPerpetualPositions()
+				perpetualId := positions[pseudoRand.Intn(len(positions))].PerpetualId
 
 				_, err := k.MaybeDeleverageSubaccount(ctx, subaccountId, perpetualId, deltaQuantums)
 				if err != nil {
@@ -633,15 +649,10 @@ func (k Keeper) GetPerpetualPositionToLiquidate(
 
 	var perpetualPosition *satypes.PerpetualPosition
 
-	// Randomly (with deterministic seeding) select a perpetual position. This is done by iterating through
-	// the slice at-most-once starting at a random index.
-	// Note that this could run in O(n^2) time. This is fine for now because we have less than a hundred
-	// perpetuals and only liquidate once per subaccount per block.
-	numPositions := len(subaccount.PerpetualPositions)
-	indexOffset := k.GetPseudoRand(ctx).Intn(numPositions)
-	for i := 0; i < numPositions; i++ {
-		ppi := (i + indexOffset) % numPositions
-		position := subaccount.PerpetualPositions[ppi]
+	for _, position := range subaccount.PerpetualPositions {
+		// Note that this could run in O(n^2) time. This is fine for now because we have less than a hundred
+		// perpetuals and only liquidate once per subaccount per block. This means that the position with smallest
+		// id will be liquidated first.
 		if !subaccountLiquidationInfo.HasPerpetualBeenLiquidatedForSubaccount(position.PerpetualId) {
 			perpetualPosition = position
 			break

--- a/protocol/x/clob/keeper/random.go
+++ b/protocol/x/clob/keeper/random.go
@@ -1,0 +1,16 @@
+package keeper
+
+import (
+	"math/rand"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// GetPseudoRand returns a random number generator seeded with a pseudorandom seed.
+// The seed is based on the previous block timestamp.
+func (k *Keeper) GetPseudoRand(ctx sdk.Context) *rand.Rand {
+	s := rand.NewSource(
+		k.blockTimeKeeper.GetPreviousBlockInfo(ctx).Timestamp.Unix(),
+	)
+	return rand.New(s)
+}


### PR DESCRIPTION
### Changelist
- Port over changes from v0.3.x release branch to main.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new flag `MaxDeleveragingSubaccountsToIterate` to the `ClobFlags` struct, allowing users to specify the maximum number of subaccounts to iterate for deleveraging.
- Refactor: Updated the `OffsetSubaccountPerpetualPosition` function to iterate over subaccounts, check their positions, and perform offsetting operations more efficiently.
- New Feature: Introduced a pseudorandom number generator in the `liquidations.go` file to process a maximum of `MaxLiquidationOrdersPerBlock` subaccounts from a pseudorandom location.
- New Feature: Added a new function `GetPseudoRand` to the `keeper` package, providing a random number generator seeded with a pseudorandom seed based on the previous block timestamp.
- Test: Updated test cases in `flags_test.go` to accommodate the new `MaxDeleveragingSubaccountsToIterate` flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->