### PR TITLE
Update cosmos/proto-builder image to 14.0

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -80,7 +80,7 @@ jobs:
   protocol-gen:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cosmos/proto-builder:0.11.5
+      image: ghcr.io/cosmos/proto-builder:0.14.0
       options: --user root
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Changelist
Proto gen workflow is broken because the old proto-builder image doesn't have go 1.21. This updated image have it.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
