### PR TITLE
[CORE-659] Standardize keys for x/blocktime

### DIFF
--- a/protocol/x/blocktime/keeper/keeper.go
+++ b/protocol/x/blocktime/keeper/keeper.go
@@ -16,11 +16,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
 )
 
-const (
-	allDowntimeInfoKey   = "AllDowntimeInfo/value"
-	previousBlockInfoKey = "PreviousBlockInfo/value/"
-)
-
 type (
 	Keeper struct {
 		cdc         codec.BinaryCodec
@@ -54,7 +49,7 @@ func (k Keeper) InitializeForGenesis(ctx sdk.Context) {}
 
 func (k Keeper) GetAllDowntimeInfo(ctx sdk.Context) *types.AllDowntimeInfo {
 	store := ctx.KVStore(k.storeKey)
-	bytes := store.Get([]byte(allDowntimeInfoKey))
+	bytes := store.Get([]byte(types.AllDowntimeInfoKey))
 
 	if bytes == nil {
 		return &types.AllDowntimeInfo{}
@@ -70,12 +65,12 @@ func (k Keeper) GetAllDowntimeInfo(ctx sdk.Context) *types.AllDowntimeInfo {
 func (k Keeper) SetAllDowntimeInfo(ctx sdk.Context, info *types.AllDowntimeInfo) {
 	store := ctx.KVStore(k.storeKey)
 	b := k.cdc.MustMarshal(info)
-	store.Set([]byte(allDowntimeInfoKey), b)
+	store.Set([]byte(types.AllDowntimeInfoKey), b)
 }
 
 func (k Keeper) GetPreviousBlockInfo(ctx sdk.Context) types.BlockInfo {
 	store := ctx.KVStore(k.storeKey)
-	bytes := store.Get([]byte(previousBlockInfoKey))
+	bytes := store.Get([]byte(types.PreviousBlockInfoKey))
 
 	if bytes == nil {
 		return types.BlockInfo{}
@@ -89,7 +84,7 @@ func (k Keeper) GetPreviousBlockInfo(ctx sdk.Context) types.BlockInfo {
 func (k Keeper) SetPreviousBlockInfo(ctx sdk.Context, info *types.BlockInfo) {
 	store := ctx.KVStore(k.storeKey)
 	b := k.cdc.MustMarshal(info)
-	store.Set([]byte(previousBlockInfoKey), b)
+	store.Set([]byte(types.PreviousBlockInfoKey), b)
 }
 
 // UpdateAllDowntimeInfo updates AllDowntimeInfo by considering the downtime between the current block and

--- a/protocol/x/blocktime/types/keys.go
+++ b/protocol/x/blocktime/types/keys.go
@@ -13,4 +13,10 @@ const (
 const (
 	// DowntimeParamsKey defines the key for the DowntimeParams
 	DowntimeParamsKey = "DowntimeParams"
+
+	// AllDowntimeInfoKey defines the key for AllDowntimeInfo
+	AllDowntimeInfoKey = "AllDowntimeInfo"
+
+	// PreviousBlockInfoKey defines the key for PreviousBlockInfo
+	PreviousBlockInfoKey = "PreviousBlockInfo"
 )


### PR DESCRIPTION
### Changelist
These keys were missed in the original pass for standardizing keys.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
