### PR TITLE
[IND-402] Have vulcan re-queue cached order updates instead of ender.

### DIFF
--- a/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
@@ -45,7 +45,6 @@ import { STATEFUL_ORDER_ORDER_FILL_EVENT_TYPE } from '../../../src/constants';
 import { producer } from '@dydxprotocol-indexer/kafka';
 import { ORDER_FLAG_LONG_TERM } from '@dydxprotocol-indexer/v4-proto-parser';
 import { createPostgresFunctions } from '../../../src/helpers/postgres/postgres-functions';
-import { redisClient } from '../../../src/helpers/redis/redis-controller';
 
 describe('statefulOrderPlacementHandler', () => {
   beforeAll(async () => {

--- a/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
@@ -19,7 +19,6 @@ import {
   IndexerOrder,
   OrderPlaceV1_OrderPlacementStatus,
   StatefulOrderEventV1,
-  OrderUpdateV1,
 } from '@dydxprotocol-indexer/v4-protos';
 import { KafkaMessage } from 'kafkajs';
 import { onMessage } from '../../../src/lib/on-message';
@@ -46,9 +45,6 @@ import { STATEFUL_ORDER_ORDER_FILL_EVENT_TYPE } from '../../../src/constants';
 import { producer } from '@dydxprotocol-indexer/kafka';
 import { ORDER_FLAG_LONG_TERM } from '@dydxprotocol-indexer/v4-proto-parser';
 import { createPostgresFunctions } from '../../../src/helpers/postgres/postgres-functions';
-import {
-  redis, redisTestConstants, StatefulOrderUpdateInfo, StatefulOrderUpdatesCache,
-} from '@dydxprotocol-indexer/redis';
 import { redisClient } from '../../../src/helpers/redis/redis-controller';
 
 describe('statefulOrderPlacementHandler', () => {
@@ -69,7 +65,6 @@ describe('statefulOrderPlacementHandler', () => {
 
   afterEach(async () => {
     await dbHelpers.clearData();
-    await redis.deleteAllAsync(redisClient);
     jest.clearAllMocks();
   });
 
@@ -144,48 +139,15 @@ describe('statefulOrderPlacementHandler', () => {
 
   it.each([
     // TODO(IND-334): Remove after deprecating StatefulOrderPlacementEvent
-    [
-      'stateful order placement and no cached update',
-      defaultStatefulOrderEvent,
-      undefined,
-    ],
-    [
-      'stateful long term order placement and no cached update',
-      defaultStatefulOrderLongTermEvent,
-      undefined,
-    ],
-    [
-      'stateful order placement and cached update',
-      defaultStatefulOrderEvent,
-      {
-        ...redisTestConstants.orderUpdate.orderUpdate,
-        orderId: defaultOrder.orderId,
-      },
-    ],
-    [
-      'stateful long term order placement and cached update',
-      defaultStatefulOrderLongTermEvent,
-      {
-        ...redisTestConstants.orderUpdate.orderUpdate,
-        orderId: defaultOrder.orderId,
-      },
-    ],
+    ['stateful order placement', defaultStatefulOrderEvent],
+    ['stateful long term order placement', defaultStatefulOrderLongTermEvent],
   ])('successfully places order with %s', async (
     _name: string,
     statefulOrderEvent: StatefulOrderEventV1,
-    cachedOrderUpdate: OrderUpdateV1 | undefined,
   ) => {
     const kafkaMessage: KafkaMessage = createKafkaMessageFromStatefulOrderEvent(
       statefulOrderEvent,
     );
-    if (cachedOrderUpdate !== undefined) {
-      await StatefulOrderUpdatesCache.addStatefulOrderUpdate(
-        orderId,
-        cachedOrderUpdate,
-        Date.now(),
-        redisClient,
-      );
-    }
 
     await onMessage(kafkaMessage);
     const order: OrderFromDatabase | undefined = await OrderTable.findById(orderId);
@@ -224,25 +186,6 @@ describe('statefulOrderPlacementHandler', () => {
       orderId: defaultOrder.orderId!,
       offchainUpdate: expectedOffchainUpdate,
     });
-
-    // If there was a cached order update, expect the cache to be empty and a corresponding
-    // off-chain update to have been sent to the Kafka producer
-    if (cachedOrderUpdate !== undefined) {
-      const orderUpdates: StatefulOrderUpdateInfo[] = await StatefulOrderUpdatesCache
-        .getOldOrderUpdates(
-          Date.now(),
-          redisClient,
-        );
-      expect(orderUpdates).toHaveLength(0);
-
-      expectVulcanKafkaMessage({
-        producerSendMock,
-        orderId: defaultOrder.orderId!,
-        offchainUpdate: {
-          orderUpdate: cachedOrderUpdate,
-        },
-      });
-    }
   });
 
   it.each([

--- a/indexer/services/ender/src/handlers/stateful-order/stateful-order-placement-handler.ts
+++ b/indexer/services/ender/src/handlers/stateful-order/stateful-order-placement-handler.ts
@@ -6,17 +6,14 @@ import {
   perpetualMarketRefresher,
   OrderStatus,
 } from '@dydxprotocol-indexer/postgres';
-import { StatefulOrderUpdatesCache } from '@dydxprotocol-indexer/redis';
 import { getOrderIdHash } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   OrderPlaceV1_OrderPlacementStatus,
   OffChainUpdateV1,
   IndexerOrder,
   StatefulOrderEventV1,
-  OrderUpdateV1,
 } from '@dydxprotocol-indexer/v4-protos';
 
-import { redisClient } from '../../helpers/redis/redis-controller';
 import { ConsolidatedKafkaEvent } from '../../lib/types';
 import { AbstractStatefulOrderHandler } from '../abstract-stateful-order-handler';
 
@@ -75,21 +72,6 @@ export class StatefulOrderPlacementHandler extends
       getOrderIdHash(order.orderId!),
       offChainUpdate,
     ));
-
-    const pendingOrderUpdate: OrderUpdateV1 | undefined = await StatefulOrderUpdatesCache
-      .removeStatefulOrderUpdate(
-        OrderTable.orderIdToUuid(order.orderId!),
-        Date.now(),
-        redisClient,
-      );
-    if (pendingOrderUpdate !== undefined) {
-      kafakEvents.push(this.generateConsolidatedVulcanKafkaEvent(
-        getOrderIdHash(order.orderId!),
-        OffChainUpdateV1.fromPartial({
-          orderUpdate: pendingOrderUpdate,
-        }),
-      ));
-    }
 
     return kafakEvents;
   }

--- a/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
@@ -71,7 +71,7 @@ jest.mock('@dydxprotocol-indexer/base', () => ({
 interface OffchainUpdateRecord {
   key: Buffer,
   offchainUpdate: OffChainUpdateV1
-};
+}
 
 describe('order-place-handler', () => {
   beforeAll(() => {
@@ -708,7 +708,7 @@ describe('order-place-handler', () => {
           key: getOrderIdHash(orderToPlace.orderId!),
           offchainUpdate: {
             orderUpdate: cachedOrderUpdate,
-          }
+          },
         };
       }
 

--- a/indexer/services/vulcan/__tests__/helpers/websocket-helpers.ts
+++ b/indexer/services/vulcan/__tests__/helpers/websocket-helpers.ts
@@ -1,5 +1,5 @@
 import { KafkaTopics } from '@dydxprotocol-indexer/kafka';
-import { OrderbookMessage, SubaccountMessage } from '@dydxprotocol-indexer/v4-protos';
+import { OffChainUpdateV1, OrderbookMessage, SubaccountMessage } from '@dydxprotocol-indexer/v4-protos';
 import { ProducerRecord } from 'kafkajs';
 
 export function expectWebsocketSubaccountMessage(
@@ -28,4 +28,21 @@ export function expectWebsocketOrderbookMessage(
     orderbookMessageValueBinary,
   );
   expect(orderbookMessage).toEqual(expectedOrderbookMessage);
+}
+
+export function expectOffchainUpdateMessage(
+  offchainUpdateProducerRecord: ProducerRecord,
+  expectedKey: Buffer,
+  expectedOffchainUpdate: OffChainUpdateV1,
+): void {
+  expect(offchainUpdateProducerRecord.topic).toEqual(KafkaTopics.TO_VULCAN);
+  const offchainUpdateMessageValueBinary: Uint8Array = new Uint8Array(
+    offchainUpdateProducerRecord.messages[0].value as Buffer,
+  );
+  const key: Buffer = offchainUpdateProducerRecord.messages[0].key as Buffer;
+  const offchainUpdate: OffChainUpdateV1 = OffChainUpdateV1.decode(
+    offchainUpdateMessageValueBinary,
+  );
+  expect(offchainUpdate).toEqual(expectedOffchainUpdate);
+  expect(key).toEqual(expectedKey);
 }

--- a/indexer/services/vulcan/src/config.ts
+++ b/indexer/services/vulcan/src/config.ts
@@ -20,7 +20,7 @@ export const configSchema = {
   ...kafkaConfigSchema,
   ...redisConfigSchema,
 
-  FLUSH_WEBSOCKET_MESSAGES_INTERVAL_MS: parseNumber({
+  FLUSH_KAFKA_MESSAGES_INTERVAL_MS: parseNumber({
     default: 10,
   }),
   MAX_WEBSOCKET_MESSAGES_TO_QUEUE_PER_TOPIC: parseNumber({

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -23,21 +23,24 @@ import {
   PlaceOrderResult,
   placeOrder,
   CanceledOrdersCache,
+  StatefulOrderUpdatesCache,
 } from '@dydxprotocol-indexer/redis';
-import { ORDER_FLAG_SHORT_TERM } from '@dydxprotocol-indexer/v4-proto-parser';
+import { ORDER_FLAG_SHORT_TERM, getOrderIdHash, isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   OffChainUpdateV1,
   IndexerOrder,
   OrderPlaceV1,
   OrderPlaceV1_OrderPlacementStatus,
+  OrderUpdateV1,
   RedisOrder,
   SubaccountMessage,
 } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
+import { Message } from 'kafkajs';
 
 import config from '../config';
 import { redisClient } from '../helpers/redis/redis-controller';
-import { sendWebsocketWrapper } from '../lib/send-websocket-helper';
+import { sendMessageWrapper } from '../lib/send-message-helper';
 import { Handler } from './handler';
 import { convertToRedisOrder, getTriggerPrice } from './helpers';
 
@@ -47,6 +50,8 @@ import { convertToRedisOrder, getTriggerPrice } from './helpers';
  * - Add the order to the OrdersCache, OrdersDataCache, and SubaccountOrderIdsCache
  *  - this is done using the `placeOrder` function from the `redis` package
  *  - Remove the order from the CanceledOrdersCache if it exists
+ * - If the order is a stateful order, attempt to remove any cached order update from the
+ *   StatefulOrderUpdatesCache, and then queue the order update to be re-sent and re-processed
  * - If the order doesn't already exist in the caches, return
  * - If the order exists in the caches, but was not replaced due to the expiry of the existing order
  *   being greater than or equal to the expiry of the order in the OrderPlace message, return
@@ -123,9 +128,10 @@ export class OrderPlaceHandler extends Handler {
     if (this.shouldSendSubaccountMessage(update.orderPlace!)) {
       // TODO(IND-171): Determine whether we should always be sending a message, even when the cache
       // isn't updated.
-      // for stateful and conditional orders, look the order up in the db for the createdAtHeight
+      // For stateful and conditional orders, look the order up in the db for the createdAtHeight
+      // and send any cached order updates for the stateful or conditional order
       let dbOrder: OrderFromDatabase | undefined;
-      if (redisOrder.order!.goodTilBlockTime !== undefined) {
+      if (isStatefulOrder(redisOrder.order!.orderId!.orderFlags)) {
         const orderUuid: string = OrderTable.orderIdToUuid(redisOrder.order!.orderId!);
         dbOrder = await OrderTable.findById(orderUuid);
         if (dbOrder === undefined) {
@@ -135,25 +141,30 @@ export class OrderPlaceHandler extends Handler {
           });
           throw new Error(`Stateful order not found in database: ${orderUuid}`);
         }
+        await this.sendCachedOrderUpdate(orderUuid);
       }
-      const subaccountMessage: Buffer = this.createSubaccountWebsocketMessage(
-        redisOrder,
-        dbOrder,
-        perpetualMarket,
-        placementStatus,
-      );
-      sendWebsocketWrapper(subaccountMessage, KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS);
+      const subaccountMessage: Message = {
+        value: this.createSubaccountWebsocketMessage(
+          redisOrder,
+          dbOrder,
+          perpetualMarket,
+          placementStatus,
+        ),
+      };
+      sendMessageWrapper(subaccountMessage, KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS);
     }
 
     // TODO(IND-68): Remove once order replacement flow in V4 protocol removes the old order and
     // places the updated order.
     if (updatedQuantums !== undefined) {
-      const orderbookMessage: Buffer = this.createOrderbookWebsocketMessage(
-        placeOrderResult.oldOrder!,
-        perpetualMarket,
-        updatedQuantums,
-      );
-      sendWebsocketWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
+      const orderbookMessage: Message = {
+        value: this.createOrderbookWebsocketMessage(
+          placeOrderResult.oldOrder!,
+          perpetualMarket,
+          updatedQuantums,
+        ),
+      };
+      sendMessageWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
     }
   }
 
@@ -341,5 +352,34 @@ export class OrderPlaceHandler extends Handler {
       CanceledOrdersCache.removeOrderFromCache(orderId, redisClient),
       this.generateTimingStatsOptions('remove_order_from_cancel_cache'),
     );
+  }
+
+  /**
+   * Removes and sends the cached order update for the given order id if it exists.
+   *
+   * @param orderId
+   * @returns
+   */
+  protected async sendCachedOrderUpdate(
+    orderId: string,
+  ): Promise<void> {
+    const cachedOrderUpdate: OrderUpdateV1 | undefined = await StatefulOrderUpdatesCache
+    .removeStatefulOrderUpdate(
+      orderId,
+      Date.now(),
+      redisClient,
+    );
+
+    if (cachedOrderUpdate === undefined) {
+      return;
+    }
+
+    const orderUpdateMessage: Message = {
+      key: getOrderIdHash(cachedOrderUpdate.orderId!),
+      value: Buffer.from(
+        Uint8Array.from(OffChainUpdateV1.encode({ orderUpdate: cachedOrderUpdate }).finish()),
+      ),
+    };
+    sendMessageWrapper(orderUpdateMessage, KafkaTopics.TO_VULCAN);
   }
 }

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -364,11 +364,11 @@ export class OrderPlaceHandler extends Handler {
     orderId: string,
   ): Promise<void> {
     const cachedOrderUpdate: OrderUpdateV1 | undefined = await StatefulOrderUpdatesCache
-    .removeStatefulOrderUpdate(
-      orderId,
-      Date.now(),
-      redisClient,
-    );
+      .removeStatefulOrderUpdate(
+        orderId,
+        Date.now(),
+        redisClient,
+      );
 
     if (cachedOrderUpdate === undefined) {
       return;

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -33,10 +33,11 @@ import {
   SubaccountMessage,
 } from '@dydxprotocol-indexer/v4-protos';
 import { Big } from 'big.js';
+import { Message } from 'kafkajs';
 
 import config from '../config';
 import { redisClient } from '../helpers/redis/redis-controller';
-import { sendWebsocketWrapper } from '../lib/send-websocket-helper';
+import { sendMessageWrapper } from '../lib/send-message-helper';
 import { Handler } from './handler';
 import { getTriggerPrice } from './helpers';
 
@@ -218,12 +219,14 @@ export class OrderRemoveHandler extends Handler {
       return;
     }
 
-    const subaccountMessage: Buffer = this.createSubaccountWebsocketMessageFromPostgresOrder(
-      order,
-      orderRemove,
-      perpetualMarket.ticker,
-    );
-    sendWebsocketWrapper(subaccountMessage, KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS);
+    const subaccountMessage: Message = {
+      value: this.createSubaccountWebsocketMessageFromPostgresOrder(
+        order,
+        orderRemove,
+        perpetualMarket.ticker,
+      ),
+    };
+    sendMessageWrapper(subaccountMessage, KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS);
 
     // If an order was removed from the Orders cache and was resting on the book, update the
     // orderbook levels cache
@@ -273,15 +276,17 @@ export class OrderRemoveHandler extends Handler {
       this.generateTimingStatsOptions('cancel_order_in_postgres'),
     );
 
-    const subaccountMessage: Buffer = this.createSubaccountWebsocketMessageFromRemoveOrderResult(
-      removeOrderResult,
-      orderRemove,
-      perpetualMarket,
-    );
+    const subaccountMessage: Message = {
+      value: this.createSubaccountWebsocketMessageFromRemoveOrderResult(
+        removeOrderResult,
+        orderRemove,
+        perpetualMarket,
+      ),
+    };
 
     // TODO(IND-147): Remove this check once fully-filled orders are removed by ender
     if (this.shouldSendSubaccountMessage(orderRemove, removeOrderResult)) {
-      sendWebsocketWrapper(subaccountMessage, KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS);
+      sendMessageWrapper(subaccountMessage, KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS);
     }
 
     const remainingQuantums: Big = Big(this.getSizeDeltaInQuantums(
@@ -315,12 +320,14 @@ export class OrderRemoveHandler extends Handler {
       ),
       this.generateTimingStatsOptions('update_price_level_cache'),
     );
-    const orderbookMessage: Buffer = this.createOrderbookWebsocketMessage(
-      removeOrderResult.removedOrder!,
-      perpetualMarket,
-      updatedQuantums,
-    );
-    sendWebsocketWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
+    const orderbookMessage: Message = {
+      value: this.createOrderbookWebsocketMessage(
+        removeOrderResult.removedOrder!,
+        perpetualMarket,
+        updatedQuantums,
+      ),
+    };
+    sendMessageWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
   }
 
   /**

--- a/indexer/services/vulcan/src/handlers/order-update-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-update-handler.ts
@@ -24,10 +24,11 @@ import {
   RedisOrder,
 } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
+import { Message } from 'kafkajs';
 
 import config from '../config';
 import { redisClient } from '../helpers/redis/redis-controller';
-import { sendWebsocketWrapper } from '../lib/send-websocket-helper';
+import { sendMessageWrapper } from '../lib/send-message-helper';
 import { Handler } from './handler';
 
 /**
@@ -157,12 +158,14 @@ export class OrderUpdateHandler extends Handler {
       return;
     }
 
-    const orderbookMessage: Buffer = this.createOrderbookWebsocketMessage(
-      updateResult.order!,
-      perpetualMarket,
-      updatedQuantums,
-    );
-    sendWebsocketWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
+    const orderbookMessage: Message = {
+      value: this.createOrderbookWebsocketMessage(
+        updateResult.order!,
+        perpetualMarket,
+        updatedQuantums,
+      ),
+    };
+    sendMessageWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
   }
 
   /**

--- a/indexer/services/vulcan/src/index.ts
+++ b/indexer/services/vulcan/src/index.ts
@@ -8,7 +8,7 @@ import {
   connect as connectToRedis,
   redisClient,
 } from './helpers/redis/redis-controller';
-import { flushAllQueues } from './lib/send-websocket-helper';
+import { flushAllQueues } from './lib/send-message-helper';
 
 async function startService(): Promise<void> {
   logger.info({


### PR DESCRIPTION
### Changelist
Fixes issue found in testing #683 , where `ender` does not find the cached update. There's a race condition where `ender` processes a block before `vulcan` caches the order update. Moved re-queuing logic to `vulcan` to fix the issue as the order update will either be cached beforethe order place is received, or the order update will be processed after the order place is received.


Other updates:
- remove re-queuing of order updates from `ender`
- update `vulcan` to send both keys and values in Kafka messages

### Test Plan
Unit tested, and tested on `dev`.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
