### PR TITLE
Return short-term orders in initial payload for v4_subaccounts channel.

### DIFF
--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -12,6 +12,8 @@
 * [#469](https://github.com/dydxprotocol/v4-chain/pull/469) Added a reason field to `/screen` endpoint to display a reason for blocking an address.
   
 ### Bug Fixes
+* [#579](https://github.com/dydxprotocol/v4-chain/pull/579) Fixed bug where open short-term orders were not being returned in the initial payload when subscribing to the v4_subaccounts channel.
+
 * [#552](https://github.com/dydxprotocol/v4-chain/pull/552) Fixed bug with Elliptic compliance client where the API key was incorrectly used instead of the API secret to generate the auth headers for the Elliptic request.
 
 * [#528](https://github.com/dydxprotocol/v4-chain/pull/528) Fixed bug with bulk SQL queries with nullable numeric / string / boolean values.

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -47,7 +47,7 @@ describe('Subscriptions', () => {
   const initialResponseUrlPatterns: Record<Channel, string[] | undefined> = {
     [Channel.V4_ACCOUNTS]: [
       '/v4/addresses/.+/subaccountNumber/.+',
-      '/v4/orders?.+OPEN,UNTRIGGERED',
+      '/v4/orders?.+OPEN,UNTRIGGERED,BEST_EFFORT_OPENED',
     ],
     [Channel.V4_CANDLES]: ['/v4/candles/perpetualMarkets/.+?resolution=.+'],
     [Channel.V4_MARKETS]: ['/v4/perpetualMarkets'],

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -504,7 +504,7 @@ export class Subscriptions {
         // TODO(DEC-1462): Use the /active-orders endpoint once it's added.
         axiosRequest({
           method: RequestMethod.GET,
-          url: `${COMLINK_URL}/v4/orders?address=${address}&subaccountNumber=${subaccountNumber}&status=OPEN,UNTRIGGERED`,
+          url: `${COMLINK_URL}/v4/orders?address=${address}&subaccountNumber=${subaccountNumber}&status=OPEN,UNTRIGGERED,BEST_EFFORT_OPENED`,
           timeout: config.INITIAL_GET_TIMEOUT_MS,
           transformResponse: (res) => res,
         }),
@@ -519,6 +519,10 @@ export class Subscriptions {
       // such subaccounts can be subscribed to and events can be sent when the subaccounts are
       // indexed to an existing subscription.
       if (error instanceof AxiosSafeServerError && (error as AxiosSafeServerError).status === 404) {
+        return EMPTY_INITIAL_RESPONSE;
+      }
+      // A 403 means the user is blocked due to compliance issues
+      if (error instanceof AxiosSafeServerError && (error as AxiosSafeServerError).status === 403) {
         return EMPTY_INITIAL_RESPONSE;
       }
       throw error;

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -521,11 +521,6 @@ export class Subscriptions {
       if (error instanceof AxiosSafeServerError && (error as AxiosSafeServerError).status === 404) {
         return EMPTY_INITIAL_RESPONSE;
       }
-      // A 403 means the user is blocked due to compliance issues
-      if (error instanceof AxiosSafeServerError && (error as AxiosSafeServerError).status === 403) {
-        return EMPTY_INITIAL_RESPONSE;
-      }
-      throw error;
     }
   }
 

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -521,6 +521,7 @@ export class Subscriptions {
       if (error instanceof AxiosSafeServerError && (error as AxiosSafeServerError).status === 404) {
         return EMPTY_INITIAL_RESPONSE;
       }
+      throw error;
     }
   }
 


### PR DESCRIPTION
### Changelist
Bugfix. The initial payload for the `v4_subaccounts` websocket channel should contain all active (open or untriggered) orders, but currently doesn't contain any open (`BEST_EFFORT_OPENED`) short-term orders.

### Test Plan
Unit test added to ensure the initial payload URL is updated correctly.
Tested in a dev environment for verify the actual behavior.

### Author/Reviewer Checklist
- [x] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
