### PR TITLE
[CORE-672] - x/prices genesis test refactors

### DIFF
--- a/protocol/x/prices/genesis_test.go
+++ b/protocol/x/prices/genesis_test.go
@@ -1,6 +1,7 @@
 package prices_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -9,16 +10,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenesis(t *testing.T) {
-	genesisState := constants.Prices_DefaultGenesisState
+func TestInitExportGenesis(t *testing.T) {
+	tests := map[string]struct {
+		genesisState *types.GenesisState
+	}{
+		"default genesis": {
+			genesisState: types.DefaultGenesis(),
+		},
+		"empty genesis": {
+			genesisState: &types.GenesisState{
+				MarketParams: []types.MarketParam{},
+				MarketPrices: []types.MarketPrice{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, k, _, _, _, mockTimeProvider := keepertest.PricesKeepers(t)
+			mockTimeProvider.On("Now").Return(constants.TimeT)
 
+			prices.InitGenesis(ctx, *k, *tc.genesisState)
+
+			// Verify expected keeper state after InitGenesis.
+			require.Equal(t, tc.genesisState.MarketParams, k.GetAllMarketParams(ctx))
+			require.Equal(t, tc.genesisState.MarketPrices, k.GetAllMarketPrices(ctx))
+
+			// Verify expected exported genesis state matches input.
+			exportedState := prices.ExportGenesis(ctx, *k)
+			require.Equal(t, tc.genesisState, exportedState)
+		})
+	}
+}
+
+// invalidGenesis returns a genesis state that doesn't pass validation.
+func invalidGenesis() types.GenesisState {
+	genesisState := constants.Prices_DefaultGenesisState
+	// Create a genesis state with a market price that doesn't match ids the market param in the same list position.
+	genesisState.MarketPrices[0].Id = genesisState.MarketParams[0].Id + 1
+	return genesisState
+}
+
+func TestInitGenesis_Panics(t *testing.T) {
 	ctx, k, _, _, _, mockTimeProvider := keepertest.PricesKeepers(t)
 	mockTimeProvider.On("Now").Return(constants.TimeT)
-	prices.InitGenesis(ctx, *k, genesisState)
-	got := prices.ExportGenesis(ctx, *k)
-	require.NotNil(t, got)
 
-	require.ElementsMatch(t, genesisState.MarketParams, got.MarketParams)
+	// Verify InitGenesis panics when given an invalid genesis state.
+	require.Panics(t, func() {
+		prices.InitGenesis(ctx, *k, invalidGenesis())
+	})
 }
 
 func TestInitGenesisEmitsMarketUpdates(t *testing.T) {

--- a/protocol/x/prices/genesis_test.go
+++ b/protocol/x/prices/genesis_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInitExportGenesis(t *testing.T) {
+func TestExportGenesis(t *testing.T) {
 	tests := map[string]struct {
 		genesisState *types.GenesisState
 	}{


### PR DESCRIPTION
### Changelist
- `ExportGenesis`was already tested, but I wrote a more comprehensive test that also validates keeper state after genesis import before exporting.
- Added panic test for invalid genesis state.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
