### PR TITLE
Fix `AdvanceToBlock` blocktime behavior

### DIFF
--- a/protocol/x/bridge/app_test.go
+++ b/protocol/x/bridge/app_test.go
@@ -142,6 +142,7 @@ func TestBridge_Success(t *testing.T) {
 						genesisState.SafetyParams = tc.safetyParams
 					},
 				)
+				genesis.GenesisTime = tc.blockTime
 				return genesis
 			}).WithTesting(t).Build()
 			ctx := tApp.InitChain()
@@ -178,9 +179,7 @@ func TestBridge_Success(t *testing.T) {
 
 			// Advance to block right before bridge completion, if necessary.
 			if blockHeightOfBridgeCompletion-1 > uint32(ctx.BlockHeight()) {
-				ctx = tApp.AdvanceToBlock(blockHeightOfBridgeCompletion-1, testapp.AdvanceToBlockOptions{
-					BlockTime: tc.blockTime.Add(-time.Second * 1),
-				})
+				ctx = tApp.AdvanceToBlock(blockHeightOfBridgeCompletion-1, testapp.AdvanceToBlockOptions{})
 			}
 			// Verify that balances have not changed yet.
 			for _, event := range tc.bridgeEvents {
@@ -194,9 +193,7 @@ func TestBridge_Success(t *testing.T) {
 
 			// Verify that balances are updated, if bridge events were proposed, at the block of
 			// bridge completion.
-			ctx = tApp.AdvanceToBlock(blockHeightOfBridgeCompletion, testapp.AdvanceToBlockOptions{
-				BlockTime: tc.blockTime,
-			})
+			ctx = tApp.AdvanceToBlock(blockHeightOfBridgeCompletion, testapp.AdvanceToBlockOptions{})
 			for _, event := range tc.bridgeEvents {
 				balance := tApp.App.BankKeeper.GetBalance(
 					ctx,

--- a/protocol/x/stats/keeper/keeper_test.go
+++ b/protocol/x/stats/keeper/keeper_test.go
@@ -197,12 +197,13 @@ func TestExpireOldStats(t *testing.T) {
 	})
 	windowDuration := tApp.App.StatsKeeper.GetWindowDuration(ctx)
 	// 5 epochs are out of the window
-	ctx = tApp.AdvanceToBlock(100, testapp.AdvanceToBlockOptions{
+	ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{
 		BlockTime: time.Unix(0, 0).
 			Add(windowDuration).
 			Add((time.Duration(5*epochstypes.StatsEpochDuration) + 1) * time.Second).
 			UTC(),
 	})
+	ctx = tApp.AdvanceToBlock(100, testapp.AdvanceToBlockOptions{})
 	k := tApp.App.StatsKeeper
 
 	// Create a bunch of EpochStats.

--- a/protocol/x/stats/keeper/keeper_test.go
+++ b/protocol/x/stats/keeper/keeper_test.go
@@ -197,7 +197,7 @@ func TestExpireOldStats(t *testing.T) {
 	})
 	windowDuration := tApp.App.StatsKeeper.GetWindowDuration(ctx)
 	// 5 epochs are out of the window
-	ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{
+	tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{
 		BlockTime: time.Unix(0, 0).
 			Add(windowDuration).
 			Add((time.Duration(5*epochstypes.StatsEpochDuration) + 1) * time.Second).


### PR DESCRIPTION
### Changelist
Discussed offline with @lcwik to fix the blocktime behavior of `AdvanceToBlock` function. Previously comment indicates that `options.BlockTime` is only for the requested (latest) block, but the implementation actually applies `options.BlockTime` to the first advanced block.

### Test Plan
Fixed a few e2e tests affected by this behavior change. All other e2e tests still passing

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
