### PR TITLE
[CORE-686] - Pricefeed integration tests bugfix

### DIFF
--- a/protocol/daemons/pricefeed/client/client_integration_test.go
+++ b/protocol/daemons/pricefeed/client/client_integration_test.go
@@ -363,7 +363,8 @@ func (s *PriceDaemonIntegrationTestSuite) expectPricesWithTimeout(
 		for marketId, expectedPrice := range expectedPrices {
 			actualPrice, ok := prices[marketId]
 			if !ok {
-				continue
+				allPricesMatch = false
+				break
 			}
 
 			if actualPrice != expectedPrice {

--- a/protocol/daemons/pricefeed/client/client_integration_test.go
+++ b/protocol/daemons/pricefeed/client/client_integration_test.go
@@ -265,7 +265,7 @@ func (s *PriceDaemonIntegrationTestSuite) SetupTest() {
 	s.exchangeServer.SetPrice(exchange_config.MARKET_LINK_USD, 3_000_000)
 
 	// Set USDT to 90 cents.
-	s.exchangeServer.SetPrice(exchange_config.MARKET_USDT_USD, 900_000_000)
+	s.exchangeServer.SetPrice(exchange_config.MARKET_USDT_USD, .9)
 
 	// Save daemon flags to use for client startup.
 	s.daemonFlags = flags.GetDefaultDaemonFlags()
@@ -357,6 +357,9 @@ func (s *PriceDaemonIntegrationTestSuite) expectPricesWithTimeout(
 		if len(prices) != len(expectedPrices) {
 			continue
 		}
+
+		allPricesMatch := true
+
 		for marketId, expectedPrice := range expectedPrices {
 			actualPrice, ok := prices[marketId]
 			if !ok {
@@ -364,10 +367,13 @@ func (s *PriceDaemonIntegrationTestSuite) expectPricesWithTimeout(
 			}
 
 			if actualPrice != expectedPrice {
-				continue
+				allPricesMatch = false
+				break
 			}
 		}
-		return
+		if allPricesMatch {
+			return
+		}
 	}
 }
 

--- a/protocol/daemons/pricefeed/client/client_integration_test.go
+++ b/protocol/daemons/pricefeed/client/client_integration_test.go
@@ -362,12 +362,7 @@ func (s *PriceDaemonIntegrationTestSuite) expectPricesWithTimeout(
 
 		for marketId, expectedPrice := range expectedPrices {
 			actualPrice, ok := prices[marketId]
-			if !ok {
-				allPricesMatch = false
-				break
-			}
-
-			if actualPrice != expectedPrice {
+			if !ok || actualPrice != expectedPrice {
 				allPricesMatch = false
 				break
 			}


### PR DESCRIPTION
### Changelist
`expectPricesWithTimeout` was not properly checking for equality of all expected prices. Updated the logic and fixed an incorrectly set price for USDT conversions. 

### Test Plan
Validated all test output for the file was terminating as expected with print statements.


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
