### PR TITLE
[CORE-652] add more test cases and comments to bridge module

### DIFF
--- a/protocol/x/bridge/app_test.go
+++ b/protocol/x/bridge/app_test.go
@@ -23,7 +23,7 @@ const (
 
 func TestBridge_Success(t *testing.T) {
 	tests := map[string]struct {
-		// Setup.
+		/* --- Setup --- */
 		// bridge events.
 		bridgeEvents []bridgetypes.BridgeEvent
 		// propose params.
@@ -33,7 +33,7 @@ func TestBridge_Success(t *testing.T) {
 		// block time to advance to.
 		blockTime time.Time
 
-		// Expectations.
+		/* --- Expectations --- */
 		// whether bridge tx should have non-empty bridge events.
 		expectNonEmptyBridgeTx bool
 	}{
@@ -54,7 +54,25 @@ func TestBridge_Success(t *testing.T) {
 			blockTime:              time.Now(),
 			expectNonEmptyBridgeTx: true,
 		},
-		"Success: 4 bridge event, delay 27 blocks": {
+		"Success: 2 bridge events, delay 0 blocks": {
+			bridgeEvents: []bridgetypes.BridgeEvent{
+				constants.BridgeEvent_Id0_Height0,
+				constants.BridgeEvent_Id1_Height0,
+			},
+			proposeParams: bridgetypes.ProposeParams{
+				MaxBridgesPerBlock:           2,
+				ProposeDelayDuration:         0,
+				SkipRatePpm:                  0, // do not skip proposing bridge events.
+				SkipIfBlockDelayedByDuration: time.Second * 10,
+			},
+			safetyParams: bridgetypes.SafetyParams{
+				IsDisabled:  false,
+				DelayBlocks: 0,
+			},
+			blockTime:              time.Now(),
+			expectNonEmptyBridgeTx: true,
+		},
+		"Success: 4 bridge events, delay 27 blocks": {
 			bridgeEvents: []bridgetypes.BridgeEvent{
 				constants.BridgeEvent_Id0_Height0,
 				constants.BridgeEvent_Id1_Height0,
@@ -151,15 +169,20 @@ func TestBridge_Success(t *testing.T) {
 			require.NoError(t, error)
 			require.Equal(t, &api.AddBridgeEventsResponse{}, res)
 
-			// Verify that balances have not changed at the block right before the one where complete
-			// bridge messages should be executed, which is `DelayBlocks+2` because
+			// 'MsgCompleteBridge's should be executed at block height `DelayBlocks+2` because
 			// 1. Bridge events are recognized by server at block 1.
 			// 2. Bridge events are proposed at block 2 and complete bridge messages are delayed for
 			//    `DelayBlocks` number of blocks.
 			// 3. Complete bridge messages are executed at block `DelayBlocks+2`.
-			ctx = tApp.AdvanceToBlock(tc.safetyParams.DelayBlocks+1, testapp.AdvanceToBlockOptions{
-				BlockTime: tc.blockTime.Add(-time.Second * 1),
-			})
+			blockHeightOfBridgeCompletion := tc.safetyParams.DelayBlocks + 2
+
+			// Advance to block right before bridge completion, if necessary.
+			if blockHeightOfBridgeCompletion-1 > uint32(ctx.BlockHeight()) {
+				ctx = tApp.AdvanceToBlock(blockHeightOfBridgeCompletion-1, testapp.AdvanceToBlockOptions{
+					BlockTime: tc.blockTime.Add(-time.Second * 1),
+				})
+			}
+			// Verify that balances have not changed yet.
 			for _, event := range tc.bridgeEvents {
 				balance := tApp.App.BankKeeper.GetBalance(
 					ctx,
@@ -169,9 +192,9 @@ func TestBridge_Success(t *testing.T) {
 				require.Equal(t, initialBalances[event.Address], balance)
 			}
 
-			// Verify that balances are updated, if bridge events were proposed, at the block where
-			// complete bridge messages are executed.
-			ctx = tApp.AdvanceToBlock(tc.safetyParams.DelayBlocks+2, testapp.AdvanceToBlockOptions{
+			// Verify that balances are updated, if bridge events were proposed, at the block of
+			// bridge completion.
+			ctx = tApp.AdvanceToBlock(blockHeightOfBridgeCompletion, testapp.AdvanceToBlockOptions{
 				BlockTime: tc.blockTime,
 			})
 			for _, event := range tc.bridgeEvents {
@@ -195,12 +218,26 @@ func TestBridge_REJECT(t *testing.T) {
 	e1 := constants.BridgeEvent_Id1_Height0
 
 	tests := map[string]struct {
-		// bridge events.
+		// bridge events to propose.
 		bridgeEvents []bridgetypes.BridgeEvent
 		// whether bridging is disabled.
 		bridgingDisabled bool
 	}{
-		"Bad coin": {
+		"Bad coin denom": {
+			bridgeEvents: []bridgetypes.BridgeEvent{
+				constants.BridgeEvent_Id0_Height0,
+				{
+					Id: e1.Id,
+					Coin: sdk.NewCoin(
+						e1.Coin.Denom+"a", // bad denom.
+						e1.Coin.Amount,
+					),
+					Address:        e1.Address,
+					EthBlockHeight: e1.EthBlockHeight,
+				},
+			},
+		},
+		"Bad coin amount": {
 			bridgeEvents: []bridgetypes.BridgeEvent{
 				constants.BridgeEvent_Id0_Height0,
 				{
@@ -211,6 +248,34 @@ func TestBridge_REJECT(t *testing.T) {
 					),
 					Address:        e1.Address,
 					EthBlockHeight: e1.EthBlockHeight,
+				},
+			},
+		},
+		"Bad address": {
+			bridgeEvents: []bridgetypes.BridgeEvent{
+				constants.BridgeEvent_Id0_Height0,
+				{
+					Id: e1.Id,
+					Coin: sdk.NewCoin(
+						e1.Coin.Denom,
+						e1.Coin.Amount,
+					),
+					Address:        e1.Address + "a", // bad address.
+					EthBlockHeight: e1.EthBlockHeight,
+				},
+			},
+		},
+		"Bad eth block height": {
+			bridgeEvents: []bridgetypes.BridgeEvent{
+				constants.BridgeEvent_Id0_Height0,
+				{
+					Id: e1.Id,
+					Coin: sdk.NewCoin(
+						e1.Coin.Denom,
+						e1.Coin.Amount,
+					),
+					Address:        e1.Address,
+					EthBlockHeight: e1.EthBlockHeight + 1, // bad eth block height.
 				},
 			},
 		},

--- a/protocol/x/bridge/keeper/acknowledge_bridges.go
+++ b/protocol/x/bridge/keeper/acknowledge_bridges.go
@@ -78,7 +78,7 @@ func (k Keeper) GetAcknowledgeBridges(
 // AcknowledgeBridges acknowledges a list of bridge events and returns an error if any of following
 // - bridging is disabled.
 // - fails to delay a `MsgCompleteBridge` for any bridge event.
-// - fails to upate `AcknowledgedEventInfo` in state.
+// - fails to update `AcknowledgedEventInfo` in state.
 func (k Keeper) AcknowledgeBridges(
 	ctx sdk.Context,
 	bridgeEvents []types.BridgeEvent,

--- a/protocol/x/bridge/keeper/acknowledge_bridges.go
+++ b/protocol/x/bridge/keeper/acknowledge_bridges.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -76,11 +75,24 @@ func (k Keeper) GetAcknowledgeBridges(
 	}
 }
 
-// AcknowledgeBridges acknowledges a list of bridge events.
+// AcknowledgeBridges acknowledges a list of bridge events and returns an error if any of following
+// - bridging is disabled.
+// - fails to delay a `MsgCompleteBridge` for any bridge event.
+// - fails to upate `AcknowledgedEventInfo` in state.
 func (k Keeper) AcknowledgeBridges(
 	ctx sdk.Context,
 	bridgeEvents []types.BridgeEvent,
 ) (err error) {
+	if len(bridgeEvents) == 0 {
+		return nil
+	}
+	safetyParams := k.GetSafetyParams(ctx)
+	if safetyParams.IsDisabled {
+		// Do not acknowledge bridges if bridging is disabled.
+		return types.ErrBridgingDisabled
+	}
+
+	// Measure latency if there are bridge events to acknowledge.
 	defer telemetry.ModuleMeasureSince(
 		types.ModuleName,
 		time.Now(),
@@ -88,16 +100,8 @@ func (k Keeper) AcknowledgeBridges(
 		metrics.Latency,
 	)
 
-	safetyParams := k.GetSafetyParams(ctx)
-	if len(bridgeEvents) == 0 {
-		return nil
-	} else if safetyParams.IsDisabled {
-		// Do not acknowledge bridges if bridging is disabled.
-		return types.ErrBridgingDisabled
-	}
-
 	// For each bridge event, delay a `MsgCompleteBridge` to be executed `safetyParams.DelayBlocks`
-	// blocks in the future. Panic if fails to delay any of the messages.
+	// blocks in the future. Returns error if fails to delay any of the messages.
 	delayMsgModuleAccAddrString := authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String()
 	for _, bridgeEvent := range bridgeEvents {
 		// delaymsg module should be the authority for completing bridges.
@@ -111,16 +115,13 @@ func (k Keeper) AcknowledgeBridges(
 			safetyParams.DelayBlocks,
 		)
 		if err != nil {
-			panic(
-				fmt.Sprintf(
-					"failed to delay completing bridge: %s",
-					err.Error(),
-				),
-			)
+			return err
 		}
 	}
 
 	// Update `AcknowledgedEventInfo` in state.
+	// - `NextId` is set to ID of last acknowledged bridge event + 1
+	// - `EthBlockHeight`is set to block height of last acknowledged bridge event
 	lastBridgeEvent := bridgeEvents[len(bridgeEvents)-1]
 	if err = k.SetAcknowledgedEventInfo(ctx, types.BridgeEventInfo{
 		NextId:         lastBridgeEvent.GetId() + 1,

--- a/protocol/x/bridge/keeper/acknowledge_bridges_test.go
+++ b/protocol/x/bridge/keeper/acknowledge_bridges_test.go
@@ -100,7 +100,7 @@ func TestAcknowledgeBridges(t *testing.T) {
 				// Verify that error is as expected.
 				require.ErrorContains(t, err, tc.expectedError)
 
-				// Verify that AEI was not updated.
+				// Verify that AcknowledgedEventInfo was not updated.
 				require.Equal(t, initialAei, bridgeKeeper.GetAcknowledgedEventInfo(ctx))
 
 				if tc.bridgingDisabled {
@@ -111,7 +111,7 @@ func TestAcknowledgeBridges(t *testing.T) {
 				// Verify that AcknowledgeBridges returns no error.
 				require.NoError(t, err)
 
-				// Assert expected AcknowledgedEventInfo.
+				// Verify that AcknowledgedEventInfo is updated in state.
 				aei := bridgeKeeper.GetAcknowledgedEventInfo(ctx)
 				require.Equal(t, tc.expectedAEI, aei)
 

--- a/protocol/x/bridge/keeper/acknowledge_bridges_test.go
+++ b/protocol/x/bridge/keeper/acknowledge_bridges_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -13,12 +14,19 @@ import (
 
 func TestAcknowledgeBridges(t *testing.T) {
 	tests := map[string]struct {
+		/* --- Setup --- */
 		// Bridge events to acknowledge.
-		bridgeEvents     []types.BridgeEvent
+		bridgeEvents []types.BridgeEvent
+		// Whether bridging is disabled.
 		bridgingDisabled bool
+		// Error responses of mock delayMsgKeeper.
+		delayMsgErrors []error
 
+		/* --- Expectations --- */
 		// Expected AcknowledgedEventInfo.
 		expectedAEI types.BridgeEventInfo
+		// Expected error.
+		expectedError string
 	}{
 		"Success: no events": {
 			bridgeEvents: []types.BridgeEvent{},
@@ -31,6 +39,7 @@ func TestAcknowledgeBridges(t *testing.T) {
 			bridgeEvents: []types.BridgeEvent{
 				constants.BridgeEvent_Id55_Height15,
 			},
+			delayMsgErrors: []error{nil},
 			expectedAEI: types.BridgeEventInfo{
 				NextId:         56,
 				EthBlockHeight: 15,
@@ -41,6 +50,7 @@ func TestAcknowledgeBridges(t *testing.T) {
 				constants.BridgeEvent_Id0_Height0,
 				constants.BridgeEvent_Id1_Height0,
 			},
+			delayMsgErrors: []error{nil, nil},
 			expectedAEI: types.BridgeEventInfo{
 				NextId:         2,
 				EthBlockHeight: 0,
@@ -50,7 +60,17 @@ func TestAcknowledgeBridges(t *testing.T) {
 			bridgeEvents: []types.BridgeEvent{
 				constants.BridgeEvent_Id55_Height15,
 			},
+			delayMsgErrors:   []error{nil},
 			bridgingDisabled: true,
+			expectedError:    types.ErrBridgingDisabled.Error(),
+		},
+		"Error: 2 events, delaying second msg returns error": {
+			bridgeEvents: []types.BridgeEvent{
+				constants.BridgeEvent_Id0_Height0,
+				constants.BridgeEvent_Id1_Height0,
+			},
+			delayMsgErrors: []error{nil, errors.New("failed to delay message 1")},
+			expectedError:  "failed to delay message 1",
 		},
 	}
 
@@ -69,23 +89,25 @@ func TestAcknowledgeBridges(t *testing.T) {
 					ctx,
 					mock.Anything,
 					mock.Anything,
-				).Return(uint32(i), nil).Once()
+				).Return(uint32(i), tc.delayMsgErrors[i]).Once()
 			}
 			initialAei := bridgeKeeper.GetAcknowledgedEventInfo(ctx)
 
 			// Invoke AcknowledgeBridges.
 			err = bridgeKeeper.AcknowledgeBridges(ctx, tc.bridgeEvents)
 
-			if tc.bridgingDisabled { // bridging is disabled.
-				// Verify that AcknowledgeBridges returns ErrBridgingDisabled.
-				require.ErrorIs(t, err, types.ErrBridgingDisabled)
+			if tc.expectedError != "" {
+				// Verify that error is as expected.
+				require.ErrorContains(t, err, tc.expectedError)
 
-				// Verify that no messages were delayed.
-				mockDelayMsgKeeper.AssertNotCalled(t, "DelayMessageByBlocks")
-
-				// Verify that AcknowledgedEventInfo was not updated.
+				// Verify that AEI was not updated.
 				require.Equal(t, initialAei, bridgeKeeper.GetAcknowledgedEventInfo(ctx))
-			} else { // bridging is not disabled.
+
+				if tc.bridgingDisabled {
+					// Verify that no messages were delayed.
+					mockDelayMsgKeeper.AssertNotCalled(t, "DelayMessageByBlocks")
+				}
+			} else {
 				// Verify that AcknowledgeBridges returns no error.
 				require.NoError(t, err)
 
@@ -161,6 +183,28 @@ func TestGetAcknowledgeBridges(t *testing.T) {
 				constants.BridgeEvent_Id1_Height0,
 				constants.BridgeEvent_Id2_Height1,
 				constants.BridgeEvent_Id3_Height3, // this event should not be proposed.
+			},
+			expectedMsg: &types.MsgAcknowledgeBridges{
+				Events: []types.BridgeEvent{
+					constants.BridgeEvent_Id0_Height0,
+					constants.BridgeEvent_Id1_Height0,
+					constants.BridgeEvent_Id2_Height1,
+				},
+			},
+		},
+		"MaxBridgesPerBlock events recognized": {
+			blockTimestamp: timeNow,
+			eventTimestamp: timeNow.Add(-time.Second * 2),
+			proposeParams: types.ProposeParams{
+				SkipRatePpm:                  0,           // do not skip based on pseudo-randomness.
+				SkipIfBlockDelayedByDuration: time.Second, // do not skip based on time.
+				MaxBridgesPerBlock:           3,           // propose up to 3 events per block.
+				ProposeDelayDuration:         time.Second, // propose events recognized at least one second ago.
+			},
+			bridgeEventsToAdd: []types.BridgeEvent{
+				constants.BridgeEvent_Id0_Height0,
+				constants.BridgeEvent_Id1_Height0,
+				constants.BridgeEvent_Id2_Height1,
 			},
 			expectedMsg: &types.MsgAcknowledgeBridges{
 				Events: []types.BridgeEvent{

--- a/protocol/x/bridge/keeper/bridge_event.go
+++ b/protocol/x/bridge/keeper/bridge_event.go
@@ -5,6 +5,8 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 )
 
+// `GetBridgeEventFromServer` returns the bridge event with the given id from the server. `found` is false
+// if the event is not found.
 func (k Keeper) GetBridgeEventFromServer(ctx sdk.Context, id uint32) (event types.BridgeEvent, found bool) {
 	event, _, found = k.bridgeEventManager.GetBridgeEventById(id)
 	return event, found

--- a/protocol/x/bridge/keeper/bridge_event_info.go
+++ b/protocol/x/bridge/keeper/bridge_event_info.go
@@ -50,7 +50,7 @@ func (k Keeper) SetAcknowledgedEventInfo(
 
 // GetRecognizedEventInfo returns `RecognizedEventInfo` from `BridgeEventManager`.
 // This has the next event id that has not yet been recognized by this node’s daemon.
-// This also has the height of the highest Ethereum block from which a bridge event
+// This also has the height of the highest Ethereum block at which a bridge event
 // was recognized. These values are not in-consensus.
 func (k Keeper) GetRecognizedEventInfo(
 	ctx sdk.Context,

--- a/protocol/x/bridge/keeper/complete_bridge.go
+++ b/protocol/x/bridge/keeper/complete_bridge.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 )
 
-// `CompleteBridge` processes a bridge event by transfer the appropriate tokens
+// `CompleteBridge` processes a bridge event by transferring the specified coin
 // from bridge module account to the given address. The id of the bridge is not
 // validated as it should have already been validated by AcknowledgeBridges.
 func (k Keeper) CompleteBridge(
@@ -57,6 +57,7 @@ func (k Keeper) CompleteBridge(
 
 // `GetDelayedCompleteBridgeMessages` returns all delayed complete bridge
 // messages and corresponding block heights at which they'll execute.
+// If `address` is given, only returns messages for that address.
 func (k Keeper) GetDelayedCompleteBridgeMessages(
 	ctx sdk.Context,
 	address string,

--- a/protocol/x/bridge/keeper/complete_bridge_test.go
+++ b/protocol/x/bridge/keeper/complete_bridge_test.go
@@ -43,6 +43,20 @@ func TestCompleteBridge(t *testing.T) {
 			expectedError:   "invalid coin",
 			expectedBalance: sdk.NewCoin("adv4tnt", sdkmath.NewInt(1_000)),
 		},
+		"Failure: coin amount is negative": {
+			initialBalance: sdk.NewCoin("adv4tnt", sdkmath.NewInt(1_000)),
+			bridgeEvent: types.BridgeEvent{
+				Id:      7,
+				Address: constants.BobAccAddress.String(),
+				Coin: sdk.Coin{
+					Denom:  "adv4tnt",
+					Amount: sdkmath.NewInt(-1),
+				},
+				EthBlockHeight: 3,
+			},
+			expectedError:   "invalid coin",
+			expectedBalance: sdk.NewCoin("adv4tnt", sdkmath.NewInt(1_000)),
+		},
 		"Failure: invalid address string": {
 			initialBalance: sdk.NewCoin("adv4tnt", sdkmath.NewInt(1_000)),
 			bridgeEvent: types.BridgeEvent{

--- a/protocol/x/bridge/keeper/grpc_query_test.go
+++ b/protocol/x/bridge/keeper/grpc_query_test.go
@@ -274,11 +274,11 @@ func TestDelayedCompleteBridgeMessages(t *testing.T) {
 				)
 			}
 
-			// Get all in flight complete bridge messages and verify they are as expected.
+			// Get all delayed complete bridge messages and verify they are as expected.
 			msgs := k.GetDelayedCompleteBridgeMessages(ctx, "")
 			require.Equal(t, expectedMsgs, msgs)
 
-			// Get in flight complete bridge messages for each address and verify they are as expected.
+			// Get delayed complete bridge messages for each address and verify they are as expected.
 			for address, expectedMsgsForAddr := range expectedMsgsByAddress {
 				msgs := k.GetDelayedCompleteBridgeMessages(ctx, address)
 				require.Equal(t, expectedMsgsForAddr, msgs)


### PR DESCRIPTION
### Changelist
1. add more test cases and comments to bridge module, specifically
* delay bridge completion by 0 blocks
* more failure cases of bridge tx rejection due to mismatching bridge event content
* delay msg error is propagated `AcknowledgeBridges`
* completing a bridge whose coin amount is negative
2. do not panic in `AcknowledgeBridges` if it fails to delay a complete bridge message
3. do not measure latency if there's no bridge event to acknowledge or if bridging is disabled

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
