### PR TITLE
Code clean-up, require testing.TB instance for testapp

### DIFF
--- a/protocol/app/msgs/app_test.go
+++ b/protocol/app/msgs/app_test.go
@@ -193,7 +193,7 @@ func TestDisallowMsgs_CheckTx_Fail(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup app.
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
 			// Setup msgs.
@@ -254,7 +254,7 @@ func TestDisallowMsgs_PrepareProposal_Filter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup app.
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
 			// Setup msg tx.
@@ -316,7 +316,7 @@ func TestDisallowMsgs_ProcessProposal_Fail(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup app.
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
 			// Setup msgs.

--- a/protocol/app/prepare/full_node_prepare_proposal_test.go
+++ b/protocol/app/prepare/full_node_prepare_proposal_test.go
@@ -28,7 +28,7 @@ func TestFullNodePrepareProposalHandler(t *testing.T) {
 		flags.NonValidatingFullNodeFlag: true,
 		testlog.LoggerInstanceForTest:   logger,
 	}
-	tApp := testApp.NewTestAppBuilder().WithTesting(t).WithAppCreatorFn(testApp.DefaultTestAppCreatorFn(appOpts)).Build()
+	tApp := testApp.NewTestAppBuilder(t).WithAppCreatorFn(testApp.DefaultTestAppCreatorFn(appOpts)).Build()
 
 	found := false
 	tApp.AdvanceToBlock(2, testApp.AdvanceToBlockOptions{

--- a/protocol/app/prepare/other_msgs_test.go
+++ b/protocol/app/prepare/other_msgs_test.go
@@ -162,7 +162,7 @@ func TestRemoveDisallowMsgs(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testApp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			txs := prepare.RemoveDisallowMsgs(ctx, encodingCfg.TxConfig.TxDecoder(), tc.txs)
 			require.Equal(t, tc.expectedTxs, txs)

--- a/protocol/lib/tx_mode_test.go
+++ b/protocol/lib/tx_mode_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAssertDeliverTxMode(t *testing.T) {
-	tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testApp.NewTestAppBuilder(t).Build()
 	// Initializing the chain returns a checkTx context so swap to a deliverTx context
 	ctx := tApp.InitChain().WithIsCheckTx(false)
 
@@ -24,7 +24,7 @@ func TestAssertDeliverTxMode(t *testing.T) {
 }
 
 func TestIsDeliverTxMode(t *testing.T) {
-	tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testApp.NewTestAppBuilder(t).Build()
 	// Initializing the chain returns a checkTx context so swap to a deliverTx context
 	ctx := tApp.InitChain().WithIsCheckTx(false)
 
@@ -34,7 +34,7 @@ func TestIsDeliverTxMode(t *testing.T) {
 }
 
 func TestAssertCheckTxMode(t *testing.T) {
-	tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testApp.NewTestAppBuilder(t).Build()
 	// Initializing the chain returns a checkTx context so swap to a deliverTx context
 	ctx := tApp.InitChain().WithIsCheckTx(false)
 
@@ -50,7 +50,7 @@ func TestAssertCheckTxMode(t *testing.T) {
 }
 
 func TestTxMode(t *testing.T) {
-	tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testApp.NewTestAppBuilder(t).Build()
 	// Initializing the chain returns a checkTx context so swap to a deliverTx context
 	ctx := tApp.InitChain().WithIsCheckTx(false)
 

--- a/protocol/testing/e2e/gov/add_new_market_test.go
+++ b/protocol/testing/e2e/gov/add_new_market_test.go
@@ -263,7 +263,7 @@ func TestAddNewMarketProposal(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -272,7 +272,7 @@ func TestAddNewMarketProposal(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			initMarketParams := tApp.App.PricesKeeper.GetAllMarketParams(ctx)

--- a/protocol/testing/e2e/gov/bridge_test.go
+++ b/protocol/testing/e2e/gov/bridge_test.go
@@ -48,7 +48,7 @@ func TestUpdateEventParams(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -57,7 +57,7 @@ func TestUpdateEventParams(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Submit and tally governance proposal that includes `MsgUpdateEventParams`.
@@ -115,7 +115,7 @@ func TestUpdateProposeParams(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -124,7 +124,7 @@ func TestUpdateProposeParams(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Submit and tally governance proposal that includes `MsgUpdateProposeParams`.
@@ -178,7 +178,7 @@ func TestUpdateSafetyParams(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -187,7 +187,7 @@ func TestUpdateSafetyParams(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Submit and tally governance proposal that includes `MsgUpdateSafetyParams`.

--- a/protocol/testing/e2e/gov/sending_test.go
+++ b/protocol/testing/e2e/gov/sending_test.go
@@ -68,7 +68,7 @@ func TestSendFromModuleToAccount(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			senderModuleAddress := authtypes.NewModuleAddress(tc.msg.SenderModuleName)
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -89,7 +89,7 @@ func TestSendFromModuleToAccount(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 			initialModuleBalance := tApp.App.BankKeeper.GetBalance(ctx, senderModuleAddress, tc.msg.Coin.Denom)
 			initialRecipientBalance := tApp.App.BankKeeper.GetBalance(

--- a/protocol/testing/e2e/gov/stats_test.go
+++ b/protocol/testing/e2e/gov/stats_test.go
@@ -42,7 +42,7 @@ func TestUpdateParams(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -60,7 +60,7 @@ func TestUpdateParams(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 			initialParams := tApp.App.StatsKeeper.GetParams(ctx)
 

--- a/protocol/x/blocktime/genesis_test.go
+++ b/protocol/x/blocktime/genesis_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenesis(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	got := blocktime.ExportGenesis(ctx, tApp.App.BlockTimeKeeper)
 	require.NotNil(t, got)

--- a/protocol/x/blocktime/keeper/grpc_query_test.go
+++ b/protocol/x/blocktime/keeper/grpc_query_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDowntimeParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BlockTimeKeeper
 
@@ -48,7 +48,7 @@ func TestDowntimeParams(t *testing.T) {
 }
 
 func TestAllDowntimeInfo(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BlockTimeKeeper
 	info := &types.AllDowntimeInfo{
@@ -95,7 +95,7 @@ func TestAllDowntimeInfo(t *testing.T) {
 }
 
 func TestPreviousBlockInfo(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BlockTimeKeeper
 	info := &types.BlockInfo{

--- a/protocol/x/blocktime/keeper/keeper_test.go
+++ b/protocol/x/blocktime/keeper/keeper_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	logger := tApp.App.BlockTimeKeeper.Logger(ctx)
@@ -128,7 +128,7 @@ func TestUpdateAllDowntimeInfo(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			tApp.InitChain()
 			ctx := tApp.AdvanceToBlock(
 				tc.previousBlockInfo.Height+1,
@@ -196,7 +196,7 @@ func TestGetDowntimeInfoFor(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			tApp.InitChain()
 			ctx := tApp.AdvanceToBlock(
 				40,

--- a/protocol/x/blocktime/keeper/msg_server_test.go
+++ b/protocol/x/blocktime/keeper/msg_server_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BlockTimeKeeper
 

--- a/protocol/x/blocktime/keeper/params_test.go
+++ b/protocol/x/blocktime/keeper/params_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGetDowntimeParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BlockTimeKeeper
 
@@ -18,7 +18,7 @@ func TestGetDowntimeParams(t *testing.T) {
 }
 
 func TestSetDowntimeParams_Success(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	tApp.InitChain()
 	ctx := tApp.AdvanceToBlock(
 		40,

--- a/protocol/x/bridge/app_test.go
+++ b/protocol/x/bridge/app_test.go
@@ -133,7 +133,7 @@ func TestBridge_Success(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -143,7 +143,7 @@ func TestBridge_Success(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Get initial balances of addresses and their expected balances after bridging.
@@ -303,7 +303,7 @@ func TestBridge_REJECT(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -315,7 +315,7 @@ func TestBridge_REJECT(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
 			// Add good bridge events to app server.
@@ -358,7 +358,7 @@ func TestBridge_REJECT(t *testing.T) {
 //     accepted by the rest of the chain.
 //   - the node restarts.
 func TestBridge_AcknowledgedEventIdGreaterThanRecognizedEventId(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 		genesis = testapp.DefaultGenesis()
 		testapp.UpdateGenesisDocWithAppStateForModule(
 			&genesis,
@@ -370,7 +370,7 @@ func TestBridge_AcknowledgedEventIdGreaterThanRecognizedEventId(t *testing.T) {
 			},
 		)
 		return genesis
-	}).WithTesting(t).Build()
+	}).Build()
 	ctx := tApp.InitChain()
 
 	// Verify that AcknowledgedEventInfo.NextId is 2.

--- a/protocol/x/bridge/genesis_test.go
+++ b/protocol/x/bridge/genesis_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenesis(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	got := bridge.ExportGenesis(ctx, tApp.App.BridgeKeeper)
 	require.NotNil(t, got)

--- a/protocol/x/bridge/keeper/bridge_event_info_test.go
+++ b/protocol/x/bridge/keeper/bridge_event_info_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetAcknowledgedEventInfo(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -24,7 +24,7 @@ func TestGetAcknowledgedEventInfo(t *testing.T) {
 }
 
 func TestSetAcknowledgedEventInfo(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 

--- a/protocol/x/bridge/keeper/grpc_query_test.go
+++ b/protocol/x/bridge/keeper/grpc_query_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestEventParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -54,7 +54,7 @@ func TestEventParams(t *testing.T) {
 }
 
 func TestProposeParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -89,7 +89,7 @@ func TestProposeParams(t *testing.T) {
 }
 
 func TestSafetyParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -124,7 +124,7 @@ func TestSafetyParams(t *testing.T) {
 }
 
 func TestAcknowledgedEventInfo(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -159,7 +159,7 @@ func TestAcknowledgedEventInfo(t *testing.T) {
 }
 
 func TestRecognizedEventInfo(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -222,7 +222,7 @@ func TestDelayedCompleteBridgeMessages(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			// Initialize test app.
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			k := tApp.App.BridgeKeeper
 			delayMsgKeeper := tApp.App.DelayMsgKeeper

--- a/protocol/x/bridge/keeper/keeper_test.go
+++ b/protocol/x/bridge/keeper/keeper_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	logger := tApp.App.BridgeKeeper.Logger(ctx)

--- a/protocol/x/bridge/keeper/msg_server_test.go
+++ b/protocol/x/bridge/keeper/msg_server_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 

--- a/protocol/x/bridge/keeper/params_test.go
+++ b/protocol/x/bridge/keeper/params_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetEventParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -17,7 +17,7 @@ func TestGetEventParams(t *testing.T) {
 }
 
 func TestUpdateEventParams_Success(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -33,7 +33,7 @@ func TestUpdateEventParams_Success(t *testing.T) {
 }
 
 func TestGetProposeParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -41,7 +41,7 @@ func TestGetProposeParams(t *testing.T) {
 }
 
 func TestUpdateProposeParams_Success(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -58,7 +58,7 @@ func TestUpdateProposeParams_Success(t *testing.T) {
 }
 
 func TestUpdateProposeParams_ValidationError(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -73,7 +73,7 @@ func TestUpdateProposeParams_ValidationError(t *testing.T) {
 }
 
 func TestGetSafetyParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 
@@ -81,7 +81,7 @@ func TestGetSafetyParams(t *testing.T) {
 }
 
 func TestUpdateSafetyParams_Success(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.BridgeKeeper
 

--- a/protocol/x/clob/abci_test.go
+++ b/protocol/x/clob/abci_test.go
@@ -1019,7 +1019,7 @@ func TestLiquidateSubaccounts(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis tmtypes.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis tmtypes.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -1049,7 +1049,7 @@ func TestLiquidateSubaccounts(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 			// Create all existing orders.

--- a/protocol/x/clob/e2e/app_test.go
+++ b/protocol/x/clob/e2e/app_test.go
@@ -188,7 +188,7 @@ var (
 func TestConcurrentMatchesAndCancels(t *testing.T) {
 	r := rand.NewRand()
 	simAccounts := simtypes.RandomAccounts(r, 1000)
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 		genesis = testapp.DefaultGenesis()
 		testapp.UpdateGenesisDocWithAppStateForModule(
 			&genesis,
@@ -397,23 +397,11 @@ func TestFailsDeliverTxWithIncorrectlySignedPlaceOrderTx(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r != nil {
-					require.ErrorContains(
-						t,
-						r.(error),
-						"invalid pubkey: MsgProposedOperations is invalid",
-					)
-				} else {
-					t.Error("Expected panic")
-				}
-			}()
 			msgSender := msgsender.NewIndexerMessageSenderInMemoryCollector()
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tAppBuilder := testapp.NewTestAppBuilder().WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts))
-			tApp := tAppBuilder.Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
 			tApp.InitChain()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
@@ -446,7 +434,21 @@ func TestFailsDeliverTxWithIncorrectlySignedPlaceOrderTx(t *testing.T) {
 				},
 			)
 
-			tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{RequestProcessProposalTxsOverride: proposal.Txs})
+			tApp.AdvanceToBlock(3,
+				testapp.AdvanceToBlockOptions{
+					RequestProcessProposalTxsOverride: proposal.Txs,
+					ValidateDeliverTxs: func(
+						ctx sdktypes.Context,
+						request abcitypes.RequestDeliverTx,
+						response abcitypes.ResponseDeliverTx,
+						txIndex int,
+					) (haltchain bool) {
+						require.Condition(t, response.IsErr, "Expected DeliverTx to fail but passed %+v", response)
+						require.Contains(t, response.Log, "invalid pubkey: MsgProposedOperations is invalid")
+						return true
+					},
+				},
+			)
 		})
 	}
 }
@@ -468,31 +470,33 @@ func TestFailsDeliverTxWithUnsignedTransactions(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r != nil {
-					require.ErrorContains(
-						t,
-						r.(error),
-						"Error: no signatures supplied: MsgProposedOperations is invalid",
-					)
-				} else {
-					t.Error("Expected panic")
-				}
-			}()
-
 			msgSender := msgsender.NewIndexerMessageSenderInMemoryCollector()
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tAppBuilder := testapp.NewTestAppBuilder().WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts))
-			tApp := tAppBuilder.Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
 			tApp.InitChain()
 			tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
 			proposal := tApp.PrepareProposal()
 			proposal.Txs[0] = tc.proposedOperationsTx
 
-			tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{RequestProcessProposalTxsOverride: proposal.Txs})
+			tApp.AdvanceToBlock(
+				3,
+				testapp.AdvanceToBlockOptions{
+					RequestProcessProposalTxsOverride: proposal.Txs,
+					ValidateDeliverTxs: func(
+						ctx sdktypes.Context,
+						request abcitypes.RequestDeliverTx,
+						response abcitypes.ResponseDeliverTx,
+						txIndex int,
+					) (haltchain bool) {
+						require.Condition(t, response.IsErr, "Expected DeliverTx to fail but passed %+v", response)
+						require.Contains(t, response.Log, "Error: no signatures supplied: MsgProposedOperations is invalid")
+						return true
+					},
+				},
+			)
 		})
 	}
 }
@@ -502,8 +506,7 @@ func TestStats(t *testing.T) {
 	appOpts := map[string]interface{}{
 		indexer.MsgSenderInstanceForTest: msgSender,
 	}
-	tAppBuilder := testapp.NewTestAppBuilder().WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts))
-	tApp := tAppBuilder.Build()
+	tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
 
 	// Epochs start at block height 2.
 	startTime := time.Unix(10, 0).UTC()

--- a/protocol/x/clob/e2e/conditional_orders_test.go
+++ b/protocol/x/clob/e2e/conditional_orders_test.go
@@ -487,7 +487,7 @@ func TestConditionalOrder(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -527,7 +527,7 @@ func TestConditionalOrder(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Create all orders.
@@ -667,7 +667,7 @@ func TestConditionalOrderCancellation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -707,7 +707,7 @@ func TestConditionalOrderCancellation(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Create all orders.
@@ -975,7 +975,7 @@ func TestConditionalOrderExpiration(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -1015,7 +1015,7 @@ func TestConditionalOrderExpiration(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Create all orders.

--- a/protocol/x/clob/e2e/equity_tier_limit_test.go
+++ b/protocol/x/clob/e2e/equity_tier_limit_test.go
@@ -522,7 +522,7 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() types.GenesisDoc {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() types.GenesisDoc {
 				genesis := testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *satypes.GenesisState) {
 					state.Subaccounts = []satypes.Subaccount{
@@ -697,7 +697,7 @@ func TestPlaceOrder_EquityTierLimit_OrderExpiry(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() types.GenesisDoc {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() types.GenesisDoc {
 				genesis := testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *satypes.GenesisState) {
 					state.Subaccounts = []satypes.Subaccount{
@@ -1004,7 +1004,7 @@ func TestPlaceOrder_EquityTierLimit_OrderFill(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() types.GenesisDoc {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() types.GenesisDoc {
 				genesis := testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *satypes.GenesisState) {
 					state.Subaccounts = []satypes.Subaccount{

--- a/protocol/x/clob/e2e/liquidation_deleveraging_test.go
+++ b/protocol/x/clob/e2e/liquidation_deleveraging_test.go
@@ -375,7 +375,7 @@ func TestPlacePerpetualLiquidation_Deleveraging(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -445,7 +445,7 @@ func TestPlacePerpetualLiquidation_Deleveraging(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 

--- a/protocol/x/clob/e2e/long_term_orders_test.go
+++ b/protocol/x/clob/e2e/long_term_orders_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestPlaceOrder_StatefulCancelFollowedByPlaceInSameBlockErrorsInCheckTx(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	// Place the order.
@@ -170,7 +170,7 @@ func TestCancelStatefulOrder(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 
 			for _, blockWithMessages := range tc.blockWithMessages {
 				ctx := tApp.AdvanceToBlock(blockWithMessages.Block, testapp.AdvanceToBlockOptions{})
@@ -202,7 +202,7 @@ func TestCancelStatefulOrder(t *testing.T) {
 }
 
 func TestImmediateExecutionLongTermOrders(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	// Reject long-term IOC in CheckTx
@@ -248,7 +248,7 @@ func TestImmediateExecutionLongTermOrders(t *testing.T) {
 }
 
 func TestLongTermOrderExpires(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	order := constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy100_Price10_GTBT15
@@ -284,7 +284,7 @@ func TestLongTermOrderExpires(t *testing.T) {
 }
 
 func TestPlaceLongTermOrder(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	// subaccounts for indexer expectation assertions
@@ -1221,7 +1221,7 @@ func TestPlaceLongTermOrder(t *testing.T) {
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
 			ctx := tApp.InitChain()
 
 			for _, ordersAndExpectations := range tc.ordersAndExpectationsPerBlock {

--- a/protocol/x/clob/e2e/order_matches_test.go
+++ b/protocol/x/clob/e2e/order_matches_test.go
@@ -222,7 +222,7 @@ func TestDeliverTxMatchValidation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,

--- a/protocol/x/clob/e2e/order_removal_test.go
+++ b/protocol/x/clob/e2e/order_removal_test.go
@@ -236,7 +236,7 @@ func TestConditionalOrderRemoval(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -277,7 +277,7 @@ func TestConditionalOrderRemoval(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Create all orders.
@@ -643,7 +643,7 @@ func TestOrderRemoval_Invalid(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -684,7 +684,7 @@ func TestOrderRemoval_Invalid(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Create all orders and add to deliverTxsOverride
@@ -853,7 +853,7 @@ func TestOrderRemoval(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -894,7 +894,7 @@ func TestOrderRemoval(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Create all orders.
@@ -950,7 +950,7 @@ func TestOrderRemoval(t *testing.T) {
 }
 
 func TestOrderRemoval_MultipleReplayOperationsDuringPrepareCheckState(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 		genesis = testapp.DefaultGenesis()
 		testapp.UpdateGenesisDocWithAppStateForModule(
 			&genesis,
@@ -987,7 +987,7 @@ func TestOrderRemoval_MultipleReplayOperationsDuringPrepareCheckState(t *testing
 			},
 		)
 		return genesis
-	}).WithTesting(t).Build()
+	}).Build()
 	ctx := tApp.InitChain()
 
 	// Create a resting order for alice.

--- a/protocol/x/clob/e2e/rate_limit_test.go
+++ b/protocol/x/clob/e2e/rate_limit_test.go
@@ -98,7 +98,7 @@ func TestRateLimitingOrders_RateLimitsAreEnforced(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -115,7 +115,7 @@ func TestRateLimitingOrders_RateLimitsAreEnforced(t *testing.T) {
 						}
 					})
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			firstCheckTx := testapp.MustMakeCheckTx(
@@ -168,7 +168,7 @@ func TestRateLimitingOrders_RateLimitsAreEnforced(t *testing.T) {
 }
 
 func TestCancellationAndMatchInTheSameBlock_Regression(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 
 	LPlaceOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20 := *clobtypes.NewMsgPlaceOrder(MustScaleOrder(
 		clobtypes.Order{
@@ -293,7 +293,7 @@ func TestStatefulCancellation_Deduplication(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 			for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(
 				ctx, tApp.App, LPlaceOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20) {
@@ -375,7 +375,7 @@ func TestStatefulOrderPlacement_Deduplication(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -386,7 +386,7 @@ func TestStatefulOrderPlacement_Deduplication(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
 			// First placement should pass since the order is unknown.
@@ -428,7 +428,7 @@ func TestStatefulOrderPlacement_Deduplication(t *testing.T) {
 }
 
 func TestRateLimitingOrders_StatefulOrdersDuringDeliverTxAreNotRateLimited(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 		genesis = testapp.DefaultGenesis()
 		testapp.UpdateGenesisDocWithAppStateForModule(
 			&genesis,
@@ -444,7 +444,7 @@ func TestRateLimitingOrders_StatefulOrdersDuringDeliverTxAreNotRateLimited(t *te
 			},
 		)
 		return genesis
-	}).WithTesting(t).Build()
+	}).Build()
 	ctx := tApp.InitChain()
 
 	firstMarketCheckTx := testapp.MustMakeCheckTx(
@@ -513,7 +513,7 @@ func TestRateLimitingShortTermOrders_GuardedAgainstReplayAttacks(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -530,7 +530,7 @@ func TestRateLimitingShortTermOrders_GuardedAgainstReplayAttacks(t *testing.T) {
 						}
 					})
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.AdvanceToBlock(5, testapp.AdvanceToBlockOptions{})
 
 			replayLessGTBTx := testapp.MustMakeCheckTx(

--- a/protocol/x/clob/e2e/short_term_orders_test.go
+++ b/protocol/x/clob/e2e/short_term_orders_test.go
@@ -29,8 +29,7 @@ func TestPlaceOrder(t *testing.T) {
 	appOpts := map[string]interface{}{
 		indexer.MsgSenderInstanceForTest: msgSender,
 	}
-	tAppBuilder := testapp.NewTestAppBuilder().WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts))
-	tApp := tAppBuilder.Build()
+	tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
 	ctx := tApp.InitChain()
 
 	aliceSubaccount := tApp.App.SubaccountsKeeper.GetSubaccount(ctx, constants.Alice_Num0)

--- a/protocol/x/clob/keeper/grpc_query_equity_tier_limit_config_test.go
+++ b/protocol/x/clob/keeper/grpc_query_equity_tier_limit_config_test.go
@@ -12,7 +12,7 @@ import (
 func TestEquityTierLimitConfiguration(
 	t *testing.T,
 ) {
-	tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testApp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	expected := types.QueryEquityTierLimitConfigurationResponse{
 		EquityTierLimitConfig: tApp.App.ClobKeeper.GetEquityTierLimitConfiguration(ctx),

--- a/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_block_rate_limit_config_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestUpdateBlockRateLimitConfig(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() types.GenesisDoc {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() types.GenesisDoc {
 		genesis := testapp.DefaultGenesis()
 		testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *satypes.GenesisState) {
 			state.Subaccounts = []satypes.Subaccount{

--- a/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config_test.go
+++ b/protocol/x/clob/keeper/msg_server_update_equity_tier_limit_config_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestUpdateEquityTierLimitConfig(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() types.GenesisDoc {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() types.GenesisDoc {
 		genesis := testapp.DefaultGenesis()
 		testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *satypes.GenesisState) {
 			state.Subaccounts = []satypes.Subaccount{

--- a/protocol/x/clob/keeper/order_cancellation_test.go
+++ b/protocol/x/clob/keeper/order_cancellation_test.go
@@ -405,7 +405,7 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() cmt.GenesisDoc {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() cmt.GenesisDoc {
 				genesis := testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *types.GenesisState) {
 					state.ClobPairs = []types.ClobPair{

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -1675,7 +1675,7 @@ func TestPerformStatefulOrderValidation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithGenesisDocFn(func() cmt.GenesisDoc {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() cmt.GenesisDoc {
 				genesis := testapp.DefaultGenesis()
 				clobPairs := []types.ClobPair{
 					{

--- a/protocol/x/clob/keeper/rate_limit_test.go
+++ b/protocol/x/clob/keeper/rate_limit_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRateLimitPlaceOrderIsNoopOutsideOfCheckTxAndReCheckTx(t *testing.T) {
-	tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testApp.NewTestAppBuilder(t).Build()
 	checkTxCtx := tApp.AdvanceToBlock(21, testApp.AdvanceToBlockOptions{})
 	deliverTxCtx := checkTxCtx.WithIsCheckTx(false).WithIsReCheckTx(false)
 	msg := clobtypes.NewMsgPlaceOrder(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price5_GTB20)
@@ -26,7 +26,7 @@ func TestRateLimitPlaceOrderIsNoopOutsideOfCheckTxAndReCheckTx(t *testing.T) {
 }
 
 func TestRateLimitCancelOrderIsNoopOutsideOfCheckTxAndReCheckTx(t *testing.T) {
-	tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testApp.NewTestAppBuilder(t).Build()
 	checkTxCtx := tApp.AdvanceToBlock(21, testApp.AdvanceToBlockOptions{})
 	deliverTxCtx := checkTxCtx.WithIsCheckTx(false).WithIsReCheckTx(false)
 	msg := clobtypes.NewMsgCancelOrderShortTerm(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price5_GTB20.OrderId, 20)

--- a/protocol/x/clob/keeper/untriggered_conditional_orders_test.go
+++ b/protocol/x/clob/keeper/untriggered_conditional_orders_test.go
@@ -88,7 +88,7 @@ func TestAddUntriggeredConditionalOrder(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testApp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			untriggeredConditionalOrders := tApp.App.ClobKeeper.NewUntriggeredConditionalOrders()
 			tApp.App.ClobKeeper.UntriggeredConditionalOrders[0] = untriggeredConditionalOrders
@@ -201,7 +201,7 @@ func TestRemoveUntriggeredConditionalOrders(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testApp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testApp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			untriggeredConditionalOrders := tApp.App.ClobKeeper.NewUntriggeredConditionalOrders()
 			tApp.App.ClobKeeper.UntriggeredConditionalOrders[0] = untriggeredConditionalOrders

--- a/protocol/x/clob/rate_limit/multi_block_rate_limiter_test.go
+++ b/protocol/x/clob/rate_limit/multi_block_rate_limiter_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMultiBlockRateLimiter_SingleRateLimit(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	rl := rate_limit.NewMultiBlockRateLimiter[string]("test", []types.MaxPerNBlocksRateLimit{
 		{
@@ -47,7 +47,7 @@ func TestMultiBlockRateLimiter_SingleRateLimit(t *testing.T) {
 }
 
 func TestMultiBlockRateLimiter_MultipleRateLimits(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	rl := rate_limit.NewMultiBlockRateLimiter[string]("test", []types.MaxPerNBlocksRateLimit{
 		{

--- a/protocol/x/clob/rate_limit/noop_rate_limiter_test.go
+++ b/protocol/x/clob/rate_limit/noop_rate_limiter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoOpRateLimiter(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	rl := rate_limit.NewNoOpRateLimiter[int]()
 	for i := 0; i < 100_000; i += 1 {

--- a/protocol/x/clob/rate_limit/panic_rate_limiter_test.go
+++ b/protocol/x/clob/rate_limit/panic_rate_limiter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPanicRateLimiter(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	rl := rate_limit.NewPanicRateLimiter[int]()
 	require.Panics(t, func() {

--- a/protocol/x/clob/rate_limit/single_block_rate_limiter_test.go
+++ b/protocol/x/clob/rate_limit/single_block_rate_limiter_test.go
@@ -18,7 +18,7 @@ func TestNewSingleBlockRateLimiter_InvalidNumBlocks(t *testing.T) {
 }
 
 func TestSingleBlockRateLimiter(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	rl := rate_limit.NewSingleBlockRateLimiter[string]("test", types.MaxPerNBlocksRateLimit{
 		NumBlocks: 1,

--- a/protocol/x/delaymsg/keeper/dispatch_test.go
+++ b/protocol/x/delaymsg/keeper/dispatch_test.go
@@ -378,7 +378,7 @@ func TestSendDelayedCompleteBridgeMessage(t *testing.T) {
 		BlockHeight: 2,
 	}
 
-	tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
 		genesis = testapp.DefaultGenesis()
 		// Add the delayed message to the genesis state.
 		testapp.UpdateGenesisDocWithAppStateForModule(
@@ -389,7 +389,7 @@ func TestSendDelayedCompleteBridgeMessage(t *testing.T) {
 			},
 		)
 		return genesis
-	}).WithTesting(t).Build()
+	}).Build()
 	ctx := tApp.InitChain()
 
 	// Sanity check: the delayed message is in the keeper scheduled for block 2.
@@ -431,7 +431,7 @@ func TestSendDelayedCompleteBridgeMessage(t *testing.T) {
 // test, we modify the genesis state to apply the parameter update on block 2 to validate that the update is applied
 // correctly.
 func TestSendDelayedPerpetualFeeParamsUpdate(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
 		genesis = testapp.DefaultGenesis()
 		// Update the genesis state to execute the perpetual fee params update at block 2.
 		testapp.UpdateGenesisDocWithAppStateForModule(
@@ -443,7 +443,7 @@ func TestSendDelayedPerpetualFeeParamsUpdate(t *testing.T) {
 			},
 		)
 		return genesis
-	}).WithTesting(t).Build()
+	}).Build()
 	ctx := tApp.InitChain()
 
 	resp, err := tApp.App.FeeTiersKeeper.PerpetualFeeParams(ctx, &feetierstypes.QueryPerpetualFeeParamsRequest{})
@@ -477,7 +477,7 @@ func TestSendDelayedCompleteBridgeMessage_Failure(t *testing.T) {
 		BlockHeight: 2,
 	}
 
-	tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
+	tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
 		genesis = testapp.DefaultGenesis()
 		// Add the delayed message to the genesis state.
 		testapp.UpdateGenesisDocWithAppStateForModule(
@@ -488,7 +488,7 @@ func TestSendDelayedCompleteBridgeMessage_Failure(t *testing.T) {
 			},
 		)
 		return genesis
-	}).WithTesting(t).Build()
+	}).Build()
 	ctx := tApp.InitChain()
 
 	// Sanity check: at block 1, balances are as expected before the message is sent.

--- a/protocol/x/feetiers/genesis_test.go
+++ b/protocol/x/feetiers/genesis_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenesis(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	got := feetiers.ExportGenesis(ctx, tApp.App.FeeTiersKeeper)
 	require.NotNil(t, got)

--- a/protocol/x/feetiers/keeper/grpc_query_test.go
+++ b/protocol/x/feetiers/keeper/grpc_query_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.FeeTiersKeeper
 
@@ -47,7 +47,7 @@ func TestParams(t *testing.T) {
 }
 
 func TestUserFeeTier(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.FeeTiersKeeper
 

--- a/protocol/x/feetiers/keeper/keeper_test.go
+++ b/protocol/x/feetiers/keeper/keeper_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	logger := tApp.App.FeeTiersKeeper.Logger(ctx)
@@ -72,7 +72,7 @@ func TestGetPerpetualFeePpm(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			user := "alice"
 			k := tApp.App.FeeTiersKeeper
@@ -187,7 +187,7 @@ func TestGetMaxMakerRebate(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			k := tApp.App.FeeTiersKeeper
 			err := k.SetPerpetualFeeParams(

--- a/protocol/x/feetiers/keeper/msg_server_test.go
+++ b/protocol/x/feetiers/keeper/msg_server_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.FeeTiersKeeper
 

--- a/protocol/x/feetiers/keeper/params_test.go
+++ b/protocol/x/feetiers/keeper/params_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.FeeTiersKeeper
 
@@ -17,7 +17,7 @@ func TestGetParams(t *testing.T) {
 }
 
 func TestSetPerpetualFeeParams_Success(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.FeeTiersKeeper
 

--- a/protocol/x/rewards/genesis_test.go
+++ b/protocol/x/rewards/genesis_test.go
@@ -14,7 +14,7 @@ func TestGenesis(t *testing.T) {
 		Params: types.DefaultParams(),
 	}
 
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.RewardsKeeper
 

--- a/protocol/x/rewards/keeper/grpc_query_test.go
+++ b/protocol/x/rewards/keeper/grpc_query_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestQueryParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.RewardsKeeper
 

--- a/protocol/x/rewards/keeper/keeper_test.go
+++ b/protocol/x/rewards/keeper/keeper_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 func TestRewardShareStorage_DefaultValue(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.RewardsKeeper
 
@@ -51,7 +51,7 @@ func TestRewardShareStorage_DefaultValue(t *testing.T) {
 }
 
 func TestRewardShareStorage_Exists(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.RewardsKeeper
 
@@ -66,7 +66,7 @@ func TestRewardShareStorage_Exists(t *testing.T) {
 }
 
 func TestSetRewardShare_FailsWithNonpositiveWeight(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.RewardsKeeper
 
@@ -80,7 +80,7 @@ func TestSetRewardShare_FailsWithNonpositiveWeight(t *testing.T) {
 }
 
 func TestAddRewardShareToAddress(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 
 	tests := map[string]struct {
 		prevRewardShare     *types.RewardShare // nil if no previous share
@@ -143,7 +143,7 @@ func TestAddRewardShareToAddress(t *testing.T) {
 }
 
 func TestAddRewardSharesForFill(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	makerAddress := TestAddress1
 	takerAdderss := TestAddress2
 
@@ -637,7 +637,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 	// Run tests.
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				// Set up treasury account balance in genesis state
 				testapp.UpdateGenesisDocWithAppStateForModule(
@@ -652,7 +652,7 @@ func TestProcessRewardsForBlock(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 
 			tApp.Reset()
 			ctx := tApp.InitChain()

--- a/protocol/x/rewards/keeper/msg_server_test.go
+++ b/protocol/x/rewards/keeper/msg_server_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.RewardsKeeper
 

--- a/protocol/x/rewards/keeper/params_test.go
+++ b/protocol/x/rewards/keeper/params_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.RewardsKeeper
 
@@ -17,7 +17,7 @@ func TestGetParams(t *testing.T) {
 }
 
 func TestSetParams_Success(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.RewardsKeeper
 

--- a/protocol/x/sending/app_test.go
+++ b/protocol/x/sending/app_test.go
@@ -95,7 +95,7 @@ func TestMsgDepositToSubaccount(t *testing.T) {
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 			// Clear any messages produced prior to CheckTx calls.
 			msgSender.Clear()
@@ -203,7 +203,7 @@ func TestMsgDepositToSubaccount(t *testing.T) {
 
 func TestMsgDepositToSubaccount_NonExistentAccount(t *testing.T) {
 	// Setup tApp.
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 	// Generate a random account.
 	randomAccount := simtypes.RandomAccounts(rand.NewRand(), 1)[0]
@@ -284,7 +284,7 @@ func TestMsgWithdrawFromSubaccount(t *testing.T) {
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 			// Clear any messages produced prior to CheckTx calls.
 			msgSender.Clear()
@@ -392,7 +392,7 @@ func TestMsgWithdrawFromSubaccount(t *testing.T) {
 
 func TestMsgWithdrawFromSubaccount_NonExistentSubaccount(t *testing.T) {
 	// Setup tApp.
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 	// Generate a random account.
 	randomAccount := simtypes.RandomAccounts(rand.NewRand(), 1)[0]

--- a/protocol/x/stats/genesis_test.go
+++ b/protocol/x/stats/genesis_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenesis(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	got := stats.ExportGenesis(ctx, tApp.App.StatsKeeper)
 	require.NotNil(t, got)

--- a/protocol/x/stats/keeper/grpc_query_test.go
+++ b/protocol/x/stats/keeper/grpc_query_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.StatsKeeper
 
@@ -47,7 +47,7 @@ func TestParams(t *testing.T) {
 }
 
 func TestStatsMetadata(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.StatsKeeper
 	statsMetadata := &types.StatsMetadata{
@@ -86,7 +86,7 @@ func TestStatsMetadata(t *testing.T) {
 }
 
 func TestGlobalStats(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.StatsKeeper
 	globalStats := &types.GlobalStats{
@@ -125,7 +125,7 @@ func TestGlobalStats(t *testing.T) {
 }
 
 func TestUserStats(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.StatsKeeper
 	user := "alice"

--- a/protocol/x/stats/keeper/keeper_test.go
+++ b/protocol/x/stats/keeper/keeper_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	logger := tApp.App.StatsKeeper.Logger(ctx)
@@ -75,7 +75,7 @@ func TestRecordFill(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			k := tApp.App.StatsKeeper
 
@@ -88,7 +88,7 @@ func TestRecordFill(t *testing.T) {
 }
 
 func TestProcessBlockStats(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 
 	// Epochs initialize at block height 2
 	tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{
@@ -189,7 +189,7 @@ func TestProcessBlockStats(t *testing.T) {
 }
 
 func TestExpireOldStats(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 
 	// Epochs start at block height 2
 	ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{

--- a/protocol/x/stats/keeper/msg_server_test.go
+++ b/protocol/x/stats/keeper/msg_server_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.StatsKeeper
 

--- a/protocol/x/stats/keeper/params_test.go
+++ b/protocol/x/stats/keeper/params_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGetParams(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.StatsKeeper
 
@@ -18,7 +18,7 @@ func TestGetParams(t *testing.T) {
 }
 
 func TestSetParams_Success(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.StatsKeeper
 

--- a/protocol/x/vest/genesis_test.go
+++ b/protocol/x/vest/genesis_test.go
@@ -13,7 +13,7 @@ import (
 func TestGenesis(t *testing.T) {
 	genesisState := types.DefaultGenesis()
 
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 
@@ -24,7 +24,7 @@ func TestGenesis(t *testing.T) {
 }
 
 func TestInvalidGenesis_Panics(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 

--- a/protocol/x/vest/keeper/grpc_query_test.go
+++ b/protocol/x/vest/keeper/grpc_query_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestVestEntryQuery(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 

--- a/protocol/x/vest/keeper/keeper_test.go
+++ b/protocol/x/vest/keeper/keeper_test.go
@@ -49,7 +49,7 @@ var (
 )
 
 func TestVestEntryStorage_NotFound(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 
@@ -58,7 +58,7 @@ func TestVestEntryStorage_NotFound(t *testing.T) {
 }
 
 func TestVestEntryStorage_Exists(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 
@@ -71,7 +71,7 @@ func TestVestEntryStorage_Exists(t *testing.T) {
 }
 
 func TestGetAllVestEntries(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 
@@ -252,7 +252,7 @@ func TestProcessVesting(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder().WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				// Update x/vest genesis state with test vest entry
 				testapp.UpdateGenesisDocWithAppStateForModule(
@@ -274,7 +274,7 @@ func TestProcessVesting(t *testing.T) {
 					},
 				)
 				return genesis
-			}).WithTesting(t).Build()
+			}).Build()
 			ctx := tApp.InitChain()
 
 			// Set previous block time
@@ -306,7 +306,7 @@ func TestProcessVesting(t *testing.T) {
 }
 
 func TestDeleteVestEntry_Success(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 
@@ -322,7 +322,7 @@ func TestDeleteVestEntry_Success(t *testing.T) {
 }
 
 func TestDeleteVestEntry_NotFound(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 

--- a/protocol/x/vest/keeper/msg_server_test.go
+++ b/protocol/x/vest/keeper/msg_server_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Context) {
-	tApp := testapp.NewTestAppBuilder().WithTesting(t).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 	k := tApp.App.VestKeeper
 


### PR DESCRIPTION
### Changelist
This simplifies the testapp API to always take a testing instance.

### Test Plan
Existing tests updated to not use the removed WithTesting method. Also a method that was relying on a panic instead of using `ValidateDeliverTxsFn`.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
