### PR TITLE
[refactor] Remove duplicate CLOB `PrepareCheckState` latency metric

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -98,7 +98,6 @@ const (
 	CancelShortTermOrder                         = "cancel_short_term_order"
 	CancelStatefulOrder                          = "cancel_stateful_order"
 	ClobPairId                                   = "clob_pair_id"
-	ClobPrepareCheckState                        = "prepare_check_state"
 	ClobLiquidateSubaccountsAgainstOrderbook     = "liquidate_subaccounts_against_orderbook"
 	LiquidateSubaccounts_GetLiquidations         = "liquidate_subaccounts_against_orderbook_get_liquidations"
 	LiquidateSubaccounts_PlaceLiquidations       = "liquidate_subaccounts_against_orderbook_place_liquidations"

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -121,13 +121,6 @@ func PrepareCheckState(
 	keeper *keeper.Keeper,
 	liquidatableSubaccountIds *liquidationtypes.LiquidatableSubaccountIds,
 ) {
-	defer telemetry.MeasureSince(
-		time.Now(),
-		types.ModuleName,
-		metrics.ClobPrepareCheckState,
-		metrics.Latency,
-	)
-
 	// Get the events generated from processing the matches in the latest block.
 	processProposerMatchesEvents := keeper.GetProcessProposerMatchesEvents(ctx)
 	if ctx.BlockHeight() != int64(processProposerMatchesEvents.BlockHeight) {


### PR DESCRIPTION
### Changelist
Remove duplicate CLOB `PrepareCheckState` latency metric. Currently using the `commit` metric instead in datadog [here](https://app.datadoghq.com/dashboard/fbc-gkh-ywa/xclob?refresh_mode=paused&from_ts=1696875609087&to_ts=1697480409087&live=false&tile_focus=8842746538142110), which is measured in the codebase [here](https://github.com/dydxprotocol/v4-chain/blob/9338c8cfc940ff71260d34c023413d6e39110ede/protocol/x/clob/module.go#L193).

### Test Plan
N/A.

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
