### PR TITLE
set next id in bridge events script to event id + 1

### DIFF
--- a/protocol/scripts/bridge_events/bridge_events.go
+++ b/protocol/scripts/bridge_events/bridge_events.go
@@ -110,7 +110,7 @@ func main() {
 	// Iterate over each event and populate the above fields
 	for _, log := range logs {
 		event := libeth.BridgeLogToEvent(log, denom)
-		aei.NextId = lib.Max(aei.NextId, event.Id)
+		aei.NextId = lib.Max(aei.NextId, event.Id+1)
 		aei.EthBlockHeight = lib.Max(aei.EthBlockHeight, log.BlockNumber)
 
 		// Add amount to total bridged amount.


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
command run:
`go run scripts/bridge_events/bridge_events.go -toblock 4179719`
* Next ID is expected to be 1 as there's only one event up to block 4179719 

output:
```
Total amount bridged: 123
Remaining bridge module account balance: 999999999999999999999999877
"bridge.event_params": {
  "denom": "adv4tnt",
  "eth_chain_id": 11155111,
  "eth_address": "0xcca9D5f0a3c58b6f02BD0985fC7F9420EA24C1f0"
}
"bridge.acknowledged_event_info": {
  "next_id": 1,
  "eth_block_height": 4179719
}
"bank.balances": [
  {
    "address": "dydx1zg69v7yszg69v7yszg69v7yszg69v7ysuz0wqr",
    "coins": [
      {
        "amount": "123",
        "denom": "adv4tnt"
      }
    ]
  }
]
```


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
