### PR TITLE
[DEC-2155] Set `gov.params.min_initial_deposit_ratio` to 0.2 to avoid spamming

### DIFF
--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -107,6 +107,7 @@ function overwrite_genesis_production() {
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.quorum' -v '0.33400' # 33.4%
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.threshold' -v '0.50000' # 50%
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.veto_threshold' -v '0.33400' # 33.4%
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_initial_deposit_ratio' -v '0.20000' # 20%
 	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_proposal_deposit_prevote' -v 'false' 
 	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_vote_quorum' -v 'false' 
 	dasel put -t bool -f "$GENESIS" '.app_state.gov.params.burn_vote_veto' -v 'true'

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -1,6 +1,7 @@
 {
   "app_hash": "",
   "app_state": {
+    "07-tendermint": null,
     "assets": {
       "assets": [
         {
@@ -521,6 +522,7 @@
         }
       }
     },
+    "consensus": null,
     "crisis": {
       "constant_fee": {
         "amount": "1000000000000000000",
@@ -754,6 +756,7 @@
       "gen_txs": []
     },
     "gov": {
+      "deposit_params": null,
       "deposits": [],
       "params": {
         "burn_proposal_deposit_prevote": false,
@@ -766,7 +769,7 @@
             "denom": "asample"
           }
         ],
-        "min_initial_deposit_ratio": "0.000000000000000000",
+        "min_initial_deposit_ratio": "0.20000",
         "quorum": "0.33400",
         "threshold": "0.50000",
         "veto_threshold": "0.33400",
@@ -774,7 +777,9 @@
       },
       "proposals": [],
       "starting_proposal_id": "1",
-      "votes": []
+      "tally_params": null,
+      "votes": [],
+      "voting_params": null
     },
     "ibc": {
       "channel_genesis": {
@@ -808,6 +813,7 @@
         }
       }
     },
+    "params": null,
     "perpetuals": {
       "liquidity_tiers": [
         {

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -1,7 +1,6 @@
 {
   "app_hash": "",
   "app_state": {
-    "07-tendermint": null,
     "assets": {
       "assets": [
         {
@@ -522,7 +521,6 @@
         }
       }
     },
-    "consensus": null,
     "crisis": {
       "constant_fee": {
         "amount": "1000000000000000000",
@@ -756,7 +754,6 @@
       "gen_txs": []
     },
     "gov": {
-      "deposit_params": null,
       "deposits": [],
       "params": {
         "burn_proposal_deposit_prevote": false,
@@ -777,9 +774,7 @@
       },
       "proposals": [],
       "starting_proposal_id": "1",
-      "tally_params": null,
-      "votes": [],
-      "voting_params": null
+      "votes": []
     },
     "ibc": {
       "channel_genesis": {
@@ -813,7 +808,6 @@
         }
       }
     },
-    "params": null,
     "perpetuals": {
       "liquidity_tiers": [
         {

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -82,7 +82,7 @@ function edit_genesis() {
 	# reduced deposit period
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.max_deposit_period' -v '300s'
 	# reduced voting period
-	dasel put -t string -f "$GENESIS" '.app_state.gov.params.voting_period' -v '300s' 
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.voting_period' -v '300s'
 
 	# Update staking module.
 	dasel put -t string -f "$GENESIS" '.app_state.staking.params.unbonding_time' -v '1814400s' # 21 days

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -83,6 +83,8 @@ function edit_genesis() {
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.max_deposit_period' -v '300s'
 	# reduced voting period
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.voting_period' -v '300s'
+	# set initial deposit ratio to prevent spamming
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_initial_deposit_ratio' -v '0.20000' # 20%
 
 	# Update staking module.
 	dasel put -t string -f "$GENESIS" '.app_state.staking.params.unbonding_time' -v '1814400s' # 21 days

--- a/protocol/testing/testnet-external/pregenesis.sh
+++ b/protocol/testing/testnet-external/pregenesis.sh
@@ -161,6 +161,7 @@ function overwrite_genesis_public_testnet() {
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.quorum' -v '0.33400' # 33.4%
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.threshold' -v '0.50000' # 50%
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.veto_threshold' -v '0.33400' # 33.4%
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_initial_deposit_ratio' -v '0.20000' # 20%
 }
 
 create_pregenesis_file() {


### PR DESCRIPTION
### Changelist
* Sets the `gov.params.min_initial_deposit_ratio` to 0.2 (=20%) to avoid gov proposal spamming.
* Run `make update-sample-pregenesis`

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
