### PR TITLE
[CORE-704] Initial E2E testing framework for funding

### DIFF
--- a/protocol/testing/e2e/funding/funding_e2e_test.go
+++ b/protocol/testing/e2e/funding/funding_e2e_test.go
@@ -174,8 +174,8 @@ func TestFunding(t *testing.T) {
 			)
 
 			ctx = tApp.AdvanceToBlock(BlockHeightAtFirstFundingTick, testapp.AdvanceToBlockOptions{
-				BlockTime:                 FirstFundingTick,
-				GradualBlockTimeIncrement: true,
+				BlockTime:                    FirstFundingTick,
+				LinearBlockTimeInterpolation: true,
 			})
 
 			premiumSamples := tApp.App.PerpetualsKeeper.GetPremiumSamples(ctx)
@@ -201,8 +201,8 @@ func TestFunding(t *testing.T) {
 			ctx = tApp.AdvanceToBlock(
 				testapp.EstimatedHeightForBlockTime(GenesisTime, LastFundingSampleOfSecondFundingTickEpoch, BlockTimeDuration),
 				testapp.AdvanceToBlockOptions{
-					BlockTime:                 LastFundingSampleOfSecondFundingTickEpoch,
-					GradualBlockTimeIncrement: true,
+					BlockTime:                    LastFundingSampleOfSecondFundingTickEpoch,
+					LinearBlockTimeInterpolation: true,
 				})
 
 			premiumSamples = tApp.App.PerpetualsKeeper.GetPremiumSamples(ctx)

--- a/protocol/testing/e2e/funding/funding_e2e_test.go
+++ b/protocol/testing/e2e/funding/funding_e2e_test.go
@@ -170,7 +170,9 @@ func TestFunding(t *testing.T) {
 				ctx,
 				tApp.App,
 				pricestest.MustHumanPriceToMarketPrice(tc.initialIndexPrice[0], -5),
-				time.Now(),
+				// Only index price past a certain threshold is used for premium calculation.
+				// Use additional buffer here to ensure `test-race` passes.
+				time.Now().Add(1*time.Hour),
 			)
 
 			ctx = tApp.AdvanceToBlock(BlockHeightAtFirstFundingTick, testapp.AdvanceToBlockOptions{
@@ -190,7 +192,9 @@ func TestFunding(t *testing.T) {
 				ctx,
 				tApp.App,
 				pricestest.MustHumanPriceToMarketPrice(tc.indexPriceForPremium[0], -5),
-				time.Now(),
+				// Only index price past a certain threshold is used for premium calculation.
+				// Use additional buffer here to ensure `test-race` passes.
+				time.Now().Add(1*time.Hour),
 			)
 
 			// We just entered a new `funding-tick` epoch, there should be 0 funding premium samples.
@@ -222,7 +226,9 @@ func TestFunding(t *testing.T) {
 				ctx,
 				tApp.App,
 				pricestest.MustHumanPriceToMarketPrice(tc.oracelPriceForFundingIndex[0], -5),
-				time.Now(),
+				// Only index price past a certain threshold is used for premium calculation.
+				// Use additional buffer here to ensure `test-race` passes.
+				time.Now().Add(1*time.Hour),
 			)
 			// Advance another 30 seconds to the end of the second funding-tick epoch. This will trigger processing
 			// of `funding-tick`, which calculates the final funding rate and updates the funding index.

--- a/protocol/testing/e2e/funding/funding_e2e_test.go
+++ b/protocol/testing/e2e/funding/funding_e2e_test.go
@@ -1,0 +1,247 @@
+package funding_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/types"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	pricefeed_testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/pricefeed"
+	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	epochstypes "github.com/dydxprotocol/v4-chain/protocol/x/epochs/types"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/stretchr/testify/require"
+)
+
+type TestHumanOrder struct {
+	Order      clobtypes.Order
+	HumanPrice string
+	HumanSize  string
+}
+
+const (
+	BlockTimeDuration             = 2 * time.Second
+	NumBlocksPerMinute            = int64(time.Minute / BlockTimeDuration) // 30
+	BlockHeightAtFirstFundingTick = 1000
+)
+
+var (
+	OrderTemplate_Alice_Num0_Id0_Clob0_Buy_LongTerm = clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side: clobtypes.Order_SIDE_BUY,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+			GoodTilBlockTime: uint32(GenesisTime.Add(24 * time.Hour).Unix()),
+		},
+	}
+	OrderTemplate_Alice_Num0_Id1_Clob0_Buy_LongTerm = clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     1,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side: clobtypes.Order_SIDE_BUY,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+			GoodTilBlockTime: uint32(GenesisTime.Add(24 * time.Hour).Unix()),
+		},
+	}
+	OrderTemplate_Bob_Num0_Id0_Clob0_Sell_LongTerm = clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Bob_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side: clobtypes.Order_SIDE_SELL,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+			GoodTilBlockTime: uint32(GenesisTime.Add(24 * time.Hour).Unix()),
+		},
+	}
+	OrderTemplate_Bob_Num0_Id1_Clob0_Sell_LongTerm = clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Bob_Num0,
+			ClientId:     1,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side: clobtypes.Order_SIDE_SELL,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+			GoodTilBlockTime: uint32(GenesisTime.Add(24 * time.Hour).Unix()),
+		},
+	}
+	// Genesis time of the chain
+	GenesisTime                               = time.Unix(1690000000, 0)
+	FirstFundingSampleTick                    = time.Unix(1690000050, 0)
+	FirstFundingTick                          = time.Unix(1690002000, 0)
+	LastFundingSampleOfSecondFundingTickEpoch = time.Unix(1690005570, 0)
+	SecondFundingTick                         = time.Unix(
+		1690002000+int64(epochstypes.FundingTickEpochDuration),
+		0,
+	)
+)
+
+func TestFunding(t *testing.T) {
+	tests := map[string]struct {
+		testHumanOrders   []TestHumanOrder
+		initialIndexPrice map[uint32]string
+		// index price to be used in premium calculation
+		indexPriceForPremium map[uint32]string
+		// oracle price for funding index calculation
+		oracelPriceForFundingIndex map[uint32]string
+		expectedFundingPremium     int32
+		expectedFundingIndex       int64
+	}{
+		"Test funding": {
+			testHumanOrders: []TestHumanOrder{
+				// Unmatched orders to generate funding premiums.
+				{
+					Order:      OrderTemplate_Bob_Num0_Id0_Clob0_Sell_LongTerm,
+					HumanPrice: "28005",
+					HumanSize:  "2",
+				},
+				{
+					Order:      OrderTemplate_Alice_Num0_Id0_Clob0_Buy_LongTerm,
+					HumanPrice: "28000",
+					HumanSize:  "2",
+				},
+				// Matched orders to set up Alice and Bob's positions.
+				{
+					Order:      OrderTemplate_Bob_Num0_Id1_Clob0_Sell_LongTerm,
+					HumanPrice: "28003",
+					HumanSize:  "1",
+				},
+				{
+					Order:      OrderTemplate_Alice_Num0_Id1_Clob0_Buy_LongTerm,
+					HumanPrice: "28003",
+					HumanSize:  "1",
+				},
+			},
+			initialIndexPrice: map[uint32]string{
+				0: "28002",
+			},
+			indexPriceForPremium: map[uint32]string{
+				0: "27960",
+			},
+			oracelPriceForFundingIndex: map[uint32]string{
+				0: "27000",
+			},
+			expectedFundingPremium: 1430, // 28_000 / 27_960 - 1 ~= 0.001430
+			// 1430 / 8 * 27000 * 10^(btc_atomic_resolution - quote_atomic_resolution) ~= 483
+			expectedFundingIndex: 483,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+				genesis = testapp.DefaultGenesis()
+				genesis.GenesisTime = GenesisTime
+				return genesis
+			}).Build()
+			ctx := tApp.InitChain()
+
+			// Place orders on the book.
+			for _, testHumanOrder := range tc.testHumanOrders {
+				order := clobtest.MustMakeOrderFromHumanInput(
+					ctx,
+					tApp.App,
+					testHumanOrder.Order,
+					testHumanOrder.HumanPrice,
+					testHumanOrder.HumanSize,
+				)
+
+				checkTx := testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(order))
+				resp := tApp.CheckTx(checkTx[0])
+				require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
+			}
+
+			// Update initial index price. This price is meant to be within the impact price range,
+			// leading to zero sampled premiums.
+			pricefeed_testutil.UpdateIndexPrice(
+				t,
+				ctx,
+				tApp.App,
+				pricestest.MustHumanPriceToMarketPrice(tc.initialIndexPrice[0], -5),
+				time.Now(),
+			)
+
+			ctx = tApp.AdvanceToBlock(BlockHeightAtFirstFundingTick, testapp.AdvanceToBlockOptions{
+				BlockTime:                 FirstFundingTick,
+				GradualBlockTimeIncrement: true,
+			})
+
+			premiumSamples := tApp.App.PerpetualsKeeper.GetPremiumSamples(ctx)
+			// No non-zero premium samples yet.
+			require.Len(t, premiumSamples.AllMarketPremiums, 0)
+			// Zero premium samples since we just entered a new `funding-tick` epoch.
+			require.Equal(t, uint32(0), premiumSamples.NumPremiums)
+
+			// Update index price for each validator so they use this price for premium calculation.
+			pricefeed_testutil.UpdateIndexPrice(
+				t,
+				ctx,
+				tApp.App,
+				pricestest.MustHumanPriceToMarketPrice(tc.indexPriceForPremium[0], -5),
+				time.Now(),
+			)
+
+			// We just entered a new `funding-tick` epoch, there should be 0 funding premium samples.
+			require.Equal(t, tApp.App.PerpetualsKeeper.GetPremiumSamples(ctx).NumPremiums, uint32(0))
+
+			// Advance to the end of the last funding-sample epoch during the second funding-tick epoch.
+			// At this point, 60 funding-sample epochs have passed, so we should expect 60 premium samples.
+			ctx = tApp.AdvanceToBlock(
+				testapp.EstimatedHeightForBlockTime(GenesisTime, LastFundingSampleOfSecondFundingTickEpoch, BlockTimeDuration),
+				testapp.AdvanceToBlockOptions{
+					BlockTime:                 LastFundingSampleOfSecondFundingTickEpoch,
+					GradualBlockTimeIncrement: true,
+				})
+
+			premiumSamples = tApp.App.PerpetualsKeeper.GetPremiumSamples(ctx)
+			require.Equal(t, 60, int(premiumSamples.NumPremiums))
+			expectedAllMarketPremiums := []perptypes.MarketPremiums{
+				{
+					PerpetualId: 0,
+					Premiums:    constants.GenerateConstantFundingPremiums(tc.expectedFundingPremium, 60),
+				},
+			}
+			require.Equal(t, expectedAllMarketPremiums, premiumSamples.AllMarketPremiums)
+
+			// Update index price for each validator so they propose this price as the new oracle price.
+			// This price will be used for calculating the funding index at the end of `funding-tick`.
+			pricefeed_testutil.UpdateIndexPrice(
+				t,
+				ctx,
+				tApp.App,
+				pricestest.MustHumanPriceToMarketPrice(tc.oracelPriceForFundingIndex[0], -5),
+				time.Now(),
+			)
+			// Advance another 30 seconds to the end of the second funding-tick epoch. This will trigger processing
+			// of `funding-tick`, which calculates the final funding rate and updates the funding index.
+			ctx = tApp.AdvanceToBlock(uint32(ctx.BlockHeight()+NumBlocksPerMinute-1), testapp.AdvanceToBlockOptions{
+				BlockTime: SecondFundingTick.Add(-BlockTimeDuration),
+			})
+			ctx = tApp.AdvanceToBlock(uint32(ctx.BlockHeight())+1, testapp.AdvanceToBlockOptions{
+				BlockTime: SecondFundingTick,
+			})
+
+			premiumSamples = tApp.App.PerpetualsKeeper.GetPremiumSamples(ctx)
+			require.Equal(t, uint32(0), premiumSamples.NumPremiums)
+			require.Len(t, premiumSamples.AllMarketPremiums, 0)
+
+			// Check that the funding index is correctly updated.
+			btcPerp, err := tApp.App.PerpetualsKeeper.GetPerpetual(ctx, 0)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedFundingIndex, btcPerp.FundingIndex.BigInt().Int64())
+			// TODO(CORE-703): Settle Alice and Bob's positions, so we can measure that the funding payment as processed.
+		})
+	}
+}

--- a/protocol/testing/e2e/funding/funding_e2e_test.go
+++ b/protocol/testing/e2e/funding/funding_e2e_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cometbft/cometbft/types"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
-	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	pricefeed_testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/pricefeed"
 	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
@@ -137,6 +136,7 @@ func TestFunding(t *testing.T) {
 			// 1430 / 8 * 27000 * 10^(btc_atomic_resolution - quote_atomic_resolution) ~= 483
 			expectedFundingIndex: 483,
 		},
+		// TODO(CORE-712): Add more test cases
 	}
 
 	for name, tc := range tests {
@@ -150,7 +150,7 @@ func TestFunding(t *testing.T) {
 
 			// Place orders on the book.
 			for _, testHumanOrder := range tc.testHumanOrders {
-				order := clobtest.MustMakeOrderFromHumanInput(
+				order := testapp.MustMakeOrderFromHumanInput(
 					ctx,
 					tApp.App,
 					testHumanOrder.Order,

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -84,6 +84,8 @@ type AdvanceToBlockOptions struct {
 	BlockTime time.Time
 
 	// Whether to increment the block time gradually and evenly among the advanced blocks.
+	// TODO(DEC-2156): Instead of an option, pass in a `BlockTimeFunc` to map each block to a
+	// time. This gives user more flexibility.
 	GradualBlockTimeIncrement bool
 
 	// RequestPrepareProposalTxsOverride allows overriding the txs that gets passed into the

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -83,7 +83,7 @@ type AdvanceToBlockOptions struct {
 	// The time associated with the block. If left at the default value then block time will be left unchanged.
 	BlockTime time.Time
 
-	// Whether to increment the block time using linear extrapolation among the blocks.
+	// Whether to increment the block time using linear interpolation among the blocks.
 	// TODO(DEC-2156): Instead of an option, pass in a `BlockTimeFunc` to map each block to a
 	// time giving user greater flexibility.
 	LinearBlockTimeInterpolation bool

--- a/protocol/testutil/app/block_advancement.go
+++ b/protocol/testutil/app/block_advancement.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
@@ -132,4 +133,12 @@ func (b BlockAdvancement) getProposedOperationsTxBytes(ctx sdktypes.Context, app
 	}
 
 	return testtx.MustGetTxBytes(msgProposedOperations)
+}
+
+func EstimatedHeightForBlockTime(
+	genesisTime time.Time,
+	targetBlockTime time.Time,
+	blockTimeDuration time.Duration,
+) uint32 {
+	return uint32(targetBlockTime.Sub(genesisTime) / blockTimeDuration)
 }

--- a/protocol/testutil/app/block_advancement.go
+++ b/protocol/testutil/app/block_advancement.go
@@ -135,6 +135,8 @@ func (b BlockAdvancement) getProposedOperationsTxBytes(ctx sdktypes.Context, app
 	return testtx.MustGetTxBytes(msgProposedOperations)
 }
 
+// Given genesis time, target block time and block time duration, return the estimated height
+// at which the target block time is reached.
 func EstimatedHeightForBlockTime(
 	genesisTime time.Time,
 	targetBlockTime time.Time,

--- a/protocol/testutil/app/order.go
+++ b/protocol/testutil/app/order.go
@@ -1,4 +1,7 @@
-package clob
+package app
+
+// This file includes clob helpers used in the end-to-end test suites. Functions here cannot live in
+// protocol/testutil/clob because they depend on the TestApp struct, and would create an import cycle.
 
 import (
 	"fmt"
@@ -6,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/app"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
 	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
 	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -24,7 +28,7 @@ func MustMakeOrderFromHumanInput(
 	if !exists {
 		panic(fmt.Sprintf("clobPair does not exist: %v", order.OrderId.ClobPairId))
 	}
-	perp, err := app.PerpetualsKeeper.GetPerpetual(ctx, MustPerpetualId(clobPair))
+	perp, err := app.PerpetualsKeeper.GetPerpetual(ctx, clobtest.MustPerpetualId(clobPair))
 	if err != nil {
 		panic(err)
 	}

--- a/protocol/testutil/clob/order.go
+++ b/protocol/testutil/clob/order.go
@@ -1,0 +1,50 @@
+package clob
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/app"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
+	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+)
+
+// Subsitute quantums and subticks with value converted from human readable price and amount.
+func MustMakeOrderFromHumanInput(
+	ctx sdk.Context,
+	app *app.App,
+	order clobtypes.Order,
+	humanPrice string,
+	humanSize string,
+) clobtypes.Order {
+	clobPair, exists := app.ClobKeeper.GetClobPair(ctx, clobtypes.ClobPairId(order.OrderId.ClobPairId))
+	if !exists {
+		panic(fmt.Sprintf("clobPair does not exist: %v", order.OrderId.ClobPairId))
+	}
+	perp, err := app.PerpetualsKeeper.GetPerpetual(ctx, MustPerpetualId(clobPair))
+	if err != nil {
+		panic(err)
+	}
+	baseQuantums := perptest.MustHumanSizeToBaseQuantums(humanSize, perp.Params.AtomicResolution)
+	order.Quantums = baseQuantums
+
+	marketParams, exists := app.PricesKeeper.GetMarketParam(ctx, perp.Params.MarketId)
+	if !exists {
+		panic(fmt.Sprintf("marketParam does not exist: %v", perp.Params.MarketId))
+	}
+	marketPrice := pricestest.MustHumanPriceToMarketPrice(humanPrice, marketParams.Exponent)
+	subticks := clobtypes.PriceToSubticks(
+		pricestypes.MarketPrice{
+			Price:    marketPrice,
+			Exponent: marketParams.Exponent,
+		},
+		clobPair,
+		perp.Params.AtomicResolution,
+		lib.QuoteCurrencyAtomicResolution,
+	)
+	order.Subticks = subticks.Num().Uint64()
+	return order
+}

--- a/protocol/testutil/perpetuals/perpetuals_test.go
+++ b/protocol/testutil/perpetuals/perpetuals_test.go
@@ -1,0 +1,44 @@
+package perpetuals_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustHumanSizeToBaseQuantums(t *testing.T) {
+	tests := []struct {
+		humanSize        string
+		atomicResolution int32
+		expected         uint64
+		expectPanic      bool
+	}{
+		{"1.123", -8, 112_300_000, false},
+		{"0.55", -9, 550_000_000, false},
+		{"0.00000001", -8, 1, false},
+		{"235", 1, 2350, false},
+		{"1", -10, 10_000_000_000, false},
+		{"0.0000000001", -10, 1, false},
+		{"abc", -8, 0, true}, // Invalid humanSize
+	}
+
+	for _, test := range tests {
+		if test.expectPanic {
+			require.Panics(t, func() {
+				perpetuals.MustHumanSizeToBaseQuantums(test.humanSize, test.atomicResolution)
+			}, "For humanSize %v and atomicResolution %v, expected a panic", test.humanSize, test.atomicResolution)
+		} else {
+			result := perpetuals.MustHumanSizeToBaseQuantums(test.humanSize, test.atomicResolution)
+			require.Equal(t,
+				test.expected,
+				result,
+				"expected = %v, result =%v, for humanSize %v and atomicResolution %v",
+				test.expected,
+				result,
+				test.humanSize,
+				test.atomicResolution,
+			)
+		}
+	}
+}

--- a/protocol/testutil/pricefeed/index_price.go
+++ b/protocol/testutil/pricefeed/index_price.go
@@ -1,8 +1,14 @@
 package pricefeed
 
 import (
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"testing"
+	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dydxprotocol/v4-chain/protocol/app"
 	pricefeedapi "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
 )
 
@@ -20,4 +26,41 @@ func GetTestMarketPriceUpdates(n int) (indexPrices []*pricefeedapi.MarketPriceUp
 		)
 	}
 	return indexPrices
+}
+
+func UpdateIndexPrice(
+	t *testing.T,
+	ctx sdk.Context,
+	tApp *app.App,
+	price uint64,
+	lastUpdatedTime time.Time,
+) {
+	_, err := tApp.Server.UpdateMarketPrices(
+		ctx,
+		&pricefeedapi.UpdateMarketPricesRequest{
+			MarketPriceUpdates: []*pricefeedapi.MarketPriceUpdate{
+				{
+					MarketId: 0,
+					ExchangePrices: []*pricefeedapi.ExchangePrice{
+						{
+							ExchangeId:     "exchange-a",
+							Price:          price,
+							LastUpdateTime: &lastUpdatedTime,
+						},
+						{
+							ExchangeId:     "exchange-b",
+							Price:          price,
+							LastUpdateTime: &lastUpdatedTime,
+						},
+						{
+							ExchangeId:     "exchange-c",
+							Price:          price,
+							LastUpdateTime: &lastUpdatedTime,
+						},
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
 }

--- a/protocol/testutil/prices/market_param_price_test.go
+++ b/protocol/testutil/prices/market_param_price_test.go
@@ -1,0 +1,37 @@
+package prices_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustHumanPriceToMarketPrice(t *testing.T) {
+	tests := []struct {
+		humanPrice  string
+		exponent    int32
+		expected    uint64
+		expectPanic bool
+	}{
+		{"20000", -5, 2000_000_000, false},
+		{"12345.67", -3, 12_345_670, false},
+		{"1.123", -8, 112_300_000, false},
+		{"0.00000001", -8, 1, false},
+		{"1", -10, 10_000_000_000, false},
+		{"0.0000000001", -10, 1, false},
+		{"abc", -8, 0, true}, // Invalid humanPrice
+	}
+
+	for _, test := range tests {
+		if test.expectPanic {
+			require.Panics(t, func() {
+				prices.MustHumanPriceToMarketPrice(test.humanPrice, test.exponent)
+			}, "For humanPrice %s and exponent %d, expected a panic", test.humanPrice, test.exponent)
+		} else {
+			result := prices.MustHumanPriceToMarketPrice(test.humanPrice, test.exponent)
+			require.Equal(t, test.expected, result, "expected = %v, result = %v for humanPrice %s and exponent %d",
+				test.expected, result, test.humanPrice, test.exponent)
+		}
+	}
+}


### PR DESCRIPTION
### Changelist
Added an funding e2e test that can be built upon in the future. Current behavior tested:
- Set up orders on the book
- Advance to start of full `funding-tick` period
- Measure a full `60 min` `funding-tick` period and check expected funding samples and resulting `fundingIndex`. 

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
