### PR TITLE
[DEC-2145] Audit: Explicitly panic when insurance fund delta is not int64

### DIFF
--- a/protocol/x/clob/keeper/mev.go
+++ b/protocol/x/clob/keeper/mev.go
@@ -520,9 +520,12 @@ func (k Keeper) GetMEVDataFromOperations(
 						return nil, err
 					}
 
+					if !insuranceFundDelta.IsInt64() {
+						panic(fmt.Sprintf("insurance fund delta (%v) is not an int64", insuranceFundDelta.String()))
+					}
+
 					mevLiquidationMatch := types.MEVLiquidationMatch{
-						LiquidatedSubaccountId: matchLiquidation.Liquidated,
-						// TODO: Panic if insurance fund delta is not an int64.
+						LiquidatedSubaccountId:          matchLiquidation.Liquidated,
 						InsuranceFundDeltaQuoteQuantums: insuranceFundDelta.Int64(),
 
 						MakerOrderSubaccountId: makerOrder.OrderId.SubaccountId,

--- a/protocol/x/clob/keeper/mev.go
+++ b/protocol/x/clob/keeper/mev.go
@@ -528,7 +528,8 @@ func (k Keeper) GetMEVDataFromOperations(
 					}
 
 					mevLiquidationMatch := types.MEVLiquidationMatch{
-						LiquidatedSubaccountId:          matchLiquidation.Liquidated,
+						LiquidatedSubaccountId: matchLiquidation.Liquidated,
+						// TODO(CLOB-957): Use `SerializableInt` for insurance fund delta
 						InsuranceFundDeltaQuoteQuantums: insuranceFundDelta.Int64(),
 
 						MakerOrderSubaccountId: makerOrder.OrderId.SubaccountId,

--- a/protocol/x/clob/keeper/mev.go
+++ b/protocol/x/clob/keeper/mev.go
@@ -520,6 +520,9 @@ func (k Keeper) GetMEVDataFromOperations(
 						return nil, err
 					}
 
+					// `insuranceFundDelta` is measured in int64 quote quantums.
+					// It represents up to ~9 trillion USDC which should always be enough for insurance fund delta.
+					// We explicitly panic if there's an int64 overflow.
 					if !insuranceFundDelta.IsInt64() {
 						panic(fmt.Sprintf("insurance fund delta (%v) is not an int64", insuranceFundDelta.String()))
 					}


### PR DESCRIPTION
From `bigint.int64()` audit