### PR TITLE
[CORE-658] - Migrate set type to map with empty struct value

### DIFF
--- a/protocol/x/prices/keeper/validate_market_price_updates.go
+++ b/protocol/x/prices/keeper/validate_market_price_updates.go
@@ -285,9 +285,9 @@ func (k Keeper) GetMarketsMissingFromPriceUpdates(
 	marketPriceUpdates []*types.MsgUpdateMarketPrices_MarketPrice,
 ) []uint32 {
 	// Gather all markets that are part of the proposed updates.
-	proposedUpdatesMap := make(map[uint32]bool, len(marketPriceUpdates))
+	proposedUpdatesMap := make(map[uint32]struct{}, len(marketPriceUpdates))
 	for _, proposedUpdate := range marketPriceUpdates {
-		proposedUpdatesMap[proposedUpdate.MarketId] = true
+		proposedUpdatesMap[proposedUpdate.MarketId] = struct{}{}
 	}
 
 	// Gather all markets that we think should be updated.


### PR DESCRIPTION
Map with bool values is less efficient as a set implementation in go than map of empty structs. See [this article](https://itnext.io/set-in-go-map-bool-and-map-struct-performance-comparison-5315b4b107b).

This one is a pretty big nit because the set is small and this change is unlikely to have a large performance impact, but it makes our codebase more canonical.

### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
