### PR TITLE
fix edge case where position is closed before deleveraging

### DIFF
--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -138,8 +138,13 @@ func (k Keeper) LiquidateSubaccountsAgainstOrderbook(
 	for i := 0; i < int(k.Flags.MaxDeleveragingAttemptsPerBlock) && i < len(unfilledLiquidations); i++ {
 		liquidationOrder := unfilledLiquidations[i]
 
-		subaccountId := liquidationOrder.GetSubaccountId()
 		perpetualId := liquidationOrder.MustGetLiquidatedPerpetualId()
+		subaccountId := liquidationOrder.GetSubaccountId()
+
+		subaccount := k.subaccountsKeeper.GetSubaccount(ctx, subaccountId)
+		if _, exists := subaccount.GetPerpetualPositionForId(perpetualId); !exists {
+			continue
+		}
 
 		_, err := k.MaybeDeleverageSubaccount(ctx, subaccountId, perpetualId)
 		if err != nil {

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -138,13 +138,8 @@ func (k Keeper) LiquidateSubaccountsAgainstOrderbook(
 	for i := 0; i < int(k.Flags.MaxDeleveragingAttemptsPerBlock) && i < len(unfilledLiquidations); i++ {
 		liquidationOrder := unfilledLiquidations[i]
 
-		perpetualId := liquidationOrder.MustGetLiquidatedPerpetualId()
 		subaccountId := liquidationOrder.GetSubaccountId()
-
-		subaccount := k.subaccountsKeeper.GetSubaccount(ctx, subaccountId)
-		if _, exists := subaccount.GetPerpetualPositionForId(perpetualId); !exists {
-			continue
-		}
+		perpetualId := liquidationOrder.MustGetLiquidatedPerpetualId()
 
 		_, err := k.MaybeDeleverageSubaccount(ctx, subaccountId, perpetualId)
 		if err != nil {


### PR DESCRIPTION
### Changelist
- technically it's possible that the position is closed before deleveraging is attempted. so this PR is meant to address that extreme edge case.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
