### PR TITLE
[CORE-673] - Remove extraneous authtypes.NewModuleAddress, consolidate constants

### DIFF
--- a/protocol/app/ante_whitebox_test.go
+++ b/protocol/app/ante_whitebox_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"reflect"
 	"testing"
 
@@ -14,7 +15,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	feegrantkeeper "github.com/cosmos/cosmos-sdk/x/feegrant/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	libante "github.com/dydxprotocol/v4-chain/protocol/lib/ante"
 	clobante "github.com/dydxprotocol/v4-chain/protocol/x/clob/ante"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/flags"
@@ -35,7 +35,7 @@ func newTestHandlerOptions() HandlerOptions {
 		authtypes.ProtoBaseAccount,
 		nil,
 		sdk.Bech32MainPrefix,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 
 	bankKeeper := bankkeeper.NewBaseKeeper(
@@ -43,7 +43,7 @@ func newTestHandlerOptions() HandlerOptions {
 		nil,
 		accountKeeper,
 		BlockedAddresses(),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 
 	feeGrantKeeper := feegrantkeeper.NewKeeper(appCodec, nil, accountKeeper)
@@ -55,8 +55,8 @@ func newTestHandlerOptions() HandlerOptions {
 		nil,
 		nil,
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 		memClob,
 		nil,

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -676,8 +676,8 @@ func New(
 		app.IndexerEventManager,
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			delaymsgmoduletypes.ModuleAddress.String(),
 			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	pricesModule := pricesmodule.NewAppModule(appCodec, app.PricesKeeper, app.AccountKeeper, app.BankKeeper)
@@ -695,8 +695,8 @@ func New(
 		keys[blocktimemoduletypes.StoreKey],
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			delaymsgmoduletypes.ModuleAddress.String(),
 			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	blockTimeModule := blocktimemodule.NewAppModule(appCodec, app.BlockTimeKeeper)
@@ -747,8 +747,8 @@ func New(
 		tkeys[statsmoduletypes.TransientStoreKey],
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			delaymsgmoduletypes.ModuleAddress.String(),
 			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	statsModule := statsmodule.NewAppModule(appCodec, app.StatsKeeper)
@@ -759,8 +759,8 @@ func New(
 		keys[feetiersmoduletypes.StoreKey],
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			delaymsgmoduletypes.ModuleAddress.String(),
 			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	feeTiersModule := feetiersmodule.NewAppModule(appCodec, app.FeeTiersKeeper)
@@ -772,8 +772,8 @@ func New(
 		app.BlockTimeKeeper,
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			delaymsgmoduletypes.ModuleAddress.String(),
 			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	vestModule := vestmodule.NewAppModule(appCodec, app.VestKeeper)
@@ -788,8 +788,8 @@ func New(
 		app.PricesKeeper,
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			delaymsgmoduletypes.ModuleAddress.String(),
 			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	rewardsModule := rewardsmodule.NewAppModule(appCodec, app.RewardsKeeper)
@@ -819,8 +819,8 @@ func New(
 		tkeys[clobmoduletypes.TransientStoreKey],
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			delaymsgmoduletypes.ModuleAddress.String(),
 			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 		memClob,
 		app.SubaccountsKeeper,

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -376,7 +376,7 @@ func New(
 
 	// set the BaseApp's parameter store
 	app.ConsensusParamsKeeper = consensusparamkeeper.NewKeeper(
-		appCodec, keys[upgradetypes.StoreKey], authtypes.NewModuleAddress(govtypes.ModuleName).String())
+		appCodec, keys[upgradetypes.StoreKey], lib.GovModuleAddress.String())
 	bApp.SetParamStore(&app.ConsensusParamsKeeper)
 
 	// add capability keeper and ScopeToModule for ibc module
@@ -397,21 +397,21 @@ func New(
 		authtypes.ProtoBaseAccount,
 		maccPerms,
 		sdk.Bech32MainPrefix,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec,
 		keys[banktypes.StoreKey],
 		app.AccountKeeper,
 		BlockedAddresses(),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 	app.StakingKeeper = stakingkeeper.NewKeeper(
 		appCodec,
 		keys[stakingtypes.StoreKey],
 		app.AccountKeeper,
 		app.BankKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 
 	app.DistrKeeper = distrkeeper.NewKeeper(
@@ -421,7 +421,7 @@ func New(
 		app.BankKeeper,
 		app.StakingKeeper,
 		authtypes.FeeCollectorName,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 
 	app.SlashingKeeper = slashingkeeper.NewKeeper(
@@ -429,12 +429,12 @@ func New(
 		legacyAmino,
 		keys[slashingtypes.StoreKey],
 		app.StakingKeeper,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 
 	invCheckPeriod := cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod))
 	app.CrisisKeeper = crisiskeeper.NewKeeper(appCodec, keys[crisistypes.StoreKey], invCheckPeriod,
-		app.BankKeeper, authtypes.FeeCollectorName, authtypes.NewModuleAddress(govtypes.ModuleName).String())
+		app.BankKeeper, authtypes.FeeCollectorName, lib.GovModuleAddress.String())
 
 	app.FeeGrantKeeper = feegrantkeeper.NewKeeper(appCodec, keys[feegrant.StoreKey], app.AccountKeeper)
 
@@ -457,7 +457,7 @@ func New(
 		appCodec,
 		homePath,
 		app.BaseApp,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 
 	// ... other modules keepers
@@ -477,7 +477,7 @@ func New(
 	*/
 	govKeeper := govkeeper.NewKeeper(
 		appCodec, keys[govtypes.StoreKey], app.AccountKeeper, app.BankKeeper,
-		app.StakingKeeper, app.MsgServiceRouter(), govConfig, authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		app.StakingKeeper, app.MsgServiceRouter(), govConfig, lib.GovModuleAddress.String(),
 	)
 
 	app.GovKeeper = govKeeper.SetHooks(
@@ -676,8 +676,8 @@ func New(
 		app.IndexerEventManager,
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 	pricesModule := pricesmodule.NewAppModule(appCodec, app.PricesKeeper, app.AccountKeeper, app.BankKeeper)
@@ -695,8 +695,8 @@ func New(
 		keys[blocktimemoduletypes.StoreKey],
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 	blockTimeModule := blocktimemodule.NewAppModule(appCodec, app.BlockTimeKeeper)
@@ -707,7 +707,7 @@ func New(
 		bApp.MsgServiceRouter(),
 		// Permit delayed messages to be signed by the following modules.
 		[]string{
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 	delayMsgModule := delaymsgmodule.NewAppModule(appCodec, app.DelayMsgKeeper)
@@ -720,8 +720,8 @@ func New(
 		app.DelayMsgKeeper,
 		// gov module and delayMsg module accounts are allowed to send messages to the bridge module.
 		[]string{
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
+			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	bridgeModule := bridgemodule.NewAppModule(appCodec, app.BridgeKeeper)
@@ -734,8 +734,8 @@ func New(
 		app.IndexerEventManager,
 		// gov module and delayMsg module accounts are allowed to send messages to the bridge module.
 		[]string{
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
+			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	perpetualsModule := perpetualsmodule.NewAppModule(appCodec, app.PerpetualsKeeper, app.AccountKeeper, app.BankKeeper)
@@ -747,8 +747,8 @@ func New(
 		tkeys[statsmoduletypes.TransientStoreKey],
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 	statsModule := statsmodule.NewAppModule(appCodec, app.StatsKeeper)
@@ -759,8 +759,8 @@ func New(
 		keys[feetiersmoduletypes.StoreKey],
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 	feeTiersModule := feetiersmodule.NewAppModule(appCodec, app.FeeTiersKeeper)
@@ -772,8 +772,8 @@ func New(
 		app.BlockTimeKeeper,
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 	vestModule := vestmodule.NewAppModule(appCodec, app.VestKeeper)
@@ -788,8 +788,8 @@ func New(
 		app.PricesKeeper,
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 	rewardsModule := rewardsmodule.NewAppModule(appCodec, app.RewardsKeeper)
@@ -819,8 +819,8 @@ func New(
 		tkeys[clobmoduletypes.TransientStoreKey],
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 		memClob,
 		app.SubaccountsKeeper,
@@ -856,8 +856,8 @@ func New(
 		app.IndexerEventManager,
 		// gov module and delayMsg module accounts are allowed to send messages to the sending module.
 		[]string{
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
+			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 	sendingModule := sendingmodule.NewAppModule(

--- a/protocol/lib/module_addresses.go
+++ b/protocol/lib/module_addresses.go
@@ -1,0 +1,11 @@
+package lib
+
+import (
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+)
+
+var (
+	// GovModuleAddress is the module address for the gov module.
+	GovModuleAddress = authtypes.NewModuleAddress(govtypes.ModuleName)
+)

--- a/protocol/lib/module_addresses_test.go
+++ b/protocol/lib/module_addresses_test.go
@@ -1,0 +1,11 @@
+package lib_test
+
+import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGovModuleAddress(t *testing.T) {
+	require.Equal(t, "dydx10d07y265gmmuvt4z0w9aw880jnsr700jnmapky", lib.GovModuleAddress.String())
+}

--- a/protocol/testing/e2e/gov/add_new_market_test.go
+++ b/protocol/testing/e2e/gov/add_new_market_test.go
@@ -1,12 +1,12 @@
 package gov_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	"github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
@@ -35,7 +35,7 @@ func TestAddNewMarketProposal(t *testing.T) {
 		perptest.WithMarketId(testId),
 	)
 	msgUpdateClobPairToActive := &clobtypes.MsgUpdateClobPair{
-		Authority: authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
+		Authority: lib.GovModuleAddress.String(),
 		ClobPair: *clobtest.GenerateClobPair(
 			clobtest.WithId(testId),
 			clobtest.WithPerpetualId(testId),
@@ -43,7 +43,7 @@ func TestAddNewMarketProposal(t *testing.T) {
 		),
 	}
 	msgUpdateClobPairToActive_WrongClobPairId := &clobtypes.MsgUpdateClobPair{
-		Authority: authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
+		Authority: delaymsgtypes.ModuleAddress.String(),
 		ClobPair: *clobtest.GenerateClobPair(
 			clobtest.WithId(9999), // non existing clob pair
 			clobtest.WithPerpetualId(testId),
@@ -51,7 +51,7 @@ func TestAddNewMarketProposal(t *testing.T) {
 		),
 	}
 	msgUpdateClobPairToActive_WrongAuthority := &clobtypes.MsgUpdateClobPair{
-		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		Authority: lib.GovModuleAddress.String(),
 		ClobPair: *clobtest.GenerateClobPair(
 			clobtest.WithId(testId),
 			clobtest.WithPerpetualId(testId),
@@ -69,19 +69,19 @@ func TestAddNewMarketProposal(t *testing.T) {
 		"Success with 4 standard messages": {
 			proposedMsgs: []sdk.Msg{
 				&pricestypes.MsgCreateOracleMarket{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testMarketParam.Param,
 				},
 				&perptypes.MsgCreatePerpetual{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testPerpetual.Params,
 				},
 				&clobtypes.MsgCreateClobPair{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					ClobPair:  *testClobPair,
 				},
 				&delaymsgtypes.MsgDelayMessage{
-					Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority:   lib.GovModuleAddress.String(),
 					Msg:         encoding.EncodeMessageToAny(t, msgUpdateClobPairToActive),
 					DelayBlocks: 10,
 				},
@@ -92,19 +92,19 @@ func TestAddNewMarketProposal(t *testing.T) {
 		"Success with 4 standard messages, delay blocks = 1": {
 			proposedMsgs: []sdk.Msg{
 				&pricestypes.MsgCreateOracleMarket{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testMarketParam.Param,
 				},
 				&perptypes.MsgCreatePerpetual{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testPerpetual.Params,
 				},
 				&clobtypes.MsgCreateClobPair{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					ClobPair:  *testClobPair,
 				},
 				&delaymsgtypes.MsgDelayMessage{
-					Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority:   lib.GovModuleAddress.String(),
 					Msg:         encoding.EncodeMessageToAny(t, msgUpdateClobPairToActive),
 					DelayBlocks: 1,
 				},
@@ -115,19 +115,19 @@ func TestAddNewMarketProposal(t *testing.T) {
 		"Success with 4 standard messages, delay blocks = 0": {
 			proposedMsgs: []sdk.Msg{
 				&pricestypes.MsgCreateOracleMarket{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testMarketParam.Param,
 				},
 				&perptypes.MsgCreatePerpetual{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testPerpetual.Params,
 				},
 				&clobtypes.MsgCreateClobPair{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					ClobPair:  *testClobPair,
 				},
 				&delaymsgtypes.MsgDelayMessage{
-					Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority:   lib.GovModuleAddress.String(),
 					Msg:         encoding.EncodeMessageToAny(t, msgUpdateClobPairToActive),
 					DelayBlocks: 0,
 				},
@@ -138,19 +138,19 @@ func TestAddNewMarketProposal(t *testing.T) {
 		"Success with 4 standard messages, delayed `UpdateClobPair` msg failure": {
 			proposedMsgs: []sdk.Msg{
 				&pricestypes.MsgCreateOracleMarket{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testMarketParam.Param,
 				},
 				&perptypes.MsgCreatePerpetual{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testPerpetual.Params,
 				},
 				&clobtypes.MsgCreateClobPair{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					ClobPair:  *testClobPair,
 				},
 				&delaymsgtypes.MsgDelayMessage{
-					Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority:   lib.GovModuleAddress.String(),
 					Msg:         encoding.EncodeMessageToAny(t, msgUpdateClobPairToActive_WrongClobPairId),
 					DelayBlocks: 10,
 				},
@@ -162,20 +162,20 @@ func TestAddNewMarketProposal(t *testing.T) {
 		"Fail: proposal execution fails due to incorrectly ordered messages": {
 			proposedMsgs: []sdk.Msg{
 				&pricestypes.MsgCreateOracleMarket{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testMarketParam.Param,
 				},
 				// Create clob pair before creating perpetual, which will fail.
 				&clobtypes.MsgCreateClobPair{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					ClobPair:  *testClobPair,
 				},
 				&perptypes.MsgCreatePerpetual{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testPerpetual.Params,
 				},
 				&delaymsgtypes.MsgDelayMessage{
-					Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority:   lib.GovModuleAddress.String(),
 					Msg:         encoding.EncodeMessageToAny(t, msgUpdateClobPairToActive),
 					DelayBlocks: 10,
 				},
@@ -186,25 +186,25 @@ func TestAddNewMarketProposal(t *testing.T) {
 		"Fail: proposal execution fails due to existing objects": {
 			proposedMsgs: []sdk.Msg{
 				&pricestypes.MsgCreateOracleMarket{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params: pricestest.GenerateMarketParamPrice(
 						pricestest.WithId(5), // already exists
 					).Param,
 				},
 				&perptypes.MsgCreatePerpetual{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params: perptest.GeneratePerpetual(
 						perptest.WithId(5), // already exists
 					).Params,
 				},
 				&clobtypes.MsgCreateClobPair{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					ClobPair: *clobtest.GenerateClobPair(
 						clobtest.WithId(5), // already exists
 					),
 				},
 				&delaymsgtypes.MsgDelayMessage{
-					Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority:   lib.GovModuleAddress.String(),
 					Msg:         encoding.EncodeMessageToAny(t, msgUpdateClobPairToActive),
 					DelayBlocks: 10,
 				},
@@ -219,15 +219,15 @@ func TestAddNewMarketProposal(t *testing.T) {
 					Params:    testMarketParam.Param,
 				},
 				&perptypes.MsgCreatePerpetual{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testPerpetual.Params,
 				},
 				&clobtypes.MsgCreateClobPair{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					ClobPair:  *testClobPair,
 				},
 				&delaymsgtypes.MsgDelayMessage{
-					Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority:   lib.GovModuleAddress.String(),
 					Msg:         encoding.EncodeMessageToAny(t, msgUpdateClobPairToActive),
 					DelayBlocks: 10,
 				},
@@ -239,19 +239,19 @@ func TestAddNewMarketProposal(t *testing.T) {
 		"Fail: proposal execution fails - invalid signer on `MsgDelayMessage`": {
 			proposedMsgs: []sdk.Msg{
 				&pricestypes.MsgCreateOracleMarket{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testMarketParam.Param,
 				},
 				&perptypes.MsgCreatePerpetual{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					Params:    testPerpetual.Params,
 				},
 				&clobtypes.MsgCreateClobPair{
-					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority: lib.GovModuleAddress.String(),
 					ClobPair:  *testClobPair,
 				},
 				&delaymsgtypes.MsgDelayMessage{
-					Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Authority:   lib.GovModuleAddress.String(),
 					Msg:         encoding.EncodeMessageToAny(t, msgUpdateClobPairToActive_WrongAuthority),
 					DelayBlocks: 10,
 				},

--- a/protocol/testing/e2e/gov/add_new_market_test.go
+++ b/protocol/testing/e2e/gov/add_new_market_test.go
@@ -35,7 +35,7 @@ func TestAddNewMarketProposal(t *testing.T) {
 		perptest.WithMarketId(testId),
 	)
 	msgUpdateClobPairToActive := &clobtypes.MsgUpdateClobPair{
-		Authority: lib.GovModuleAddress.String(),
+		Authority: delaymsgtypes.ModuleAddress.String(),
 		ClobPair: *clobtest.GenerateClobPair(
 			clobtest.WithId(testId),
 			clobtest.WithPerpetualId(testId),

--- a/protocol/testing/e2e/gov/bridge_test.go
+++ b/protocol/testing/e2e/gov/bridge_test.go
@@ -1,12 +1,11 @@
 package gov_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	"github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -24,7 +23,7 @@ func TestUpdateEventParams(t *testing.T) {
 	}{
 		"Success": {
 			msg: &bridgetypes.MsgUpdateEventParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: lib.GovModuleAddress.String(),
 				Params: bridgetypes.EventParams{
 					Denom:      genesisEventParams.Denom + "updated",
 					EthChainId: genesisEventParams.EthChainId + 1,
@@ -89,7 +88,7 @@ func TestUpdateProposeParams(t *testing.T) {
 	}{
 		"Success": {
 			msg: &bridgetypes.MsgUpdateProposeParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: lib.GovModuleAddress.String(),
 				Params: bridgetypes.ProposeParams{
 					MaxBridgesPerBlock:           genesisProposeParams.MaxBridgesPerBlock + 1,
 					ProposeDelayDuration:         genesisProposeParams.ProposeDelayDuration + 1,
@@ -156,7 +155,7 @@ func TestUpdateSafetyParams(t *testing.T) {
 	}{
 		"Success": {
 			msg: &bridgetypes.MsgUpdateSafetyParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: lib.GovModuleAddress.String(),
 				Params: bridgetypes.SafetyParams{
 					IsDisabled:  !genesisSafetyParams.IsDisabled,
 					DelayBlocks: genesisSafetyParams.DelayBlocks + 1,

--- a/protocol/testing/e2e/gov/sending_test.go
+++ b/protocol/testing/e2e/gov/sending_test.go
@@ -1,13 +1,13 @@
 package gov_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	"github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -25,7 +25,7 @@ func TestSendFromModuleToAccount(t *testing.T) {
 	}{
 		"Success: send from module to user account": {
 			msg: &sendingtypes.MsgSendFromModuleToAccount{
-				Authority:        authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority:        lib.GovModuleAddress.String(),
 				SenderModuleName: vesttypes.CommunityTreasuryAccountName,
 				Recipient:        constants.AliceAccAddress.String(),
 				Coin:             sdk.NewCoin("adv4tnt", sdk.NewInt(123)),
@@ -35,7 +35,7 @@ func TestSendFromModuleToAccount(t *testing.T) {
 		},
 		"Success: send from module to module account": {
 			msg: &sendingtypes.MsgSendFromModuleToAccount{
-				Authority:        authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority:        lib.GovModuleAddress.String(),
 				SenderModuleName: vesttypes.CommunityTreasuryAccountName,
 				Recipient:        authtypes.NewModuleAddress(vesttypes.CommunityVesterAccountName).String(),
 				Coin:             sdk.NewCoin("adv4tnt", sdk.NewInt(123)),
@@ -45,7 +45,7 @@ func TestSendFromModuleToAccount(t *testing.T) {
 		},
 		"Failure: insufficient balance": {
 			msg: &sendingtypes.MsgSendFromModuleToAccount{
-				Authority:        authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority:        lib.GovModuleAddress.String(),
 				SenderModuleName: vesttypes.CommunityTreasuryAccountName,
 				Recipient:        authtypes.NewModuleAddress(vesttypes.CommunityVesterAccountName).String(),
 				Coin:             sdk.NewCoin("adv4tnt", sdk.NewInt(124)),

--- a/protocol/testing/e2e/gov/stats_test.go
+++ b/protocol/testing/e2e/gov/stats_test.go
@@ -1,13 +1,13 @@
 package gov_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 	"time"
 
 	"github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	statstypes "github.com/dydxprotocol/v4-chain/protocol/x/stats/types"
@@ -22,7 +22,7 @@ func TestUpdateParams(t *testing.T) {
 	}{
 		"Success": {
 			msg: &statstypes.MsgUpdateParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: lib.GovModuleAddress.String(),
 				Params: statstypes.Params{
 					WindowDuration: time.Hour,
 				},

--- a/protocol/testutil/ante/testutil.go
+++ b/protocol/testutil/ante/testutil.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -71,7 +72,7 @@ func SetupTestSuite(t *testing.T, isCheckTx bool) *AnteTestSuite {
 		types.ProtoBaseAccount,
 		maccPerms,
 		sdk.Bech32MainPrefix,
-		types.NewModuleAddress("gov").String(),
+		lib.GovModuleAddress.String(),
 	)
 	suite.AccountKeeper.GetModuleAccount(suite.Ctx, types.FeeCollectorName)
 	err := suite.AccountKeeper.SetParams(suite.Ctx, types.DefaultParams())

--- a/protocol/testutil/app/gov.go
+++ b/protocol/testutil/app/gov.go
@@ -100,7 +100,7 @@ func SubmitAndTallyProposal(
 			validator,
 			1, // proposal ID
 			govtypesv1.VoteOption_VOTE_OPTION_YES,
-			"", // metdata
+			"", // metadata
 		)
 		voteCheckTx := MustMakeCheckTxWithPrivKeySupplier(
 			ctx,

--- a/protocol/testutil/constants/bridge.go
+++ b/protocol/testutil/constants/bridge.go
@@ -3,10 +3,7 @@ package constants
 import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
-	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethcoretypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -38,9 +35,6 @@ var (
 		Amount: sdkmath.NewIntFromUint64(888),
 	}
 
-	// Public
-	GovModuleAccAddressString      = authtypes.NewModuleAddress(govtypes.ModuleName).String()
-	DelayMsgModuleAccAddressString = authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String()
 	// Bridge Event.
 	BridgeEvent_Id0_Height0 = types.BridgeEvent{
 		Id:             0,

--- a/protocol/testutil/constants/delaymsg.go
+++ b/protocol/testutil/constants/delaymsg.go
@@ -3,7 +3,6 @@ package constants
 import (
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bridgetypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 )
@@ -11,19 +10,19 @@ import (
 var (
 	// MsgCompleteBridge is an example of an expected Msg type in the delaymsg module.
 	TestMsg1 = &bridgetypes.MsgCompleteBridge{
-		Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
+		Authority: types.ModuleAddress.String(),
 		Event: bridgetypes.BridgeEvent{
 			Id: 1,
 		},
 	}
 	TestMsg2 = &bridgetypes.MsgCompleteBridge{
-		Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
+		Authority: types.ModuleAddress.String(),
 		Event: bridgetypes.BridgeEvent{
 			Id: 2,
 		},
 	}
 	TestMsg3 = &bridgetypes.MsgCompleteBridge{
-		Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
+		Authority: types.ModuleAddress.String(),
 		Event: bridgetypes.BridgeEvent{
 			Id: 3,
 		},

--- a/protocol/testutil/keeper/auth.go
+++ b/protocol/testutil/keeper/auth.go
@@ -8,9 +8,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	bridgetypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -47,7 +47,7 @@ func createAccountKeeper(
 		types.ProtoBaseAccount,
 		maccPerms,
 		sdk.Bech32MainPrefix,
-		types.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 
 	return &k, storeKey

--- a/protocol/testutil/keeper/bank.go
+++ b/protocol/testutil/keeper/bank.go
@@ -6,10 +6,9 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
 
 func createBankKeeper(
@@ -26,7 +25,7 @@ func createBankKeeper(
 		storeKey,
 		accountKeeper,
 		map[string]bool{},
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		lib.GovModuleAddress.String(),
 	)
 
 	return &k, storeKey

--- a/protocol/testutil/keeper/blocktime.go
+++ b/protocol/testutil/keeper/blocktime.go
@@ -5,8 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/blocktime/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
 	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
@@ -21,8 +20,8 @@ func createBlockTimeKeeper(
 	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
 
 	authorities := []string{
-		authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		delaymsgtypes.ModuleAddress.String(),
+		lib.GovModuleAddress.String(),
 	}
 	k := keeper.NewKeeper(
 		cdc,

--- a/protocol/testutil/keeper/bridge.go
+++ b/protocol/testutil/keeper/bridge.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	"testing"
 
 	tmdb "github.com/cometbft/cometbft-db"
@@ -8,14 +10,11 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	bridgeserver_types "github.com/dydxprotocol/v4-chain/protocol/daemons/server/types/bridge"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
-	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 )
 
 func BridgeKeepers(
@@ -75,8 +74,8 @@ func createBridgeKeeper(
 		bankKeeper,
 		mockDelayMsgKeeper,
 		[]string{
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-			authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
+			lib.GovModuleAddress.String(),
+			delaymsgtypes.ModuleAddress.String(),
 		},
 	)
 

--- a/protocol/testutil/keeper/clob.go
+++ b/protocol/testutil/keeper/clob.go
@@ -1,10 +1,9 @@
 package keeper
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
@@ -199,8 +198,8 @@ func createClobKeeper(
 		memKey,
 		transientStoreKey,
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 		memClob,
 		saKeeper,

--- a/protocol/testutil/keeper/delaymsg.go
+++ b/protocol/testutil/keeper/delaymsg.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	tmdb "github.com/cometbft/cometbft-db"
@@ -10,9 +11,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	bridgekeeper "github.com/dydxprotocol/v4-chain/protocol/x/bridge/keeper"
 	bridgetypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
@@ -56,8 +55,8 @@ func DelayMsgKeepers(
 		bridgetypes.RegisterMsgServer(router, bridgekeeper.NewMsgServerImpl(bridgeKeeper))
 
 		authorities = []string{
-			authtypes.NewModuleAddress(bridgetypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			bridgetypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		}
 		delayMsgKeeper, storeKey = createDelayMsgKeeper(
 			stateStore,
@@ -106,8 +105,8 @@ func DelayMsgKeeperWithMockBridgeKeeper(
 		bridgetypes.RegisterMsgServer(router, bridgekeeper.NewMsgServerImpl(bridgeKeeper))
 
 		authorities = []string{
-			authtypes.NewModuleAddress(bridgetypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			bridgetypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		}
 		delayMsgKeeper, storeKey = createDelayMsgKeeper(
 			stateStore,

--- a/protocol/testutil/keeper/feetiers.go
+++ b/protocol/testutil/keeper/feetiers.go
@@ -1,14 +1,13 @@
 package keeper
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 
 	tmdb "github.com/cometbft/cometbft-db"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
@@ -28,8 +27,8 @@ func createFeeTiersKeeper(
 	mockMsgSender.On("Enabled").Return(true)
 
 	authorities := []string{
-		authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		delaymsgtypes.ModuleAddress.String(),
+		lib.GovModuleAddress.String(),
 	}
 	k := keeper.NewKeeper(
 		cdc,

--- a/protocol/testutil/keeper/perpetuals.go
+++ b/protocol/testutil/keeper/perpetuals.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	pricefeedserver_types "github.com/dydxprotocol/v4-chain/protocol/daemons/server/types/pricefeed"
@@ -17,8 +18,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	assetskeeper "github.com/dydxprotocol/v4-chain/protocol/x/assets/keeper"
 	delaymsgmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	epochskeeper "github.com/dydxprotocol/v4-chain/protocol/x/epochs/keeper"
@@ -117,8 +116,8 @@ func createPerpetualsKeeperWithClobHelpers(
 		ek,
 		mockIndexerEventsManager,
 		[]string{
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
+			lib.GovModuleAddress.String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
 		},
 	)
 

--- a/protocol/testutil/keeper/prices.go
+++ b/protocol/testutil/keeper/prices.go
@@ -16,8 +16,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	pricefeedserver_types "github.com/dydxprotocol/v4-chain/protocol/daemons/server/types/pricefeed"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -91,8 +89,8 @@ func createPricesKeeper(
 		mockTimeProvider,
 		mockIndexerEventsManager,
 		[]string{
-			authtypes.NewModuleAddress(delaymsgmoduletypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgmoduletypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 

--- a/protocol/testutil/keeper/rewards.go
+++ b/protocol/testutil/keeper/rewards.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"testing"
 
@@ -9,9 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	assetskeeper "github.com/dydxprotocol/v4-chain/protocol/x/assets/keeper"
 	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	feetierskeeper "github.com/dydxprotocol/v4-chain/protocol/x/feetiers/keeper"
@@ -101,8 +100,8 @@ func createRewardsKeeper(
 	mockMsgSender.On("Enabled").Return(true)
 
 	authorities := []string{
-		authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		delaymsgtypes.ModuleAddress.String(),
+		lib.GovModuleAddress.String(),
 	}
 	k := rewardskeeper.NewKeeper(
 		cdc,

--- a/protocol/testutil/keeper/sending.go
+++ b/protocol/testutil/keeper/sending.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -14,9 +15,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	assetskeeper "github.com/dydxprotocol/v4-chain/protocol/x/assets/keeper"
 	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	perpkeeper "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/keeper"
@@ -132,8 +131,8 @@ func createSendingKeeper(
 		saKeeper,
 		mockIndexerEventsManager,
 		[]string{
-			authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			delaymsgtypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		},
 	)
 

--- a/protocol/testutil/keeper/stats.go
+++ b/protocol/testutil/keeper/stats.go
@@ -1,15 +1,14 @@
 package keeper
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
+	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 
 	tmdb "github.com/cometbft/cometbft-db"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	epochskeeper "github.com/dydxprotocol/v4-chain/protocol/x/epochs/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/stats/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/stats/types"
@@ -31,8 +30,8 @@ func createStatsKeeper(
 	mockMsgSender.On("Enabled").Return(true)
 
 	authorities := []string{
-		authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		delaymsgtypes.ModuleAddress.String(),
+		lib.GovModuleAddress.String(),
 	}
 	k := keeper.NewKeeper(
 		cdc,

--- a/protocol/testutil/keeper/vest.go
+++ b/protocol/testutil/keeper/vest.go
@@ -6,9 +6,8 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	blocktimekeeper "github.com/dydxprotocol/v4-chain/protocol/x/blocktime/keeper"
 	bridgetypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vest/keeper"
@@ -35,8 +34,8 @@ func VestKeepers(
 		transientStoreKey storetypes.StoreKey,
 	) []GenesisInitializer {
 		authorities = []string{
-			authtypes.NewModuleAddress(bridgetypes.ModuleName).String(),
-			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			bridgetypes.ModuleAddress.String(),
+			lib.GovModuleAddress.String(),
 		}
 		accountKeeper, _ := createAccountKeeper(stateStore, db, cdc, registry)
 		bankKeeper, _ = createBankKeeper(stateStore, db, cdc, accountKeeper)

--- a/protocol/x/blocktime/keeper/msg_server_test.go
+++ b/protocol/x/blocktime/keeper/msg_server_test.go
@@ -2,20 +2,15 @@ package keeper_test
 
 import (
 	"context"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/x/blocktime/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
@@ -45,7 +40,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgUpdateDowntimeParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params:    types.DefaultGenesis().Params,
 			},
 			expErr: false,
@@ -62,7 +57,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "invalid params: unordered durations",
 			input: &types.MsgUpdateDowntimeParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.DowntimeParams{
 					Durations: []time.Duration{
 						5 * time.Second,

--- a/protocol/x/blocktime/keeper/msg_server_test.go
+++ b/protocol/x/blocktime/keeper/msg_server_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
 	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
 	ctx := tApp.InitChain()
@@ -41,7 +45,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgUpdateDowntimeParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    types.DefaultGenesis().Params,
 			},
 			expErr: false,
@@ -58,7 +62,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "invalid params: unordered durations",
 			input: &types.MsgUpdateDowntimeParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: types.DowntimeParams{
 					Durations: []time.Duration{
 						5 * time.Second,

--- a/protocol/x/bridge/keeper/acknowledge_bridges.go
+++ b/protocol/x/bridge/keeper/acknowledge_bridges.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
@@ -102,7 +101,7 @@ func (k Keeper) AcknowledgeBridges(
 
 	// For each bridge event, delay a `MsgCompleteBridge` to be executed `safetyParams.DelayBlocks`
 	// blocks in the future. Returns error if fails to delay any of the messages.
-	delayMsgModuleAccAddrString := authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String()
+	delayMsgModuleAccAddrString := delaymsgtypes.ModuleAddress.String()
 	for _, bridgeEvent := range bridgeEvents {
 		// delaymsg module should be the authority for completing bridges.
 		msgCompleteBridge := types.MsgCompleteBridge{

--- a/protocol/x/bridge/keeper/complete_bridge_test.go
+++ b/protocol/x/bridge/keeper/complete_bridge_test.go
@@ -6,7 +6,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
@@ -120,11 +119,7 @@ func TestCompleteBridge(t *testing.T) {
 				require.Equal(t, tc.bridgeEvent.Coin.Amount, balance.Amount)
 			}
 			// Assert that bridge module account's balance is as expected.
-			modAccBalance := bankKeeper.GetBalance(
-				ctx,
-				authtypes.NewModuleAddress(types.ModuleName),
-				tc.bridgeEvent.Coin.Denom,
-			)
+			modAccBalance := bankKeeper.GetBalance(ctx, types.ModuleAddress, tc.bridgeEvent.Coin.Denom)
 			require.Equal(t, tc.expectedBalance.Denom, modAccBalance.Denom)
 			require.Equal(t, tc.expectedBalance.Amount, modAccBalance.Amount)
 		})

--- a/protocol/x/bridge/keeper/grpc_query_test.go
+++ b/protocol/x/bridge/keeper/grpc_query_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -16,6 +15,10 @@ import (
 	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
+)
+
+var (
+	DelayMsgAuthority = delaymsgtypes.ModuleAddress.String()
 )
 
 func TestEventParams(t *testing.T) {
@@ -234,7 +237,7 @@ func TestDelayedCompleteBridgeMessages(t *testing.T) {
 			_, err = delayMsgKeeper.DelayMessageByBlocks(
 				ctx,
 				sendingtypes.NewMsgSendFromModuleToAccount(
-					authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
+					DelayMsgAuthority,
 					types.ModuleName,
 					constants.AliceAccAddress.String(),
 					sdk.NewCoin("adv4tnt", sdk.NewInt(100)),
@@ -245,7 +248,7 @@ func TestDelayedCompleteBridgeMessages(t *testing.T) {
 			_, err = delayMsgKeeper.DelayMessageByBlocks(
 				ctx,
 				&pricestypes.MsgUpdateMarketParam{
-					Authority:   authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
+					Authority:   DelayMsgAuthority,
 					MarketParam: pricestest.GenerateMarketParamPrice().Param,
 				},
 				123,
@@ -253,7 +256,7 @@ func TestDelayedCompleteBridgeMessages(t *testing.T) {
 			require.NoError(t, err)
 
 			// Construct expected responses.
-			delayMsgAuthority := authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String()
+			delayMsgAuthority := DelayMsgAuthority
 			blockOfExecution := k.GetSafetyParams(ctx).DelayBlocks + uint32(ctx.BlockHeight())
 			expectedMsgs := make([]types.DelayedCompleteBridgeMessage, 0)
 			expectedMsgsByAddress := make(map[string][]types.DelayedCompleteBridgeMessage)

--- a/protocol/x/bridge/keeper/msg_server_complete_bridge_test.go
+++ b/protocol/x/bridge/keeper/msg_server_complete_bridge_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"fmt"
+	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	"testing"
 
 	sdkmath "cosmossdk.io/math"
@@ -22,14 +23,14 @@ func TestMsgServerCompleteBridge(t *testing.T) {
 	}{
 		"Success": {
 			testMsg: types.MsgCompleteBridge{
-				Authority: constants.DelayMsgModuleAccAddressString,
+				Authority: delaymsgtypes.ModuleAddress.String(),
 				Event:     constants.BridgeEvent_Id0_Height0,
 			},
 			expectedResp: &types.MsgCompleteBridgeResponse{},
 		},
 		"Failure: invalid address": {
 			testMsg: types.MsgCompleteBridge{
-				Authority: constants.DelayMsgModuleAccAddressString,
+				Authority: delaymsgtypes.ModuleAddress.String(),
 				Event: types.BridgeEvent{
 					Id:             0,
 					Coin:           sdk.NewCoin("adv4tnt", sdkmath.NewInt(1)),

--- a/protocol/x/bridge/keeper/msg_server_update_event_params_test.go
+++ b/protocol/x/bridge/keeper/msg_server_update_event_params_test.go
@@ -2,9 +2,9 @@ package keeper_test
 
 import (
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ func TestMsgServerUpdateEventParams(t *testing.T) {
 	}{
 		"Success": {
 			testMsg: types.MsgUpdateEventParams{
-				Authority: constants.GovModuleAccAddressString,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.EventParams{
 					Denom:      "denom",
 					EthChainId: 1,
@@ -30,7 +30,7 @@ func TestMsgServerUpdateEventParams(t *testing.T) {
 		},
 		"Failure: invalid params": {
 			testMsg: types.MsgUpdateEventParams{
-				Authority: constants.GovModuleAccAddressString,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.EventParams{
 					Denom:      "7coin",
 					EthChainId: 1,

--- a/protocol/x/bridge/keeper/msg_server_update_propose_params_test.go
+++ b/protocol/x/bridge/keeper/msg_server_update_propose_params_test.go
@@ -2,10 +2,10 @@ package keeper_test
 
 import (
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 	"time"
 
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +20,7 @@ func TestMsgServerUpdateProposeParams(t *testing.T) {
 	}{
 		"Success": {
 			testMsg: types.MsgUpdateProposeParams{
-				Authority: constants.GovModuleAccAddressString,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.ProposeParams{
 					MaxBridgesPerBlock:           3,
 					ProposeDelayDuration:         time.Second,
@@ -32,7 +32,7 @@ func TestMsgServerUpdateProposeParams(t *testing.T) {
 		},
 		"Failure: invalid params": {
 			testMsg: types.MsgUpdateProposeParams{
-				Authority: constants.GovModuleAccAddressString,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.ProposeParams{
 					MaxBridgesPerBlock:           3,
 					ProposeDelayDuration:         -time.Second, // invalid

--- a/protocol/x/bridge/keeper/msg_server_update_safety_params_test.go
+++ b/protocol/x/bridge/keeper/msg_server_update_safety_params_test.go
@@ -2,9 +2,9 @@ package keeper_test
 
 import (
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ func TestMsgServerUpdateSafetyParams(t *testing.T) {
 	}{
 		"Success": {
 			testMsg: types.MsgUpdateSafetyParams{
-				Authority: constants.GovModuleAccAddressString,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.SafetyParams{
 					IsDisabled:  false,
 					DelayBlocks: 100,

--- a/protocol/x/bridge/types/addresses.go
+++ b/protocol/x/bridge/types/addresses.go
@@ -1,0 +1,7 @@
+package types
+
+import authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+var (
+	ModuleAddress = authtypes.NewModuleAddress(ModuleName)
+)

--- a/protocol/x/bridge/types/addresses_test.go
+++ b/protocol/x/bridge/types/addresses_test.go
@@ -1,0 +1,11 @@
+package types_test
+
+import (
+	"github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestModuleAddress(t *testing.T) {
+	require.Equal(t, "dydx1zlefkpe3g0vvm9a4h0jf9000lmqutlh9jwjnsv", types.ModuleAddress.String())
+}

--- a/protocol/x/clob/abci_test.go
+++ b/protocol/x/clob/abci_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	liquidationtypes "github.com/dydxprotocol/v4-chain/protocol/daemons/server/types/liquidations"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
@@ -659,7 +658,7 @@ func TestEndBlocker_Success(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				authtypes.NewModuleAddress(types.InsuranceFundName),
+				types.InsuranceFundAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))),
@@ -1337,7 +1336,7 @@ func TestPrepareCheckState(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				authtypes.NewModuleAddress(types.InsuranceFundName),
+				types.InsuranceFundAddress,
 				constants.Usdc.Denom,
 			).Return(sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))))
 			mockBankKeeper.On(

--- a/protocol/x/clob/abci_test.go
+++ b/protocol/x/clob/abci_test.go
@@ -658,7 +658,7 @@ func TestEndBlocker_Success(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				types.InsuranceFundAddress,
+				types.InsuranceFundModuleAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))),
@@ -1336,7 +1336,7 @@ func TestPrepareCheckState(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				types.InsuranceFundAddress,
+				types.InsuranceFundModuleAddress,
 				constants.Usdc.Denom,
 			).Return(sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))))
 			mockBankKeeper.On(

--- a/protocol/x/clob/client/testutil/genesis_state.go
+++ b/protocol/x/clob/client/testutil/genesis_state.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/network"
@@ -23,7 +22,7 @@ func CreateBankGenesisState(
 	bankGenState := banktypes.GenesisState{
 		Balances: []banktypes.Balance{
 			{
-				Address: authtypes.NewModuleAddress(satypes.ModuleName).String(),
+				Address: satypes.ModuleAddress.String(),
 				Coins: []sdk.Coin{
 					sdk.NewInt64Coin(
 						constants.Usdc.Denom,

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
@@ -125,7 +124,7 @@ func (k Keeper) GetInsuranceFundBalance(
 	}
 	insuranceFundBalance := k.bankKeeper.GetBalance(
 		ctx,
-		authtypes.NewModuleAddress(types.InsuranceFundName),
+		types.InsuranceFundAddress,
 		usdcAsset.Denom,
 	)
 

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -124,7 +124,7 @@ func (k Keeper) GetInsuranceFundBalance(
 	}
 	insuranceFundBalance := k.bankKeeper.GetBalance(
 		ctx,
-		types.InsuranceFundAddress,
+		types.InsuranceFundModuleAddress,
 		usdcAsset.Denom,
 	)
 

--- a/protocol/x/clob/keeper/deleveraging_test.go
+++ b/protocol/x/clob/keeper/deleveraging_test.go
@@ -10,7 +10,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -94,7 +93,7 @@ func TestGetInsuranceFundBalance(t *testing.T) {
 				bankMock.On(
 					"GetBalance",
 					mock.Anything,
-					authtypes.NewModuleAddress(types.InsuranceFundName),
+					types.InsuranceFundAddress,
 					constants.Usdc.Denom,
 				).Return(
 					sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),
@@ -192,7 +191,7 @@ func TestIsValidInsuranceFundDelta(t *testing.T) {
 			bankMock.On(
 				"GetBalance",
 				mock.Anything,
-				authtypes.NewModuleAddress(types.InsuranceFundName),
+				types.InsuranceFundAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),
@@ -269,7 +268,7 @@ func TestCanDeleverageSubaccount(t *testing.T) {
 			bankMock.On(
 				"GetBalance",
 				mock.Anything,
-				authtypes.NewModuleAddress(types.InsuranceFundName),
+				types.InsuranceFundAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),

--- a/protocol/x/clob/keeper/deleveraging_test.go
+++ b/protocol/x/clob/keeper/deleveraging_test.go
@@ -93,7 +93,7 @@ func TestGetInsuranceFundBalance(t *testing.T) {
 				bankMock.On(
 					"GetBalance",
 					mock.Anything,
-					types.InsuranceFundAddress,
+					types.InsuranceFundModuleAddress,
 					constants.Usdc.Denom,
 				).Return(
 					sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),
@@ -191,7 +191,7 @@ func TestIsValidInsuranceFundDelta(t *testing.T) {
 			bankMock.On(
 				"GetBalance",
 				mock.Anything,
-				types.InsuranceFundAddress,
+				types.InsuranceFundModuleAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),
@@ -268,7 +268,7 @@ func TestCanDeleverageSubaccount(t *testing.T) {
 			bankMock.On(
 				"GetBalance",
 				mock.Anything,
-				types.InsuranceFundAddress,
+				types.InsuranceFundModuleAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(tc.insuranceFundBalance)),

--- a/protocol/x/clob/keeper/liquidations_test.go
+++ b/protocol/x/clob/keeper/liquidations_test.go
@@ -260,7 +260,7 @@ func TestPlacePerpetualLiquidation(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				types.InsuranceFundAddress,
+				types.InsuranceFundModuleAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(
@@ -4513,7 +4513,7 @@ func TestMaybeGetLiquidationOrder(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				types.InsuranceFundAddress,
+				types.InsuranceFundModuleAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(

--- a/protocol/x/clob/keeper/liquidations_test.go
+++ b/protocol/x/clob/keeper/liquidations_test.go
@@ -260,7 +260,7 @@ func TestPlacePerpetualLiquidation(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				authtypes.NewModuleAddress(types.InsuranceFundName),
+				types.InsuranceFundAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(
@@ -4513,7 +4513,7 @@ func TestMaybeGetLiquidationOrder(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				authtypes.NewModuleAddress(types.InsuranceFundName),
+				types.InsuranceFundAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(

--- a/protocol/x/clob/keeper/mev_test.go
+++ b/protocol/x/clob/keeper/mev_test.go
@@ -836,7 +836,7 @@ func TestRecordMevMetrics(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				types.InsuranceFundAddress,
+				types.InsuranceFundModuleAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))),

--- a/protocol/x/clob/keeper/mev_test.go
+++ b/protocol/x/clob/keeper/mev_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/dydxprotocol/v4-chain/protocol/app/process"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
@@ -837,7 +836,7 @@ func TestRecordMevMetrics(t *testing.T) {
 			mockBankKeeper.On(
 				"GetBalance",
 				mock.Anything,
-				authtypes.NewModuleAddress(types.InsuranceFundName),
+				types.InsuranceFundAddress,
 				constants.Usdc.Denom,
 			).Return(
 				sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))),

--- a/protocol/x/clob/keeper/msg_server_create_clob_pair_test.go
+++ b/protocol/x/clob/keeper/msg_server_create_clob_pair_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -67,7 +68,7 @@ func TestCreateClobPair(t *testing.T) {
 				).Return()
 			},
 			msg: &types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair:  testClobPair1,
 			},
 			expectedClobPairs: []types.ClobPair{testClobPair1},
@@ -93,7 +94,7 @@ func TestCreateClobPair(t *testing.T) {
 				keepertest.CreateTestClobPairs(t, ks.Ctx, ks.ClobKeeper, []types.ClobPair{testClobPair1})
 			},
 			msg: &types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair:  testClobPair1,
 			},
 			expectedClobPairs: []types.ClobPair{testClobPair1},
@@ -120,7 +121,7 @@ func TestCreateClobPair(t *testing.T) {
 				keepertest.CreateTestClobPairs(t, ks.Ctx, ks.ClobKeeper, []types.ClobPair{testClobPair1})
 			},
 			msg: &types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair:  *clobtest.GenerateClobPair(clobtest.WithId(3), clobtest.WithPerpetualId(1)),
 			},
 			expectedClobPairs: []types.ClobPair{testClobPair1},
@@ -130,7 +131,7 @@ func TestCreateClobPair(t *testing.T) {
 			setup: func(t *testing.T, ks keepertest.ClobKeepersTestContext, mockIndexerEventManager *mocks.IndexerEventManager) {
 			},
 			msg: &types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair:  testClobPair1,
 			},
 			expectedClobPairs: nil,

--- a/protocol/x/clob/keeper/msg_server_create_clob_pair_test.go
+++ b/protocol/x/clob/keeper/msg_server_create_clob_pair_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
@@ -69,7 +67,7 @@ func TestCreateClobPair(t *testing.T) {
 				).Return()
 			},
 			msg: &types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair:  testClobPair1,
 			},
 			expectedClobPairs: []types.ClobPair{testClobPair1},
@@ -95,7 +93,7 @@ func TestCreateClobPair(t *testing.T) {
 				keepertest.CreateTestClobPairs(t, ks.Ctx, ks.ClobKeeper, []types.ClobPair{testClobPair1})
 			},
 			msg: &types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair:  testClobPair1,
 			},
 			expectedClobPairs: []types.ClobPair{testClobPair1},
@@ -122,7 +120,7 @@ func TestCreateClobPair(t *testing.T) {
 				keepertest.CreateTestClobPairs(t, ks.Ctx, ks.ClobKeeper, []types.ClobPair{testClobPair1})
 			},
 			msg: &types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair:  *clobtest.GenerateClobPair(clobtest.WithId(3), clobtest.WithPerpetualId(1)),
 			},
 			expectedClobPairs: []types.ClobPair{testClobPair1},
@@ -132,7 +130,7 @@ func TestCreateClobPair(t *testing.T) {
 			setup: func(t *testing.T, ks keepertest.ClobKeepersTestContext, mockIndexerEventManager *mocks.IndexerEventManager) {
 			},
 			msg: &types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair:  testClobPair1,
 			},
 			expectedClobPairs: nil,

--- a/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"github.com/cometbft/cometbft/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -79,7 +80,7 @@ func TestUpdateBlockRateLimitConfig(t *testing.T) {
 	require.Equal(t, originalConfig, tApp.App.ClobKeeper.GetBlockRateLimitConfiguration(ctx))
 
 	requestWithAuthority := clobtypes.MsgUpdateBlockRateLimitConfiguration{
-		Authority:            GovAuthority,
+		Authority:            lib.GovModuleAddress.String(),
 		BlockRateLimitConfig: expectedConfig,
 	}
 	_, err = handler(ctx, &requestWithAuthority)

--- a/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config_test.go
@@ -2,8 +2,6 @@ package keeper_test
 
 import (
 	"github.com/cometbft/cometbft/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -81,7 +79,7 @@ func TestUpdateBlockRateLimitConfig(t *testing.T) {
 	require.Equal(t, originalConfig, tApp.App.ClobKeeper.GetBlockRateLimitConfiguration(ctx))
 
 	requestWithAuthority := clobtypes.MsgUpdateBlockRateLimitConfiguration{
-		Authority:            authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		Authority:            GovAuthority,
 		BlockRateLimitConfig: expectedConfig,
 	}
 	_, err = handler(ctx, &requestWithAuthority)

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func TestMsgServerUpdateClobPair(t *testing.T) {
 	tests := map[string]struct {
 		msg          *types.MsgUpdateClobPair
@@ -33,7 +37,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 	}{
 		"Success": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -76,7 +80,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: unsupported status transition from active to initializing": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -104,7 +108,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Panic: clob pair not found": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -149,7 +153,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: cannot update metadata with new perpetual id": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -176,7 +180,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: cannot update step base quantums": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -203,7 +207,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: cannot update subticks per tick": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -230,7 +234,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: cannot update quantum conversion exponent": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{

--- a/protocol/x/clob/keeper/msg_server_update_clob_pair_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_clob_pair_test.go
@@ -7,7 +7,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
@@ -24,10 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
-)
-
 func TestMsgServerUpdateClobPair(t *testing.T) {
 	tests := map[string]struct {
 		msg          *types.MsgUpdateClobPair
@@ -37,7 +32,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 	}{
 		"Success": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -80,7 +75,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: unsupported status transition from active to initializing": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -108,7 +103,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Panic: clob pair not found": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -153,7 +148,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: cannot update metadata with new perpetual id": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -180,7 +175,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: cannot update step base quantums": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -207,7 +202,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: cannot update subticks per tick": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{
@@ -234,7 +229,7 @@ func TestMsgServerUpdateClobPair(t *testing.T) {
 		},
 		"Error: cannot update quantum conversion exponent": {
 			msg: &types.MsgUpdateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Id: 0,
 					Metadata: &types.ClobPair_PerpetualClobMetadata{

--- a/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config_test.go
@@ -2,8 +2,6 @@ package keeper_test
 
 import (
 	"github.com/cometbft/cometbft/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -87,7 +85,7 @@ func TestUpdateEquityTierLimitConfig(t *testing.T) {
 	require.Equal(t, originalConfig, tApp.App.ClobKeeper.GetEquityTierLimitConfiguration(ctx))
 
 	requestWithAuthority := clobtypes.MsgUpdateEquityTierLimitConfiguration{
-		Authority:             authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		Authority:             GovAuthority,
 		EquityTierLimitConfig: expectedConfig,
 	}
 	_, err = handler(ctx, &requestWithAuthority)

--- a/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"github.com/cometbft/cometbft/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -85,7 +86,7 @@ func TestUpdateEquityTierLimitConfig(t *testing.T) {
 	require.Equal(t, originalConfig, tApp.App.ClobKeeper.GetEquityTierLimitConfiguration(ctx))
 
 	requestWithAuthority := clobtypes.MsgUpdateEquityTierLimitConfiguration{
-		Authority:             GovAuthority,
+		Authority:             lib.GovModuleAddress.String(),
 		EquityTierLimitConfig: expectedConfig,
 	}
 	_, err = handler(ctx, &requestWithAuthority)

--- a/protocol/x/clob/keeper/msg_server_update_liquidations_config_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_liquidations_config_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"testing"
 
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -23,13 +22,13 @@ func TestUpdateLiquidationsConfig(t *testing.T) {
 	}{
 		"Succeeds": {
 			msg: &types.MsgUpdateLiquidationsConfig{
-				Authority:          authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority:          GovAuthority,
 				LiquidationsConfig: constants.LiquidationsConfig_No_Limit,
 			},
 		},
 		"Error: invalid liquidations config": {
 			msg: &types.MsgUpdateLiquidationsConfig{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				LiquidationsConfig: types.LiquidationsConfig{
 					MaxLiquidationFeePpm: 5_000,
 					FillablePriceConfig: types.FillablePriceConfig{

--- a/protocol/x/clob/keeper/msg_server_update_liquidations_config_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_liquidations_config_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -22,13 +23,13 @@ func TestUpdateLiquidationsConfig(t *testing.T) {
 	}{
 		"Succeeds": {
 			msg: &types.MsgUpdateLiquidationsConfig{
-				Authority:          GovAuthority,
+				Authority:          lib.GovModuleAddress.String(),
 				LiquidationsConfig: constants.LiquidationsConfig_No_Limit,
 			},
 		},
 		"Error: invalid liquidations config": {
 			msg: &types.MsgUpdateLiquidationsConfig{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				LiquidationsConfig: types.LiquidationsConfig{
 					MaxLiquidationFeePpm: 5_000,
 					FillablePriceConfig: types.FillablePriceConfig{

--- a/protocol/x/clob/module_test.go
+++ b/protocol/x/clob/module_test.go
@@ -87,7 +87,7 @@ func createAppModuleWithKeeper(t *testing.T) (
 	mockBankKeeper.On(
 		"GetBalance",
 		mock.Anything,
-		clob_types.InsuranceFundAddress,
+		clob_types.InsuranceFundModuleAddress,
 		constants.Usdc.Denom,
 	).Return(
 		sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))),

--- a/protocol/x/clob/module_test.go
+++ b/protocol/x/clob/module_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	liquidations_types "github.com/dydxprotocol/v4-chain/protocol/daemons/server/types/liquidations"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -88,7 +87,7 @@ func createAppModuleWithKeeper(t *testing.T) (
 	mockBankKeeper.On(
 		"GetBalance",
 		mock.Anything,
-		authtypes.NewModuleAddress(clob_types.InsuranceFundName),
+		clob_types.InsuranceFundAddress,
 		constants.Usdc.Denom,
 	).Return(
 		sdk.NewCoin(constants.Usdc.Denom, sdkmath.NewIntFromBigInt(new(big.Int))),

--- a/protocol/x/clob/types/addresses.go
+++ b/protocol/x/clob/types/addresses.go
@@ -3,5 +3,5 @@ package types
 import authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 var (
-	InsuranceFundAddress = authtypes.NewModuleAddress(InsuranceFundName)
+	InsuranceFundModuleAddress = authtypes.NewModuleAddress(InsuranceFundName)
 )

--- a/protocol/x/clob/types/addresses.go
+++ b/protocol/x/clob/types/addresses.go
@@ -1,0 +1,7 @@
+package types
+
+import authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+var (
+	InsuranceFundAddress = authtypes.NewModuleAddress(InsuranceFundName)
+)

--- a/protocol/x/clob/types/addresses_test.go
+++ b/protocol/x/clob/types/addresses_test.go
@@ -1,0 +1,11 @@
+package types_test
+
+import (
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestInsuranceFundModuleAddress(t *testing.T) {
+	require.Equal(t, "dydx1c7ptc87hkd54e3r7zjy92q29xkq7t79w64slrq", types.InsuranceFundModuleAddress.String())
+}

--- a/protocol/x/clob/types/message_create_clob_pair_test.go
+++ b/protocol/x/clob/types/message_create_clob_pair_test.go
@@ -1,18 +1,13 @@
 package types_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
 )
 
 func TestMsgCreateClobPair_GetSigners(t *testing.T) {
@@ -31,7 +26,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "Invalid Metadata (SpotClobMetadata)",
 			msg: types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_SpotClobMetadata{},
 					StepBaseQuantums: 1,
@@ -57,7 +52,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "Unsupported Status",
 			msg: types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 					StepBaseQuantums: 1,
@@ -70,7 +65,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "StepBaseQuantums <= 0",
 			msg: types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 					StepBaseQuantums: 0,
@@ -83,7 +78,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "SubticksPerTick <= 0",
 			msg: types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 					StepBaseQuantums: 1,
@@ -96,7 +91,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "Valid ClobPair",
 			msg: types.MsgCreateClobPair{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 					StepBaseQuantums: 1,

--- a/protocol/x/clob/types/message_create_clob_pair_test.go
+++ b/protocol/x/clob/types/message_create_clob_pair_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func TestMsgCreateClobPair_GetSigners(t *testing.T) {
 	msg := types.MsgCreateClobPair{
 		Authority: constants.AliceAccAddress.String(),
@@ -27,7 +31,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "Invalid Metadata (SpotClobMetadata)",
 			msg: types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_SpotClobMetadata{},
 					StepBaseQuantums: 1,
@@ -53,7 +57,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "Unsupported Status",
 			msg: types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 					StepBaseQuantums: 1,
@@ -66,7 +70,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "StepBaseQuantums <= 0",
 			msg: types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 					StepBaseQuantums: 0,
@@ -79,7 +83,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "SubticksPerTick <= 0",
 			msg: types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 					StepBaseQuantums: 1,
@@ -92,7 +96,7 @@ func TestMsgCreateClobPair_ValidateBasic(t *testing.T) {
 		{
 			desc: "Valid ClobPair",
 			msg: types.MsgCreateClobPair{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				ClobPair: types.ClobPair{
 					Metadata:         &types.ClobPair_PerpetualClobMetadata{},
 					StepBaseQuantums: 1,

--- a/protocol/x/delaymsg/keeper/delayed_message.go
+++ b/protocol/x/delaymsg/keeper/delayed_message.go
@@ -8,7 +8,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	gogotypes "github.com/cosmos/gogoproto/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
@@ -179,8 +178,7 @@ func validateSigners(msg sdk.Msg) error {
 			"message must have exactly one signer",
 		)
 	}
-	moduleAddress := authtypes.NewModuleAddress(types.ModuleName)
-	if !bytes.Equal(signers[0], moduleAddress) {
+	if !bytes.Equal(signers[0], types.ModuleAddress) {
 		return errorsmod.Wrapf(
 			types.ErrInvalidSigner,
 			"message signer must be delaymsg module address",

--- a/protocol/x/delaymsg/keeper/delayed_message_test.go
+++ b/protocol/x/delaymsg/keeper/delayed_message_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/encoding"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
@@ -53,7 +52,7 @@ func routableInvalidSdkMsg() sdk.Msg {
 func unencodableSdkMsg() sdk.Msg {
 	msg := &FakeRoutableMsg{}
 	msg.On("ValidateBasic").Return(nil)
-	msg.On("GetSigners").Return([]sdk.AccAddress{authtypes.NewModuleAddress(types.ModuleName)})
+	msg.On("GetSigners").Return([]sdk.AccAddress{types.ModuleAddress})
 	return msg
 }
 
@@ -177,7 +176,7 @@ func TestDelayMessageByBlocks_Failures(t *testing.T) {
 		},
 		"Message fails validation": {
 			msg: &bridgetypes.MsgCompleteBridge{
-				Authority: authtypes.NewModuleAddress(bridgetypes.ModuleName).String(),
+				Authority: bridgetypes.ModuleAddress.String(),
 				Event:     constants.BridgeEvent_Id0_Height0,
 			},
 			expectedError: "message signer must be delaymsg module address: Invalid signer",
@@ -358,7 +357,7 @@ func TestValidateMsg(t *testing.T) {
 		},
 		"Message fails validateSigners": {
 			msg: &bridgetypes.MsgCompleteBridge{
-				Authority: authtypes.NewModuleAddress(bridgetypes.ModuleName).String(),
+				Authority: bridgetypes.ModuleAddress.String(),
 				Event:     constants.BridgeEvent_Id0_Height0,
 			},
 			expectedError: "message signer must be delaymsg module address: Invalid signer",
@@ -402,7 +401,7 @@ func TestSetDelayedMessage(t *testing.T) {
 				Msg: encoding.EncodeMessageToAny(
 					t,
 					&bridgetypes.MsgCompleteBridge{
-						Authority: authtypes.NewModuleAddress(bridgetypes.ModuleName).String(),
+						Authority: bridgetypes.ModuleAddress.String(),
 						Event:     constants.BridgeEvent_Id0_Height0,
 					},
 				),

--- a/protocol/x/delaymsg/keeper/dispatch_test.go
+++ b/protocol/x/delaymsg/keeper/dispatch_test.go
@@ -12,7 +12,6 @@ import (
 	cometbfttypes "github.com/cometbft/cometbft/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -27,10 +26,10 @@ import (
 )
 
 var (
-	BridgeAuthority      = authtypes.NewModuleAddress(bridgetypes.ModuleName).String()
+	BridgeAuthority      = bridgetypes.ModuleAddress.String()
 	BridgeAccountAddress = sdk.MustAccAddressFromBech32(BridgeAuthority)
 
-	DelayMsgAuthority = authtypes.NewModuleAddress(types.ModuleName).String()
+	DelayMsgAuthority = types.ModuleAddress
 
 	testDenom = "adv4tnt"
 
@@ -347,7 +346,7 @@ func TestDispatchMessagesForBlock_Mixed(t *testing.T) {
 // generateBridgeEventMsgAny wraps bridge event in a MsgCompleteBridge and encodes it into an Any.
 func generateBridgeEventMsgAny(t *testing.T, event bridgetypes.BridgeEvent) *codectypes.Any {
 	msgCompleteBridge := bridgetypes.MsgCompleteBridge{
-		Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
+		Authority: DelayMsgAuthority.String(),
 		Event:     event,
 	}
 	any, err := codectypes.NewAnyWithValue(&msgCompleteBridge)
@@ -536,7 +535,7 @@ func TestDispatchMessagesForBlock_EventsArePropagated(t *testing.T) {
 	_, err = k.DelayMessageByBlocks(
 		ctx,
 		&bridgetypes.MsgCompleteBridge{
-			Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
+			Authority: DelayMsgAuthority.String(),
 			Event:     bridgeEvent,
 		},
 		0,

--- a/protocol/x/delaymsg/keeper/dispatch_test.go
+++ b/protocol/x/delaymsg/keeper/dispatch_test.go
@@ -61,7 +61,7 @@ func TestDispatchMessagesForBlock(t *testing.T) {
 	// Mock the bridge keeper methods called by the bridge msg server.
 	bridgeKeeper.On("CompleteBridge", mock.AnythingOfType("types.Context"), mock.Anything).
 		Return(nil).Times(len(constants.AllMsgs))
-	bridgeKeeper.On("HasAuthority", DelayMsgAuthority).Return(true).Times(len(constants.AllMsgs))
+	bridgeKeeper.On("HasAuthority", DelayMsgAuthority.String()).Return(true).Times(len(constants.AllMsgs))
 
 	// Dispatch messages for block 0.
 

--- a/protocol/x/delaymsg/keeper/msg_server_test.go
+++ b/protocol/x/delaymsg/keeper/msg_server_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	AcceptedAuthority = authtypes.NewModuleAddress(bridgemoduletypes.ModuleName).String()
+	AcceptedAuthority = bridgemoduletypes.ModuleAddress.String()
 	InvalidAuthority  = authtypes.NewModuleAddress("INVALID_AUTHORITY").String()
 	TestError         = fmt.Errorf("test error")
 	TestMsgId         = uint32(0)

--- a/protocol/x/delaymsg/types/addresses.go
+++ b/protocol/x/delaymsg/types/addresses.go
@@ -1,0 +1,7 @@
+package types
+
+import authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+var (
+	ModuleAddress = authtypes.NewModuleAddress(ModuleName)
+)

--- a/protocol/x/delaymsg/types/addresses_test.go
+++ b/protocol/x/delaymsg/types/addresses_test.go
@@ -1,0 +1,11 @@
+package types_test
+
+import (
+	"github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestModuleAddress(t *testing.T) {
+	require.Equal(t, "dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr", types.ModuleAddress.String())
+}

--- a/protocol/x/delaymsg/types/msg_delay_message_test.go
+++ b/protocol/x/delaymsg/types/msg_delay_message_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/encoding"
 	"github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
@@ -13,7 +12,7 @@ import (
 )
 
 var (
-	AcceptedAuthority = authtypes.NewModuleAddress(types.ModuleName)
+	AcceptedAuthority = types.ModuleAddress
 )
 
 func TestMsgDelayMessage_GetSigners(t *testing.T) {

--- a/protocol/x/feetiers/keeper/msg_server_test.go
+++ b/protocol/x/feetiers/keeper/msg_server_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
 	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
 	ctx := tApp.InitChain()
@@ -40,7 +44,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgUpdatePerpetualFeeParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    types.DefaultGenesis().Params,
 			},
 			expErr: false,
@@ -57,7 +61,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "invalid params: negative duration",
 			input: &types.MsgUpdatePerpetualFeeParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: types.PerpetualFeeParams{
 					Tiers: []*types.PerpetualFeeTier{
 						{TotalVolumeShareRequirementPpm: 1},

--- a/protocol/x/feetiers/keeper/msg_server_test.go
+++ b/protocol/x/feetiers/keeper/msg_server_test.go
@@ -2,19 +2,14 @@ package keeper_test
 
 import (
 	"context"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
@@ -44,7 +39,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgUpdatePerpetualFeeParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params:    types.DefaultGenesis().Params,
 			},
 			expErr: false,
@@ -61,7 +56,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "invalid params: negative duration",
 			input: &types.MsgUpdatePerpetualFeeParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.PerpetualFeeParams{
 					Tiers: []*types.PerpetualFeeTier{
 						{TotalVolumeShareRequirementPpm: 1},

--- a/protocol/x/perpetuals/keeper/msg_server_create_perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/msg_server_create_perpetual_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -41,7 +42,7 @@ func TestCreatePerpetual(t *testing.T) {
 				)
 			},
 			msg: &types.MsgCreatePerpetual{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params:    testPerp1.Params,
 			},
 			expectedPerpetuals: []types.Perpetual{testPerp1},
@@ -58,7 +59,7 @@ func TestCreatePerpetual(t *testing.T) {
 				)
 			},
 			msg: &types.MsgCreatePerpetual{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params:    testPerp2.Params,
 			},
 			expectedPerpetuals: []types.Perpetual{testPerp1, testPerp2},
@@ -75,7 +76,7 @@ func TestCreatePerpetual(t *testing.T) {
 				)
 			},
 			msg: &types.MsgCreatePerpetual{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params:    testPerp1.Params,
 			},
 			expectedPerpetuals: []types.Perpetual{testPerp1},
@@ -86,7 +87,7 @@ func TestCreatePerpetual(t *testing.T) {
 				keepertest.CreateTestLiquidityTiers(t, ctx, perpKeeper)
 			},
 			msg: &types.MsgCreatePerpetual{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params:    testPerp1.Params,
 			},
 			expectedPerpetuals: nil,

--- a/protocol/x/perpetuals/keeper/msg_server_create_perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/msg_server_create_perpetual_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
 	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
@@ -43,7 +41,7 @@ func TestCreatePerpetual(t *testing.T) {
 				)
 			},
 			msg: &types.MsgCreatePerpetual{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    testPerp1.Params,
 			},
 			expectedPerpetuals: []types.Perpetual{testPerp1},
@@ -60,7 +58,7 @@ func TestCreatePerpetual(t *testing.T) {
 				)
 			},
 			msg: &types.MsgCreatePerpetual{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    testPerp2.Params,
 			},
 			expectedPerpetuals: []types.Perpetual{testPerp1, testPerp2},
@@ -77,7 +75,7 @@ func TestCreatePerpetual(t *testing.T) {
 				)
 			},
 			msg: &types.MsgCreatePerpetual{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    testPerp1.Params,
 			},
 			expectedPerpetuals: []types.Perpetual{testPerp1},
@@ -88,7 +86,7 @@ func TestCreatePerpetual(t *testing.T) {
 				keepertest.CreateTestLiquidityTiers(t, ctx, perpKeeper)
 			},
 			msg: &types.MsgCreatePerpetual{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    testPerp1.Params,
 			},
 			expectedPerpetuals: nil,

--- a/protocol/x/perpetuals/keeper/msg_server_set_liquidity_tier_test.go
+++ b/protocol/x/perpetuals/keeper/msg_server_set_liquidity_tier_test.go
@@ -1,21 +1,16 @@
 package keeper_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	lttest "github.com/dydxprotocol/v4-chain/protocol/testutil/liquidity_tier"
 	perpkeeper "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
 )
 
 func TestSetLiquidityTier(t *testing.T) {
@@ -34,7 +29,7 @@ func TestSetLiquidityTier(t *testing.T) {
 	}{
 		"Success: update name and initial margin ppm": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id,
 					Name:                   "large-cap",
@@ -47,7 +42,7 @@ func TestSetLiquidityTier(t *testing.T) {
 		},
 		"Success: update all parameters": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id,
 					Name:                   "medium-cap",
@@ -60,7 +55,7 @@ func TestSetLiquidityTier(t *testing.T) {
 		},
 		"Success: create a new liquidity tier": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id + 1,
 					Name:                   "medium-cap",
@@ -73,7 +68,7 @@ func TestSetLiquidityTier(t *testing.T) {
 		},
 		"Failure: initial margin ppm exceeds max": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id,
 					Name:                   "medium-cap",
@@ -87,7 +82,7 @@ func TestSetLiquidityTier(t *testing.T) {
 		},
 		"Failure: maintenance fraction ppm exceeds max": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id,
 					Name:                   "medium-cap",

--- a/protocol/x/perpetuals/keeper/msg_server_set_liquidity_tier_test.go
+++ b/protocol/x/perpetuals/keeper/msg_server_set_liquidity_tier_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func TestSetLiquidityTier(t *testing.T) {
 	testLt := *lttest.GenerateLiquidityTier(
 		lttest.WithId(1),
@@ -30,7 +34,7 @@ func TestSetLiquidityTier(t *testing.T) {
 	}{
 		"Success: update name and initial margin ppm": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id,
 					Name:                   "large-cap",
@@ -43,7 +47,7 @@ func TestSetLiquidityTier(t *testing.T) {
 		},
 		"Success: update all parameters": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id,
 					Name:                   "medium-cap",
@@ -56,7 +60,7 @@ func TestSetLiquidityTier(t *testing.T) {
 		},
 		"Success: create a new liquidity tier": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id + 1,
 					Name:                   "medium-cap",
@@ -69,7 +73,7 @@ func TestSetLiquidityTier(t *testing.T) {
 		},
 		"Failure: initial margin ppm exceeds max": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id,
 					Name:                   "medium-cap",
@@ -83,7 +87,7 @@ func TestSetLiquidityTier(t *testing.T) {
 		},
 		"Failure: maintenance fraction ppm exceeds max": {
 			msg: &types.MsgSetLiquidityTier{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				LiquidityTier: types.LiquidityTier{
 					Id:                     testLt.Id,
 					Name:                   "medium-cap",

--- a/protocol/x/perpetuals/keeper/msg_server_update_params_test.go
+++ b/protocol/x/perpetuals/keeper/msg_server_update_params_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	perpkeeper "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/keeper"
@@ -26,7 +24,7 @@ func TestUpdateParams(t *testing.T) {
 	}{
 		"Success: modify funding rate clamp factor": {
 			msg: &types.MsgUpdateParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: types.Params{
 					FundingRateClampFactorPpm: 1_234,
 					PremiumVoteClampFactorPpm: initialParams.PremiumVoteClampFactorPpm,
@@ -36,7 +34,7 @@ func TestUpdateParams(t *testing.T) {
 		},
 		"Success: modify premium vote clamp factor and min num votes": {
 			msg: &types.MsgUpdateParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: types.Params{
 					FundingRateClampFactorPpm: initialParams.FundingRateClampFactorPpm,
 					PremiumVoteClampFactorPpm: 1_234,
@@ -46,7 +44,7 @@ func TestUpdateParams(t *testing.T) {
 		},
 		"Failure: parameters are not valid": {
 			msg: &types.MsgUpdateParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: types.Params{
 					FundingRateClampFactorPpm: initialParams.FundingRateClampFactorPpm,
 					PremiumVoteClampFactorPpm: 0, // invalid

--- a/protocol/x/perpetuals/keeper/msg_server_update_params_test.go
+++ b/protocol/x/perpetuals/keeper/msg_server_update_params_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -24,7 +25,7 @@ func TestUpdateParams(t *testing.T) {
 	}{
 		"Success: modify funding rate clamp factor": {
 			msg: &types.MsgUpdateParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.Params{
 					FundingRateClampFactorPpm: 1_234,
 					PremiumVoteClampFactorPpm: initialParams.PremiumVoteClampFactorPpm,
@@ -34,7 +35,7 @@ func TestUpdateParams(t *testing.T) {
 		},
 		"Success: modify premium vote clamp factor and min num votes": {
 			msg: &types.MsgUpdateParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.Params{
 					FundingRateClampFactorPpm: initialParams.FundingRateClampFactorPpm,
 					PremiumVoteClampFactorPpm: 1_234,
@@ -44,7 +45,7 @@ func TestUpdateParams(t *testing.T) {
 		},
 		"Failure: parameters are not valid": {
 			msg: &types.MsgUpdateParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.Params{
 					FundingRateClampFactorPpm: initialParams.FundingRateClampFactorPpm,
 					PremiumVoteClampFactorPpm: 0, // invalid

--- a/protocol/x/perpetuals/keeper/msg_server_update_perpetual_params_test.go
+++ b/protocol/x/perpetuals/keeper/msg_server_update_perpetual_params_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -43,7 +44,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id,
 					Ticker:            "DUMMY-USD",
@@ -66,7 +67,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id,
 					Ticker:            "PIKACHU-XXX",
@@ -89,7 +90,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id + 1,
 					Ticker:            "DUMMY-USD",
@@ -113,7 +114,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id,
 					Ticker:            "DUMMY-USD",
@@ -137,7 +138,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id,
 					Ticker:            "DUMMY-USD",

--- a/protocol/x/perpetuals/keeper/msg_server_update_perpetual_params_test.go
+++ b/protocol/x/perpetuals/keeper/msg_server_update_perpetual_params_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
@@ -45,7 +43,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id,
 					Ticker:            "DUMMY-USD",
@@ -68,7 +66,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id,
 					Ticker:            "PIKACHU-XXX",
@@ -91,7 +89,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id + 1,
 					Ticker:            "DUMMY-USD",
@@ -115,7 +113,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id,
 					Ticker:            "DUMMY-USD",
@@ -139,7 +137,7 @@ func TestUpdatePerpetualParams(t *testing.T) {
 				)
 			},
 			msg: &types.MsgUpdatePerpetualParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				PerpetualParams: types.PerpetualParams{
 					Id:                testPerp.Params.Id,
 					Ticker:            "DUMMY-USD",

--- a/protocol/x/prices/keeper/msg_server_create_oracle_market_test.go
+++ b/protocol/x/prices/keeper/msg_server_create_oracle_market_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -28,7 +29,7 @@ func TestCreateOracleMarket(t *testing.T) {
 		"Succeeds: create new oracle market (id = 1)": {
 			setup: func(t *testing.T, ctx sdk.Context, pricesKeeper *keeper.Keeper) {},
 			msg: &pricestypes.MsgCreateOracleMarket{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params:    testMarket1.Param,
 			},
 			expectedMarkets: []pricestypes.MarketParamPrice{testMarket1},
@@ -36,7 +37,7 @@ func TestCreateOracleMarket(t *testing.T) {
 		"Failure: empty pair": {
 			setup: func(t *testing.T, ctx sdk.Context, pricesKeeper *keeper.Keeper) {},
 			msg: &pricestypes.MsgCreateOracleMarket{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: pricestest.GenerateMarketParamPrice(
 					pricestest.WithPair(""),
 					pricestest.WithExponent(-8), // for both Param and Price
@@ -48,7 +49,7 @@ func TestCreateOracleMarket(t *testing.T) {
 		"Failure: typo in exchange config json": {
 			setup: func(t *testing.T, ctx sdk.Context, pricesKeeper *keeper.Keeper) {},
 			msg: &pricestypes.MsgCreateOracleMarket{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: pricestest.GenerateMarketParamPrice(
 					pricestest.WithPair("BTC-USD"),
 					pricestest.WithExponent(-8), // for both Param and Price
@@ -68,7 +69,7 @@ func TestCreateOracleMarket(t *testing.T) {
 				)
 			},
 			msg: &pricestypes.MsgCreateOracleMarket{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: pricestest.GenerateMarketParamPrice(
 					pricestest.WithId(1), // same id as testMarket1
 				).Param,

--- a/protocol/x/prices/keeper/msg_server_create_oracle_market_test.go
+++ b/protocol/x/prices/keeper/msg_server_create_oracle_market_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
@@ -30,7 +28,7 @@ func TestCreateOracleMarket(t *testing.T) {
 		"Succeeds: create new oracle market (id = 1)": {
 			setup: func(t *testing.T, ctx sdk.Context, pricesKeeper *keeper.Keeper) {},
 			msg: &pricestypes.MsgCreateOracleMarket{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    testMarket1.Param,
 			},
 			expectedMarkets: []pricestypes.MarketParamPrice{testMarket1},
@@ -38,7 +36,7 @@ func TestCreateOracleMarket(t *testing.T) {
 		"Failure: empty pair": {
 			setup: func(t *testing.T, ctx sdk.Context, pricesKeeper *keeper.Keeper) {},
 			msg: &pricestypes.MsgCreateOracleMarket{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: pricestest.GenerateMarketParamPrice(
 					pricestest.WithPair(""),
 					pricestest.WithExponent(-8), // for both Param and Price
@@ -50,7 +48,7 @@ func TestCreateOracleMarket(t *testing.T) {
 		"Failure: typo in exchange config json": {
 			setup: func(t *testing.T, ctx sdk.Context, pricesKeeper *keeper.Keeper) {},
 			msg: &pricestypes.MsgCreateOracleMarket{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: pricestest.GenerateMarketParamPrice(
 					pricestest.WithPair("BTC-USD"),
 					pricestest.WithExponent(-8), // for both Param and Price
@@ -70,7 +68,7 @@ func TestCreateOracleMarket(t *testing.T) {
 				)
 			},
 			msg: &pricestypes.MsgCreateOracleMarket{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: pricestest.GenerateMarketParamPrice(
 					pricestest.WithId(1), // same id as testMarket1
 				).Param,

--- a/protocol/x/prices/keeper/msg_server_update_market_param_test.go
+++ b/protocol/x/prices/keeper/msg_server_update_market_param_test.go
@@ -1,21 +1,16 @@
 package keeper_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/keeper"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
 )
 
 func TestUpdateMarketParam(t *testing.T) {
@@ -33,7 +28,7 @@ func TestUpdateMarketParam(t *testing.T) {
 	}{
 		"Succeeds: update all parameters except exponent": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               "PIKACHU-XXX",
@@ -46,7 +41,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Succeeds: update min price change ppm only": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,
@@ -59,7 +54,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update to an empty pair": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               "", // invalid
@@ -73,7 +68,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update to 0 min exchanges": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,
@@ -87,7 +82,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update to 0 min price change ppm": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,
@@ -101,7 +96,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update to invalid exchange config json": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,
@@ -115,7 +110,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update market exponent": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,

--- a/protocol/x/prices/keeper/msg_server_update_market_param_test.go
+++ b/protocol/x/prices/keeper/msg_server_update_market_param_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func TestUpdateMarketParam(t *testing.T) {
 	testMarket := *pricestest.GenerateMarketParamPrice(
 		pricestest.WithId(1),
@@ -29,7 +33,7 @@ func TestUpdateMarketParam(t *testing.T) {
 	}{
 		"Succeeds: update all parameters except exponent": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               "PIKACHU-XXX",
@@ -42,7 +46,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Succeeds: update min price change ppm only": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,
@@ -55,7 +59,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update to an empty pair": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               "", // invalid
@@ -69,7 +73,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update to 0 min exchanges": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,
@@ -83,7 +87,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update to 0 min price change ppm": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,
@@ -97,7 +101,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update to invalid exchange config json": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,
@@ -111,7 +115,7 @@ func TestUpdateMarketParam(t *testing.T) {
 		},
 		"Failure: update market exponent": {
 			msg: &pricestypes.MsgUpdateMarketParam{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				MarketParam: pricestypes.MarketParam{
 					Id:                 testMarketParam.Id,
 					Pair:               testMarketParam.Pair,

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -284,7 +284,7 @@ func (k Keeper) ProcessRewardsForBlock(
 	bigIntRewardTokenAmount := lib.BigRatRound(bigRatRewardTokenAmount, false)
 
 	// Calculate value of `T`, the reward tokens balance in the `treasury_account`.
-	rewardTokenBalance := k.bankKeeper.GetBalance(ctx, types.TreasuryAddress, params.Denom)
+	rewardTokenBalance := k.bankKeeper.GetBalance(ctx, types.TreasuryModuleAddress, params.Denom)
 
 	// Get tokenToDistribute as the min(F, T).
 	tokensToDistribute := lib.BigMin(rewardTokenBalance.Amount.BigInt(), bigIntRewardTokenAmount)
@@ -343,7 +343,7 @@ func (k Keeper) ProcessRewardsForBlock(
 	}
 
 	// Measure treasury balance after distribution.
-	remainingTreasuryBalance := k.bankKeeper.GetBalance(ctx, types.TreasuryAddress, params.Denom)
+	remainingTreasuryBalance := k.bankKeeper.GetBalance(ctx, types.TreasuryModuleAddress, params.Denom)
 	telemetry.SetGauge(
 		metrics.GetMetricValueFromBigInt(remainingTreasuryBalance.Amount.BigInt()),
 		types.ModuleName,

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -14,7 +14,6 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -285,11 +284,7 @@ func (k Keeper) ProcessRewardsForBlock(
 	bigIntRewardTokenAmount := lib.BigRatRound(bigRatRewardTokenAmount, false)
 
 	// Calculate value of `T`, the reward tokens balance in the `treasury_account`.
-	rewardTokenBalance := k.bankKeeper.GetBalance(
-		ctx,
-		authtypes.NewModuleAddress(params.TreasuryAccount),
-		params.Denom,
-	)
+	rewardTokenBalance := k.bankKeeper.GetBalance(ctx, types.TreasuryAddress, params.Denom)
 
 	// Get tokenToDistribute as the min(F, T).
 	tokensToDistribute := lib.BigMin(rewardTokenBalance.Amount.BigInt(), bigIntRewardTokenAmount)
@@ -348,11 +343,7 @@ func (k Keeper) ProcessRewardsForBlock(
 	}
 
 	// Measure treasury balance after distribution.
-	remainingTreasuryBalance := k.bankKeeper.GetBalance(
-		ctx,
-		authtypes.NewModuleAddress(params.TreasuryAccount),
-		params.Denom,
-	)
+	remainingTreasuryBalance := k.bankKeeper.GetBalance(ctx, types.TreasuryAddress, params.Denom)
 	telemetry.SetGauge(
 		metrics.GetMetricValueFromBigInt(remainingTreasuryBalance.Amount.BigInt()),
 		types.ModuleName,

--- a/protocol/x/rewards/keeper/keeper_test.go
+++ b/protocol/x/rewards/keeper/keeper_test.go
@@ -8,7 +8,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 	cometbfttypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
@@ -28,7 +27,7 @@ const (
 
 var (
 	ZeroTreasuryAccountBalance = banktypes.Balance{
-		Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+		Address: types.TreasuryAddress.String(),
 		Coins: []sdk.Coin{{
 			Denom:  TestRewardTokenDenom,
 			Amount: sdkmath.NewInt(0),
@@ -336,7 +335,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 			// 1$ / 2$ * 100% = 0.5 full coin, all paid to TestAddress1
 			expectedBalances: []banktypes.Balance{
 				{
-					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+					Address: types.TreasuryAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(1_000_000_000),
@@ -364,7 +363,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+					Address: types.TreasuryAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(999_500_000), // 999.5 full coins
@@ -392,7 +391,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+					Address: types.TreasuryAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(999_525_000), // 999.525 full coins
@@ -486,7 +485,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+					Address: types.TreasuryAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom: TestRewardTokenDenom,
 						Amount: sdkmath.NewIntFromBigInt(
@@ -537,7 +536,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+					Address: types.TreasuryAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(1), // 0.000001 full coins left due to rounding
@@ -586,7 +585,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+					Address: types.TreasuryAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(2), // 0.000002 full coins left due to rounding
@@ -624,7 +623,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+					Address: types.TreasuryAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(1),
@@ -644,7 +643,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					&genesis,
 					func(genesisState *banktypes.GenesisState) {
 						genesisState.Balances = append(genesisState.Balances, banktypes.Balance{
-							Address: authtypes.NewModuleAddress(types.TreasuryAccountName).String(),
+							Address: types.TreasuryAddress.String(),
 							Coins: []sdk.Coin{
 								sdk.NewCoin(TestRewardTokenDenom, tc.treasuryAccountBalance),
 							},

--- a/protocol/x/rewards/keeper/keeper_test.go
+++ b/protocol/x/rewards/keeper/keeper_test.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	ZeroTreasuryAccountBalance = banktypes.Balance{
-		Address: types.TreasuryAddress.String(),
+		Address: types.TreasuryModuleAddress.String(),
 		Coins: []sdk.Coin{{
 			Denom:  TestRewardTokenDenom,
 			Amount: sdkmath.NewInt(0),
@@ -335,7 +335,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 			// 1$ / 2$ * 100% = 0.5 full coin, all paid to TestAddress1
 			expectedBalances: []banktypes.Balance{
 				{
-					Address: types.TreasuryAddress.String(),
+					Address: types.TreasuryModuleAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(1_000_000_000),
@@ -363,7 +363,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: types.TreasuryAddress.String(),
+					Address: types.TreasuryModuleAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(999_500_000), // 999.5 full coins
@@ -391,7 +391,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: types.TreasuryAddress.String(),
+					Address: types.TreasuryModuleAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(999_525_000), // 999.525 full coins
@@ -485,7 +485,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: types.TreasuryAddress.String(),
+					Address: types.TreasuryModuleAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom: TestRewardTokenDenom,
 						Amount: sdkmath.NewIntFromBigInt(
@@ -536,7 +536,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: types.TreasuryAddress.String(),
+					Address: types.TreasuryModuleAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(1), // 0.000001 full coins left due to rounding
@@ -585,7 +585,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: types.TreasuryAddress.String(),
+					Address: types.TreasuryModuleAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(2), // 0.000002 full coins left due to rounding
@@ -623,7 +623,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					}},
 				},
 				{
-					Address: types.TreasuryAddress.String(),
+					Address: types.TreasuryModuleAddress.String(),
 					Coins: []sdk.Coin{{
 						Denom:  TestRewardTokenDenom,
 						Amount: sdkmath.NewInt(1),
@@ -643,7 +643,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					&genesis,
 					func(genesisState *banktypes.GenesisState) {
 						genesisState.Balances = append(genesisState.Balances, banktypes.Balance{
-							Address: types.TreasuryAddress.String(),
+							Address: types.TreasuryModuleAddress.String(),
 							Coins: []sdk.Coin{
 								sdk.NewCoin(TestRewardTokenDenom, tc.treasuryAccountBalance),
 							},

--- a/protocol/x/rewards/keeper/msg_server_test.go
+++ b/protocol/x/rewards/keeper/msg_server_test.go
@@ -2,20 +2,15 @@ package keeper_test
 
 import (
 	"context"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 
 	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
@@ -45,7 +40,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgUpdateParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params:    types.DefaultParams(),
 			},
 			expErr: false,
@@ -62,7 +57,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "invalid params: invalid denom",
 			input: &types.MsgUpdateParams{
-				Authority: GovAuthority,
+				Authority: lib.GovModuleAddress.String(),
 				Params: types.Params{
 					TreasuryAccount: "rewards_treasury",
 					Denom:           "",

--- a/protocol/x/rewards/keeper/msg_server_test.go
+++ b/protocol/x/rewards/keeper/msg_server_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
 	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
 	ctx := tApp.InitChain()
@@ -41,7 +45,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgUpdateParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    types.DefaultParams(),
 			},
 			expErr: false,
@@ -58,7 +62,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "invalid params: invalid denom",
 			input: &types.MsgUpdateParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: types.Params{
 					TreasuryAccount: "rewards_treasury",
 					Denom:           "",

--- a/protocol/x/rewards/types/addresses.go
+++ b/protocol/x/rewards/types/addresses.go
@@ -3,5 +3,5 @@ package types
 import authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 var (
-	TreasuryAddress = authtypes.NewModuleAddress(TreasuryAccountName)
+	TreasuryModuleAddress = authtypes.NewModuleAddress(TreasuryAccountName)
 )

--- a/protocol/x/rewards/types/addresses.go
+++ b/protocol/x/rewards/types/addresses.go
@@ -1,0 +1,7 @@
+package types
+
+import authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+var (
+	TreasuryAddress = authtypes.NewModuleAddress(TreasuryAccountName)
+)

--- a/protocol/x/rewards/types/addresses_test.go
+++ b/protocol/x/rewards/types/addresses_test.go
@@ -1,0 +1,11 @@
+package types_test
+
+import (
+	"github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTreasuryModuleAddress(t *testing.T) {
+	require.Equal(t, "dydx16wrau2x4tsg033xfrrdpae6kxfn9kyuerr5jjp", types.TreasuryModuleAddress.String())
+}

--- a/protocol/x/sending/keeper/msg_server_create_transfer_test.go
+++ b/protocol/x/sending/keeper/msg_server_create_transfer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -268,7 +269,7 @@ func TestMsgServerSendFromModuleToAccount(t *testing.T) {
 	}{
 		"Success": {
 			testMsg: types.MsgSendFromModuleToAccount{
-				Authority:        constants.GovModuleAccAddressString,
+				Authority:        lib.GovModuleAddress.String(),
 				SenderModuleName: "community_treasury",
 				Recipient:        constants.AliceAccAddress.String(),
 				Coin:             sdk.NewCoin("adv4tnt", sdk.NewInt(1)),
@@ -289,7 +290,7 @@ func TestMsgServerSendFromModuleToAccount(t *testing.T) {
 		},
 		"Failure: keeper method returns error": {
 			testMsg: types.MsgSendFromModuleToAccount{
-				Authority:        constants.GovModuleAccAddressString,
+				Authority:        lib.GovModuleAddress.String(),
 				SenderModuleName: "community_treasury",
 				Recipient:        constants.CarlAccAddress.String(),
 				Coin:             sdk.NewCoin("adv4tnt", sdk.NewInt(1)),

--- a/protocol/x/sending/keeper/transfer_test.go
+++ b/protocol/x/sending/keeper/transfer_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"errors"
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"math/big"
 	"testing"
 
@@ -523,7 +524,7 @@ func TestSendFromModuleToAccount(t *testing.T) {
 			err = sendingKeeper.SendFromModuleToAccount(
 				ctx,
 				&types.MsgSendFromModuleToAccount{
-					Authority:        constants.GovModuleAccAddressString,
+					Authority:        lib.GovModuleAddress.String(),
 					SenderModuleName: testModuleName,
 					Recipient:        tc.recipientAddress,
 					Coin:             sdk.NewCoin(testDenom, sdk.NewInt(int64(tc.balanceToSend))),
@@ -583,7 +584,7 @@ func TestSendFromModuleToAccount(t *testing.T) {
 
 func TestSendFromModuleToAccount_InvalidMsg(t *testing.T) {
 	msgEmptySender := &types.MsgSendFromModuleToAccount{
-		Authority:        constants.GovModuleAccAddressString,
+		Authority:        lib.GovModuleAddress.String(),
 		SenderModuleName: "",
 		Recipient:        constants.AliceAccAddress.String(),
 		Coin:             sdk.NewCoin("adv4tnt", sdk.NewInt(100)),
@@ -596,7 +597,7 @@ func TestSendFromModuleToAccount_InvalidMsg(t *testing.T) {
 
 func TestSendFromModuleToAccount_NonExistentSenderModule(t *testing.T) {
 	msgNonExistentSender := &types.MsgSendFromModuleToAccount{
-		Authority:        constants.GovModuleAccAddressString,
+		Authority:        lib.GovModuleAddress.String(),
 		SenderModuleName: "nonexistent",
 		Recipient:        constants.AliceAccAddress.String(),
 		Coin:             sdk.NewCoin("adv4tnt", sdk.NewInt(100)),
@@ -618,7 +619,7 @@ func TestSendFromModuleToAccount_InvalidRecipient(t *testing.T) {
 	err := ks.SendingKeeper.SendFromModuleToAccount(
 		ks.Ctx,
 		&types.MsgSendFromModuleToAccount{
-			Authority:        constants.GovModuleAccAddressString,
+			Authority:        lib.GovModuleAddress.String(),
 			SenderModuleName: "bridge",
 			Recipient:        "dydx1abc", // invalid recipient address
 			Coin:             sdk.NewCoin("dv4tnt", sdk.NewInt(1)),

--- a/protocol/x/stats/keeper/msg_server_test.go
+++ b/protocol/x/stats/keeper/msg_server_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
 	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
 	ctx := tApp.InitChain()
@@ -40,7 +44,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgUpdateParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params:    types.DefaultGenesis().Params,
 			},
 			expErr: false,
@@ -57,7 +61,7 @@ func TestMsgUpdateParams(t *testing.T) {
 		{
 			name: "invalid params: negative duration",
 			input: &types.MsgUpdateParams{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Params: types.Params{
 					WindowDuration: -1,
 				},

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -226,10 +226,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 			)
 
 			// Check the subaccount module balance.
-			subaccountsModuleAccBalance := bankKeeper.GetBalance(
-				ctx, authtypes.NewModuleAddress(types.ModuleName),
-				tc.asset.Denom,
-			)
+			subaccountsModuleAccBalance := bankKeeper.GetBalance(ctx, types.ModuleAddress, tc.asset.Denom)
 			require.Equal(t,
 				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
 				subaccountsModuleAccBalance,
@@ -462,10 +459,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 			)
 
 			// Check the subaccount module balance stays the same.
-			subaccountsModuleAccBalance := bankKeeper.GetBalance(
-				ctx, authtypes.NewModuleAddress(types.ModuleName),
-				tc.asset.Denom,
-			)
+			subaccountsModuleAccBalance := bankKeeper.GetBalance(ctx, types.ModuleAddress, tc.asset.Denom)
 			require.Equal(t,
 				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.subaccountModuleAccBalance)),
 				subaccountsModuleAccBalance,
@@ -774,10 +768,7 @@ func TestTransferFundsFromSubaccountToModule_TransferFundsFromModuleToSubaccount
 			)
 
 			// Check the subaccount module balance.
-			subaccountsModuleAccBalance := bankKeeper.GetBalance(
-				ctx, authtypes.NewModuleAddress(types.ModuleName),
-				tc.asset.Denom,
-			)
+			subaccountsModuleAccBalance := bankKeeper.GetBalance(ctx, types.ModuleAddress, tc.asset.Denom)
 			require.Equal(t,
 				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
 				subaccountsModuleAccBalance,
@@ -954,10 +945,7 @@ func TestTransferFeesToFeeCollectorModule(t *testing.T) {
 			}
 
 			// Check the subaccount module balance.
-			subaccountsModuleAccBalance := bankKeeper.GetBalance(
-				ctx, authtypes.NewModuleAddress(types.ModuleName),
-				tc.asset.Denom,
-			)
+			subaccountsModuleAccBalance := bankKeeper.GetBalance(ctx, types.ModuleAddress, tc.asset.Denom)
 			require.Equal(t,
 				sdk.NewCoin(tc.asset.Denom, sdkmath.NewIntFromBigInt(tc.expectedSubaccountsModuleAccBalance)),
 				subaccountsModuleAccBalance,
@@ -1115,11 +1103,7 @@ func TestTransferInsuranceFundPayments(t *testing.T) {
 			}
 
 			// Check the subaccount module balance.
-			subaccountsModuleAccBalance := bankKeeper.GetBalance(
-				ctx,
-				authtypes.NewModuleAddress(types.ModuleName),
-				constants.Usdc.Denom,
-			)
+			subaccountsModuleAccBalance := bankKeeper.GetBalance(ctx, types.ModuleAddress, constants.Usdc.Denom)
 			require.Equal(
 				t,
 				sdk.NewInt64Coin(constants.Usdc.Denom, tc.expectedSubaccountsModuleAccBalance),

--- a/protocol/x/subaccounts/simulation/genesis.go
+++ b/protocol/x/subaccounts/simulation/genesis.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sim_helpers"
@@ -100,7 +99,7 @@ func updateBankModuleGenesisState(
 
 	// Define the balance of the `subaccounts` module.
 	subaccountsUsdcBalance := banktypes.Balance{
-		Address: authtypes.NewModuleAddress(types.ModuleName).String(),
+		Address: types.ModuleAddress.String(),
 		Coins: []sdk.Coin{{
 			Denom:  asstypes.AssetUsdc.Denom,
 			Amount: totalUsdcSupply,

--- a/protocol/x/subaccounts/simulation/genesis_test.go
+++ b/protocol/x/subaccounts/simulation/genesis_test.go
@@ -9,7 +9,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banksim "github.com/cosmos/cosmos-sdk/x/bank/simulation"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	testutil_rand "github.com/dydxprotocol/v4-chain/protocol/testutil/rand"
@@ -75,7 +74,7 @@ func TestRandomizedGenState(t *testing.T) {
 		simState.Cdc.MustUnmarshalJSON(bankGenStateJson, &bankGenesis)
 
 		foundSubaccountsBalance := false
-		subaccountsAddress := authtypes.NewModuleAddress(types.ModuleName).String()
+		subaccountsAddress := types.ModuleAddress.String()
 
 		for _, balance := range bankGenesis.Balances {
 			if balance.Address == subaccountsAddress {

--- a/protocol/x/subaccounts/types/addresses.go
+++ b/protocol/x/subaccounts/types/addresses.go
@@ -1,0 +1,7 @@
+package types
+
+import authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+var (
+	ModuleAddress = authtypes.NewModuleAddress(ModuleName)
+)

--- a/protocol/x/subaccounts/types/addresses_test.go
+++ b/protocol/x/subaccounts/types/addresses_test.go
@@ -1,0 +1,11 @@
+package types_test
+
+import (
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestModuleAddress(t *testing.T) {
+	require.Equal(t, "dydx1v88c3xv9xyv3eetdx0tvcmq7ung3dywp5upwc6", types.ModuleAddress.String())
+}

--- a/protocol/x/vest/keeper/msg_server_test.go
+++ b/protocol/x/vest/keeper/msg_server_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	GovAuthority = authtypes.NewModuleAddress(govtypes.ModuleName).String()
+)
+
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
 	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
 	ctx := tApp.InitChain()
@@ -41,7 +45,7 @@ func TestMsgSetVestEntry(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgSetVestEntry{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Entry:     TestValidEntry,
 			},
 			expectedErr: "",
@@ -57,7 +61,7 @@ func TestMsgSetVestEntry(t *testing.T) {
 		{
 			name: "invalid params: invalid denom",
 			input: &types.MsgSetVestEntry{
-				Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority: GovAuthority,
 				Entry: types.VestEntry{
 					VesterAccount:   TestVesterAccount,
 					TreasuryAccount: TestTreasuryAccount,
@@ -90,7 +94,7 @@ func TestMsgDeleteVestEntry(t *testing.T) {
 		{
 			name: "valid params",
 			input: &types.MsgDeleteVestEntry{
-				Authority:     authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority:     GovAuthority,
 				VesterAccount: TestVesterAccount,
 			},
 			expectedErr: "",
@@ -106,7 +110,7 @@ func TestMsgDeleteVestEntry(t *testing.T) {
 		{
 			name: "delete non-existent entry",
 			input: &types.MsgDeleteVestEntry{
-				Authority:     authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Authority:     GovAuthority,
 				VesterAccount: "non_existent_vester",
 			},
 			expectedErr: "account is not associated with a vest entry",


### PR DESCRIPTION
### Changelist
- add a module/types/addresses.go file with module address constant where sensible.
- added a constant also for the gov module address
- refactored everywhere a module-specific or gov address was used to use the defined constant instead.

Note: coderabbit summary is good!

### Test Plan
Regular tests should pass.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
