### PR TITLE
Conditionally info log in PlaceOrder DeliverTx if collat check fails

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -103,6 +103,7 @@ const (
 	LiquidateSubaccounts_PlaceLiquidations       = "liquidate_subaccounts_against_orderbook_place_liquidations"
 	LiquidateSubaccounts_Deleverage              = "liquidate_subaccounts_against_orderbook_deleverage"
 	CollateralizationCheck                       = "place_order_collateralization_check"
+	CollateralizationCheckFailed                 = "collateralization_check_failed"
 	CollateralizationCheckSubaccounts            = "collateralization_check_subaccounts"
 	Conditional                                  = "conditional"
 	ConditionalOrderTriggered                    = "conditional_order_triggered"

--- a/protocol/x/clob/keeper/msg_server_cancel_orders.go
+++ b/protocol/x/clob/keeper/msg_server_cancel_orders.go
@@ -58,6 +58,10 @@ func (k msgServer) CancelOrder(
 					)
 					k.Keeper.Logger(ctx).Info(
 						err.Error(),
+						metrics.BlockHeight, ctx.BlockHeight(),
+						metrics.Handler, "CancelOrder",
+						metrics.Callback, metrics.DeliverTx,
+						metrics.Msg, msg,
 					)
 					return
 				}

--- a/protocol/x/clob/keeper/msg_server_cancel_orders_test.go
+++ b/protocol/x/clob/keeper/msg_server_cancel_orders_test.go
@@ -79,6 +79,8 @@ func TestCancelOrder_InfoLogIfOrderNotFound(t *testing.T) {
 				orderToCancel.OrderId,
 			).Error(),
 		).Error(),
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return()
 	ctx = ctx.WithLogger(mockLogger)
 	ctx = ctx.WithBlockTime(time.Unix(int64(2), 0))
@@ -114,11 +116,9 @@ func TestCancelOrder_ErrorLogIfGTBTTooLow(t *testing.T) {
 	mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
 	mockLogger.On(
 		"Error",
-		[]interface{}{
-			types.ErrTimeExceedsGoodTilBlockTime.Error(),
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		}...,
+		types.ErrTimeExceedsGoodTilBlockTime.Error(),
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return()
 	ctx = ctx.WithLogger(mockLogger)
 	ctx = ctx.WithBlockTime(time.Unix(int64(2), 0))

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -6,6 +6,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
@@ -34,6 +35,15 @@ func (k msgServer) PlaceOrder(goCtx context.Context, msg *types.MsgPlaceOrder) (
 		)
 		if err != nil {
 			if errors.Is(err, types.ErrStatefulOrderCollateralizationCheckFailed) {
+				telemetry.IncrCounterWithLabels(
+					[]string{
+						types.ModuleName,
+						metrics.PlaceOrder,
+						metrics.CollateralizationCheckFailed,
+					},
+					1,
+					msg.Order.GetOrderLabels(),
+				)
 				k.Keeper.Logger(ctx).Info(
 					err.Error(),
 					metrics.BlockHeight, ctx.BlockHeight(),

--- a/protocol/x/clob/keeper/msg_server_place_order_test.go
+++ b/protocol/x/clob/keeper/msg_server_place_order_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -88,7 +89,7 @@ func TestPlaceOrder_Error(t *testing.T) {
 
 			mockLogger := &mocks.Logger{}
 			mockLogger.On("With", mock.Anything, mock.Anything).Return(mockLogger)
-			if tc.ExpectedError == types.ErrStatefulOrderCollateralizationCheckFailed {
+			if errors.Is(tc.ExpectedError, types.ErrStatefulOrderCollateralizationCheckFailed) {
 				mockLogger.On("Info",
 					errorsmod.Wrapf(
 						types.ErrStatefulOrderCollateralizationCheckFailed,


### PR DESCRIPTION
This PR updates MsgPlaceOrder DeliverTx `defer` logic to log errors due to failed collateralization checks as `info` instead of `error`. Errors should be actionable, and it is a legitimate possibility that this error occurs due to collateralization of an account changing between CheckTx and DeliverTx due to matches in the operations queue processed before the placement in DeliverTx. 

Slack thread: https://dydx-team.slack.com/archives/C03SLFHC3L7/p1697479226938579?thread_ts=1697463950.962099&cid=C03SLFHC3L7