### PR TITLE
[CLO-987] Subaccount equity tier count was double counting conditional orders.

### DIFF
--- a/protocol/x/clob/e2e/equity_tier_limit_test.go
+++ b/protocol/x/clob/e2e/equity_tier_limit_test.go
@@ -1,6 +1,7 @@
 package clob_test
 
 import (
+	"fmt"
 	"github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
@@ -16,19 +17,21 @@ import (
 
 func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 	tests := map[string]struct {
-		firstOrder                   clobtypes.Order
-		secondOrder                  clobtypes.Order
+		allowedOrders                []clobtypes.Order
+		limitedOrder                 clobtypes.Order
 		equityTierLimitConfiguration clobtypes.EquityTierLimitConfiguration
 		cancellation                 *clobtypes.MsgCancelOrder
 		advanceBlock                 bool
 		expectError                  bool
 	}{
 		"Short-term order would exceed max open short-term orders in same block": {
-			firstOrder: MustScaleOrder(
-				constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.Order_Alice_Num0_Id0_Clob1_Buy5_Price10_GTB15,
 				testapp.DefaultGenesis(),
 			),
@@ -50,12 +53,47 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			},
 			expectError: true,
 		},
-		"Long-term order would exceed max open stateful orders in same block": {
-			firstOrder: MustScaleOrder(
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
+		"Short-term order would exceed max open short-term orders in same block with multiple orders": {
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
+					testapp.DefaultGenesis(),
+				),
+				MustScaleOrder(
+					constants.Order_Alice_Num0_Id0_Clob1_Buy5_Price10_GTB15,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
+				constants.Order_Alice_Num0_Id0_Clob0_Buy6_Price10_GTB20,
 				testapp.DefaultGenesis(),
 			),
-			secondOrder: MustScaleOrder(
+			equityTierLimitConfiguration: clobtypes.EquityTierLimitConfiguration{
+				ShortTermOrderEquityTiers: []clobtypes.EquityTierLimit{
+					{
+						UsdTncRequired: dtypes.NewInt(0),
+						Limit:          0,
+					},
+					{
+						UsdTncRequired: dtypes.NewInt(5_000_000_000), // $5,000
+						Limit:          2,
+					},
+					{
+						UsdTncRequired: dtypes.NewInt(70_000_000_000), // $70,000
+						Limit:          100,
+					},
+				},
+			},
+			expectError: true,
+		},
+		"Long-term order would exceed max open stateful orders in same block": {
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 				testapp.DefaultGenesis(),
 			),
@@ -68,6 +106,39 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 					{
 						UsdTncRequired: dtypes.NewInt(5_000_000_000), // $5,000
 						Limit:          1,
+					},
+					{
+						UsdTncRequired: dtypes.NewInt(70_000_000_000), // $70,000
+						Limit:          100,
+					},
+				},
+			},
+			expectError: true,
+		},
+		"Long-term order would exceed max open stateful orders in same block with multiple orders": {
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
+					testapp.DefaultGenesis(),
+				),
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob1_Buy5_Price10_GTBT15_StopLoss20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
+				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
+				testapp.DefaultGenesis(),
+			),
+			equityTierLimitConfiguration: clobtypes.EquityTierLimitConfiguration{
+				StatefulOrderEquityTiers: []clobtypes.EquityTierLimit{
+					{
+						UsdTncRequired: dtypes.NewInt(0),
+						Limit:          0,
+					},
+					{
+						UsdTncRequired: dtypes.NewInt(5_000_000_000), // $5,000
+						Limit:          2,
 					},
 					{
 						UsdTncRequired: dtypes.NewInt(70_000_000_000), // $70,000
@@ -78,11 +149,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			expectError: true,
 		},
 		"Conditional order would exceed max open stateful orders in same block": {
-			firstOrder: MustScaleOrder(
-				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
 				testapp.DefaultGenesis(),
 			),
@@ -104,12 +177,47 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			},
 			expectError: true,
 		},
-		"Short-term order would exceed max open short-term orders across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
+		"Conditional order would exceed max open stateful orders in same block with multiple orders": {
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
+					testapp.DefaultGenesis(),
+				),
+				MustScaleOrder(
+					constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
 				testapp.DefaultGenesis(),
 			),
-			secondOrder: MustScaleOrder(
+			equityTierLimitConfiguration: clobtypes.EquityTierLimitConfiguration{
+				StatefulOrderEquityTiers: []clobtypes.EquityTierLimit{
+					{
+						UsdTncRequired: dtypes.NewInt(0),
+						Limit:          0,
+					},
+					{
+						UsdTncRequired: dtypes.NewInt(5_000_000_000), // $5,000
+						Limit:          2,
+					},
+					{
+						UsdTncRequired: dtypes.NewInt(70_000_000_000), // $70,000
+						Limit:          100,
+					},
+				},
+			},
+			expectError: true,
+		},
+		"Short-term order would exceed max open short-term orders across blocks": {
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.Order_Alice_Num0_Id0_Clob1_Buy5_Price10_GTB15,
 				testapp.DefaultGenesis(),
 			),
@@ -133,11 +241,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			expectError:  true,
 		},
 		"Long-term order would exceed max open stateful orders across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 				testapp.DefaultGenesis(),
 			),
@@ -161,11 +271,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			expectError:  true,
 		},
 		"Long-term order would exceed max open stateful orders (due to untriggered conditional order) across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_TakeProfit20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_TakeProfit20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 				testapp.DefaultGenesis(),
 			),
@@ -189,11 +301,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			expectError:  true,
 		},
 		"Conditional order would exceed max open stateful orders across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
 				testapp.DefaultGenesis(),
 			),
@@ -217,11 +331,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			expectError:  true,
 		},
 		"Conditional FoK order would exceed max open stateful orders across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price50_GTBT10_StopLoss51_FOK,
 				testapp.DefaultGenesis(),
 			),
@@ -245,11 +361,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			expectError:  true,
 		},
 		"Conditional IoC order would exceed max open stateful orders across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price50_GTBT10_StopLoss51_FOK,
 				testapp.DefaultGenesis(),
 			),
@@ -273,11 +391,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			expectError:  true,
 		},
 		"Order cancellation prevents exceeding max open short-term orders for short-term order in same block": {
-			firstOrder: MustScaleOrder(
-				constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.Order_Alice_Num0_Id0_Clob1_Buy5_Price10_GTB15,
 				testapp.DefaultGenesis(),
 			),
@@ -303,11 +423,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			},
 		},
 		"Order cancellation prevents exceeding max open stateful orders for long-term order in same block": {
-			firstOrder: MustScaleOrder(
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 				testapp.DefaultGenesis(),
 			),
@@ -334,11 +456,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 		},
 		"Order cancellation of untriggered order prevents exceeding max open stateful orders for long-term order in " +
 			"same block": {
-			firstOrder: MustScaleOrder(
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_TakeProfit20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_TakeProfit20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 				testapp.DefaultGenesis(),
 			),
@@ -364,11 +488,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			},
 		},
 		"Order cancellation prevents exceeding max open stateful orders for conditional order in same block": {
-			firstOrder: MustScaleOrder(
-				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
 				testapp.DefaultGenesis(),
 			),
@@ -394,11 +520,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			},
 		},
 		"Order cancellation prevents exceeding max open short-term orders for short-term order across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.Order_Alice_Num0_Id0_Clob1_Buy5_Price10_GTB15,
 				testapp.DefaultGenesis(),
 			),
@@ -425,11 +553,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			advanceBlock: true,
 		},
 		"Order cancellation prevents exceeding max open stateful orders for long-term order across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 				testapp.DefaultGenesis(),
 			),
@@ -457,11 +587,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 		},
 		"Order cancellation of untriggered order prevents exceeding max open stateful orders for long-term order " +
 			"across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_TakeProfit20,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_TakeProfit20,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 				testapp.DefaultGenesis(),
 			),
@@ -488,11 +620,13 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 			advanceBlock: true,
 		},
 		"Order cancellation prevents exceeding max open stateful orders for conditional order across blocks": {
-			firstOrder: MustScaleOrder(
-				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
-				testapp.DefaultGenesis(),
-			),
-			secondOrder: MustScaleOrder(
+			allowedOrders: []clobtypes.Order{
+				MustScaleOrder(
+					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
+					testapp.DefaultGenesis(),
+				),
+			},
+			limitedOrder: MustScaleOrder(
 				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20,
 				testapp.DefaultGenesis(),
 			),
@@ -531,15 +665,19 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 				})
 				testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *clobtypes.GenesisState) {
 					state.EquityTierLimitConfig = tc.equityTierLimitConfiguration
+					// Don't enforce the block rate limit.
+					state.BlockRateLimitConfig = clobtypes.BlockRateLimitConfiguration{}
 				})
 				return genesis
 			}).Build()
 
 			ctx := tApp.InitChain()
 
-			for _, tx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(tc.firstOrder)) {
-				resp := tApp.CheckTx(tx)
-				require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
+			for _, allowedOrder := range tc.allowedOrders {
+				for _, tx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(allowedOrder)) {
+					resp := tApp.CheckTx(tx)
+					require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
+				}
 			}
 
 			if tc.advanceBlock {
@@ -557,11 +695,19 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 				ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{})
 			}
 
-			for _, tx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(tc.secondOrder)) {
+			for _, tx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(tc.limitedOrder)) {
 				resp := tApp.CheckTx(tx)
 				if tc.expectError {
 					require.Conditionf(t, resp.IsErr, "Expected CheckTx to error. Response: %+v", resp)
-					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1. Order count: 1,")
+					require.Contains(
+						t,
+						resp.Log,
+						fmt.Sprintf(
+							"Opening order would exceed equity tier limit of %d. Order count: %d,",
+							len(tc.allowedOrders),
+							len(tc.allowedOrders),
+						),
+					)
 
 					checkThatFoKOrderIsNotBlockedByEquityTierLimits(t, tApp, ctx)
 				} else {

--- a/protocol/x/clob/e2e/equity_tier_limit_test.go
+++ b/protocol/x/clob/e2e/equity_tier_limit_test.go
@@ -561,7 +561,7 @@ func TestPlaceOrder_EquityTierLimit(t *testing.T) {
 				resp := tApp.CheckTx(tx)
 				if tc.expectError {
 					require.Conditionf(t, resp.IsErr, "Expected CheckTx to error. Response: %+v", resp)
-					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1.")
+					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1. Order count: 1,")
 
 					checkThatFoKOrderIsNotBlockedByEquityTierLimits(t, tApp, ctx)
 				} else {
@@ -726,7 +726,7 @@ func TestPlaceOrder_EquityTierLimit_OrderExpiry(t *testing.T) {
 				resp := tApp.CheckTx(tx)
 				if tc.expectError {
 					require.Conditionf(t, resp.IsErr, "Expected CheckTx to error. Response: %+v", resp)
-					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1.")
+					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1. Order count: 1,")
 
 					checkThatFoKOrderIsNotBlockedByEquityTierLimits(t, tApp, ctx)
 				} else {
@@ -1040,7 +1040,7 @@ func TestPlaceOrder_EquityTierLimit_OrderFill(t *testing.T) {
 				resp := tApp.CheckTx(tx)
 				if tc.expectError {
 					require.Conditionf(t, resp.IsErr, "Expected CheckTx to error. Response: %+v", resp)
-					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1.")
+					require.Contains(t, resp.Log, "Opening order would exceed equity tier limit of 1. Order count: 1,")
 				} else {
 					require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
 				}

--- a/protocol/x/clob/keeper/equity_tier_limit.go
+++ b/protocol/x/clob/keeper/equity_tier_limit.go
@@ -145,9 +145,10 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForNewOrder(ctx sdk.Context, or
 	if lib.MustConvertIntegerToUint32(equityTierCount) >= equityTierLimit.Limit {
 		return errorsmod.Wrapf(
 			types.ErrOrderWouldExceedMaxOpenOrdersEquityTierLimit,
-			"Opening order would exceed equity tier limit of %d. Order count: %d, order id: %+v",
+			"Opening order would exceed equity tier limit of %d. Order count: %d, total net collateral: %+v, order id: %+v",
 			equityTierLimit.Limit,
 			equityTierCount,
+			netCollateral,
 			order.GetOrderId(),
 		)
 	}

--- a/protocol/x/clob/keeper/equity_tier_limit.go
+++ b/protocol/x/clob/keeper/equity_tier_limit.go
@@ -114,24 +114,20 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForNewOrder(ctx sdk.Context, or
 
 	equityTierCount := uint32(0)
 	if order.IsStatefulOrder() {
-		// For stateful orders we get the stateful order count which represents how many long term and
-		// triggered conditional orders exist in state. We add to that all untriggered conditional orders.
+		// For stateful orders we get the stateful order count.
 		// If this is `CheckTx` then we must also add the number of uncommitted stateful orders that this validator
 		// is aware of (orders that are part of the mempool but have yet to proposed in a block).
 		equityTierCount = k.GetStatefulOrderCount(ctx, order.OrderId.SubaccountId)
-		equityTierCount += k.CountUntriggeredSubaccountStatefulOrders(ctx, subaccountId)
 		if !lib.IsDeliverTxMode(ctx) {
 			equityTierCountMaybeNegative := k.GetUncommittedStatefulOrderCount(ctx, order.OrderId) + int32(equityTierCount)
 			if equityTierCountMaybeNegative < 0 {
 				panic(
 					fmt.Errorf(
 						"Expected ValidateSubaccountEquityTierLimitForNewOrder for new order %+v to be >= 0. "+
-							"equityTierCount %d, statefulOrderCount %d, untriggeredSubaccountOrders %d, "+
-							"uncommittedStatefulOrderCount %d.",
+							"equityTierCount %d, statefulOrderCount %d, uncommittedStatefulOrderCount %d.",
 						order,
 						equityTierCountMaybeNegative,
 						k.GetStatefulOrderCount(ctx, order.OrderId.SubaccountId),
-						k.CountUntriggeredSubaccountStatefulOrders(ctx, subaccountId),
 						k.GetUncommittedStatefulOrderCount(ctx, order.OrderId),
 					),
 				)
@@ -149,8 +145,9 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForNewOrder(ctx sdk.Context, or
 	if lib.MustConvertIntegerToUint32(equityTierCount) >= equityTierLimit.Limit {
 		return errorsmod.Wrapf(
 			types.ErrOrderWouldExceedMaxOpenOrdersEquityTierLimit,
-			"Opening order would exceed equity tier limit of %d. Order id: %+v",
+			"Opening order would exceed equity tier limit of %d. Order count: %d, order id: %+v",
 			equityTierLimit.Limit,
+			equityTierCount,
 			order.GetOrderId(),
 		)
 	}

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -518,8 +518,7 @@ func (k Keeper) getUntriggeredConditionalOrdersIterator(ctx sdk.Context) sdk.Ite
 	return sdk.KVStorePrefixIterator(store, []byte{})
 }
 
-// GetStatefulOrderCount gets a count of how many stateful orders are written to state for a subaccount. This does not
-// include any untriggered conditional orders.
+// GetStatefulOrderCount gets a count of how many stateful orders are written to state for a subaccount.
 func (k Keeper) GetStatefulOrderCount(
 	ctx sdk.Context,
 	subaccountId satypes.SubaccountId,

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -533,8 +533,7 @@ func (k Keeper) GetStatefulOrderCount(
 	return result.Value
 }
 
-// SetStatefulOrderCount sets a count of how many stateful orders are written to state. This does not
-// include any untriggered conditional orders.
+// SetStatefulOrderCount sets a count of how many stateful orders are written to state.
 func (k Keeper) SetStatefulOrderCount(
 	ctx sdk.Context,
 	subaccountId satypes.SubaccountId,

--- a/protocol/x/clob/keeper/untriggered_conditional_orders.go
+++ b/protocol/x/clob/keeper/untriggered_conditional_orders.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
 // UntriggeredConditionalOrders is an in-memory struct stored on the clob Keeper.
@@ -315,25 +314,4 @@ func (k Keeper) MaybeTriggerConditionalOrders(ctx sdk.Context) (triggeredConditi
 		)
 	}
 	return triggeredConditionalOrderIds
-}
-
-// CountUntriggeredSubaccountStatefulOrders will count all untriggered stateful conditional orders for a given
-// subaccount.
-func (k Keeper) CountUntriggeredSubaccountStatefulOrders(ctx sdk.Context,
-	subaccountId satypes.SubaccountId,
-) uint32 {
-	count := uint32(0)
-	for _, untriggeredConditionalOrders := range k.UntriggeredConditionalOrders {
-		for _, order := range untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceGTETriggerPrice {
-			if order.OrderId.SubaccountId == subaccountId && order.IsStatefulOrder() {
-				count++
-			}
-		}
-		for _, order := range untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceLTETriggerPrice {
-			if order.OrderId.SubaccountId == subaccountId && order.IsStatefulOrder() {
-				count++
-			}
-		}
-	}
-	return count
 }

--- a/protocol/x/clob/keeper/untriggered_conditional_orders_test.go
+++ b/protocol/x/clob/keeper/untriggered_conditional_orders_test.go
@@ -89,7 +89,7 @@ func TestAddUntriggeredConditionalOrder(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tApp := testApp.NewTestAppBuilder(t).Build()
-			ctx := tApp.InitChain()
+			tApp.InitChain()
 			untriggeredConditionalOrders := tApp.App.ClobKeeper.NewUntriggeredConditionalOrders()
 			tApp.App.ClobKeeper.UntriggeredConditionalOrders[0] = untriggeredConditionalOrders
 
@@ -107,13 +107,6 @@ func TestAddUntriggeredConditionalOrder(t *testing.T) {
 				tc.expectedOrdersToTriggerWhenOraclePriceLTETriggerPrice,
 				untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceLTETriggerPrice,
 			)
-
-			// There should be exacly one match for all these cases.
-			orderIdToMatch := tc.conditionalOrdersToAdd[0].OrderId
-			require.Equal(t, tc.expectedNumberOfMatches, tApp.App.ClobKeeper.CountUntriggeredSubaccountStatefulOrders(
-				ctx,
-				orderIdToMatch.SubaccountId,
-			))
 		})
 	}
 }
@@ -202,7 +195,7 @@ func TestRemoveUntriggeredConditionalOrders(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tApp := testApp.NewTestAppBuilder(t).Build()
-			ctx := tApp.InitChain()
+			tApp.InitChain()
 			untriggeredConditionalOrders := tApp.App.ClobKeeper.NewUntriggeredConditionalOrders()
 			tApp.App.ClobKeeper.UntriggeredConditionalOrders[0] = untriggeredConditionalOrders
 
@@ -221,16 +214,6 @@ func TestRemoveUntriggeredConditionalOrders(t *testing.T) {
 				t,
 				tc.expectedOrdersToTriggerWhenOraclePriceLTETriggerPrice,
 				untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceLTETriggerPrice,
-			)
-
-			require.Equal(
-				t,
-				uint32(len(tc.expectedOrdersToTriggerWhenOraclePriceGTETriggerPrice)+
-					len(tc.expectedOrdersToTriggerWhenOraclePriceLTETriggerPrice)),
-				tApp.App.ClobKeeper.CountUntriggeredSubaccountStatefulOrders(
-					ctx,
-					constants.Alice_Num0,
-				),
 			)
 		})
 	}

--- a/protocol/x/clob/types/keys.go
+++ b/protocol/x/clob/types/keys.go
@@ -91,20 +91,20 @@ const (
 	NextStatefulOrderBlockTransactionIndexKey = "NextTxIdx"
 
 	// UncommittedStatefulOrderPlacementKeyPrefix is the key to retrieve an uncommitted stateful order and information
-	// about when it was placed. uncommitted orders are orders that this validator is aware of that have yet to be
+	// about when it was placed. Uncommitted orders are orders that this validator is aware of that have yet to be
 	// committed to a block and are stored in a transient store.
-	UncommittedStatefulOrderPlacementKeyPrefix = "UncmtLT:"
+	UncommittedStatefulOrderPlacementKeyPrefix = "UncmtSO:"
 
 	// UncommittedStatefulOrderCancellationKeyPrefix is the key to retrieve an uncommitted stateful order cancellation.
-	// uncommitted cancelleations are cancellations that this validator is aware of that have yet to be
+	// Uncommitted cancelleations are cancellations that this validator is aware of that have yet to be
 	// committed to a block and are stored in a transient store.
-	UncommittedStatefulOrderCancellationKeyPrefix = "UncmtLTCxl:"
+	UncommittedStatefulOrderCancellationKeyPrefix = "UncmtSOCxl:"
 
 	// UncommittedStatefulOrderCountPrefix is the key to retrieve an uncommitted stateful order count.
-	// uncommitted orders are orders that this validator is aware of that have yet to be committed to a block and
+	// Uncommitted orders are orders that this validator is aware of that have yet to be committed to a block and
 	// are stored in a transient store. This count represents the number of uncommitted stateful
 	// `placements - cancellations`.
-	UncommittedStatefulOrderCountPrefix = "NumUncmtLT:"
+	UncommittedStatefulOrderCountPrefix = "NumUncmtSO:"
 )
 
 // Module Accounts

--- a/protocol/x/clob/types/keys.go
+++ b/protocol/x/clob/types/keys.go
@@ -74,6 +74,10 @@ const (
 	// ProcessProposerMatchesEventsKey is the key to retrieve information about how to update
 	// memclob state based on the latest block.
 	ProcessProposerMatchesEventsKey = "ProposerEvents"
+
+	// StatefulOrderCountPrefix is the key to retrieve the stateful order count. The stateful order count
+	// represents the number of stateful orders stored in state.
+	StatefulOrderCountPrefix = "NumSO:"
 )
 
 // Transient Store
@@ -101,10 +105,6 @@ const (
 	// are stored in a transient store. This count represents the number of uncommitted stateful
 	// `placements - cancellations`.
 	UncommittedStatefulOrderCountPrefix = "NumUncmtLT:"
-
-	// StatefulOrderCountPrefix is the key to retrieve the stateful order count. The stateful order count
-	// represents the number of long term order placements and triggered conditional orders stored in state.
-	StatefulOrderCountPrefix = "NumLT:"
 )
 
 // Module Accounts

--- a/protocol/x/clob/types/keys_test.go
+++ b/protocol/x/clob/types/keys_test.go
@@ -32,8 +32,8 @@ func TestStoreAndMemstoreKeys(t *testing.T) {
 	require.Equal(t, "SO/P/T:", types.TriggeredConditionalOrderKeyPrefix)
 	require.Equal(t, "SO/P/L:", types.LongTermOrderPlacementKeyPrefix)
 	require.Equal(t, "SO/U:", types.UntriggeredConditionalOrderKeyPrefix)
-	require.Equal(t, "NumSO:", types.StatefulOrderCountPrefix)
 
+	require.Equal(t, "NumSO:", types.StatefulOrderCountPrefix)
 	require.Equal(t, "ProposerEvents", types.ProcessProposerMatchesEventsKey)
 }
 

--- a/protocol/x/clob/types/keys_test.go
+++ b/protocol/x/clob/types/keys_test.go
@@ -32,6 +32,7 @@ func TestStoreAndMemstoreKeys(t *testing.T) {
 	require.Equal(t, "SO/P/T:", types.TriggeredConditionalOrderKeyPrefix)
 	require.Equal(t, "SO/P/L:", types.LongTermOrderPlacementKeyPrefix)
 	require.Equal(t, "SO/U:", types.UntriggeredConditionalOrderKeyPrefix)
+	require.Equal(t, "NumSO:", types.StatefulOrderCountPrefix)
 
 	require.Equal(t, "ProposerEvents", types.ProcessProposerMatchesEventsKey)
 }
@@ -39,10 +40,9 @@ func TestStoreAndMemstoreKeys(t *testing.T) {
 func TestTransientStoreKeys(t *testing.T) {
 	require.Equal(t, "SaLiqInfo:", types.SubaccountLiquidationInfoKeyPrefix)
 	require.Equal(t, "NextTxIdx", types.NextStatefulOrderBlockTransactionIndexKey)
-	require.Equal(t, "UncmtLT:", types.UncommittedStatefulOrderPlacementKeyPrefix)
-	require.Equal(t, "UncmtLTCxl:", types.UncommittedStatefulOrderCancellationKeyPrefix)
-	require.Equal(t, "NumUncmtLT:", types.UncommittedStatefulOrderCountPrefix)
-	require.Equal(t, "NumLT:", types.StatefulOrderCountPrefix)
+	require.Equal(t, "UncmtSO:", types.UncommittedStatefulOrderPlacementKeyPrefix)
+	require.Equal(t, "UncmtSOCxl:", types.UncommittedStatefulOrderCancellationKeyPrefix)
+	require.Equal(t, "NumUncmtSO:", types.UncommittedStatefulOrderCountPrefix)
 }
 
 func TestModuleAccountKeys(t *testing.T) {


### PR DESCRIPTION
### Changelist
Remove counting of untriggered conditional orders since they are already in the subaccount order state count.

### Test Plan
The change to the error message contains the actual count which was 2 in the case of the conditional order and not 1 showing the double counting.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
