### PR TITLE
[CLOB-930] Run three other instances of the application during e2e tests that check for non-determinism

### DIFF
--- a/protocol/app/simulation_test.go
+++ b/protocol/app/simulation_test.go
@@ -204,6 +204,7 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 			return app.New(
 				logger,
 				db,
+				dbm.NewMemDB(),
 				nil,
 				true,
 				appOptions,
@@ -277,6 +278,7 @@ func TestFullAppSimulation(t *testing.T) {
 			return app.New(
 				logger,
 				db,
+				dbm.NewMemDB(),
 				nil,
 				true,
 				appOptions,
@@ -349,6 +351,7 @@ func TestAppStateDeterminism(t *testing.T) {
 					return app.New(
 						logger,
 						db,
+						dbm.NewMemDB(),
 						nil,
 						true,
 						appOptions,

--- a/protocol/app/simulation_test.go
+++ b/protocol/app/simulation_test.go
@@ -191,10 +191,9 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 		b.Skip("skipping benchmark application simulation")
 	}
 
-	defer func() {
-		require.NoError(b, db.Close())
+	b.Cleanup(func() {
 		require.NoError(b, os.RemoveAll(dir))
-	}()
+	})
 
 	appOptions := defaultAppOptionsForSimulation()
 
@@ -265,10 +264,9 @@ func TestFullAppSimulation(t *testing.T) {
 	}
 	require.NoError(t, err, "simulation setup failed")
 
-	defer func() {
-		require.NoError(t, db.Close())
+	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(dir))
-	}()
+	})
 
 	appOptions := defaultAppOptionsForSimulation()
 

--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -300,6 +300,7 @@ func (a appCreator) newApp(
 	return dydxapp.New(
 		logger,
 		db,
+		snapshotDB,
 		traceStore,
 		true,
 		appOpts,
@@ -339,6 +340,7 @@ func (a appCreator) appExport(
 	dydxApp := dydxapp.New(
 		logger,
 		db,
+		dbm.NewMemDB(),
 		traceStore,
 		height == -1, // -1: no height provided
 		appOpts,

--- a/protocol/testing/e2e/funding/funding_e2e_test.go
+++ b/protocol/testing/e2e/funding/funding_e2e_test.go
@@ -141,11 +141,15 @@ func TestFunding(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
-				genesis = testapp.DefaultGenesis()
-				genesis.GenesisTime = GenesisTime
-				return genesis
-			}).Build()
+			tApp := testapp.NewTestAppBuilder(t).
+				// UpdateIndexPrice only contacts the tApp.App.Server causing non-determinism in the
+				// other App instances in TestApp used for non-determinism checking.
+				WithNonDeterminismChecksEnabled(false).
+				WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+					genesis = testapp.DefaultGenesis()
+					genesis.GenesisTime = GenesisTime
+					return genesis
+				}).Build()
 			ctx := tApp.InitChain()
 
 			// Place orders on the book.

--- a/protocol/testutil/network/network.go
+++ b/protocol/testutil/network/network.go
@@ -147,6 +147,7 @@ func DefaultConfig(options *NetworkConfigOptions) network.Config {
 			return app.New(
 				val.GetCtx().Logger,
 				tmdb.NewMemDB(),
+				tmdb.NewMemDB(),
 				nil,
 				true,
 				appOptions,
@@ -174,11 +175,19 @@ func DefaultConfig(options *NetworkConfigOptions) network.Config {
 // NewTestNetworkFixture returns a new simapp AppConstructor for network simulation tests
 func NewTestNetworkFixture() network.TestFixture {
 	appOptions := appoptions.GetDefaultTestAppOptionsFromTempDirectory("", nil)
-	dydxApp := app.New(log.NewNopLogger(), tmdb.NewMemDB(), nil, true, appOptions)
+	dydxApp := app.New(
+		log.NewNopLogger(),
+		tmdb.NewMemDB(),
+		tmdb.NewMemDB(),
+		nil,
+		true,
+		appOptions,
+	)
 
 	appCtr := func(val network.ValidatorI) servertypes.Application {
 		return app.New(
 			val.GetCtx().Logger,
+			tmdb.NewMemDB(),
 			tmdb.NewMemDB(),
 			nil,
 			true,

--- a/protocol/x/bridge/app_test.go
+++ b/protocol/x/bridge/app_test.go
@@ -150,18 +150,22 @@ func TestBridge_Success(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
-				genesis = testapp.DefaultGenesis()
-				testapp.UpdateGenesisDocWithAppStateForModule(
-					&genesis,
-					func(genesisState *bridgetypes.GenesisState) {
-						genesisState.ProposeParams = tc.proposeParams
-						genesisState.SafetyParams = tc.safetyParams
-					},
-				)
-				genesis.GenesisTime = tc.blockTime
-				return genesis
-			}).Build()
+			tApp := testapp.NewTestAppBuilder(t).
+				// These tests only contact the tApp.App.Server causing non-determinism in the
+				// other App instances in TestApp used for non-determinism checking.
+				WithNonDeterminismChecksEnabled(false).
+				WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+					genesis = testapp.DefaultGenesis()
+					testapp.UpdateGenesisDocWithAppStateForModule(
+						&genesis,
+						func(genesisState *bridgetypes.GenesisState) {
+							genesisState.ProposeParams = tc.proposeParams
+							genesisState.SafetyParams = tc.safetyParams
+						},
+					)
+					genesis.GenesisTime = tc.blockTime
+					return genesis
+				}).Build()
 			ctx := tApp.InitChain()
 
 			// Get initial balances of addresses and their expected balances after bridging.

--- a/protocol/x/clob/keeper/order_cancellation_test.go
+++ b/protocol/x/clob/keeper/order_cancellation_test.go
@@ -405,24 +405,27 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() cmt.GenesisDoc {
-				genesis := testapp.DefaultGenesis()
-				testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *types.GenesisState) {
-					state.ClobPairs = []types.ClobPair{
-						{
-							Metadata: &types.ClobPair_PerpetualClobMetadata{
-								PerpetualClobMetadata: &types.PerpetualClobMetadata{
-									PerpetualId: 0,
+			tApp := testapp.NewTestAppBuilder(t).
+				// Disable non-determinism checks since we mutate keeper state directly.
+				WithNonDeterminismChecksEnabled(false).
+				WithGenesisDocFn(func() cmt.GenesisDoc {
+					genesis := testapp.DefaultGenesis()
+					testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *types.GenesisState) {
+						state.ClobPairs = []types.ClobPair{
+							{
+								Metadata: &types.ClobPair_PerpetualClobMetadata{
+									PerpetualClobMetadata: &types.PerpetualClobMetadata{
+										PerpetualId: 0,
+									},
 								},
+								Status:           types.ClobPair_STATUS_ACTIVE,
+								StepBaseQuantums: 12,
+								SubticksPerTick:  39,
 							},
-							Status:           types.ClobPair_STATUS_ACTIVE,
-							StepBaseQuantums: 12,
-							SubticksPerTick:  39,
-						},
-					}
-				})
-				return genesis
-			}).Build()
+						}
+					})
+					return genesis
+				}).Build()
 
 			ctx := tApp.AdvanceToBlock(
 				// Stateful validation happens at blockHeight+1 for short term order cancelations.

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -1675,28 +1675,31 @@ func TestPerformStatefulOrderValidation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() cmt.GenesisDoc {
-				genesis := testapp.DefaultGenesis()
-				clobPairs := []types.ClobPair{
-					{
-						Metadata: &types.ClobPair_PerpetualClobMetadata{
-							PerpetualClobMetadata: &types.PerpetualClobMetadata{
-								PerpetualId: 0,
+			tApp := testapp.NewTestAppBuilder(t).
+				// Disable non-determinism checks since the tests update state via keeper directly.
+				WithNonDeterminismChecksEnabled(false).
+				WithGenesisDocFn(func() cmt.GenesisDoc {
+					genesis := testapp.DefaultGenesis()
+					clobPairs := []types.ClobPair{
+						{
+							Metadata: &types.ClobPair_PerpetualClobMetadata{
+								PerpetualClobMetadata: &types.PerpetualClobMetadata{
+									PerpetualId: 0,
+								},
 							},
+							Status:           types.ClobPair_STATUS_ACTIVE,
+							StepBaseQuantums: 12,
+							SubticksPerTick:  39,
 						},
-						Status:           types.ClobPair_STATUS_ACTIVE,
-						StepBaseQuantums: 12,
-						SubticksPerTick:  39,
-					},
-				}
-				if tc.clobPairs != nil {
-					clobPairs = tc.clobPairs
-				}
-				testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *types.GenesisState) {
-					state.ClobPairs = clobPairs
-				})
-				return genesis
-			}).Build()
+					}
+					if tc.clobPairs != nil {
+						clobPairs = tc.clobPairs
+					}
+					testapp.UpdateGenesisDocWithAppStateForModule(&genesis, func(state *types.GenesisState) {
+						state.ClobPairs = clobPairs
+					})
+					return genesis
+				}).Build()
 
 			ctx := tApp.AdvanceToBlock(
 				// Stateful validation happens at blockHeight+1 for short term order placements.


### PR DESCRIPTION
### Changelist
Add 3 additional validator invariant checkers (PR) for almost all existing e2e tests:
* parallelApp is responsible for seeing all CheckTx requests, block proposals, blocks, and RecheckTx requests. This allows it to detect state differences due to inconsistent in-memory structures (for example iteration order in maps).
* noCheckTxApp is responsible for seeing all block proposals and blocks. This allows it to simulate a validator that never received any of the CheckTx requests and that it will still accept blocks and arrive at the same state hash.
* crashingApp is responsible for restarting before processing a block and sees all CheckTx requests, block proposals, and blocks. This allows it to check that in memory state can be restored successfully on application restart and that it will accept a block after a crash and arrive at the same state hash.

### Test Plan
Existing tests pass beyond the few places where I had to disable non-determinism checks in certain tests that mutate keeper state directly in a way where non-determinism would be falsely detected or they rely on in-memory state that can't survive app restart.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
