### PR TITLE
Add `misspell` to linter. Fix common typos.

### DIFF
--- a/protocol/.golangci.yml
+++ b/protocol/.golangci.yml
@@ -2,6 +2,7 @@ linters:
   disable-all: true
   enable:
     - errcheck
+    - errorlint
     - gofmt
     - gosimple
     - govet
@@ -14,7 +15,6 @@ linters:
     - typecheck
     - unused
     - whitespace
-    - errorlint
 linters-settings:
   revive:
     rules:

--- a/protocol/.golangci.yml
+++ b/protocol/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - importas
     - ineffassign
     - lll
+    - misspell
     - revive
     - staticcheck
     - typecheck

--- a/protocol/daemons/pricefeed/client/price_fetcher/price_fetcher.go
+++ b/protocol/daemons/pricefeed/client/price_fetcher/price_fetcher.go
@@ -154,7 +154,7 @@ func (p *PriceFetcher) getNumQueriesPerTaskLoop() int {
 
 // RunTaskLoop queries the exchange for market prices.
 // Each goroutine makes a single exchange query for a specific set of one or more markets.
-// RunTaskLoop blocks until all spwaned goroutines have completed.
+// RunTaskLoop blocks until all spawned goroutines have completed.
 func (pf *PriceFetcher) RunTaskLoop(requestHandler daemontypes.RequestHandler) {
 	taskLoopDefinition := pf.getTaskLoopDefinition()
 

--- a/protocol/lib/ante/disallow_msg_test.go
+++ b/protocol/lib/ante/disallow_msg_test.go
@@ -14,7 +14,7 @@ import (
 func TestIsDisallowExternalSubmitMsg(t *testing.T) {
 	// All disallow msgs should return true.
 	disallowSampleMsgs := testmsgs.GetNonNilSampleMsgs(appmsgs.DisallowMsgs)
-	// +1 for "/cosmos.auth.v1beta1.MsgUpdateParams" not having a corresponding Repsonse msg type.
+	// +1 for "/cosmos.auth.v1beta1.MsgUpdateParams" not having a corresponding Response msg type.
 	require.Len(t, disallowSampleMsgs, len(appmsgs.DisallowMsgs)/2+1)
 	for _, sampleMsg := range disallowSampleMsgs {
 		result := ante.IsDisallowExternalSubmitMsg(sampleMsg.Msg)

--- a/protocol/lib/ante/internal_msg_test.go
+++ b/protocol/lib/ante/internal_msg_test.go
@@ -48,7 +48,7 @@ func TestIsInternalMsg_Invalid(t *testing.T) {
 
 func TestIsInternalMsg_Valid(t *testing.T) {
 	sampleMsgs := testmsgs.GetNonNilSampleMsgs(appmsgs.InternalMsgSamplesAll)
-	// +1 for "/cosmos.auth.v1beta1.MsgUpdateParams" not having a corresponding Repsonse msg type.
+	// +1 for "/cosmos.auth.v1beta1.MsgUpdateParams" not having a corresponding Response msg type.
 	require.Len(t, sampleMsgs, len(appmsgs.InternalMsgSamplesAll)/2+1)
 	for _, sampleMsg := range sampleMsgs {
 		t.Run(sampleMsg.Name, func(t *testing.T) {

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -302,7 +302,7 @@ func (tApp TestAppBuilder) Build() TestApp {
 //
 // Note that TestApp.CheckTx is thread safe. All other methods are not thread safe.
 type TestApp struct {
-	// Should only be used to fetch read only state, all mutations should preferrably happen through Genesis state,
+	// Should only be used to fetch read only state, all mutations should preferably happen through Genesis state,
 	// TestApp.CheckTx, and block proposals.
 	// TODO(CLOB-545): Hide App and copy the pointers to keepers to be prevent incorrect usage of App.CheckTx over
 	// TestApp.CheckTx.

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair_test.go
@@ -229,7 +229,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 			},
 			expectedErr: types.ErrInvalidClobPairUpdate,
 		},
-		"Error: cannot update quantum converstion exponent": {
+		"Error: cannot update quantum conversion exponent": {
 			msg: &types.MsgUpdateClobPair{
 				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 				ClobPair: types.ClobPair{

--- a/protocol/x/clob/keeper/uncommitted_stateful_order_state.go
+++ b/protocol/x/clob/keeper/uncommitted_stateful_order_state.go
@@ -98,7 +98,7 @@ func (k Keeper) SetUncommittedStatefulOrderCount(
 	)
 }
 
-// MustAddUncommittedStatefulOrderPlacement adds a new order placemenet by `OrderId` to a transient store and
+// MustAddUncommittedStatefulOrderPlacement adds a new order placements by `OrderId` to a transient store and
 // increments the per subaccount uncommitted stateful order count.
 //
 // This method will panic if the order already exists.

--- a/protocol/x/clob/memclob/memclob_get_premium_price_test.go
+++ b/protocol/x/clob/memclob/memclob_get_premium_price_test.go
@@ -499,7 +499,7 @@ func TestGetPremiumPrice(t *testing.T) {
 			impactNotionalQuoteQuantums: new(big.Int).SetUint64(5_000_000_000), // $5000
 			expectedPremiumPpm:          -100_000,
 		},
-		`Index < Impact Bid < Impact Ask = Infinitey (low liquidity); positive premium`: {
+		`Index < Impact Bid < Impact Ask = Infinity (low liquidity); positive premium`: {
 			placedMatchableOrders: []types.MatchableOrder{
 				&types.Order{
 					OrderId: types.OrderId{

--- a/protocol/x/clob/types/quantums.go
+++ b/protocol/x/clob/types/quantums.go
@@ -58,7 +58,7 @@ func FillAmountToQuoteQuantums(
 
 // GetAveragePriceSubticks computes the average price (in subticks) of filled
 // amount in `quoteQuantums` and `baseQuantums`.
-// To calulate quote quantums from base quantums and subticks, we use the
+// To calculate quote quantums from base quantums and subticks, we use the
 // following equation:
 // `sizeQuoteQuantums = subticks * baseQuantums * 10^quantumConversionExponent`.
 //

--- a/protocol/x/feetiers/keeper/keeper.go
+++ b/protocol/x/feetiers/keeper/keeper.go
@@ -94,7 +94,7 @@ func (k Keeper) GetPerpetualFeePpm(ctx sdk.Context, address string, isTaker bool
 	return userTier.MakerFeePpm
 }
 
-// GetLowestMakerFee returns the lowest maker fee amoung any tiers.
+// GetLowestMakerFee returns the lowest maker fee among any tiers.
 func (k Keeper) GetLowestMakerFee(ctx sdk.Context) int32 {
 	feeParams := k.GetPerpetualFeeParams(ctx)
 

--- a/protocol/x/perpetuals/client/cli/query_perpetual_test.go
+++ b/protocol/x/perpetuals/client/cli/query_perpetual_test.go
@@ -137,16 +137,16 @@ func TestShowPerpetual(t *testing.T) {
 	}
 }
 
-// Check the recieved perpetual matches with expected.
+// Check the received perpetual matches with expected.
 // FundingIndex field is ignored since it can vary depending on funding-tick epoch.
 // TODO(DEC-606): Improve end-to-end testing related to ticking epochs.
 func checkExpectedPerp(t *testing.T, expected types.Perpetual, received types.Perpetual) {
 	if diff := cmp.Diff(expected, received, cmpopts.IgnoreFields(types.Perpetual{}, "FundingIndex")); diff != "" {
-		t.Errorf("resp.Perpetual mismatch (-want +recieved):\n%s", diff)
+		t.Errorf("resp.Perpetual mismatch (-want +received):\n%s", diff)
 	}
 }
 
-// Check the recieved perpetual object matches one of the expected perpetuals.
+// Check the received perpetual object matches one of the expected perpetuals.
 func expectedContainsReceived(t *testing.T, expectedPerps []types.Perpetual, received types.Perpetual) {
 	for _, expected := range expectedPerps {
 		if received.Params.Id == expected.Params.Id {
@@ -154,7 +154,7 @@ func expectedContainsReceived(t *testing.T, expectedPerps []types.Perpetual, rec
 			return
 		}
 	}
-	t.Errorf("Recieved perp (%v) not found in expected perps (%v)", received, expectedPerps)
+	t.Errorf("Received perp (%v) not found in expected perps (%v)", received, expectedPerps)
 }
 
 func TestListPerpetual(t *testing.T) {
@@ -221,7 +221,7 @@ func TestListPerpetual(t *testing.T) {
 			}),
 		}
 		if diff := cmp.Diff(objs, resp.Perpetual, cmpOptions...); diff != "" {
-			t.Errorf("resp.Perpetual mismatch (-want +recieved):\n%s", diff)
+			t.Errorf("resp.Perpetual mismatch (-want +received):\n%s", diff)
 		}
 	})
 }

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1421,7 +1421,7 @@ func (k Keeper) getLiquidityTiertoMaxAbsPremiumVotePpm(
 }
 
 // IsPositionUpdatable returns whether position of a perptual is updatable.
-// A perpetual is not updatable if it satifies:
+// A perpetual is not updatable if it satisfies:
 //   - Perpetual has zero oracle price. Since new oracle prices are created at zero by default and valid
 //     oracle priceupdates are non-zero, this indicates the absence of a valid oracle price update.
 func (k Keeper) IsPositionUpdatable(

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -32,7 +32,7 @@ type (
 
 		// Needed for getting `UsdcAsset.AtomicResolution` (converting quote quantums to a full USDC).
 		assetsKeeper types.AssetsKeeper
-		// Need for getting balance of module account balance and transfering tokens.
+		// Need for getting balance of module account balance and transferring tokens.
 		bankKeeper types.BankKeeper
 		// Needed for getting lowest maker fee.
 		feeTiersKeeper types.FeeTiersKeeper

--- a/protocol/x/stats/types/errors.go
+++ b/protocol/x/stats/types/errors.go
@@ -13,6 +13,6 @@ var (
 	ErrInvalidAuthority = errorsmod.Register(
 		ModuleName,
 		401,
-		"Autority is invalid",
+		"Authority is invalid",
 	)
 )

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -69,7 +69,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 			},
 			accAddressBalance:          big.NewInt(2_500_000),  // $2.5
 			subaccountModuleAccBalance: big.NewInt(10_000_000), // $10
-			quantums:                   big.NewInt(20_000_001), // $2.0000001, only $2 transfered.
+			quantums:                   big.NewInt(20_000_001), // $2.0000001, only $2 transferred.
 			assetPositions: keepertest.CreateUsdcAssetPosition(
 				big.NewInt(30_000_001),
 			), // $3.0001

--- a/protocol/x/subaccounts/simulation/genesis.go
+++ b/protocol/x/subaccounts/simulation/genesis.go
@@ -87,7 +87,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 // assigning the total supply of USDC to the balance of the `subaccounts` module.
 // This is necessary as the protocol assumes that that the sum of quantums in all USDC
 // AssetPositions is <= the total USDC balance of the subaccounts module, and `panic`s
-// will occur when transfering fees to the `fee-collector` module during order processing
+// will occur when transferring fees to the `fee-collector` module during order processing
 // if this is not true.
 // This method assumes that USDC as a `Coin` in the bank module does not yet exist.
 func updateBankModuleGenesisState(


### PR DESCRIPTION
### Changelist
- Add the `misspell` linter to `golangci-lint`.
- Use the linter to automatically fix typos

### Test Plan
N/A

