### PR TITLE
[CLOB-930] Remove Reset method and swap to appOptions/baseAppOptions being explicitly set instead of an appCreatorFn

### DIFF
--- a/protocol/app/ante/gas_test.go
+++ b/protocol/app/ante/gas_test.go
@@ -181,10 +181,10 @@ func TestSubmitTxnWithGas(t *testing.T) {
 			}
 
 			tApp := testapp.NewTestAppBuilder(t).
-				WithAppCreatorFn(
-					testapp.DefaultTestAppCreatorFn(map[string]interface{}{},
-						baseapp.SetMinGasPrices(cmd.MinGasPrice),
-					)).
+				WithAppOptions(
+					map[string]interface{}{},
+					baseapp.SetMinGasPrices(cmd.MinGasPrice),
+				).
 				Build()
 			ctx := tApp.InitChain()
 

--- a/protocol/app/prepare/full_node_prepare_proposal_test.go
+++ b/protocol/app/prepare/full_node_prepare_proposal_test.go
@@ -28,7 +28,7 @@ func TestFullNodePrepareProposalHandler(t *testing.T) {
 		flags.NonValidatingFullNodeFlag: true,
 		testlog.LoggerInstanceForTest:   logger,
 	}
-	tApp := testApp.NewTestAppBuilder(t).WithAppCreatorFn(testApp.DefaultTestAppCreatorFn(appOpts)).Build()
+	tApp := testApp.NewTestAppBuilder(t).WithAppOptions(appOpts).Build()
 
 	found := false
 	tApp.AdvanceToBlock(2, testApp.AdvanceToBlockOptions{

--- a/protocol/x/clob/e2e/app_test.go
+++ b/protocol/x/clob/e2e/app_test.go
@@ -401,7 +401,7 @@ func TestFailsDeliverTxWithIncorrectlySignedPlaceOrderTx(t *testing.T) {
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).Build()
 			tApp.InitChain()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
@@ -474,7 +474,7 @@ func TestFailsDeliverTxWithUnsignedTransactions(t *testing.T) {
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).Build()
 			tApp.InitChain()
 			tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 
@@ -506,7 +506,7 @@ func TestStats(t *testing.T) {
 	appOpts := map[string]interface{}{
 		indexer.MsgSenderInstanceForTest: msgSender,
 	}
-	tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+	tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).Build()
 
 	// Epochs start at block height 2.
 	startTime := time.Unix(10, 0).UTC()

--- a/protocol/x/clob/e2e/long_term_orders_test.go
+++ b/protocol/x/clob/e2e/long_term_orders_test.go
@@ -1221,7 +1221,7 @@ func TestPlaceLongTermOrder(t *testing.T) {
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).Build()
 			ctx := tApp.InitChain()
 
 			for _, ordersAndExpectations := range tc.ordersAndExpectationsPerBlock {

--- a/protocol/x/clob/e2e/short_term_orders_test.go
+++ b/protocol/x/clob/e2e/short_term_orders_test.go
@@ -1,6 +1,7 @@
 package clob_test
 
 import (
+	"github.com/dydxprotocol/v4-chain/protocol/indexer"
 	"testing"
 
 	"golang.org/x/exp/slices"
@@ -9,7 +10,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 
-	"github.com/dydxprotocol/v4-chain/protocol/indexer"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/msgsender"
@@ -25,11 +25,7 @@ import (
 )
 
 func TestPlaceOrder(t *testing.T) {
-	msgSender := msgsender.NewIndexerMessageSenderInMemoryCollector()
-	appOpts := map[string]interface{}{
-		indexer.MsgSenderInstanceForTest: msgSender,
-	}
-	tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
 
 	aliceSubaccount := tApp.App.SubaccountsKeeper.GetSubaccount(ctx, constants.Alice_Num0)
@@ -568,10 +564,13 @@ func TestPlaceOrder(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Reset for each iteration of the loop
-			tApp.Reset()
-
+			msgSender := msgsender.NewIndexerMessageSenderInMemoryCollector()
+			appOpts := map[string]interface{}{
+				indexer.MsgSenderInstanceForTest: msgSender,
+			}
+			tApp = testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).Build()
 			ctx = tApp.InitChain()
+
 			// Clear any messages produced prior to these checkTx calls.
 			msgSender.Clear()
 			for _, order := range tc.orders {

--- a/protocol/x/rewards/keeper/keeper_test.go
+++ b/protocol/x/rewards/keeper/keeper_test.go
@@ -80,8 +80,6 @@ func TestSetRewardShare_FailsWithNonpositiveWeight(t *testing.T) {
 }
 
 func TestAddRewardShareToAddress(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder(t).Build()
-
 	tests := map[string]struct {
 		prevRewardShare     *types.RewardShare // nil if no previous share
 		newWeight           *big.Int
@@ -120,7 +118,7 @@ func TestAddRewardShareToAddress(t *testing.T) {
 	// Run tests.
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp.Reset()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			k := tApp.App.RewardsKeeper
 
@@ -143,7 +141,6 @@ func TestAddRewardShareToAddress(t *testing.T) {
 }
 
 func TestAddRewardSharesForFill(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder(t).Build()
 	makerAddress := TestAddress1
 	takerAdderss := TestAddress2
 
@@ -268,7 +265,7 @@ func TestAddRewardSharesForFill(t *testing.T) {
 	// Run tests.
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp.Reset()
+			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			k := tApp.App.RewardsKeeper
 
@@ -653,8 +650,6 @@ func TestProcessRewardsForBlock(t *testing.T) {
 				)
 				return genesis
 			}).Build()
-
-			tApp.Reset()
 			ctx := tApp.InitChain()
 			k := tApp.App.RewardsKeeper
 

--- a/protocol/x/sending/app_test.go
+++ b/protocol/x/sending/app_test.go
@@ -95,7 +95,7 @@ func TestMsgDepositToSubaccount(t *testing.T) {
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).Build()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 			// Clear any messages produced prior to CheckTx calls.
 			msgSender.Clear()
@@ -284,7 +284,7 @@ func TestMsgWithdrawFromSubaccount(t *testing.T) {
 			appOpts := map[string]interface{}{
 				indexer.MsgSenderInstanceForTest: msgSender,
 			}
-			tApp := testapp.NewTestAppBuilder(t).WithAppCreatorFn(testapp.DefaultTestAppCreatorFn(appOpts)).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).Build()
 			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
 			// Clear any messages produced prior to CheckTx calls.
 			msgSender.Clear()


### PR DESCRIPTION
### Changelist
Remove Reset method and swap to appOptions/baseAppOptions being explicitly set instead of an appCreatorFn

This will simplify creating e2e test framework that better tests non-determinism/flags/... since the e2e test framework will want to control how the App instance is created.

### Test Plan
Update existing tests to remove/change usage.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
