### PR TITLE
[CORE-708] Explicitly log out delayed message when execution fails

### DIFF
--- a/protocol/testutil/constants/bridge.go
+++ b/protocol/testutil/constants/bridge.go
@@ -33,6 +33,10 @@ func init() {
 
 var (
 	// Private
+	emptyCoin = sdk.Coin{
+		Denom:  "adv4tnt",
+		Amount: sdkmath.NewInt(0),
+	}
 	coin = sdk.Coin{
 		Denom:  "adv4tnt",
 		Amount: sdkmath.NewIntFromUint64(888),
@@ -65,6 +69,12 @@ var (
 		Address:        CarlAccAddress.String(),
 		Coin:           coin,
 		EthBlockHeight: 3,
+	}
+	BridgeEvent_Id4_Height0_EmptyCoin = types.BridgeEvent{
+		Id:             0,
+		Address:        AliceAccAddress.String(),
+		Coin:           emptyCoin,
+		EthBlockHeight: 0,
 	}
 	BridgeEvent_Id55_Height15 = types.BridgeEvent{
 		Id:             55,

--- a/protocol/x/bridge/app_test.go
+++ b/protocol/x/bridge/app_test.go
@@ -72,6 +72,23 @@ func TestBridge_Success(t *testing.T) {
 			blockTime:              time.Now(),
 			expectNonEmptyBridgeTx: true,
 		},
+		"Success: 1 bridge event with 0 coin denom, delay 5 blocks": {
+			bridgeEvents: []bridgetypes.BridgeEvent{
+				constants.BridgeEvent_Id4_Height0_EmptyCoin,
+			},
+			proposeParams: bridgetypes.ProposeParams{
+				MaxBridgesPerBlock:           2,
+				ProposeDelayDuration:         0,
+				SkipRatePpm:                  0, // do not skip proposing bridge events.
+				SkipIfBlockDelayedByDuration: time.Second * 10,
+			},
+			safetyParams: bridgetypes.SafetyParams{
+				IsDisabled:  false,
+				DelayBlocks: 5,
+			},
+			blockTime:              time.Now(),
+			expectNonEmptyBridgeTx: true,
+		},
 		"Success: 4 bridge events, delay 27 blocks": {
 			bridgeEvents: []bridgetypes.BridgeEvent{
 				constants.BridgeEvent_Id0_Height0,

--- a/protocol/x/bridge/app_test.go
+++ b/protocol/x/bridge/app_test.go
@@ -72,7 +72,7 @@ func TestBridge_Success(t *testing.T) {
 			blockTime:              time.Now(),
 			expectNonEmptyBridgeTx: true,
 		},
-		"Success: 1 bridge event with 0 coin denom, delay 5 blocks": {
+		"Success: 1 bridge event with 0 coin amount, delay 5 blocks": {
 			bridgeEvents: []bridgetypes.BridgeEvent{
 				constants.BridgeEvent_Id4_Height0_EmptyCoin,
 			},

--- a/protocol/x/delaymsg/keeper/dispatch.go
+++ b/protocol/x/delaymsg/keeper/dispatch.go
@@ -51,7 +51,17 @@ func DispatchMessagesForBlock(k types.DelayMsgKeeper, ctx sdk.Context) {
 			events = append(events, res.GetEvents()...)
 			return nil
 		}); err != nil {
-			k.Logger(ctx).Error("failed to execute delayed message", types.IdLogKey, id, constants.ErrorLogKey, err)
+			k.Logger(ctx).Error(
+				"failed to execute delayed message",
+				types.IdLogKey,
+				id,
+				constants.ErrorLogKey,
+				err,
+				types.MessageContentLogKey,
+				msg.String(),
+				types.MessageTypeUrlLogKey,
+				delayedMsg.Msg.TypeUrl,
+			)
 		}
 	}
 

--- a/protocol/x/delaymsg/types/keys.go
+++ b/protocol/x/delaymsg/types/keys.go
@@ -20,10 +20,3 @@ const (
 	// NextDelayedMessageIdKey is the key to retrieve next delayed message id.
 	NextDelayedMessageIdKey = "NextDelayedMessageId"
 )
-
-// Log
-const (
-	IdLogKey             = "id"
-	MessageContentLogKey = "message_content"
-	MessageTypeUrlLogKey = "message_type_url"
-)

--- a/protocol/x/delaymsg/types/keys.go
+++ b/protocol/x/delaymsg/types/keys.go
@@ -23,5 +23,7 @@ const (
 
 // Log
 const (
-	IdLogKey = "id"
+	IdLogKey             = "id"
+	MessageContentLogKey = "message_content"
+	MessageTypeUrlLogKey = "message_type_url"
 )

--- a/protocol/x/delaymsg/types/logs.go
+++ b/protocol/x/delaymsg/types/logs.go
@@ -1,0 +1,8 @@
+package types
+
+// Log
+const (
+	IdLogKey             = "id"
+	MessageContentLogKey = "message_content"
+	MessageTypeUrlLogKey = "message_type_url"
+)


### PR DESCRIPTION
### Changelist
- Explicitly log out message content and typeurl when message execution fails during dispatching. Action item from [here](https://dydx-team.slack.com/archives/C05A2JZRZ8D/p1698098164646319?thread_ts=1698095898.635139&cid=C05A2JZRZ8D)
- Also add e2e test case where delayed MsgCompleteBridge fails to execute

### Test Plan
Added e2e test where a BridgeEvent contains `0adv4tnt` transfer. The error log shows up as following:
```
E[2023-10-23|20:23:32.382] failed to execute delayed message            module=x/delaymsg id=1 error="0adv4tnt: invalid coins" message_content="authority:\"dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr\" event:<coin:<denom:\"adv4tnt\" amount:\"0\" > address:\"dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4\" > " message_type_url=/dydxprotocol.bridge.MsgCompleteBridge
```

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
