### PR TITLE
[CORE-29, CORE-682] Add Close() shutdown hook to Application which is invoked in simapp, Network, and e2e tests.

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1419,6 +1419,10 @@ func (app *App) setAnteHandler(txConfig client.TxConfig) {
 	app.SetAnteHandler(anteHandler)
 }
 
+func (app *App) Close() error {
+	return app.BaseApp.Close()
+}
+
 // RegisterSwaggerAPI registers swagger route with API Server
 func RegisterSwaggerAPI(_ client.Context, rtr *mux.Router) {
 	statikFS, err := fs.New()

--- a/protocol/app/simulation_test.go
+++ b/protocol/app/simulation_test.go
@@ -90,7 +90,7 @@ func NewSimApp(t testing.TB, appCreator func() *app.App) *SimApp {
 	// TODO(CORE-682): Remove shutdown override hook once Cosmos SDK invokes it as part of simapp.
 	t.Cleanup(func() {
 		if err := simApp.App.Close(); err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 	})
 	return simApp

--- a/protocol/testing/e2e/gov/add_new_market_test.go
+++ b/protocol/testing/e2e/gov/add_new_market_test.go
@@ -282,7 +282,7 @@ func TestAddNewMarketProposal(t *testing.T) {
 			ctx = testapp.SubmitAndTallyProposal(
 				t,
 				ctx,
-				&tApp,
+				tApp,
 				tc.proposedMsgs,
 				tc.expectSubmitProposalFail,
 				tc.expectedProposalStatus,

--- a/protocol/testing/e2e/gov/bridge_test.go
+++ b/protocol/testing/e2e/gov/bridge_test.go
@@ -64,7 +64,7 @@ func TestUpdateEventParams(t *testing.T) {
 			ctx = testapp.SubmitAndTallyProposal(
 				t,
 				ctx,
-				&tApp,
+				tApp,
 				[]sdk.Msg{tc.msg},
 				tc.expectSubmitProposalFail,
 				tc.expectedProposalStatus,
@@ -131,7 +131,7 @@ func TestUpdateProposeParams(t *testing.T) {
 			ctx = testapp.SubmitAndTallyProposal(
 				t,
 				ctx,
-				&tApp,
+				tApp,
 				[]sdk.Msg{tc.msg},
 				tc.expectSubmitProposalFail,
 				tc.expectedProposalStatus,
@@ -194,7 +194,7 @@ func TestUpdateSafetyParams(t *testing.T) {
 			ctx = testapp.SubmitAndTallyProposal(
 				t,
 				ctx,
-				&tApp,
+				tApp,
 				[]sdk.Msg{tc.msg},
 				tc.expectSubmitProposalFail,
 				tc.expectedProposalStatus,

--- a/protocol/testing/e2e/gov/sending_test.go
+++ b/protocol/testing/e2e/gov/sending_test.go
@@ -102,7 +102,7 @@ func TestSendFromModuleToAccount(t *testing.T) {
 			ctx = testapp.SubmitAndTallyProposal(
 				t,
 				ctx,
-				&tApp,
+				tApp,
 				[]sdk.Msg{tc.msg},
 				tc.expectSubmitProposalFail,
 				tc.expectedProposalStatus,

--- a/protocol/testing/e2e/gov/stats_test.go
+++ b/protocol/testing/e2e/gov/stats_test.go
@@ -68,7 +68,7 @@ func TestUpdateParams(t *testing.T) {
 			ctx = testapp.SubmitAndTallyProposal(
 				t,
 				ctx,
-				&tApp,
+				tApp,
 				[]sdk.Msg{tc.msg},
 				tc.expectSubmitProposalFail,
 				tc.expectedProposalStatus,

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -299,7 +299,7 @@ func (tApp TestAppBuilder) Build() *TestApp {
 		tApp.t.Cleanup(func() {
 			if rval.App != nil {
 				if err := rval.App.Close(); err != nil {
-					panic(err)
+					tApp.t.Fatal(err)
 				}
 			}
 		})
@@ -568,7 +568,13 @@ func (tApp *TestApp) AdvanceToBlock(
 // Reset resets the chain such that it can be initialized and executed again.
 func (tApp *TestApp) Reset() {
 	if tApp.App != nil {
-		tApp.App.Close()
+		if err := tApp.App.Close(); err != nil {
+			if tApp.builder.t != nil {
+				tApp.builder.t.Fatal(err)
+			} else {
+				panic(err)
+			}
+		}
 	}
 	tApp.App = nil
 	tApp.genesis = types.GenesisDoc{}

--- a/protocol/testutil/network/network.go
+++ b/protocol/testutil/network/network.go
@@ -83,6 +83,18 @@ func New(t *testing.T, configs ...network.Config) *network.Network {
 		cfg = configs[0]
 	}
 
+	// TODO(CORE-682): Remove shutdown override hook once Cosmos SDK invokes it as part of network#Cleanup.
+	appConstructor := cfg.AppConstructor
+	cfg.AppConstructor = func(val network.ValidatorI) servertypes.Application {
+		app := appConstructor(val)
+		t.Cleanup(func() {
+			if err := app.Close(); err != nil {
+				panic(err)
+			}
+		})
+		return app
+	}
+
 	net, err := network.New(t, t.TempDir(), cfg)
 	if err != nil {
 		panic(err)

--- a/protocol/x/clob/e2e/equity_tier_limit_test.go
+++ b/protocol/x/clob/e2e/equity_tier_limit_test.go
@@ -563,7 +563,7 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 					require.Conditionf(t, resp.IsErr, "Expected CheckTx to error. Response: %+v", resp)
 					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1.")
 
-					checkThatFoKOrderIsNotBlockedByEquityTierLimits(t, &tApp, ctx)
+					checkThatFoKOrderIsNotBlockedByEquityTierLimits(t, tApp, ctx)
 				} else {
 					require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
 				}
@@ -728,7 +728,7 @@ func TestPlaceOrder_EquityTierLimit_OrderExpiry(t *testing.T) {
 					require.Conditionf(t, resp.IsErr, "Expected CheckTx to error. Response: %+v", resp)
 					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1.")
 
-					checkThatFoKOrderIsNotBlockedByEquityTierLimits(t, &tApp, ctx)
+					checkThatFoKOrderIsNotBlockedByEquityTierLimits(t, tApp, ctx)
 				} else {
 					require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
 				}

--- a/protocol/x/clob/e2e/long_term_orders_test.go
+++ b/protocol/x/clob/e2e/long_term_orders_test.go
@@ -244,7 +244,7 @@ func TestImmediateExecutionLongTermOrders(t *testing.T) {
 			1: clobtypes.ErrLongTermOrdersCannotRequireImmediateExecution.Error(),
 		},
 	}
-	blockAdvancement.AdvanceToBlock(ctx, 2, &tApp, t)
+	blockAdvancement.AdvanceToBlock(ctx, 2, tApp, t)
 }
 
 func TestLongTermOrderExpires(t *testing.T) {

--- a/protocol/x/clob/e2e/order_matches_test.go
+++ b/protocol/x/clob/e2e/order_matches_test.go
@@ -247,7 +247,7 @@ func TestDeliverTxMatchValidation(t *testing.T) {
 			ctx := tApp.InitChain()
 
 			for i, blockAdvancement := range tc.blockAdvancements {
-				ctx = blockAdvancement.AdvanceToBlock(ctx, uint32(i+2), &tApp, t)
+				ctx = blockAdvancement.AdvanceToBlock(ctx, uint32(i+2), tApp, t)
 			}
 		})
 	}

--- a/protocol/x/delaymsg/keeper/dispatch_test.go
+++ b/protocol/x/delaymsg/keeper/dispatch_test.go
@@ -400,7 +400,7 @@ func TestSendDelayedCompleteBridgeMessage(t *testing.T) {
 	aliceAccountAddress := sdk.MustAccAddressFromBech32(constants.BridgeEvent_Id0_Height0.Address)
 
 	// Sanity check: at block 1, expect bridge balance is genesis value before the message is sent.
-	expectAccountBalance(t, ctx, &tApp, BridgeAccountAddress, BridgeGenesisAccountBalance)
+	expectAccountBalance(t, ctx, tApp, BridgeAccountAddress, BridgeGenesisAccountBalance)
 
 	// Get initial Alice balance
 	aliceInitialBalance := tApp.App.BankKeeper.GetBalance(ctx, aliceAccountAddress, testDenom)
@@ -414,8 +414,8 @@ func TestSendDelayedCompleteBridgeMessage(t *testing.T) {
 	ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
 	// Assert: balances have been updated to reflect the executed CompleteBridge message.
-	expectAccountBalance(t, ctx, &tApp, BridgeAccountAddress, BridgeExpectedAccountBalance)
-	expectAccountBalance(t, ctx, &tApp, aliceAccountAddress, aliceExpectedAccountBalance)
+	expectAccountBalance(t, ctx, tApp, BridgeAccountAddress, BridgeExpectedAccountBalance)
+	expectAccountBalance(t, ctx, tApp, aliceAccountAddress, aliceExpectedAccountBalance)
 
 	// Assert: the message has been deleted from the keeper.
 	_, found = tApp.App.DelayMsgKeeper.GetMessage(ctx, 0)
@@ -492,7 +492,7 @@ func TestSendDelayedCompleteBridgeMessage_Failure(t *testing.T) {
 	ctx := tApp.InitChain()
 
 	// Sanity check: at block 1, balances are as expected before the message is sent.
-	expectAccountBalance(t, ctx, &tApp, BridgeAccountAddress, BridgeGenesisAccountBalance)
+	expectAccountBalance(t, ctx, tApp, BridgeAccountAddress, BridgeGenesisAccountBalance)
 
 	// Sanity check: a message with this id exists within the keeper.
 	_, found := tApp.App.DelayMsgKeeper.GetMessage(ctx, 0)
@@ -507,7 +507,7 @@ func TestSendDelayedCompleteBridgeMessage_Failure(t *testing.T) {
 	ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
 	// Assert: balances have been updated to reflect the executed CompleteBridge message.
-	expectAccountBalance(t, ctx, &tApp, BridgeAccountAddress, BridgeGenesisAccountBalance)
+	expectAccountBalance(t, ctx, tApp, BridgeAccountAddress, BridgeGenesisAccountBalance)
 
 	// Assert: the message has been deleted from the keeper.
 	_, found = tApp.App.DelayMsgKeeper.GetMessage(ctx, 0)

--- a/protocol/x/sending/app_test.go
+++ b/protocol/x/sending/app_test.go
@@ -216,7 +216,7 @@ func TestMsgDepositToSubaccount_NonExistentAccount(t *testing.T) {
 		Quantums:  uint64(1_000_000),
 	}
 
-	testNonExistentSender(t, &tApp, ctx, &msgDepositToSubaccount, randomAccount.PrivKey)
+	testNonExistentSender(t, tApp, ctx, &msgDepositToSubaccount, randomAccount.PrivKey)
 }
 
 func TestMsgWithdrawFromSubaccount(t *testing.T) {
@@ -408,7 +408,7 @@ func TestMsgWithdrawFromSubaccount_NonExistentSubaccount(t *testing.T) {
 		Quantums:  uint64(1_000_000),
 	}
 
-	testNonExistentSender(t, &tApp, ctx, &msgWithdrawFromSubaccount, randomAccount.PrivKey)
+	testNonExistentSender(t, tApp, ctx, &msgWithdrawFromSubaccount, randomAccount.PrivKey)
 }
 
 // testNonExistentSender is a helper function that tests sending transfer messages with non-existent sender.


### PR DESCRIPTION
### Changelist
This hook is invoked on [application shutdown](https://github.com/cosmos/cosmos-sdk/blob/release/v0.47.x/server/start.go#L256) so we can re-use it within our tests. Note that there is an [open issue against Cosmos SDK](https://github.com/cosmos/cosmos-sdk/issues/18151) about removing the `Close` call that is added for `simapp` and `Network` tests to function.

### Test Plan
Existing tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
