### PR TITLE
Add delaymsg module as a module account

### DIFF
--- a/protocol/app/module_accounts.go
+++ b/protocol/app/module_accounts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/app/config"
 	bridgemoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	clobmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	rewardsmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	vestmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
@@ -47,6 +48,9 @@ var (
 		vestmoduletypes.CommunityTreasuryAccountName: nil,
 		// community vester account vests funds into the community treasury.
 		vestmoduletypes.CommunityVesterAccountName: nil,
+		// delaymsg module account doesn't hold funds. It's used as the authority of
+		// delayed messages.
+		delaymsgtypes.ModuleName: nil,
 	}
 	// Blocked module accounts which cannot receive external funds.
 	// By default, all native SDK module accounts are blocked. This prevents

--- a/protocol/app/module_accounts_test.go
+++ b/protocol/app/module_accounts_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/app"
 	bridgemoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	clobmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	rewardsmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	vestmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
@@ -32,6 +33,7 @@ func TestModuleAccountsToAddresses(t *testing.T) {
 		rewardsmoduletypes.VesterAccountName:         "dydx1ltyc6y4skclzafvpznpt2qjwmfwgsndp458rmp",
 		vestmoduletypes.CommunityTreasuryAccountName: "dydx15ztc7xy42tn2ukkc0qjthkucw9ac63pgp70urn",
 		vestmoduletypes.CommunityVesterAccountName:   "dydx1wxje320an3karyc6mjw4zghs300dmrjkwn7xtk",
+		delaymsgtypes.ModuleName:                     "dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr",
 	}
 
 	require.True(t, len(expectedModuleAccToAddresses) == len(app.GetMaccPerms()))
@@ -68,6 +70,7 @@ func TestMaccPerms(t *testing.T) {
 		"rewards_vester":         nil,
 		"community_treasury":     nil,
 		"community_vester":       nil,
+		"delaymsg":               nil,
 	}
 	require.Equal(t, expectedMaccPerms, maccPerms, "default macc perms list does not match expected")
 }
@@ -87,6 +90,7 @@ func TestModuleAccountAddrs(t *testing.T) {
 		"dydx1ltyc6y4skclzafvpznpt2qjwmfwgsndp458rmp": true, // x/rewards.vester
 		"dydx15ztc7xy42tn2ukkc0qjthkucw9ac63pgp70urn": true, // x/vest.communityTreasury
 		"dydx1wxje320an3karyc6mjw4zghs300dmrjkwn7xtk": true, // x/vest.communityVester
+		"dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr": true, // x/delaymsg
 	}
 
 	require.Equal(t, expectedModuleAccAddresses, app.ModuleAccountAddrs())


### PR DESCRIPTION
### Changelist
Add `x/delaymsg` as a module accounts to `maccPerms`, the list of module accounts passed to the bank module. Also added unit test that checks the address of `delaymsg` module account. This came up during audit of delay message authority. 

Note: `delaymsg` module account doesn’t really “exist in state” in the sense that it does not exist as an entry under the x/bank or x/auth state.
The only effect of this PR is that the authKeeper/bankKeeper will now also has delaymsg as a module account (in memory object) , but since it has nil permissions, is not one of the blockedModuleAccounts , so this PR is effectively backwards compatible. However we don’t need to backport to v1.x, and the main purpose of this PR is to document the address of  delaymsg

### Test Plan
N/A
### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
