### PR TITLE
Increase max open short term orders from 200 to 1000 in highest equity tier

### DIFF
--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -475,7 +475,7 @@
             "usd_tnc_required": "10000000000"
           },
           {
-            "limit": 200,
+            "limit": 1000,
             "usd_tnc_required": "100000000000"
           }
         ],

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -1366,7 +1366,7 @@ function edit_genesis() {
 	dasel put -t string -f "$GENESIS" '.app_state.clob.equity_tier_limit_config.short_term_order_equity_tiers.[4].usd_tnc_required' -v '10000000000'
 	# Max 200 open short term orders for $100,000 USDC TNC
 	dasel put -t json -f "$GENESIS" '.app_state.clob.equity_tier_limit_config.short_term_order_equity_tiers.[]' -v "{}"
-	dasel put -t int -f "$GENESIS" '.app_state.clob.equity_tier_limit_config.short_term_order_equity_tiers.[5].limit' -v '200'
+	dasel put -t int -f "$GENESIS" '.app_state.clob.equity_tier_limit_config.short_term_order_equity_tiers.[5].limit' -v '1000'
 	dasel put -t string -f "$GENESIS" '.app_state.clob.equity_tier_limit_config.short_term_order_equity_tiers.[5].usd_tnc_required' -v '100000000000'
 	# Max 0 open stateful orders for $0 USDC TNC
 	dasel put -t json -f "$GENESIS" '.app_state.clob.equity_tier_limit_config.stateful_order_equity_tiers.[]' -v "{}"

--- a/protocol/testutil/constants/genesis.go
+++ b/protocol/testutil/constants/genesis.go
@@ -287,7 +287,7 @@ const GenesisState = `{
             "usd_tnc_required": "10000"
           },
           {
-            "limit": 200,
+            "limit": 1000,
             "usd_tnc_required": "100000"
           }
         ],

--- a/protocol/x/clob/genesis_test.go
+++ b/protocol/x/clob/genesis_test.go
@@ -81,7 +81,7 @@ func TestGenesis(t *testing.T) {
 						},
 						{
 							UsdTncRequired: dtypes.NewInt(100000),
-							Limit:          200,
+							Limit:          1000,
 						},
 					},
 					StatefulOrderEquityTiers: []types.EquityTierLimit{

--- a/protocol/x/clob/module_test.go
+++ b/protocol/x/clob/module_test.go
@@ -52,7 +52,7 @@ func getValidGenesisStr() string {
 	gs += `"equity_tier_limit_config":{"short_term_order_equity_tiers":[{"limit":0,"usd_tnc_required":"0"},`
 	gs += `{"limit":1,"usd_tnc_required":"20"},{"limit":5,"usd_tnc_required":"100"},`
 	gs += `{"limit":10,"usd_tnc_required":"1000"},{"limit":100,"usd_tnc_required":"10000"},`
-	gs += `{"limit":200,"usd_tnc_required":"100000"}],"stateful_order_equity_tiers":[`
+	gs += `{"limit":1000,"usd_tnc_required":"100000"}],"stateful_order_equity_tiers":[`
 	gs += `{"limit":0,"usd_tnc_required":"0"},{"limit":1,"usd_tnc_required":"20"},`
 	gs += `{"limit":5,"usd_tnc_required":"100"},{"limit":10,"usd_tnc_required":"1000"},`
 	gs += `{"limit":100,"usd_tnc_required":"10000"},{"limit":200,"usd_tnc_required":"100000"}]}}`
@@ -400,7 +400,7 @@ func TestAppModule_InitExportGenesis(t *testing.T) {
 				},
 				{
 					UsdTncRequired: dtypes.NewInt(100000),
-					Limit:          200,
+					Limit:          1000,
 				},
 			},
 			StatefulOrderEquityTiers: []clob_types.EquityTierLimit{
@@ -450,7 +450,7 @@ func TestAppModule_InitExportGenesis(t *testing.T) {
 	expected += `"equity_tier_limit_config":{"short_term_order_equity_tiers":[{"limit":0,"usd_tnc_required":"0"},`
 	expected += `{"limit":1,"usd_tnc_required":"20"},{"limit":5,"usd_tnc_required":"100"},`
 	expected += `{"limit":10,"usd_tnc_required":"1000"},{"limit":100,"usd_tnc_required":"10000"},`
-	expected += `{"limit":200,"usd_tnc_required":"100000"}],"stateful_order_equity_tiers":[`
+	expected += `{"limit":1000,"usd_tnc_required":"100000"}],"stateful_order_equity_tiers":[`
 	expected += `{"limit":0,"usd_tnc_required":"0"},{"limit":1,"usd_tnc_required":"20"},`
 	expected += `{"limit":5,"usd_tnc_required":"100"},{"limit":10,"usd_tnc_required":"1000"},`
 	expected += `{"limit":100,"usd_tnc_required":"10000"},{"limit":200,"usd_tnc_required":"100000"}]}}`


### PR DESCRIPTION
### Changelist
Increase the max open short term orders from 200 to 1000 for the highest equity tier.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the limit value in various test and configuration files. The `limit` field in the `short_term_order_equity_tiers` array at index 5 in the `equity_tier_limit_config` object, as well as in several test functions and constants, has been increased from 200 to 1000. This change does not introduce new features or fix bugs, but adjusts the testing and configuration parameters for better alignment with the current system requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->