### PR TITLE
[CORE-650] clob governance message handlers: do not panic or emit metric on deliverTx

### DIFF
--- a/protocol/x/clob/keeper/clob_pair.go
+++ b/protocol/x/clob/keeper/clob_pair.go
@@ -416,11 +416,32 @@ func (k Keeper) UpdateClobPair(
 	ctx sdk.Context,
 	clobPair types.ClobPair,
 ) error {
-	oldClobPair := k.mustGetClobPair(ctx, types.ClobPairId(clobPair.Id))
+	oldClobPair, found := k.GetClobPair(ctx, types.ClobPairId(clobPair.Id))
+	if !found {
+		return errorsmod.Wrapf(
+			types.ErrInvalidClobPairUpdate,
+			"UpdateClobPair: ClobPair with id %d not found in state",
+			clobPair.Id,
+		)
+	}
 
 	// Note, only perpetual clob pairs are currently supported. Neither the old nor the
 	// new clob pair should be spot.
-	if clobPair.MustGetPerpetualId() != oldClobPair.MustGetPerpetualId() {
+	perpetualId, err := clobPair.GetPerpetualId()
+	if err != nil {
+		return errorsmod.Wrap(
+			types.ErrInvalidClobPairUpdate,
+			err.Error(),
+		)
+	}
+	oldPerpetualId, err := oldClobPair.GetPerpetualId()
+	if err != nil {
+		return errorsmod.Wrap(
+			types.ErrInvalidClobPairUpdate,
+			err.Error(),
+		)
+	}
+	if perpetualId != oldPerpetualId {
 		return errorsmod.Wrap(
 			types.ErrInvalidClobPairUpdate,
 			"UpdateClobPair: cannot update ClobPair perpetual id",

--- a/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config.go
@@ -6,8 +6,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
-	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -18,13 +16,6 @@ func (k msgServer) UpdateBlockRateLimitConfiguration(
 	msg *types.MsgUpdateBlockRateLimitConfiguration,
 ) (resp *types.MsgUpdateBlockRateLimitConfigurationResponse, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	defer func() {
-		metrics.IncrSuccessOrErrorCounter(err, types.ModuleName, metrics.UpdateBlockRateLimitConfiguration, metrics.DeliverTx)
-		if err != nil {
-			errorlib.LogDeliverTxError(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), "UpdateBlockRateLimitConfiguration", msg)
-		}
-	}()
 
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair.go
@@ -7,8 +7,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
-	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -17,13 +15,6 @@ func (k msgServer) UpdateClobPair(
 	msg *types.MsgUpdateClobPair,
 ) (resp *types.MsgUpdateClobPairResponse, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	defer func() {
-		metrics.IncrSuccessOrErrorCounter(err, types.ModuleName, metrics.UpdateClobPair, metrics.DeliverTx)
-		if err != nil {
-			errorlib.LogDeliverTxError(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), "UpdateClobPair", msg)
-		}
-	}()
 
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(

--- a/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config.go
@@ -6,8 +6,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
-	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -18,18 +16,6 @@ func (k msgServer) UpdateEquityTierLimitConfiguration(
 	msg *types.MsgUpdateEquityTierLimitConfiguration,
 ) (resp *types.MsgUpdateEquityTierLimitConfigurationResponse, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	defer func() {
-		metrics.IncrSuccessOrErrorCounter(
-			err,
-			types.ModuleName,
-			metrics.UpdateEquityTierLimitConfiguration,
-			metrics.DeliverTx,
-		)
-		if err != nil {
-			errorlib.LogDeliverTxError(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), "UpdateEquityTierLimitConfiguration", msg)
-		}
-	}()
 
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(

--- a/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
+++ b/protocol/x/clob/keeper/msg_server_update_liquidations_config.go
@@ -7,8 +7,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	errorlib "github.com/dydxprotocol/v4-chain/protocol/lib/error"
-	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
@@ -18,13 +16,6 @@ func (k msgServer) UpdateLiquidationsConfig(
 	msg *types.MsgUpdateLiquidationsConfig,
 ) (resp *types.MsgUpdateLiquidationsConfigResponse, err error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	defer func() {
-		metrics.IncrSuccessOrErrorCounter(err, types.ModuleName, metrics.UpdateLiquidationsConfig, metrics.DeliverTx)
-		if err != nil {
-			errorlib.LogDeliverTxError(k.Keeper.Logger(ctx), err, ctx.BlockHeight(), "UpdateLiquidationsConfig", msg)
-		}
-	}()
 
 	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(


### PR DESCRIPTION
### Changelist
cosmos sdk currently doesn't recover from a governance message execution failure (until v4-chain upgrades to cosmos 0.50 I believe).

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
