### PR TITLE
[refactor] Remove errors from subaccounts keeper functions that don't return errors

### DIFF
--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -427,6 +427,7 @@ func (k Keeper) getSettledSubaccount(
 		// division result always rounds towards negative infinity.
 		totalNetSettlementPpm.Div(totalNetSettlementPpm, lib.BigIntOneMillion()),
 	)
+	// TODO(CLOB-993): Remove this function and use `UpdateAssetPositions` instead.
 	newSubaccount.SetUsdcAssetPosition(newUsdcPosition)
 	return newSubaccount, fundingPayments, nil
 }

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -283,17 +283,17 @@ func (k Keeper) UpdateSubaccounts(
 	}
 
 	// Apply the updates to perpetual positions.
-	success, err = UpdatePerpetualPositions(
+	success = UpdatePerpetualPositions(
 		settledUpdates,
 		perpIdToFundingIndex,
 	)
-	if !success || err != nil {
+	if !success {
 		return success, successPerUpdate, err
 	}
 
 	// Apply the updates to asset positions.
-	success, err = UpdateAssetPositions(settledUpdates)
-	if !success || err != nil {
+	success = UpdateAssetPositions(settledUpdates)
+	if !success {
 		return success, successPerUpdate, err
 	}
 
@@ -433,10 +433,7 @@ func (k Keeper) getSettledSubaccount(
 		// division result always rounds towards negative infinity.
 		totalNetSettlementPpm.Div(totalNetSettlementPpm, lib.BigIntOneMillion()),
 	)
-	err = newSubaccount.SetUsdcAssetPosition(newUsdcPosition)
-	if err != nil {
-		return types.Subaccount{}, nil, err
-	}
+	newSubaccount.SetUsdcAssetPosition(newUsdcPosition)
 	return newSubaccount, fundingPayments, nil
 }
 

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -283,19 +283,13 @@ func (k Keeper) UpdateSubaccounts(
 	}
 
 	// Apply the updates to perpetual positions.
-	success = UpdatePerpetualPositions(
+	UpdatePerpetualPositions(
 		settledUpdates,
 		perpIdToFundingIndex,
 	)
-	if !success {
-		return success, successPerUpdate, err
-	}
 
 	// Apply the updates to asset positions.
-	success = UpdateAssetPositions(settledUpdates)
-	if !success {
-		return success, successPerUpdate, err
-	}
+	UpdateAssetPositions(settledUpdates)
 
 	// Apply all updates, including a subaccount update event in the Indexer block message
 	// per update and emit a cometbft event for each settled funding payment.

--- a/protocol/x/subaccounts/keeper/subaccount_helper.go
+++ b/protocol/x/subaccounts/keeper/subaccount_helper.go
@@ -106,7 +106,6 @@ func UpdatePerpetualPositions(
 	perpIdToFundingIndex map[uint32]dtypes.SerializableInt,
 ) (
 	success bool,
-	err error,
 ) {
 	// Apply the updates.
 	for i, u := range settledUpdates {
@@ -164,7 +163,8 @@ func UpdatePerpetualPositions(
 
 		settledUpdates[i].SettledSubaccount.PerpetualPositions = perpetualPositions
 	}
-	return true, nil
+
+	return true
 }
 
 // For each settledUpdate in settledUpdates, updates its SettledSubaccount.AssetPositions
@@ -173,7 +173,6 @@ func UpdateAssetPositions(
 	settledUpdates []settledUpdate,
 ) (
 	success bool,
-	err error,
 ) {
 	// Apply the updates.
 	for i, u := range settledUpdates {
@@ -226,5 +225,6 @@ func UpdateAssetPositions(
 
 		settledUpdates[i].SettledSubaccount.AssetPositions = assetPositions
 	}
-	return true, nil
+
+	return true
 }

--- a/protocol/x/subaccounts/keeper/subaccount_helper.go
+++ b/protocol/x/subaccounts/keeper/subaccount_helper.go
@@ -104,8 +104,6 @@ func getUpdatedPerpetualPositions(
 func UpdatePerpetualPositions(
 	settledUpdates []settledUpdate,
 	perpIdToFundingIndex map[uint32]dtypes.SerializableInt,
-) (
-	success bool,
 ) {
 	// Apply the updates.
 	for i, u := range settledUpdates {
@@ -163,16 +161,12 @@ func UpdatePerpetualPositions(
 
 		settledUpdates[i].SettledSubaccount.PerpetualPositions = perpetualPositions
 	}
-
-	return true
 }
 
 // For each settledUpdate in settledUpdates, updates its SettledSubaccount.AssetPositions
 // to reflect settledUpdate.AssetUpdates.
 func UpdateAssetPositions(
 	settledUpdates []settledUpdate,
-) (
-	success bool,
 ) {
 	// Apply the updates.
 	for i, u := range settledUpdates {
@@ -225,6 +219,4 @@ func UpdateAssetPositions(
 
 		settledUpdates[i].SettledSubaccount.AssetPositions = assetPositions
 	}
-
-	return true
 }

--- a/protocol/x/subaccounts/types/subaccount.go
+++ b/protocol/x/subaccounts/types/subaccount.go
@@ -73,26 +73,25 @@ func (m *Subaccount) GetUsdcPosition() *big.Int {
 }
 
 // SetUsdcAssetPosition sets the balance of the USDC asset position to `newUsdcPosition`.
-// If the absolute value of `newUsdcPosition` cannot be represented in a uint64,
-// an error is returned.
-func (m *Subaccount) SetUsdcAssetPosition(newUsdcPosition *big.Int) error {
-	if m != nil {
-		usdcAssetPosition := m.getUsdcAssetPosition()
-		if newUsdcPosition == nil || newUsdcPosition.Sign() == 0 {
-			if usdcAssetPosition != nil {
-				m.AssetPositions = m.AssetPositions[1:]
-			}
-		} else {
-			if usdcAssetPosition == nil {
-				usdcAssetPosition = &AssetPosition{
-					AssetId: assettypes.AssetUsdc.Id,
-				}
-				m.AssetPositions = append([]*AssetPosition{usdcAssetPosition}, m.AssetPositions...)
-			}
-			usdcAssetPosition.Quantums = dtypes.NewIntFromBigInt(newUsdcPosition)
-		}
+func (m *Subaccount) SetUsdcAssetPosition(newUsdcPosition *big.Int) {
+	if m == nil {
+		return
 	}
-	return nil
+
+	usdcAssetPosition := m.getUsdcAssetPosition()
+	if newUsdcPosition == nil || newUsdcPosition.Sign() == 0 {
+		if usdcAssetPosition != nil {
+			m.AssetPositions = m.AssetPositions[1:]
+		}
+	} else {
+		if usdcAssetPosition == nil {
+			usdcAssetPosition = &AssetPosition{
+				AssetId: assettypes.AssetUsdc.Id,
+			}
+			m.AssetPositions = append([]*AssetPosition{usdcAssetPosition}, m.AssetPositions...)
+		}
+		usdcAssetPosition.Quantums = dtypes.NewIntFromBigInt(newUsdcPosition)
+	}
 }
 
 func (m *Subaccount) getUsdcAssetPosition() *AssetPosition {

--- a/protocol/x/subaccounts/types/subaccount_test.go
+++ b/protocol/x/subaccounts/types/subaccount_test.go
@@ -205,7 +205,6 @@ func TestSetSubaccountQuoteBalance(t *testing.T) {
 		subaccount             *types.Subaccount
 		newQuoteBalance        *big.Int
 		expectedAssetPositions []*types.AssetPosition
-		expectedError          error
 	}{
 		"can set nil subaccount": {
 			subaccount:      nil,
@@ -311,12 +310,7 @@ func TestSetSubaccountQuoteBalance(t *testing.T) {
 	// Run tests.
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := tc.subaccount.SetUsdcAssetPosition(tc.newQuoteBalance)
-			if tc.expectedError == nil {
-				require.NoError(t, err)
-			} else {
-				require.ErrorIs(t, tc.expectedError, err)
-			}
+			tc.subaccount.SetUsdcAssetPosition(tc.newQuoteBalance)
 			if tc.subaccount != nil {
 				require.Equal(
 					t,


### PR DESCRIPTION
### Changelist

Remove errors from subaccounts keeper functions that don't return errors.

This is part of a larger subaccounts keeper refactor to simplify the code by removing returned errors when invariants are broken, and instead panicing earlier.

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
