### PR TITLE
[DEC-2081] Add tests for app/process/proposed_operations.go

### DIFF
--- a/protocol/app/process/market_prices_test.go
+++ b/protocol/app/process/market_prices_test.go
@@ -168,7 +168,6 @@ func TestUpdateMarketPricesTx_GetMsg(t *testing.T) {
 				msg = umpt.GetMsg()
 			} else {
 				msg = tc.txWrapper.GetMsg()
-				require.Equal(t, tc.expectedMsg, msg)
 			}
 			require.Equal(t, tc.expectedMsg, msg)
 		})

--- a/protocol/testutil/constants/operations.go
+++ b/protocol/testutil/constants/operations.go
@@ -8,35 +8,27 @@ func init() {
 	_ = TestTxBuilder.SetMsgs(ValidEmptyMsgProposedOperations)
 	ValidEmptyMsgProposedOperationsTxBytes, _ = TestEncodingCfg.TxConfig.TxEncoder()(TestTxBuilder.GetTx())
 
-	_ = TestTxBuilder.SetMsgs(InvalidProposedOperations)
-	InvalidProposedOperationsTxBytes, _ = TestEncodingCfg.TxConfig.TxEncoder()(TestTxBuilder.GetTx())
+	_ = TestTxBuilder.SetMsgs(InvalidProposedOperationsUnspecifiedOrderRemovalReason)
+	InvalidProposedOperationsUnspecifiedOrderRemovalReasonTxBytes, _ = TestEncodingCfg.TxConfig.TxEncoder()(
+		TestTxBuilder.GetTx())
 }
 
 var (
 	ValidEmptyMsgProposedOperations        = &types.MsgProposedOperations{}
 	ValidEmptyMsgProposedOperationsTxBytes []byte
-	// InvalidProposedOperations is invalid because the maker order for the match operation
-	// does not have a corresponding order placement operation before it in the operations queue.
-	InvalidProposedOperations = &types.MsgProposedOperations{
+	// InvalidProposedOperationsUnspecifiedOrderRemovalReason is invalid because the order removal reason is
+	// unspecified.
+	InvalidProposedOperationsUnspecifiedOrderRemovalReason = &types.MsgProposedOperations{
 		OperationsQueue: []types.OperationRaw{
 			{
-				Operation: &types.OperationRaw_Match{
-					Match: &types.ClobMatch{
-						Match: &types.ClobMatch_MatchOrders{
-							MatchOrders: &types.MatchOrders{
-								TakerOrderId: Order_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTB10.OrderId,
-								Fills: []types.MakerFill{
-									{
-										MakerOrderId: OrderId_Alice_Num0_ClientId0_Clob0,
-										FillAmount:   100_000_000,
-									},
-								},
-							},
-						},
+				Operation: &types.OperationRaw_OrderRemoval{
+					OrderRemoval: &types.OrderRemoval{
+						OrderId:       LongTermOrder_Alice_Num0_Id0_Clob0_Buy100_Price10_GTBT15.OrderId,
+						RemovalReason: types.OrderRemoval_REMOVAL_REASON_UNSPECIFIED,
 					},
 				},
 			},
 		},
 	}
-	InvalidProposedOperationsTxBytes []byte
+	InvalidProposedOperationsUnspecifiedOrderRemovalReasonTxBytes []byte
 )


### PR DESCRIPTION
### Changelist
Add tests for `app/process/proposed_operations.go`
Minor fixes to other tests which were calling `Validate` twice needlessly.

### Test Plan
New tests, no changes to existing code.

### Author/Reviewer Checklist
- [ ] If this change affects functionality (features, bug fixes, breaking changes, etc.), update `protocol/CHANGELOG.md` and/or `indexer/CHANGELOG.md` appropriately.
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
