### PR TITLE
[CORE-568] - UpdateSmoothedPrices continues to update after error

### DIFF
--- a/protocol/app/process/expected_keepers.go
+++ b/protocol/app/process/expected_keepers.go
@@ -21,6 +21,7 @@ type ProcessPricesKeeper interface {
 
 	UpdateSmoothedPrices(
 		ctx sdk.Context,
+		linearInterpolateFunc func(v0 uint64, v1 uint64, ppm uint32) (uint64, error),
 	) error
 }
 

--- a/protocol/app/process/process_proposal.go
+++ b/protocol/app/process/process_proposal.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"cosmossdk.io/log"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	error_lib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
 	"time"
 
@@ -62,7 +63,7 @@ func ProcessProposalHandler(
 		// Perform the update of smoothed prices here to ensure that smoothed prices are updated even if a block is later
 		// rejected by consensus. We want smoothed prices to be updated on fixed cadence, and we are piggybacking on
 		// consensus round to do so.
-		if err := pricesKeeper.UpdateSmoothedPrices(ctx); err != nil {
+		if err := pricesKeeper.UpdateSmoothedPrices(ctx, lib.Uint64LinearInterpolate); err != nil {
 			recordErrorMetricsWithLabel(metrics.UpdateSmoothedPrices)
 			error_lib.LogErrorWithOptionalContext(logger, "UpdateSmoothedPrices failed", err)
 		}

--- a/protocol/mocks/PricesKeeper.go
+++ b/protocol/mocks/PricesKeeper.go
@@ -229,13 +229,13 @@ func (_m *PricesKeeper) UpdateMarketPrices(ctx types.Context, updates []*pricest
 	return r0
 }
 
-// UpdateSmoothedPrices provides a mock function with given fields: ctx
-func (_m *PricesKeeper) UpdateSmoothedPrices(ctx types.Context) error {
-	ret := _m.Called(ctx)
+// UpdateSmoothedPrices provides a mock function with given fields: ctx, linearInterpolateFunc
+func (_m *PricesKeeper) UpdateSmoothedPrices(ctx types.Context, linearInterpolateFunc func(uint64, uint64, uint32) (uint64, error)) error {
+	ret := _m.Called(ctx, linearInterpolateFunc)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(types.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(types.Context, func(uint64, uint64, uint32) (uint64, error)) error); ok {
+		r0 = rf(ctx, linearInterpolateFunc)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/protocol/x/prices/keeper/smoothed_price.go
+++ b/protocol/x/prices/keeper/smoothed_price.go
@@ -1,8 +1,9 @@
 package keeper
 
 import (
+	"errors"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
@@ -10,24 +11,43 @@ import (
 // The smoothing is calculated with Basic Exponential Smoothing, see
 // https://en.wikipedia.org/wiki/Exponential_smoothing
 // If there is no valid index price for a market at this time, the smoothed price does not change.
-func (k Keeper) UpdateSmoothedPrices(ctx sdk.Context) error {
+func (k Keeper) UpdateSmoothedPrices(
+	ctx sdk.Context,
+	linearInterpolateFunc func(v0 uint64, v1 uint64, ppm uint32) (uint64, error),
+) error {
 	allMarketParams := k.GetAllMarketParams(ctx)
 	indexPrices := k.indexPriceCache.GetValidMedianPrices(allMarketParams, k.timeProvider.Now())
 
-	for market, indexPrice := range indexPrices {
-		smoothed, ok := k.marketToSmoothedPrices.GetSmoothedPrice(market)
+	// Track errors for each market.
+	updateErrors := make([]error, 0)
+
+	// Iterate through allMarketParams instead of indexPrices to ensure that we generate deterministic error messages
+	// in the case of failed updates.
+	for _, marketParam := range allMarketParams {
+		indexPrice, exists := indexPrices[marketParam.Id]
+		if !exists {
+			continue
+		}
+
+		smoothed, ok := k.marketToSmoothedPrices.GetSmoothedPrice(marketParam.Id)
 		if !ok {
 			smoothed = indexPrice
 		}
-		update, err := lib.Uint64LinearInterpolate(
+		update, err := linearInterpolateFunc(
 			smoothed,
 			indexPrice,
 			types.PriceSmoothingPpm,
 		)
 		if err != nil {
-			return err
+			updateErrors = append(
+				updateErrors,
+				fmt.Errorf("Error updating smoothed price for market %v: %w", marketParam.Id, err),
+			)
+			continue
 		}
-		k.marketToSmoothedPrices.PushSmoothedPrice(market, update)
+
+		k.marketToSmoothedPrices.PushSmoothedPrice(marketParam.Id, update)
 	}
-	return nil
+
+	return errors.Join(updateErrors...)
 }

--- a/protocol/x/prices/keeper/smoothed_price_test.go
+++ b/protocol/x/prices/keeper/smoothed_price_test.go
@@ -1,7 +1,9 @@
 package keeper_test
 
 import (
+	"fmt"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/stretchr/testify/require"
@@ -12,18 +14,37 @@ var (
 	emptySmoothedPrices = map[uint32]uint64{}
 )
 
+func errInterpolator(v0 uint64, v1 uint64, ppm uint32) (uint64, error) {
+	return 0, fmt.Errorf("error while interpolating")
+}
+
+func alternatingErrInterpolator() func(v0 uint64, v1 uint64, ppm uint32) (uint64, error) {
+	var i int
+	return func(v0 uint64, v1 uint64, ppm uint32) (uint64, error) {
+		i++
+		if i%2 == 0 {
+			return 0, fmt.Errorf("error while interpolating")
+		}
+		return lib.Uint64LinearInterpolate(v0, v1, ppm)
+	}
+}
+
 func TestUpdateSmoothedPrices(t *testing.T) {
 	tests := map[string]struct {
-		smoothedPrices map[uint32]uint64
-		indexPrices    []*api.MarketPriceUpdate
-		expectedResult map[uint32]uint64
+		smoothedPrices        map[uint32]uint64
+		indexPrices           []*api.MarketPriceUpdate
+		expectedResult        map[uint32]uint64
+		linearInterpolateFunc func(v0 uint64, v1 uint64, ppm uint32) (uint64, error)
+		expectedErr           string
 	}{
 		"Empty result - No index prices, no smoothed prices": {
-			expectedResult: emptySmoothedPrices,
+			expectedResult:        emptySmoothedPrices,
+			linearInterpolateFunc: lib.Uint64LinearInterpolate,
 		},
 		"Unchanged - No index prices": {
-			smoothedPrices: constants.AtTimeTSingleExchangeSmoothedPrices,
-			expectedResult: constants.AtTimeTSingleExchangeSmoothedPrices,
+			smoothedPrices:        constants.AtTimeTSingleExchangeSmoothedPrices,
+			expectedResult:        constants.AtTimeTSingleExchangeSmoothedPrices,
+			linearInterpolateFunc: lib.Uint64LinearInterpolate,
 		},
 		"Mixed updates and additions - mix of present and missing index prices, smoothed prices": {
 			indexPrices: constants.AtTimeTSingleExchangePriceUpdate,
@@ -38,15 +59,38 @@ func TestUpdateSmoothedPrices(t *testing.T) {
 				constants.MarketId2: constants.Exchange2_Price2_TimeT.Price + 35,
 				constants.MarketId7: constants.Price1,
 			},
+			linearInterpolateFunc: lib.Uint64LinearInterpolate,
 		},
 		"Initializes smoothed prices with index prices": {
-			indexPrices:    constants.AtTimeTSingleExchangePriceUpdate,
-			expectedResult: constants.AtTimeTSingleExchangeSmoothedPrices,
+			indexPrices:           constants.AtTimeTSingleExchangePriceUpdate,
+			expectedResult:        constants.AtTimeTSingleExchangeSmoothedPrices,
+			linearInterpolateFunc: lib.Uint64LinearInterpolate,
 		},
 		"All updated - multiple existing overlapped index and smoothed prices": {
-			indexPrices:    constants.AtTimeTSingleExchangePriceUpdate,
-			smoothedPrices: constants.AtTimeTSingleExchangeSmoothedPricesPlus10,
-			expectedResult: constants.AtTimeTSingleExchangeSmoothedPricesPlus7,
+			indexPrices:           constants.AtTimeTSingleExchangePriceUpdate,
+			smoothedPrices:        constants.AtTimeTSingleExchangeSmoothedPricesPlus10,
+			expectedResult:        constants.AtTimeTSingleExchangeSmoothedPricesPlus7,
+			linearInterpolateFunc: lib.Uint64LinearInterpolate,
+		},
+		"Interpolation errors - returns error": {
+			indexPrices:           constants.AtTimeTSingleExchangePriceUpdate,
+			smoothedPrices:        constants.AtTimeTSingleExchangeSmoothedPricesPlus10,
+			linearInterpolateFunc: errInterpolator,
+			expectedErr: "Error updating smoothed price for market 0: error while interpolating\n" +
+				"Error updating smoothed price for market 1: error while interpolating\n" +
+				"Error updating smoothed price for market 2: error while interpolating",
+			expectedResult: constants.AtTimeTSingleExchangeSmoothedPricesPlus10, // no change
+		},
+		"Single interpolation error - returns error, continues updating other markets": {
+			indexPrices:           constants.AtTimeTSingleExchangePriceUpdate,
+			smoothedPrices:        constants.AtTimeTSingleExchangeSmoothedPricesPlus10,
+			linearInterpolateFunc: alternatingErrInterpolator(),
+			expectedErr:           "Error updating smoothed price for market 1: error while interpolating",
+			expectedResult: map[uint32]uint64{
+				constants.MarketId0: constants.AtTimeTSingleExchangeSmoothedPricesPlus7[constants.MarketId0],  // update
+				constants.MarketId1: constants.AtTimeTSingleExchangeSmoothedPricesPlus10[constants.MarketId1], // no change
+				constants.MarketId2: constants.AtTimeTSingleExchangeSmoothedPricesPlus7[constants.MarketId2],  // update
+			}, // no change
 		},
 	}
 	for name, tc := range tests {
@@ -62,8 +106,12 @@ func TestUpdateSmoothedPrices(t *testing.T) {
 			}
 
 			// Run.
-			err := k.UpdateSmoothedPrices(ctx)
-			require.NoError(t, err)
+			err := k.UpdateSmoothedPrices(ctx, tc.linearInterpolateFunc)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
 
 			// Validate.
 			require.Equal(t, tc.expectedResult, marketToSmoothedPrices.GetSmoothedPricesForTest())

--- a/protocol/x/prices/types/types.go
+++ b/protocol/x/prices/types/types.go
@@ -41,6 +41,7 @@ type PricesKeeper interface {
 	// Proposal related.
 	UpdateSmoothedPrices(
 		ctx sdk.Context,
+		linearInterpolateFunc func(v0 uint64, v1 uint64, ppm uint32) (uint64, error),
 	) error
 
 	// Misc.


### PR DESCRIPTION
### Changelist
Update our price smoothing logic to not terminate early in case of error, but retain errors and continue attempting updates until all markets have been visited.

Adding testing for this behavioral change required a modification to the keeper's interface to pass in the interpolator.

I also changed the iteration pattern to be deterministic for the sake of generating consistent error messages and also ensuring that unit tests are testing the intended conditions.

### Test Plan
Additional unit tests to confirm errors.Join behavior and continuing to execute updates after errors.

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
