### PR TITLE
[CORE-695] - add queries for x/perpetuals state

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/perpetuals/query.lcd.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/perpetuals/query.lcd.ts
@@ -1,6 +1,6 @@
 import { setPaginationParams } from "../../helpers";
 import { LCDClient } from "@osmonauts/lcd";
-import { QueryPerpetualRequest, QueryPerpetualResponseSDKType, QueryAllPerpetualsRequest, QueryAllPerpetualsResponseSDKType } from "./query";
+import { QueryPerpetualRequest, QueryPerpetualResponseSDKType, QueryAllPerpetualsRequest, QueryAllPerpetualsResponseSDKType, QueryPremiumVotesRequest, QueryPremiumVotesResponseSDKType, QueryPremiumSamplesRequest, QueryPremiumSamplesResponseSDKType, QueryParamsRequest, QueryParamsResponseSDKType } from "./query";
 export class LCDQueryClient {
   req: LCDClient;
 
@@ -12,6 +12,9 @@ export class LCDQueryClient {
     this.req = requestClient;
     this.perpetual = this.perpetual.bind(this);
     this.allPerpetuals = this.allPerpetuals.bind(this);
+    this.premiumVotes = this.premiumVotes.bind(this);
+    this.premiumSamples = this.premiumSamples.bind(this);
+    this.params = this.params.bind(this);
   }
   /* Queries a Perpetual by id. */
 
@@ -36,6 +39,27 @@ export class LCDQueryClient {
 
     const endpoint = `dydxprotocol/perpetuals/perpetual`;
     return await this.req.get<QueryAllPerpetualsResponseSDKType>(endpoint, options);
+  }
+  /* Queries a list of premium votes. */
+
+
+  async premiumVotes(_params: QueryPremiumVotesRequest = {}): Promise<QueryPremiumVotesResponseSDKType> {
+    const endpoint = `dydxprotocol/perpetuals/premium_votes`;
+    return await this.req.get<QueryPremiumVotesResponseSDKType>(endpoint);
+  }
+  /* Queries a list of premium samples. */
+
+
+  async premiumSamples(_params: QueryPremiumSamplesRequest = {}): Promise<QueryPremiumSamplesResponseSDKType> {
+    const endpoint = `dydxprotocol/perpetuals/premium_samples`;
+    return await this.req.get<QueryPremiumSamplesResponseSDKType>(endpoint);
+  }
+  /* Queries the perpetual params. */
+
+
+  async params(_params: QueryParamsRequest = {}): Promise<QueryParamsResponseSDKType> {
+    const endpoint = `dydxprotocol/perpetuals/params`;
+    return await this.req.get<QueryParamsResponseSDKType>(endpoint);
   }
 
 }

--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/perpetuals/query.rpc.Query.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/perpetuals/query.rpc.Query.ts
@@ -1,7 +1,7 @@
 import { Rpc } from "../../helpers";
 import * as _m0 from "protobufjs/minimal";
 import { QueryClient, createProtobufRpcClient } from "@cosmjs/stargate";
-import { QueryPerpetualRequest, QueryPerpetualResponse, QueryAllPerpetualsRequest, QueryAllPerpetualsResponse } from "./query";
+import { QueryPerpetualRequest, QueryPerpetualResponse, QueryAllPerpetualsRequest, QueryAllPerpetualsResponse, QueryPremiumVotesRequest, QueryPremiumVotesResponse, QueryPremiumSamplesRequest, QueryPremiumSamplesResponse, QueryParamsRequest, QueryParamsResponse } from "./query";
 /** Query defines the gRPC querier service. */
 
 export interface Query {
@@ -10,6 +10,15 @@ export interface Query {
   /** Queries a list of Perpetual items. */
 
   allPerpetuals(request?: QueryAllPerpetualsRequest): Promise<QueryAllPerpetualsResponse>;
+  /** Queries a list of premium votes. */
+
+  premiumVotes(request?: QueryPremiumVotesRequest): Promise<QueryPremiumVotesResponse>;
+  /** Queries a list of premium samples. */
+
+  premiumSamples(request?: QueryPremiumSamplesRequest): Promise<QueryPremiumSamplesResponse>;
+  /** Queries the perpetual params. */
+
+  params(request?: QueryParamsRequest): Promise<QueryParamsResponse>;
 }
 export class QueryClientImpl implements Query {
   private readonly rpc: Rpc;
@@ -18,6 +27,9 @@ export class QueryClientImpl implements Query {
     this.rpc = rpc;
     this.perpetual = this.perpetual.bind(this);
     this.allPerpetuals = this.allPerpetuals.bind(this);
+    this.premiumVotes = this.premiumVotes.bind(this);
+    this.premiumSamples = this.premiumSamples.bind(this);
+    this.params = this.params.bind(this);
   }
 
   perpetual(request: QueryPerpetualRequest): Promise<QueryPerpetualResponse> {
@@ -34,6 +46,24 @@ export class QueryClientImpl implements Query {
     return promise.then(data => QueryAllPerpetualsResponse.decode(new _m0.Reader(data)));
   }
 
+  premiumVotes(request: QueryPremiumVotesRequest = {}): Promise<QueryPremiumVotesResponse> {
+    const data = QueryPremiumVotesRequest.encode(request).finish();
+    const promise = this.rpc.request("dydxprotocol.perpetuals.Query", "PremiumVotes", data);
+    return promise.then(data => QueryPremiumVotesResponse.decode(new _m0.Reader(data)));
+  }
+
+  premiumSamples(request: QueryPremiumSamplesRequest = {}): Promise<QueryPremiumSamplesResponse> {
+    const data = QueryPremiumSamplesRequest.encode(request).finish();
+    const promise = this.rpc.request("dydxprotocol.perpetuals.Query", "PremiumSamples", data);
+    return promise.then(data => QueryPremiumSamplesResponse.decode(new _m0.Reader(data)));
+  }
+
+  params(request: QueryParamsRequest = {}): Promise<QueryParamsResponse> {
+    const data = QueryParamsRequest.encode(request).finish();
+    const promise = this.rpc.request("dydxprotocol.perpetuals.Query", "Params", data);
+    return promise.then(data => QueryParamsResponse.decode(new _m0.Reader(data)));
+  }
+
 }
 export const createRpcQueryExtension = (base: QueryClient) => {
   const rpc = createProtobufRpcClient(base);
@@ -45,6 +75,18 @@ export const createRpcQueryExtension = (base: QueryClient) => {
 
     allPerpetuals(request?: QueryAllPerpetualsRequest): Promise<QueryAllPerpetualsResponse> {
       return queryService.allPerpetuals(request);
+    },
+
+    premiumVotes(request?: QueryPremiumVotesRequest): Promise<QueryPremiumVotesResponse> {
+      return queryService.premiumVotes(request);
+    },
+
+    premiumSamples(request?: QueryPremiumSamplesRequest): Promise<QueryPremiumSamplesResponse> {
+      return queryService.premiumSamples(request);
+    },
+
+    params(request?: QueryParamsRequest): Promise<QueryParamsResponse> {
+      return queryService.params(request);
     }
 
   };

--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/perpetuals/query.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/perpetuals/query.ts
@@ -1,5 +1,6 @@
 import { PageRequest, PageRequestSDKType, PageResponse, PageResponseSDKType } from "../../cosmos/base/query/v1beta1/pagination";
-import { Perpetual, PerpetualSDKType } from "./perpetual";
+import { Perpetual, PerpetualSDKType, PremiumStore, PremiumStoreSDKType } from "./perpetual";
+import { Params, ParamsSDKType } from "./params";
 import * as _m0 from "protobufjs/minimal";
 import { DeepPartial } from "../../helpers";
 /** Queries a Perpetual by id. */
@@ -45,6 +46,72 @@ export interface QueryAllPerpetualsResponse {
 export interface QueryAllPerpetualsResponseSDKType {
   perpetual: PerpetualSDKType[];
   pagination?: PageResponseSDKType;
+}
+/** QueryPremiumVotesRequest is the request type for the PremiumVotes RPC method. */
+
+export interface QueryPremiumVotesRequest {}
+/** QueryPremiumVotesRequest is the request type for the PremiumVotes RPC method. */
+
+export interface QueryPremiumVotesRequestSDKType {}
+/**
+ * QueryPremiumVotesResponse is the response type for the PremiumVotes RPC
+ * method.
+ */
+
+export interface QueryPremiumVotesResponse {
+  premiumVotes?: PremiumStore;
+}
+/**
+ * QueryPremiumVotesResponse is the response type for the PremiumVotes RPC
+ * method.
+ */
+
+export interface QueryPremiumVotesResponseSDKType {
+  premium_votes?: PremiumStoreSDKType;
+}
+/**
+ * QueryPremiumSamplesRequest is the request type for the PremiumSamples RPC
+ * method.
+ */
+
+export interface QueryPremiumSamplesRequest {}
+/**
+ * QueryPremiumSamplesRequest is the request type for the PremiumSamples RPC
+ * method.
+ */
+
+export interface QueryPremiumSamplesRequestSDKType {}
+/**
+ * QueryPremiumSamplesResponse is the response type for the PremiumSamples RPC
+ * method.
+ */
+
+export interface QueryPremiumSamplesResponse {
+  premiumSamples?: PremiumStore;
+}
+/**
+ * QueryPremiumSamplesResponse is the response type for the PremiumSamples RPC
+ * method.
+ */
+
+export interface QueryPremiumSamplesResponseSDKType {
+  premium_samples?: PremiumStoreSDKType;
+}
+/** QueryParamsResponse is the response type for the Params RPC method. */
+
+export interface QueryParamsRequest {}
+/** QueryParamsResponse is the response type for the Params RPC method. */
+
+export interface QueryParamsRequestSDKType {}
+/** QueryParamsResponse is the response type for the Params RPC method. */
+
+export interface QueryParamsResponse {
+  params?: Params;
+}
+/** QueryParamsResponse is the response type for the Params RPC method. */
+
+export interface QueryParamsResponseSDKType {
+  params?: ParamsSDKType;
 }
 
 function createBaseQueryPerpetualRequest(): QueryPerpetualRequest {
@@ -232,6 +299,243 @@ export const QueryAllPerpetualsResponse = {
     const message = createBaseQueryAllPerpetualsResponse();
     message.perpetual = object.perpetual?.map(e => Perpetual.fromPartial(e)) || [];
     message.pagination = object.pagination !== undefined && object.pagination !== null ? PageResponse.fromPartial(object.pagination) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseQueryPremiumVotesRequest(): QueryPremiumVotesRequest {
+  return {};
+}
+
+export const QueryPremiumVotesRequest = {
+  encode(_: QueryPremiumVotesRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryPremiumVotesRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryPremiumVotesRequest();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(_: DeepPartial<QueryPremiumVotesRequest>): QueryPremiumVotesRequest {
+    const message = createBaseQueryPremiumVotesRequest();
+    return message;
+  }
+
+};
+
+function createBaseQueryPremiumVotesResponse(): QueryPremiumVotesResponse {
+  return {
+    premiumVotes: undefined
+  };
+}
+
+export const QueryPremiumVotesResponse = {
+  encode(message: QueryPremiumVotesResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.premiumVotes !== undefined) {
+      PremiumStore.encode(message.premiumVotes, writer.uint32(10).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryPremiumVotesResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryPremiumVotesResponse();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.premiumVotes = PremiumStore.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<QueryPremiumVotesResponse>): QueryPremiumVotesResponse {
+    const message = createBaseQueryPremiumVotesResponse();
+    message.premiumVotes = object.premiumVotes !== undefined && object.premiumVotes !== null ? PremiumStore.fromPartial(object.premiumVotes) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseQueryPremiumSamplesRequest(): QueryPremiumSamplesRequest {
+  return {};
+}
+
+export const QueryPremiumSamplesRequest = {
+  encode(_: QueryPremiumSamplesRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryPremiumSamplesRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryPremiumSamplesRequest();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(_: DeepPartial<QueryPremiumSamplesRequest>): QueryPremiumSamplesRequest {
+    const message = createBaseQueryPremiumSamplesRequest();
+    return message;
+  }
+
+};
+
+function createBaseQueryPremiumSamplesResponse(): QueryPremiumSamplesResponse {
+  return {
+    premiumSamples: undefined
+  };
+}
+
+export const QueryPremiumSamplesResponse = {
+  encode(message: QueryPremiumSamplesResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.premiumSamples !== undefined) {
+      PremiumStore.encode(message.premiumSamples, writer.uint32(10).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryPremiumSamplesResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryPremiumSamplesResponse();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.premiumSamples = PremiumStore.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<QueryPremiumSamplesResponse>): QueryPremiumSamplesResponse {
+    const message = createBaseQueryPremiumSamplesResponse();
+    message.premiumSamples = object.premiumSamples !== undefined && object.premiumSamples !== null ? PremiumStore.fromPartial(object.premiumSamples) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseQueryParamsRequest(): QueryParamsRequest {
+  return {};
+}
+
+export const QueryParamsRequest = {
+  encode(_: QueryParamsRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryParamsRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsRequest();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(_: DeepPartial<QueryParamsRequest>): QueryParamsRequest {
+    const message = createBaseQueryParamsRequest();
+    return message;
+  }
+
+};
+
+function createBaseQueryParamsResponse(): QueryParamsResponse {
+  return {
+    params: undefined
+  };
+}
+
+export const QueryParamsResponse = {
+  encode(message: QueryParamsResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(10).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryParamsResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsResponse();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<QueryParamsResponse>): QueryParamsResponse {
+    const message = createBaseQueryParamsResponse();
+    message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
     return message;
   }
 

--- a/proto/dydxprotocol/perpetuals/query.proto
+++ b/proto/dydxprotocol/perpetuals/query.proto
@@ -4,6 +4,7 @@ package dydxprotocol.perpetuals;
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
+import "dydxprotocol/perpetuals/params.proto";
 import "dydxprotocol/perpetuals/perpetual.proto";
 
 option go_package = "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types";
@@ -19,6 +20,23 @@ service Query {
   rpc AllPerpetuals(QueryAllPerpetualsRequest)
       returns (QueryAllPerpetualsResponse) {
     option (google.api.http).get = "/dydxprotocol/perpetuals/perpetual";
+  }
+
+  // Queries a list of premium votes.
+  rpc PremiumVotes(QueryPremiumVotesRequest)
+      returns (QueryPremiumVotesResponse) {
+    option (google.api.http).get = "/dydxprotocol/perpetuals/premium_votes";
+  }
+
+  // Queries a list of premium samples.
+  rpc PremiumSamples(QueryPremiumSamplesRequest)
+      returns (QueryPremiumSamplesResponse) {
+    option (google.api.http).get = "/dydxprotocol/perpetuals/premium_samples";
+  }
+
+  // Queries the perpetual params.
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+    option (google.api.http).get = "/dydxprotocol/perpetuals/params";
   }
 }
 
@@ -39,6 +57,33 @@ message QueryAllPerpetualsRequest {
 message QueryAllPerpetualsResponse {
   repeated Perpetual perpetual = 1 [ (gogoproto.nullable) = false ];
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryPremiumVotesRequest is the request type for the PremiumVotes RPC method.
+message QueryPremiumVotesRequest {}
+
+// QueryPremiumVotesResponse is the response type for the PremiumVotes RPC
+// method.
+message QueryPremiumVotesResponse {
+  PremiumStore premium_votes = 1 [ (gogoproto.nullable) = false ];
+}
+
+// QueryPremiumSamplesRequest is the request type for the PremiumSamples RPC
+// method.
+message QueryPremiumSamplesRequest {}
+
+// QueryPremiumSamplesResponse is the response type for the PremiumSamples RPC
+// method.
+message QueryPremiumSamplesResponse {
+  PremiumStore premium_samples = 1 [ (gogoproto.nullable) = false ];
+}
+
+// QueryParamsResponse is the response type for the Params RPC method.
+message QueryParamsRequest {}
+
+// QueryParamsResponse is the response type for the Params RPC method.
+message QueryParamsResponse {
+  Params params = 1 [ (gogoproto.nullable) = false ];
 }
 
 // this line is used by starport scaffolding # 3

--- a/protocol/x/perpetuals/client/cli/query.go
+++ b/protocol/x/perpetuals/client/cli/query.go
@@ -26,6 +26,9 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 
 	cmd.AddCommand(CmdListPerpetual())
 	cmd.AddCommand(CmdShowPerpetual())
+	cmd.AddCommand(CmdQueryParams())
+	cmd.AddCommand(CmdQueryPremiumSamples())
+	cmd.AddCommand(CmdQueryPremiumVotes())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/protocol/x/perpetuals/client/cli/query_params.go
+++ b/protocol/x/perpetuals/client/cli/query_params.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"context"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/spf13/cobra"
+)
+
+func CmdQueryParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-params",
+		Short: "get the Params",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			queryClient := types.NewQueryClient(clientCtx)
+			res, err := queryClient.Params(
+				context.Background(),
+				&types.QueryParamsRequest{},
+			)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/protocol/x/perpetuals/client/cli/query_params_test.go
+++ b/protocol/x/perpetuals/client/cli/query_params_test.go
@@ -1,0 +1,27 @@
+//go:build all || integration_test
+
+package cli_test
+
+import (
+	"fmt"
+	tmcli "github.com/cometbft/cometbft/libs/cli"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/client/cli"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestParams(t *testing.T) {
+	net, _, _ := networkWithLiquidityTierAndPerpetualObjects(t, 2, 2)
+	ctx := net.Validators[0].ClientCtx
+
+	common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+
+	out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdQueryParams(), common)
+	require.NoError(t, err)
+
+	var resp types.QueryParamsResponse
+	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+	require.Equal(t, types.DefaultGenesis().Params, resp.Params)
+}

--- a/protocol/x/perpetuals/client/cli/query_premiums.go
+++ b/protocol/x/perpetuals/client/cli/query_premiums.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"context"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/spf13/cobra"
+)
+
+func CmdQueryPremiumSamples() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-premium-samples",
+		Short: "get the PremiumSamples",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			queryClient := types.NewQueryClient(clientCtx)
+			res, err := queryClient.PremiumSamples(
+				context.Background(),
+				&types.QueryPremiumSamplesRequest{},
+			)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdQueryPremiumVotes() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-premium-votes",
+		Short: "get the PremiumVotes",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			queryClient := types.NewQueryClient(clientCtx)
+			res, err := queryClient.PremiumVotes(
+				context.Background(),
+				&types.QueryPremiumVotesRequest{},
+			)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/protocol/x/perpetuals/client/cli/query_premiums.go
+++ b/protocol/x/perpetuals/client/cli/query_premiums.go
@@ -11,7 +11,7 @@ import (
 func CmdQueryPremiumSamples() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-premium-samples",
-		Short: "get the PremiumSamples",
+		Short: "Get PremiumSamples from the current funding-tick epoch",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 			queryClient := types.NewQueryClient(clientCtx)
@@ -34,7 +34,7 @@ func CmdQueryPremiumSamples() *cobra.Command {
 func CmdQueryPremiumVotes() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-premium-votes",
-		Short: "get the PremiumVotes",
+		Short: "Get PremiumVotes from the current funding-sample epoch",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 			queryClient := types.NewQueryClient(clientCtx)

--- a/protocol/x/perpetuals/client/cli/query_premiums_test.go
+++ b/protocol/x/perpetuals/client/cli/query_premiums_test.go
@@ -1,0 +1,41 @@
+//go:build all || integration_test
+
+package cli_test
+
+import (
+	"fmt"
+	tmcli "github.com/cometbft/cometbft/libs/cli"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/client/cli"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestQueryPremiumSamples(t *testing.T) {
+	net, _, _ := networkWithLiquidityTierAndPerpetualObjects(t, 2, 2)
+	ctx := net.Validators[0].ClientCtx
+
+	common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+
+	out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdQueryPremiumSamples(), common)
+	require.NoError(t, err)
+
+	var resp types.QueryPremiumSamplesResponse
+	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+	require.Equal(t, types.PremiumStore{}, resp.PremiumSamples)
+}
+
+func TestQueryPremiumVotes(t *testing.T) {
+	net, _, _ := networkWithLiquidityTierAndPerpetualObjects(t, 2, 2)
+	ctx := net.Validators[0].ClientCtx
+
+	common := []string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)}
+
+	out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdQueryPremiumVotes(), common)
+	require.NoError(t, err)
+
+	var resp types.QueryPremiumVotesResponse
+	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+	require.Equal(t, types.PremiumStore{}, resp.PremiumVotes)
+}

--- a/protocol/x/perpetuals/client/cli/query_premiums_test.go
+++ b/protocol/x/perpetuals/client/cli/query_premiums_test.go
@@ -39,7 +39,6 @@ func TestQueryPremiumVotes(t *testing.T) {
 
 	var resp types.QueryPremiumVotesResponse
 	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-	require.Equal(t, types.PremiumStore{
-		AllMarketPremiums: []types.MarketPremiums{},
-	}, resp.PremiumVotes)
+	require.NotNil(t, resp.PremiumVotes)
+	require.Equal(t, []types.MarketPremiums{}, resp.PremiumVotes.AllMarketPremiums)
 }

--- a/protocol/x/perpetuals/client/cli/query_premiums_test.go
+++ b/protocol/x/perpetuals/client/cli/query_premiums_test.go
@@ -23,7 +23,9 @@ func TestQueryPremiumSamples(t *testing.T) {
 
 	var resp types.QueryPremiumSamplesResponse
 	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-	require.Equal(t, types.PremiumStore{}, resp.PremiumSamples)
+	require.Equal(t, types.PremiumStore{
+		AllMarketPremiums: []types.MarketPremiums{},
+	}, resp.PremiumSamples)
 }
 
 func TestQueryPremiumVotes(t *testing.T) {
@@ -37,5 +39,7 @@ func TestQueryPremiumVotes(t *testing.T) {
 
 	var resp types.QueryPremiumVotesResponse
 	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-	require.Equal(t, types.PremiumStore{}, resp.PremiumVotes)
+	require.Equal(t, types.PremiumStore{
+		AllMarketPremiums: []types.MarketPremiums{},
+	}, resp.PremiumVotes)
 }

--- a/protocol/x/perpetuals/keeper/grpc_query_params.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_params.go
@@ -1,0 +1,1 @@
+package keeper

--- a/protocol/x/perpetuals/keeper/grpc_query_params.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_params.go
@@ -1,1 +1,22 @@
 package keeper
+
+import (
+	"context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (k Keeper) Params(
+	c context.Context,
+	req *types.QueryParamsRequest,
+) (*types.QueryParamsResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	params := k.GetParams(sdk.UnwrapSDKContext(c))
+
+	return &types.QueryParamsResponse{Params: params}, nil
+}

--- a/protocol/x/perpetuals/keeper/grpc_query_params_test.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_params_test.go
@@ -1,0 +1,1 @@
+package keeper

--- a/protocol/x/perpetuals/keeper/grpc_query_params_test.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_params_test.go
@@ -1,1 +1,44 @@
-package keeper
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"testing"
+)
+
+func TestParams(t *testing.T) {
+	pc := keepertest.PerpetualsKeepers(t)
+	wctx := sdk.WrapSDKContext(pc.Ctx)
+
+	tests := map[string]struct {
+		req         *types.QueryParamsRequest
+		res         *types.QueryParamsResponse
+		expectedErr error
+	}{
+		"nil request": {
+			req:         nil,
+			res:         nil,
+			expectedErr: status.Error(codes.InvalidArgument, "invalid request"),
+		},
+		"valid request": {
+			req: &types.QueryParamsRequest{},
+			res: &types.QueryParamsResponse{
+				Params: types.DefaultGenesis().Params,
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := pc.PerpetualsKeeper.Params(wctx, tc.req)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				require.Equal(t, tc.res, res)
+			}
+		})
+	}
+}

--- a/protocol/x/perpetuals/keeper/grpc_query_premiums.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_premiums.go
@@ -1,0 +1,1 @@
+package keeper

--- a/protocol/x/perpetuals/keeper/grpc_query_premiums.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_premiums.go
@@ -1,1 +1,35 @@
 package keeper
+
+import (
+	"context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (k Keeper) PremiumVotes(
+	c context.Context,
+	req *types.QueryPremiumVotesRequest,
+) (*types.QueryPremiumVotesResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	premiumVotes := k.GetPremiumVotes(sdk.UnwrapSDKContext(c))
+
+	return &types.QueryPremiumVotesResponse{PremiumVotes: premiumVotes}, nil
+}
+
+func (k Keeper) PremiumSamples(
+	c context.Context,
+	req *types.QueryPremiumSamplesRequest,
+) (*types.QueryPremiumSamplesResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	premiumSamples := k.GetPremiumSamples(sdk.UnwrapSDKContext(c))
+
+	return &types.QueryPremiumSamplesResponse{PremiumSamples: premiumSamples}, nil
+}

--- a/protocol/x/perpetuals/keeper/grpc_query_premiums_test.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_premiums_test.go
@@ -1,18 +1,77 @@
-package keeper
+package keeper_test
 
 import (
-	"context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"testing"
 )
 
-func (k Keeper) PremiumVotes(
-	c context.Context,
-	req *types.QueryPremiumVotesRequest,
-) (*types.QueryPremiumVotesResponse, error) {
-	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
-	}
+func TestPremiumVotes(t *testing.T) {
+	pc := keepertest.PerpetualsKeepers(t)
+	wctx := sdk.WrapSDKContext(pc.Ctx)
 
+	tests := map[string]struct {
+		req         *types.QueryPremiumVotesRequest
+		res         *types.QueryPremiumVotesResponse
+		expectedErr error
+	}{
+		"nil request": {
+			req:         nil,
+			res:         nil,
+			expectedErr: status.Error(codes.InvalidArgument, "invalid request"),
+		},
+		"valid request": {
+			req: &types.QueryPremiumVotesRequest{},
+			res: &types.QueryPremiumVotesResponse{
+				PremiumVotes: types.PremiumStore{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := pc.PerpetualsKeeper.PremiumVotes(wctx, tc.req)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				require.Equal(t, tc.res, res)
+			}
+		})
+	}
+}
+
+func TestPremiumSamples(t *testing.T) {
+	pc := keepertest.PerpetualsKeepers(t)
+	wctx := sdk.WrapSDKContext(pc.Ctx)
+
+	tests := map[string]struct {
+		req         *types.QueryPremiumSamplesRequest
+		res         *types.QueryPremiumSamplesResponse
+		expectedErr error
+	}{
+		"nil request": {
+			req:         nil,
+			res:         nil,
+			expectedErr: status.Error(codes.InvalidArgument, "invalid request"),
+		},
+		"valid request": {
+			req: &types.QueryPremiumSamplesRequest{},
+			res: &types.QueryPremiumSamplesResponse{
+				PremiumSamples: types.PremiumStore{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := pc.PerpetualsKeeper.PremiumSamples(wctx, tc.req)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				require.Equal(t, tc.res, res)
+			}
+		})
+	}
 }

--- a/protocol/x/perpetuals/keeper/grpc_query_premiums_test.go
+++ b/protocol/x/perpetuals/keeper/grpc_query_premiums_test.go
@@ -1,0 +1,18 @@
+package keeper
+
+import (
+	"context"
+	"github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (k Keeper) PremiumVotes(
+	c context.Context,
+	req *types.QueryPremiumVotesRequest,
+) (*types.QueryPremiumVotesResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+}

--- a/protocol/x/perpetuals/module_test.go
+++ b/protocol/x/perpetuals/module_test.go
@@ -244,9 +244,12 @@ func TestAppModuleBasic_GetQueryCmd(t *testing.T) {
 
 	cmd := am.GetQueryCmd()
 	require.Equal(t, "perpetuals", cmd.Use)
-	require.Equal(t, 2, len(cmd.Commands()))
-	require.Equal(t, "list-perpetual", cmd.Commands()[0].Name())
-	require.Equal(t, "show-perpetual", cmd.Commands()[1].Name())
+	require.Equal(t, 5, len(cmd.Commands()))
+	require.Equal(t, "get-params", cmd.Commands()[0].Name())
+	require.Equal(t, "get-premium-samples", cmd.Commands()[1].Name())
+	require.Equal(t, "get-premium-votes", cmd.Commands()[2].Name())
+	require.Equal(t, "list-perpetual", cmd.Commands()[3].Name())
+	require.Equal(t, "show-perpetual", cmd.Commands()[4].Name())
 }
 
 func TestAppModule_Name(t *testing.T) {

--- a/protocol/x/perpetuals/types/query.pb.go
+++ b/protocol/x/perpetuals/types/query.pb.go
@@ -218,11 +218,266 @@ func (m *QueryAllPerpetualsResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
+// QueryPremiumVotesRequest is the request type for the PremiumVotes RPC method.
+type QueryPremiumVotesRequest struct {
+}
+
+func (m *QueryPremiumVotesRequest) Reset()         { *m = QueryPremiumVotesRequest{} }
+func (m *QueryPremiumVotesRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryPremiumVotesRequest) ProtoMessage()    {}
+func (*QueryPremiumVotesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_13b6d29860ccef6b, []int{4}
+}
+func (m *QueryPremiumVotesRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryPremiumVotesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryPremiumVotesRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryPremiumVotesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryPremiumVotesRequest.Merge(m, src)
+}
+func (m *QueryPremiumVotesRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryPremiumVotesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryPremiumVotesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryPremiumVotesRequest proto.InternalMessageInfo
+
+// QueryPremiumVotesResponse is the response type for the PremiumVotes RPC
+// method.
+type QueryPremiumVotesResponse struct {
+	PremiumVotes PremiumStore `protobuf:"bytes,1,opt,name=premium_votes,json=premiumVotes,proto3" json:"premium_votes"`
+}
+
+func (m *QueryPremiumVotesResponse) Reset()         { *m = QueryPremiumVotesResponse{} }
+func (m *QueryPremiumVotesResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryPremiumVotesResponse) ProtoMessage()    {}
+func (*QueryPremiumVotesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_13b6d29860ccef6b, []int{5}
+}
+func (m *QueryPremiumVotesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryPremiumVotesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryPremiumVotesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryPremiumVotesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryPremiumVotesResponse.Merge(m, src)
+}
+func (m *QueryPremiumVotesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryPremiumVotesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryPremiumVotesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryPremiumVotesResponse proto.InternalMessageInfo
+
+func (m *QueryPremiumVotesResponse) GetPremiumVotes() PremiumStore {
+	if m != nil {
+		return m.PremiumVotes
+	}
+	return PremiumStore{}
+}
+
+// QueryPremiumSamplesRequest is the request type for the PremiumSamples RPC
+// method.
+type QueryPremiumSamplesRequest struct {
+}
+
+func (m *QueryPremiumSamplesRequest) Reset()         { *m = QueryPremiumSamplesRequest{} }
+func (m *QueryPremiumSamplesRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryPremiumSamplesRequest) ProtoMessage()    {}
+func (*QueryPremiumSamplesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_13b6d29860ccef6b, []int{6}
+}
+func (m *QueryPremiumSamplesRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryPremiumSamplesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryPremiumSamplesRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryPremiumSamplesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryPremiumSamplesRequest.Merge(m, src)
+}
+func (m *QueryPremiumSamplesRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryPremiumSamplesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryPremiumSamplesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryPremiumSamplesRequest proto.InternalMessageInfo
+
+// QueryPremiumSamplesResponse is the response type for the PremiumSamples RPC
+// method.
+type QueryPremiumSamplesResponse struct {
+	PremiumSamples PremiumStore `protobuf:"bytes,1,opt,name=premium_samples,json=premiumSamples,proto3" json:"premium_samples"`
+}
+
+func (m *QueryPremiumSamplesResponse) Reset()         { *m = QueryPremiumSamplesResponse{} }
+func (m *QueryPremiumSamplesResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryPremiumSamplesResponse) ProtoMessage()    {}
+func (*QueryPremiumSamplesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_13b6d29860ccef6b, []int{7}
+}
+func (m *QueryPremiumSamplesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryPremiumSamplesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryPremiumSamplesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryPremiumSamplesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryPremiumSamplesResponse.Merge(m, src)
+}
+func (m *QueryPremiumSamplesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryPremiumSamplesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryPremiumSamplesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryPremiumSamplesResponse proto.InternalMessageInfo
+
+func (m *QueryPremiumSamplesResponse) GetPremiumSamples() PremiumStore {
+	if m != nil {
+		return m.PremiumSamples
+	}
+	return PremiumStore{}
+}
+
+// QueryParamsResponse is the response type for the Params RPC method.
+type QueryParamsRequest struct {
+}
+
+func (m *QueryParamsRequest) Reset()         { *m = QueryParamsRequest{} }
+func (m *QueryParamsRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryParamsRequest) ProtoMessage()    {}
+func (*QueryParamsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_13b6d29860ccef6b, []int{8}
+}
+func (m *QueryParamsRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryParamsRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryParamsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryParamsRequest.Merge(m, src)
+}
+func (m *QueryParamsRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryParamsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryParamsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryParamsRequest proto.InternalMessageInfo
+
+// QueryParamsResponse is the response type for the Params RPC method.
+type QueryParamsResponse struct {
+	Params Params `protobuf:"bytes,1,opt,name=params,proto3" json:"params"`
+}
+
+func (m *QueryParamsResponse) Reset()         { *m = QueryParamsResponse{} }
+func (m *QueryParamsResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryParamsResponse) ProtoMessage()    {}
+func (*QueryParamsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_13b6d29860ccef6b, []int{9}
+}
+func (m *QueryParamsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryParamsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryParamsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryParamsResponse.Merge(m, src)
+}
+func (m *QueryParamsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryParamsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryParamsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryParamsResponse proto.InternalMessageInfo
+
+func (m *QueryParamsResponse) GetParams() Params {
+	if m != nil {
+		return m.Params
+	}
+	return Params{}
+}
+
 func init() {
 	proto.RegisterType((*QueryPerpetualRequest)(nil), "dydxprotocol.perpetuals.QueryPerpetualRequest")
 	proto.RegisterType((*QueryPerpetualResponse)(nil), "dydxprotocol.perpetuals.QueryPerpetualResponse")
 	proto.RegisterType((*QueryAllPerpetualsRequest)(nil), "dydxprotocol.perpetuals.QueryAllPerpetualsRequest")
 	proto.RegisterType((*QueryAllPerpetualsResponse)(nil), "dydxprotocol.perpetuals.QueryAllPerpetualsResponse")
+	proto.RegisterType((*QueryPremiumVotesRequest)(nil), "dydxprotocol.perpetuals.QueryPremiumVotesRequest")
+	proto.RegisterType((*QueryPremiumVotesResponse)(nil), "dydxprotocol.perpetuals.QueryPremiumVotesResponse")
+	proto.RegisterType((*QueryPremiumSamplesRequest)(nil), "dydxprotocol.perpetuals.QueryPremiumSamplesRequest")
+	proto.RegisterType((*QueryPremiumSamplesResponse)(nil), "dydxprotocol.perpetuals.QueryPremiumSamplesResponse")
+	proto.RegisterType((*QueryParamsRequest)(nil), "dydxprotocol.perpetuals.QueryParamsRequest")
+	proto.RegisterType((*QueryParamsResponse)(nil), "dydxprotocol.perpetuals.QueryParamsResponse")
 }
 
 func init() {
@@ -230,34 +485,47 @@ func init() {
 }
 
 var fileDescriptor_13b6d29860ccef6b = []byte{
-	// 430 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x92, 0x3f, 0x8f, 0xd3, 0x30,
-	0x18, 0xc6, 0xe3, 0xf0, 0x47, 0xaa, 0x51, 0x19, 0x2c, 0xfe, 0x46, 0x28, 0xa0, 0x80, 0x08, 0x54,
-	0xc2, 0x56, 0x5b, 0x46, 0x16, 0x3a, 0x94, 0xb5, 0x64, 0x60, 0x60, 0xc2, 0x49, 0xac, 0xd4, 0x52,
-	0x1a, 0xa7, 0xb5, 0x53, 0xb5, 0x42, 0x2c, 0x7c, 0x02, 0x24, 0x66, 0x36, 0x56, 0xbe, 0x47, 0x27,
-	0x54, 0x89, 0x85, 0x09, 0xa1, 0xf6, 0x3e, 0xc8, 0xa9, 0x4e, 0x9a, 0xa6, 0xa7, 0xf4, 0x7a, 0x77,
-	0x9b, 0xe5, 0xf7, 0x79, 0xde, 0xe7, 0xf7, 0xbe, 0x36, 0x7c, 0x1a, 0xce, 0xc3, 0x59, 0x3a, 0x11,
-	0x4a, 0x04, 0x22, 0x26, 0x29, 0x9b, 0xa4, 0x4c, 0x65, 0x34, 0x96, 0x64, 0x9c, 0xb1, 0xc9, 0x1c,
-	0xeb, 0x0a, 0xba, 0x5f, 0x15, 0xe1, 0x9d, 0xc8, 0xba, 0x13, 0x89, 0x48, 0xe8, 0x02, 0xd9, 0x9c,
-	0x72, 0xb9, 0xf5, 0x28, 0x12, 0x22, 0x8a, 0x19, 0xa1, 0x29, 0x27, 0x34, 0x49, 0x84, 0xa2, 0x8a,
-	0x8b, 0x44, 0x16, 0xd5, 0x56, 0x20, 0xe4, 0x48, 0x48, 0xe2, 0x53, 0xc9, 0xf2, 0x14, 0x32, 0x6d,
-	0xfb, 0x4c, 0xd1, 0x36, 0x49, 0x69, 0xc4, 0x13, 0x2d, 0x2e, 0xb4, 0xee, 0x21, 0xba, 0xf2, 0x98,
-	0x0b, 0x1d, 0x17, 0xde, 0x7d, 0xbf, 0x69, 0x35, 0xd8, 0xde, 0x7b, 0x6c, 0x9c, 0x31, 0xa9, 0xd0,
-	0x6d, 0x68, 0xf2, 0xf0, 0x01, 0x78, 0x02, 0x5e, 0x34, 0x3d, 0x93, 0x87, 0xce, 0x27, 0x78, 0xef,
-	0xac, 0x50, 0xa6, 0x22, 0x91, 0x0c, 0xf5, 0x61, 0xa3, 0xec, 0xaa, 0x0d, 0xb7, 0x3a, 0x0e, 0x3e,
-	0x30, 0x38, 0x2e, 0xed, 0xbd, 0xeb, 0x8b, 0x7f, 0x8f, 0x0d, 0x6f, 0x67, 0x75, 0x02, 0xf8, 0x50,
-	0x27, 0xbc, 0x8d, 0xe3, 0x52, 0x25, 0xb7, 0x38, 0x7d, 0x08, 0x77, 0x43, 0x16, 0x29, 0xcf, 0x71,
-	0xbe, 0x11, 0xbc, 0xd9, 0x08, 0xce, 0xf7, 0x5e, 0x6c, 0x04, 0x0f, 0x68, 0xc4, 0x0a, 0xaf, 0x57,
-	0x71, 0x3a, 0xbf, 0x00, 0xb4, 0xea, 0x52, 0xea, 0x67, 0xb9, 0x76, 0xc5, 0x59, 0xd0, 0xbb, 0x3d,
-	0x5c, 0x53, 0xe3, 0xba, 0x47, 0x71, 0x73, 0x88, 0x2a, 0x6f, 0xe7, 0xb7, 0x09, 0x6f, 0x68, 0x5e,
-	0xf4, 0x03, 0xc0, 0x46, 0x99, 0x88, 0xf0, 0x41, 0xaa, 0xda, 0xe7, 0xb4, 0xc8, 0x85, 0xf5, 0x39,
-	0x84, 0x43, 0xbe, 0xfe, 0x39, 0xf9, 0x6e, 0xbe, 0x44, 0x2e, 0x39, 0xfa, 0x95, 0xc8, 0x67, 0x1e,
-	0x7e, 0x41, 0x3f, 0x01, 0x6c, 0xee, 0x2d, 0x15, 0x75, 0xce, 0xcf, 0xac, 0x7b, 0x67, 0xab, 0x7b,
-	0x29, 0x4f, 0xc1, 0xda, 0xd2, 0xac, 0xcf, 0x90, 0x73, 0x9c, 0xb5, 0xf7, 0x61, 0xb1, 0xb2, 0xc1,
-	0x72, 0x65, 0x83, 0xff, 0x2b, 0x1b, 0x7c, 0x5b, 0xdb, 0xc6, 0x72, 0x6d, 0x1b, 0x7f, 0xd7, 0xb6,
-	0xf1, 0xf1, 0x4d, 0xc4, 0xd5, 0x30, 0xf3, 0x71, 0x20, 0x46, 0xfb, 0x7d, 0xa6, 0xaf, 0x5f, 0x05,
-	0x43, 0xca, 0x13, 0x52, 0xde, 0xcc, 0xaa, 0xbd, 0xd5, 0x3c, 0x65, 0xd2, 0xbf, 0xa9, 0x8b, 0xdd,
-	0xd3, 0x00, 0x00, 0x00, 0xff, 0xff, 0xd8, 0x2a, 0x78, 0x13, 0x18, 0x04, 0x00, 0x00,
+	// 634 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x95, 0xb1, 0x6f, 0xd3, 0x40,
+	0x14, 0xc6, 0xe3, 0x00, 0x91, 0x7a, 0x34, 0x41, 0x3a, 0x0a, 0x14, 0x53, 0x39, 0x60, 0x4a, 0x13,
+	0x02, 0xf8, 0x48, 0xd2, 0x11, 0x06, 0x3a, 0x94, 0x35, 0x84, 0xaa, 0x03, 0x0b, 0x5c, 0x92, 0x93,
+	0x6b, 0xc9, 0xf6, 0x5d, 0x7d, 0x4e, 0xd4, 0x08, 0xb1, 0x30, 0x33, 0x20, 0x31, 0xb3, 0xc1, 0xd8,
+	0x91, 0xff, 0xa1, 0x63, 0x25, 0x16, 0x26, 0x84, 0x12, 0xfe, 0x10, 0x94, 0xbb, 0x73, 0x62, 0xd3,
+	0xb8, 0x4e, 0xba, 0x45, 0xf7, 0xbe, 0xf7, 0xbe, 0xdf, 0x7d, 0xbe, 0xa7, 0x80, 0xfb, 0xbd, 0x61,
+	0xef, 0x88, 0x05, 0x34, 0xa4, 0x5d, 0xea, 0x22, 0x46, 0x02, 0x46, 0xc2, 0x3e, 0x76, 0x39, 0x3a,
+	0xec, 0x93, 0x60, 0x68, 0x89, 0x0a, 0xbc, 0x15, 0x17, 0x59, 0x33, 0x91, 0xbe, 0x66, 0x53, 0x9b,
+	0x8a, 0x02, 0x9a, 0xfc, 0x92, 0x72, 0x7d, 0xc3, 0xa6, 0xd4, 0x76, 0x09, 0xc2, 0xcc, 0x41, 0xd8,
+	0xf7, 0x69, 0x88, 0x43, 0x87, 0xfa, 0x5c, 0x55, 0x6b, 0x5d, 0xca, 0x3d, 0xca, 0x51, 0x07, 0x73,
+	0x22, 0x5d, 0xd0, 0xa0, 0xde, 0x21, 0x21, 0xae, 0x23, 0x86, 0x6d, 0xc7, 0x17, 0x62, 0xa5, 0xdd,
+	0x4c, 0xa3, 0x63, 0x38, 0xc0, 0x5e, 0x34, 0xb1, 0x92, 0xaa, 0x8a, 0x7e, 0x4a, 0xa1, 0x59, 0x01,
+	0x37, 0x5e, 0x4d, 0x0c, 0x5b, 0xd1, 0x79, 0x9b, 0x1c, 0xf6, 0x09, 0x0f, 0x61, 0x09, 0xe4, 0x9d,
+	0xde, 0xba, 0x76, 0x57, 0xab, 0x16, 0xdb, 0x79, 0xa7, 0x67, 0xbe, 0x03, 0x37, 0xff, 0x17, 0x72,
+	0x46, 0x7d, 0x4e, 0xe0, 0x2e, 0x58, 0x99, 0x4e, 0x15, 0x0d, 0x57, 0x1b, 0xa6, 0x95, 0x12, 0x8f,
+	0x35, 0x6d, 0xdf, 0xb9, 0x7c, 0xf2, 0xbb, 0x9c, 0x6b, 0xcf, 0x5a, 0xcd, 0x2e, 0xb8, 0x2d, 0x1c,
+	0x5e, 0xb8, 0xee, 0x54, 0xc5, 0x23, 0x9c, 0x5d, 0x00, 0x66, 0x51, 0x28, 0x97, 0x2d, 0x4b, 0xe6,
+	0x66, 0x4d, 0x72, 0xb3, 0xe4, 0xd7, 0x51, 0xb9, 0x59, 0x2d, 0x6c, 0x13, 0xd5, 0xdb, 0x8e, 0x75,
+	0x9a, 0xc7, 0x1a, 0xd0, 0xe7, 0xb9, 0xcc, 0xbf, 0xcb, 0xa5, 0x0b, 0xde, 0x05, 0xbe, 0x4c, 0xe0,
+	0xe6, 0x05, 0x6e, 0x25, 0x13, 0x57, 0x42, 0x24, 0x78, 0x75, 0xb0, 0x2e, 0x63, 0x0f, 0x88, 0xe7,
+	0xf4, 0xbd, 0x7d, 0x1a, 0x92, 0x28, 0x13, 0xd3, 0x53, 0x81, 0x25, 0x6b, 0xea, 0x26, 0x2d, 0x50,
+	0x64, 0xf2, 0xfc, 0xed, 0x60, 0x52, 0x50, 0x99, 0x3d, 0x48, 0xbf, 0x8d, 0x54, 0xbf, 0x0e, 0x69,
+	0x40, 0xd4, 0x85, 0x56, 0x59, 0x6c, 0xb2, 0xb9, 0xa1, 0x92, 0x8b, 0x84, 0xd8, 0x63, 0xee, 0x0c,
+	0x86, 0x83, 0x3b, 0x73, 0xab, 0x0a, 0x67, 0x0f, 0x5c, 0x8b, 0x70, 0xb8, 0x2c, 0x5d, 0x04, 0xa8,
+	0xc4, 0x12, 0xd3, 0xcd, 0x35, 0x00, 0xa5, 0xa9, 0x78, 0xfb, 0x11, 0xca, 0x1e, 0xb8, 0x9e, 0x38,
+	0x55, 0x08, 0xcf, 0x41, 0x41, 0xee, 0x88, 0x72, 0x2e, 0xa7, 0x3b, 0x0b, 0x99, 0xf2, 0x54, 0x4d,
+	0x8d, 0x1f, 0x05, 0x70, 0x45, 0x8c, 0x85, 0x5f, 0x35, 0xb0, 0x32, 0xfd, 0xf6, 0xd0, 0x4a, 0x1d,
+	0x33, 0x77, 0xb1, 0x74, 0xb4, 0xb0, 0x5e, 0x72, 0x9b, 0xe8, 0xe3, 0xcf, 0xbf, 0x5f, 0xf2, 0x0f,
+	0x61, 0x05, 0x65, 0x2e, 0x35, 0x7a, 0xef, 0xf4, 0x3e, 0xc0, 0x6f, 0x1a, 0x28, 0x26, 0x9e, 0x37,
+	0x6c, 0x9c, 0xef, 0x39, 0x6f, 0xe3, 0xf4, 0xe6, 0x52, 0x3d, 0x8a, 0xb5, 0x26, 0x58, 0x37, 0xa1,
+	0x99, 0xcd, 0x0a, 0xbf, 0x6b, 0x60, 0x35, 0xfe, 0x74, 0x61, 0x3d, 0x23, 0x99, 0xb3, 0x2b, 0xa0,
+	0x37, 0x96, 0x69, 0x51, 0x8c, 0x96, 0x60, 0xac, 0xc2, 0xad, 0x74, 0xc6, 0xf8, 0xe2, 0xc0, 0x63,
+	0x0d, 0x94, 0x92, 0xaf, 0x1a, 0x36, 0x17, 0xb2, 0x4d, 0x6e, 0x88, 0xbe, 0xbd, 0x5c, 0x93, 0xa2,
+	0x7d, 0x2a, 0x68, 0x6b, 0xb0, 0x9a, 0x49, 0xab, 0xf6, 0x0a, 0x7e, 0xd2, 0x40, 0x41, 0xbe, 0x60,
+	0xf8, 0x28, 0xc3, 0x32, 0xbe, 0x36, 0xfa, 0xe3, 0xc5, 0xc4, 0x8a, 0xab, 0x22, 0xb8, 0xee, 0xc1,
+	0x32, 0x3a, 0xff, 0x0f, 0x69, 0x67, 0xff, 0x64, 0x64, 0x68, 0xa7, 0x23, 0x43, 0xfb, 0x33, 0x32,
+	0xb4, 0xcf, 0x63, 0x23, 0x77, 0x3a, 0x36, 0x72, 0xbf, 0xc6, 0x46, 0xee, 0xcd, 0x33, 0xdb, 0x09,
+	0x0f, 0xfa, 0x1d, 0xab, 0x4b, 0xbd, 0xe4, 0x90, 0xc1, 0xf6, 0x93, 0xee, 0x01, 0x76, 0x7c, 0x34,
+	0x3d, 0x39, 0x8a, 0x0f, 0x0e, 0x87, 0x8c, 0xf0, 0x4e, 0x41, 0x14, 0x9b, 0xff, 0x02, 0x00, 0x00,
+	0xff, 0xff, 0xe6, 0x1c, 0x39, 0xe0, 0xaf, 0x07, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -276,6 +544,12 @@ type QueryClient interface {
 	Perpetual(ctx context.Context, in *QueryPerpetualRequest, opts ...grpc.CallOption) (*QueryPerpetualResponse, error)
 	// Queries a list of Perpetual items.
 	AllPerpetuals(ctx context.Context, in *QueryAllPerpetualsRequest, opts ...grpc.CallOption) (*QueryAllPerpetualsResponse, error)
+	// Queries a list of premium votes.
+	PremiumVotes(ctx context.Context, in *QueryPremiumVotesRequest, opts ...grpc.CallOption) (*QueryPremiumVotesResponse, error)
+	// Queries a list of premium samples.
+	PremiumSamples(ctx context.Context, in *QueryPremiumSamplesRequest, opts ...grpc.CallOption) (*QueryPremiumSamplesResponse, error)
+	// Queries the perpetual params.
+	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
 }
 
 type queryClient struct {
@@ -304,12 +578,45 @@ func (c *queryClient) AllPerpetuals(ctx context.Context, in *QueryAllPerpetualsR
 	return out, nil
 }
 
+func (c *queryClient) PremiumVotes(ctx context.Context, in *QueryPremiumVotesRequest, opts ...grpc.CallOption) (*QueryPremiumVotesResponse, error) {
+	out := new(QueryPremiumVotesResponse)
+	err := c.cc.Invoke(ctx, "/dydxprotocol.perpetuals.Query/PremiumVotes", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) PremiumSamples(ctx context.Context, in *QueryPremiumSamplesRequest, opts ...grpc.CallOption) (*QueryPremiumSamplesResponse, error) {
+	out := new(QueryPremiumSamplesResponse)
+	err := c.cc.Invoke(ctx, "/dydxprotocol.perpetuals.Query/PremiumSamples", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error) {
+	out := new(QueryParamsResponse)
+	err := c.cc.Invoke(ctx, "/dydxprotocol.perpetuals.Query/Params", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Queries a Perpetual by id.
 	Perpetual(context.Context, *QueryPerpetualRequest) (*QueryPerpetualResponse, error)
 	// Queries a list of Perpetual items.
 	AllPerpetuals(context.Context, *QueryAllPerpetualsRequest) (*QueryAllPerpetualsResponse, error)
+	// Queries a list of premium votes.
+	PremiumVotes(context.Context, *QueryPremiumVotesRequest) (*QueryPremiumVotesResponse, error)
+	// Queries a list of premium samples.
+	PremiumSamples(context.Context, *QueryPremiumSamplesRequest) (*QueryPremiumSamplesResponse, error)
+	// Queries the perpetual params.
+	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -321,6 +628,15 @@ func (*UnimplementedQueryServer) Perpetual(ctx context.Context, req *QueryPerpet
 }
 func (*UnimplementedQueryServer) AllPerpetuals(ctx context.Context, req *QueryAllPerpetualsRequest) (*QueryAllPerpetualsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AllPerpetuals not implemented")
+}
+func (*UnimplementedQueryServer) PremiumVotes(ctx context.Context, req *QueryPremiumVotesRequest) (*QueryPremiumVotesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PremiumVotes not implemented")
+}
+func (*UnimplementedQueryServer) PremiumSamples(ctx context.Context, req *QueryPremiumSamplesRequest) (*QueryPremiumSamplesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PremiumSamples not implemented")
+}
+func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsRequest) (*QueryParamsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Params not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -363,6 +679,60 @@ func _Query_AllPerpetuals_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_PremiumVotes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryPremiumVotesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).PremiumVotes(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/dydxprotocol.perpetuals.Query/PremiumVotes",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).PremiumVotes(ctx, req.(*QueryPremiumVotesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_PremiumSamples_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryPremiumSamplesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).PremiumSamples(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/dydxprotocol.perpetuals.Query/PremiumSamples",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).PremiumSamples(ctx, req.(*QueryPremiumSamplesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_Params_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryParamsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).Params(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/dydxprotocol.perpetuals.Query/Params",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).Params(ctx, req.(*QueryParamsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "dydxprotocol.perpetuals.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -374,6 +744,18 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AllPerpetuals",
 			Handler:    _Query_AllPerpetuals_Handler,
+		},
+		{
+			MethodName: "PremiumVotes",
+			Handler:    _Query_PremiumVotes_Handler,
+		},
+		{
+			MethodName: "PremiumSamples",
+			Handler:    _Query_PremiumSamples_Handler,
+		},
+		{
+			MethodName: "Params",
+			Handler:    _Query_Params_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -525,6 +907,174 @@ func (m *QueryAllPerpetualsResponse) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryPremiumVotesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryPremiumVotesRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryPremiumVotesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryPremiumVotesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryPremiumVotesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryPremiumVotesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.PremiumVotes.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryPremiumSamplesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryPremiumSamplesRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryPremiumSamplesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryPremiumSamplesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryPremiumSamplesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryPremiumSamplesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.PremiumSamples.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryParamsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryParamsRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryParamsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryParamsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryParamsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryParamsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Params.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -588,6 +1138,66 @@ func (m *QueryAllPerpetualsResponse) Size() (n int) {
 		l = m.Pagination.Size()
 		n += 1 + l + sovQuery(uint64(l))
 	}
+	return n
+}
+
+func (m *QueryPremiumVotesRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryPremiumVotesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.PremiumVotes.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryPremiumSamplesRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryPremiumSamplesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.PremiumSamples.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryParamsRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryParamsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.Params.Size()
+	n += 1 + l + sovQuery(uint64(l))
 	return n
 }
 
@@ -931,6 +1541,405 @@ func (m *QueryAllPerpetualsResponse) Unmarshal(dAtA []byte) error {
 				m.Pagination = &query.PageResponse{}
 			}
 			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryPremiumVotesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryPremiumVotesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryPremiumVotesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryPremiumVotesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryPremiumVotesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryPremiumVotesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PremiumVotes", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.PremiumVotes.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryPremiumSamplesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryPremiumSamplesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryPremiumSamplesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryPremiumSamplesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryPremiumSamplesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryPremiumSamplesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PremiumSamples", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.PremiumSamples.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryParamsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryParamsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryParamsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryParamsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Params", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/protocol/x/perpetuals/types/query.pb.gw.go
+++ b/protocol/x/perpetuals/types/query.pb.gw.go
@@ -123,6 +123,60 @@ func local_request_Query_AllPerpetuals_0(ctx context.Context, marshaler runtime.
 
 }
 
+func request_Query_PremiumVotes_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryPremiumVotesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.PremiumVotes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_PremiumVotes_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryPremiumVotesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.PremiumVotes(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Query_PremiumSamples_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryPremiumSamplesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.PremiumSamples(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_PremiumSamples_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryPremiumSamplesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.PremiumSamples(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryParamsRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.Params(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryParamsRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.Params(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -172,6 +226,75 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_AllPerpetuals_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_PremiumVotes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_PremiumVotes_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_PremiumVotes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_PremiumSamples_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_PremiumSamples_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_PremiumSamples_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_Params_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -256,6 +379,66 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_PremiumVotes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_PremiumVotes_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_PremiumVotes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_PremiumSamples_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_PremiumSamples_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_PremiumSamples_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_Params_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -263,10 +446,22 @@ var (
 	pattern_Query_Perpetual_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"dydxprotocol", "perpetuals", "perpetual", "id"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_Query_AllPerpetuals_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"dydxprotocol", "perpetuals", "perpetual"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_PremiumVotes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"dydxprotocol", "perpetuals", "premium_votes"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_PremiumSamples_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"dydxprotocol", "perpetuals", "premium_samples"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_Params_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"dydxprotocol", "perpetuals", "params"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (
 	forward_Query_Perpetual_0 = runtime.ForwardResponseMessage
 
 	forward_Query_AllPerpetuals_0 = runtime.ForwardResponseMessage
+
+	forward_Query_PremiumVotes_0 = runtime.ForwardResponseMessage
+
+	forward_Query_PremiumSamples_0 = runtime.ForwardResponseMessage
+
+	forward_Query_Params_0 = runtime.ForwardResponseMessage
 )


### PR DESCRIPTION
### Changelist
Add gRPC and cli query commands to access perpetuals state.

### Test Plan
Added cli, qRPC tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
