### PR TITLE
[CORE-664] Perpetual audit: add validation on `MinNumVotesPerSample`, add unit tests

### DIFF
--- a/protocol/x/perpetuals/e2e/authorities_test.go
+++ b/protocol/x/perpetuals/e2e/authorities_test.go
@@ -1,0 +1,46 @@
+package perpetuals_e2e_test
+
+import (
+	"testing"
+
+	"github.com/cometbft/cometbft/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasAuthority(t *testing.T) {
+	tests := map[string]struct {
+		authorityAddress string
+		hasAuthority     bool
+	}{
+		"gov is an authority": {
+			authorityAddress: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			hasAuthority:     true,
+		},
+		"delaymsg is an authority": {
+			authorityAddress: authtypes.NewModuleAddress(delaymsgtypes.ModuleName).String(),
+			hasAuthority:     true,
+		},
+		"random invalid authority": {
+			authorityAddress: "random",
+			hasAuthority:     false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+				return testapp.DefaultGenesis()
+			}).Build()
+			tApp.InitChain()
+			require.Equal(
+				t,
+				tc.hasAuthority,
+				tApp.App.PerpetualsKeeper.HasAuthority(tc.authorityAddress),
+			)
+		})
+	}
+}

--- a/protocol/x/perpetuals/keeper/perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/perpetual_test.go
@@ -255,6 +255,14 @@ func TestModifyPerpetual_Failure(t *testing.T) {
 			liquidityTier:     0,
 			expectedError:     types.ErrTickerEmptyString,
 		},
+		"Modified to empty liquidity tier": {
+			id:                0,
+			ticker:            "ticker",
+			marketId:          0,
+			defaultFundingPpm: 0,
+			liquidityTier:     999,
+			expectedError:     errorsmod.Wrap(types.ErrLiquidityTierDoesNotExist, fmt.Sprint(999)),
+		},
 	}
 
 	// Test setup.
@@ -2535,6 +2543,7 @@ func TestMaybeProcessNewFundingSampleEpoch(t *testing.T) {
 		"Not new epoch": {
 			currentEpochStartBlock: 23,
 			currentBlockHeight:     25,
+			minNumVotesPerSample:   1,
 			premiumVotes: types.PremiumStore{
 				AllMarketPremiums: []types.MarketPremiums{
 					{
@@ -2557,6 +2566,7 @@ func TestMaybeProcessNewFundingSampleEpoch(t *testing.T) {
 		"New epoch, empty premium samples storage": {
 			currentEpochStartBlock: 23,
 			currentBlockHeight:     23,
+			minNumVotesPerSample:   1,
 			premiumVotes: types.PremiumStore{
 				NumPremiums: 4,
 				AllMarketPremiums: []types.MarketPremiums{
@@ -2589,6 +2599,7 @@ func TestMaybeProcessNewFundingSampleEpoch(t *testing.T) {
 		"New epoch, add new sample to existing samples, skip zero samples": {
 			currentEpochStartBlock: 23,
 			currentBlockHeight:     23,
+			minNumVotesPerSample:   1,
 			premiumVotes: types.PremiumStore{
 				NumPremiums: 6,
 				AllMarketPremiums: []types.MarketPremiums{
@@ -2608,6 +2619,7 @@ func TestMaybeProcessNewFundingSampleEpoch(t *testing.T) {
 			},
 			prevPremiumSamples: types.PremiumStore{
 				NumPremiums: 2,
+
 				AllMarketPremiums: []types.MarketPremiums{
 					{
 						PerpetualId: 0,
@@ -2723,6 +2735,7 @@ func TestMaybeProcessNewFundingSampleEpoch(t *testing.T) {
 		"Panic: `NumPremiums` < premium entries length": {
 			currentEpochStartBlock: 23,
 			currentBlockHeight:     23,
+			minNumVotesPerSample:   1,
 			premiumVotes: types.PremiumStore{
 				NumPremiums: 1,
 				AllMarketPremiums: []types.MarketPremiums{

--- a/protocol/x/perpetuals/types/errors.go
+++ b/protocol/x/perpetuals/types/errors.go
@@ -110,7 +110,7 @@ var (
 	ErrMinNumVotesPerSampleIsZero = errorsmod.Register(
 		ModuleName,
 		22,
-		"MinNumVotesPerSamle is zero",
+		"MinNumVotesPerSample is zero",
 	)
 
 	// Errors for Not Implemented

--- a/protocol/x/perpetuals/types/errors.go
+++ b/protocol/x/perpetuals/types/errors.go
@@ -107,6 +107,11 @@ var (
 		21,
 		"Maintenance margin fraction is larger than initial margin fraction",
 	)
+	ErrMinNumVotesPerSampleIsZero = errorsmod.Register(
+		ModuleName,
+		22,
+		"MinNumVotesPerSamle is zero",
+	)
 
 	// Errors for Not Implemented
 	ErrNotImplementedFunding = errorsmod.Register(ModuleName, 1001, "Not Implemented: Perpetuals Funding")

--- a/protocol/x/perpetuals/types/genesis_test.go
+++ b/protocol/x/perpetuals/types/genesis_test.go
@@ -302,7 +302,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					MinNumVotesPerSample:      0,
 				},
 			},
-			expectedError: errors.New("MinNumVotesPerSamle is zero"),
+			expectedError: errors.New("MinNumVotesPerSample is zero"),
 		},
 		"invalid: impact notional is zero": {
 			genState: &types.GenesisState{

--- a/protocol/x/perpetuals/types/genesis_test.go
+++ b/protocol/x/perpetuals/types/genesis_test.go
@@ -43,7 +43,7 @@ func TestGenesisState_Validate(t *testing.T) {
 				Params: types.Params{
 					FundingRateClampFactorPpm: 3_000_000,
 					PremiumVoteClampFactorPpm: 30_000_000,
-					MinNumVotesPerSample:      0,
+					MinNumVotesPerSample:      15,
 				},
 			},
 			expectedError: nil,
@@ -274,6 +274,36 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 			expectedError: errors.New("Premium vote clamp factor ppm is zero"),
 		},
+		"invalid: min num votes per sample": {
+			genState: &types.GenesisState{
+				Perpetuals: []types.Perpetual{
+					{
+						Params: types.PerpetualParams{
+							Id:            0,
+							Ticker:        "EXAM-USD",
+							LiquidityTier: 0,
+						},
+						FundingIndex: dtypes.ZeroInt(),
+					},
+				},
+				LiquidityTiers: []types.LiquidityTier{
+					{
+						Id:                     0,
+						Name:                   "Large-Cap",
+						InitialMarginPpm:       200_000,
+						MaintenanceFractionPpm: 1_000_000,
+						BasePositionNotional:   100,
+						ImpactNotional:         2_500_000_000,
+					},
+				},
+				Params: types.Params{
+					FundingRateClampFactorPpm: 6_000_000,
+					PremiumVoteClampFactorPpm: 60_000_000,
+					MinNumVotesPerSample:      0,
+				},
+			},
+			expectedError: errors.New("MinNumVotesPerSamle is zero"),
+		},
 		"invalid: impact notional is zero": {
 			genState: &types.GenesisState{
 				Perpetuals: []types.Perpetual{
@@ -299,6 +329,7 @@ func TestGenesisState_Validate(t *testing.T) {
 				Params: types.Params{
 					FundingRateClampFactorPpm: 6_000_000,
 					PremiumVoteClampFactorPpm: 60_000_000,
+					MinNumVotesPerSample:      15,
 				},
 			},
 			expectedError: errors.New("Impact notional is zero"),

--- a/protocol/x/perpetuals/types/params.go
+++ b/protocol/x/perpetuals/types/params.go
@@ -8,6 +8,9 @@ func (params Params) Validate() error {
 	if params.PremiumVoteClampFactorPpm == 0 {
 		return ErrPremiumVoteClampFactorPpmIsZero
 	}
+	if params.MinNumVotesPerSample == 0 {
+		return ErrMinNumVotesPerSampleIsZero
+	}
 
 	return nil
 }

--- a/protocol/x/perpetuals/types/params_test.go
+++ b/protocol/x/perpetuals/types/params_test.go
@@ -39,6 +39,12 @@ func TestParamsValidate(t *testing.T) {
 			minNumVotesPerSample:      15,
 			expectedError:             types.ErrPremiumVoteClampFactorPpmIsZero,
 		},
+		"Failure: MinNumVotesPerSample is zero": {
+			fundingRateClampFactorPpm: 6_000_000,
+			premiumVoteClampFactorPpm: 60_000_000,
+			minNumVotesPerSample:      0,
+			expectedError:             types.ErrMinNumVotesPerSampleIsZero,
+		},
 	}
 
 	// Run tests.


### PR DESCRIPTION
### Changelist
Another round of audit changes for `x/perpetuals`. Added an additional validation for  `MinNumVotesPerSample` (state incompatible). 
Otherwise, mostly code sanitation and unit tests.

### Test Plan
Updated tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
