### PR TITLE
[CORE-658] Remove telemetry from `x/prices/EndBlocker` and rename indexer event method

### DIFF
--- a/protocol/testutil/keeper/prices.go
+++ b/protocol/testutil/keeper/prices.go
@@ -158,7 +158,7 @@ func AssertPriceUpdateEventsInIndexerBlock(
 	updatedMarketPrices []types.MarketPrice,
 ) {
 	marketEvents := getMarketEventsFromIndexerBlock(ctx, k)
-	expectedEvents := keeper.GenerateMarketPriceUpdateEvents(updatedMarketPrices)
+	expectedEvents := keeper.GenerateMarketPriceUpdateIndexerEvents(updatedMarketPrices)
 	for _, expectedEvent := range expectedEvents {
 		require.Contains(t, marketEvents, expectedEvent)
 	}

--- a/protocol/x/prices/genesis.go
+++ b/protocol/x/prices/genesis.go
@@ -8,7 +8,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
-// InitGenesis initializes the capability module's state from a provided genesis
+// InitGenesis initializes the x/prices module's state from a provided genesis
 // state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	k.InitializeForGenesis(ctx)
@@ -18,14 +18,14 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	}
 
 	// Set all the market params and prices.
-	for i, elem := range genState.MarketParams {
-		if _, err := k.CreateMarket(ctx, elem, genState.MarketPrices[i]); err != nil {
+	for i, param := range genState.MarketParams {
+		if _, err := k.CreateMarket(ctx, param, genState.MarketPrices[i]); err != nil {
 			panic(err)
 		}
 	}
 
-	marketPriceUpdates := keeper.GenerateMarketPriceUpdateEvents(genState.MarketPrices)
-	for _, update := range marketPriceUpdates {
+	priceUpdateIndexerEvents := keeper.GenerateMarketPriceUpdateIndexerEvents(genState.MarketPrices)
+	for _, update := range priceUpdateIndexerEvents {
 		k.GetIndexerEventManager().AddTxnEvent(
 			ctx,
 			indexerevents.SubtypeMarket,

--- a/protocol/x/prices/keeper/indexer.go
+++ b/protocol/x/prices/keeper/indexer.go
@@ -5,8 +5,11 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
-// GenerateMarketPriceUpdateEvents takes in a slice of market prices and returns a slice of price updates.
-func GenerateMarketPriceUpdateEvents(markets []types.MarketPrice) []*indexerevents.MarketEventV1 {
+// GenerateMarketPriceUpdateIndexerEvents takes in a slice of market prices
+// and returns a slice of price updates.
+func GenerateMarketPriceUpdateIndexerEvents(
+	markets []types.MarketPrice,
+) []*indexerevents.MarketEventV1 {
 	events := make([]*indexerevents.MarketEventV1, 0, len(markets))
 	for _, market := range markets {
 		events = append(

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -94,8 +94,8 @@ func (k Keeper) UpdateMarketPrices(
 		)
 	}
 
-	marketPriceUpdates := GenerateMarketPriceUpdateIndexerEvents(updatedMarketPrices)
-	for _, update := range marketPriceUpdates {
+	priceUpdateIndexerEvents := GenerateMarketPriceUpdateIndexerEvents(updatedMarketPrices)
+	for _, update := range priceUpdateIndexerEvents {
 		k.GetIndexerEventManager().AddTxnEvent(
 			ctx,
 			indexerevents.SubtypeMarket,

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -94,7 +94,7 @@ func (k Keeper) UpdateMarketPrices(
 		)
 	}
 
-	marketPriceUpdates := GenerateMarketPriceUpdateEvents(updatedMarketPrices)
+	marketPriceUpdates := GenerateMarketPriceUpdateIndexerEvents(updatedMarketPrices)
 	for _, update := range marketPriceUpdates {
 		k.GetIndexerEventManager().AddTxnEvent(
 			ctx,

--- a/protocol/x/prices/module.go
+++ b/protocol/x/prices/module.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -15,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/client/cli"
@@ -158,12 +156,10 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 // ConsensusVersion implements ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 { return 1 }
 
-// BeginBlock executes all ABCI BeginBlock logic respective to the prices module.
+// BeginBlock is no-op.
 func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 
-// EndBlock executes all ABCI EndBlock logic respective to the prices module. It
-// returns no validator updates.
+// EndBlock is no-op.It returns no validator updates.
 func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	defer telemetry.ModuleMeasureSince(am.Name(), time.Now(), telemetry.MetricKeyEndBlocker)
 	return []abci.ValidatorUpdate{}
 }


### PR DESCRIPTION
### Changelist
* Rename `GenerateMarketPriceUpdateEvents` to `GenerateMarketPriceUpdateIndexerEvents`
* Remove telemetry from `EndBlocker` since there's no logic there and there's no need to measure telemetry

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
