### PR TITLE
[CORE-711] Always log market id when pair information is missing.

### DIFF
--- a/protocol/daemons/pricefeed/metrics/market_pairs.go
+++ b/protocol/daemons/pricefeed/metrics/market_pairs.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/types"
@@ -19,7 +20,7 @@ var (
 	// these market pairs are very unlikely to be updated, so this solution, while not perfect, is
 	// acceptable for the use case of logging/metrics in order to manage code complexity.
 	marketToPair = map[types.MarketId]string{}
-	// lock syncronizes access to the marketToPair map.
+	// lock synchronizes access to the marketToPair map.
 	lock sync.Mutex
 )
 
@@ -39,7 +40,7 @@ func GetMarketPairForTelemetry(marketId types.MarketId) string {
 
 	marketPair, exists := marketToPair[marketId]
 	if !exists {
-		return INVALID
+		return fmt.Sprintf("id:%v", marketId)
 	}
 
 	return marketPair

--- a/protocol/daemons/pricefeed/metrics/market_pairs.go
+++ b/protocol/daemons/pricefeed/metrics/market_pairs.go
@@ -40,7 +40,7 @@ func GetMarketPairForTelemetry(marketId types.MarketId) string {
 
 	marketPair, exists := marketToPair[marketId]
 	if !exists {
-		return fmt.Sprintf("id:%v", marketId)
+		return fmt.Sprintf("invalid_id:%v", marketId)
 	}
 
 	return marketPair

--- a/protocol/daemons/pricefeed/metrics/market_pairs_test.go
+++ b/protocol/daemons/pricefeed/metrics/market_pairs_test.go
@@ -18,7 +18,7 @@ func TestGetMarketPairForTelemetry(t *testing.T) {
 		},
 		"absent id": {
 			marketId: 99,
-			expected: "INVALID",
+			expected: "id:99",
 		},
 	}
 	metrics.SetMarketPairForTelemetry(1, "BTC-USD")

--- a/protocol/daemons/pricefeed/metrics/market_pairs_test.go
+++ b/protocol/daemons/pricefeed/metrics/market_pairs_test.go
@@ -18,7 +18,7 @@ func TestGetMarketPairForTelemetry(t *testing.T) {
 		},
 		"absent id": {
 			marketId: 99,
-			expected: "id:99",
+			expected: "invalid_id:99",
 		},
 	}
 	metrics.SetMarketPairForTelemetry(1, "BTC-USD")

--- a/protocol/daemons/pricefeed/metrics/metrics_test.go
+++ b/protocol/daemons/pricefeed/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/daemons/pricefeed/exchange_config"
@@ -27,7 +28,7 @@ func TestGetLabelForMarketIdSuccess(t *testing.T) {
 func TestGetLabelForMarketIdFailure(t *testing.T) {
 	require.Equal(
 		t,
-		metrics.GetLabelForStringValue(metrics.MarketId, pricefeedmetrics.INVALID),
+		metrics.GetLabelForStringValue(metrics.MarketId, fmt.Sprintf("id:%d", INVALID_ID)),
 		pricefeedmetrics.GetLabelForMarketId(INVALID_ID),
 	)
 }

--- a/protocol/daemons/pricefeed/metrics/metrics_test.go
+++ b/protocol/daemons/pricefeed/metrics/metrics_test.go
@@ -28,7 +28,7 @@ func TestGetLabelForMarketIdSuccess(t *testing.T) {
 func TestGetLabelForMarketIdFailure(t *testing.T) {
 	require.Equal(
 		t,
-		metrics.GetLabelForStringValue(metrics.MarketId, fmt.Sprintf("id:%d", INVALID_ID)),
+		metrics.GetLabelForStringValue(metrics.MarketId, fmt.Sprintf("invalid_id:%d", INVALID_ID)),
 		pricefeedmetrics.GetLabelForMarketId(INVALID_ID),
 	)
 }


### PR DESCRIPTION
### Changelist
When getting market id labels, always return the printed market id if the pair string is not available.

### Test Plan
Updated existing tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
