### PR TITLE
[CORE-652] add params validation to bridge message validation and add non-empty authority unit test

### DIFF
--- a/protocol/x/bridge/types/msg_update_event_params.go
+++ b/protocol/x/bridge/types/msg_update_event_params.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -22,5 +23,5 @@ func (msg *MsgUpdateEventParams) ValidateBasic() error {
 			),
 		)
 	}
-	return nil
+	return msg.Params.Validate()
 }

--- a/protocol/x/bridge/types/msg_update_propose_params.go
+++ b/protocol/x/bridge/types/msg_update_propose_params.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -22,5 +23,5 @@ func (msg *MsgUpdateProposeParams) ValidateBasic() error {
 			),
 		)
 	}
-	return nil
+	return msg.Params.Validate()
 }

--- a/protocol/x/bridge/types/msg_update_safety_params.go
+++ b/protocol/x/bridge/types/msg_update_safety_params.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -22,5 +23,5 @@ func (msg *MsgUpdateSafetyParams) ValidateBasic() error {
 			),
 		)
 	}
-	return nil
+	return msg.Params.Validate()
 }

--- a/protocol/x/bridge/types/msg_update_safety_params_test.go
+++ b/protocol/x/bridge/types/msg_update_safety_params_test.go
@@ -19,7 +19,7 @@ func TestMsgUpdateSafetyParams_GetSigners(t *testing.T) {
 func TestMsgUpdateSafetyParams_ValidateBasic(t *testing.T) {
 	tests := map[string]struct {
 		msg         types.MsgUpdateSafetyParams
-		expectedErr error
+		expectedErr string
 	}{
 		"Success": {
 			msg: types.MsgUpdateSafetyParams{
@@ -30,20 +30,27 @@ func TestMsgUpdateSafetyParams_ValidateBasic(t *testing.T) {
 				},
 			},
 		},
-		"Failure: Invalid authority": {
+		"Failure: empty authority": {
 			msg: types.MsgUpdateSafetyParams{
 				Authority: "",
 			},
-			expectedErr: types.ErrInvalidAuthority,
+			expectedErr: types.ErrInvalidAuthority.Error(),
+		},
+		"Failure: invalid authority": {
+			msg: types.MsgUpdateSafetyParams{
+				Authority: "dydx1abc",
+			},
+			expectedErr: types.ErrInvalidAuthority.Error(),
 		},
 	}
+
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
-			if tc.expectedErr == nil {
+			if tc.expectedErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.ErrorIs(t, err, tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr)
 			}
 		})
 	}


### PR DESCRIPTION
### Changelist
1. add `Params` validation to bridge governance messages
2. add unit test on non-empty authority validation in bridge governance messages

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
