### PR TITLE
Make iaviewer usage more human friendly

### DIFF
--- a/protocol/scripts/iaviewer/iaviewer.go
+++ b/protocol/scripts/iaviewer/iaviewer.go
@@ -6,14 +6,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strconv"
+	"regexp"
 	"strings"
 
 	dbm "github.com/cometbft/cometbft-db"
-
 	"github.com/cosmos/iavl"
+	"github.com/spf13/cobra"
 )
 
 // TODO: make this configurable?
@@ -21,46 +20,157 @@ const (
 	DefaultCacheSize int = 10000
 )
 
+var (
+	prefixRe *regexp.Regexp = regexp.MustCompile("(s/k:[[:alpha:]]+/).*")
+)
+
+var rootCmd = &cobra.Command{
+	Use:          "iaviewer",
+	SilenceUsage: true,
+}
+
 func main() {
-	args := os.Args[1:]
-	if len(args) < 3 || (args[0] != "data" && args[0] != "shape" && args[0] != "versions") {
-		fmt.Fprintln(os.Stderr, "Usage: iaviewer <data|shape|versions> <leveldb dir> <prefix> [version number]")
-		fmt.Fprintln(os.Stderr, "<prefix> is the prefix of db, and the iavl tree of different modules in cosmos-sdk uses ")
-		fmt.Fprintln(os.Stderr, "different <prefix> to identify, just like \"s/k:gov/\" represents the prefix of gov module")
-		os.Exit(1)
+	rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.AddCommand(DataAllCmd())
+	rootCmd.AddCommand(DataCmd())
+	rootCmd.AddCommand(ShapeCmd())
+	rootCmd.AddCommand(VersionsCmd())
+}
+
+func AddPathFlag(cmd *cobra.Command) {
+	cmd.Flags().String("path", "", "path to leveldb dir")
+	cmd.MarkFlagRequired("path")
+}
+
+func AddPrefixFlag(cmd *cobra.Command) {
+	cmd.Flags().String("prefix", "", "prefix of the db e.g. \"s/k:gov/\"")
+	cmd.MarkFlagRequired("prefix")
+}
+
+func AddVersionFlag(cmd *cobra.Command) {
+	cmd.Flags().Uint64("version", 0, "version of the tree (default: latest version)")
+}
+
+func DataAllCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "data-all",
+		Short: "Get data of all iavl trees",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, _ := cmd.Flags().GetString("path")
+			version, _ := cmd.Flags().GetUint64("version")
+
+			db, err := OpenDB(path)
+			if err != nil {
+				return err
+			}
+			prefixes := GetAllPrefixes(db)
+			for _, prefix := range prefixes {
+				tree, err := ReadTree(db, version, []byte(prefix))
+				if err != nil {
+					return err
+				}
+				err = PrintTree(tree, prefix)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 	}
 
-	version := 0
-	if len(args) == 4 {
-		var err error
-		version, err = strconv.Atoi(args[3])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid version number: %s\n", err)
-			os.Exit(1)
-		}
+	AddPathFlag(cmd)
+	AddVersionFlag(cmd)
+	return cmd
+}
+
+func DataCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "data",
+		Short: "Get data of a specific iavl tree",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, _ := cmd.Flags().GetString("path")
+			prefix, _ := cmd.Flags().GetString("prefix")
+			version, _ := cmd.Flags().GetUint64("version")
+
+			db, err := OpenDB(path)
+			if err != nil {
+				return err
+			}
+			tree, err := ReadTree(db, version, []byte(prefix))
+			if err != nil {
+				return err
+			}
+			err = PrintTree(tree, prefix)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
 	}
 
-	tree, err := ReadTree(args[1], version, []byte(args[2]))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading data: %s\n", err)
-		os.Exit(1)
+	AddPathFlag(cmd)
+	AddPrefixFlag(cmd)
+	AddVersionFlag(cmd)
+	return cmd
+}
+
+func ShapeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "shape",
+		Short: "Get shape of a specific iavl tree",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, _ := cmd.Flags().GetString("path")
+			prefix, _ := cmd.Flags().GetString("prefix")
+			version, _ := cmd.Flags().GetUint64("version")
+
+			db, err := OpenDB(path)
+			if err != nil {
+				return err
+			}
+			tree, err := ReadTree(db, version, []byte(prefix))
+			if err != nil {
+				return err
+			}
+			PrintShape(tree)
+			return nil
+		},
 	}
 
-	switch args[0] {
-	case "data":
-		PrintKeys(tree)
-		hash, err := tree.Hash()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error hashing tree: %s\n", err)
-			os.Exit(1)
-		}
-		fmt.Printf("Hash: %X\n", hash)
-		fmt.Printf("Size: %X\n", tree.Size())
-	case "shape":
-		PrintShape(tree)
-	case "versions":
-		PrintVersions(tree)
+	AddPathFlag(cmd)
+	AddPrefixFlag(cmd)
+	AddVersionFlag(cmd)
+	return cmd
+}
+
+func VersionsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "versions",
+		Short: "List versions of specific iavl tree",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, _ := cmd.Flags().GetString("path")
+			prefix, _ := cmd.Flags().GetString("prefix")
+			version, _ := cmd.Flags().GetUint64("version")
+
+			db, err := OpenDB(path)
+			if err != nil {
+				return err
+			}
+			tree, err := ReadTree(db, version, []byte(prefix))
+			if err != nil {
+				return err
+			}
+			PrintVersions(tree)
+			return nil
+		},
 	}
+
+	AddPathFlag(cmd)
+	AddPrefixFlag(cmd)
+	AddVersionFlag(cmd)
+	return cmd
 }
 
 func OpenDB(dir string) (dbm.DB, error) {
@@ -91,6 +201,31 @@ func OpenDB(dir string) (dbm.DB, error) {
 	return db, nil
 }
 
+// GetAllPrefixes fetches all prefixes for iavl trees in the DB. There's no great way to do this,
+// so we just iterate through all keys and look for prefixes that match what we expect from modules.
+func GetAllPrefixes(db dbm.DB) []string {
+	it, err := db.Iterator(nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer it.Close()
+	// Luckily for us, this iterator goes in alphabetical order
+	var prefixes []string
+	for ; it.Valid(); it.Next() {
+		k := it.Key()
+		matches := prefixRe.FindStringSubmatch(string(k))
+		if matches != nil {
+			if len(prefixes) == 0 || matches[1] != prefixes[len(prefixes)-1] {
+				prefixes = append(prefixes, matches[1])
+			}
+		}
+	}
+	if err := it.Error(); err != nil {
+		panic(err)
+	}
+	return prefixes
+}
+
 func PrintDBStats(db dbm.DB) {
 	count := 0
 	prefix := map[string]int{}
@@ -114,14 +249,10 @@ func PrintDBStats(db dbm.DB) {
 	}
 }
 
-// ReadTree loads an iavl tree from the directory
+// ReadTree loads an iavl tree from a db
 // If version is 0, load latest, otherwise, load named version
 // The prefix represents which iavl tree you want to read. The iaviwer will always set a prefix.
-func ReadTree(dir string, version int, prefix []byte) (*iavl.MutableTree, error) {
-	db, err := OpenDB(dir)
-	if err != nil {
-		return nil, err
-	}
+func ReadTree(db dbm.DB, version uint64, prefix []byte) (*iavl.MutableTree, error) {
 	if len(prefix) != 0 {
 		db = dbm.NewPrefixDB(db, prefix)
 	}
@@ -131,18 +262,34 @@ func ReadTree(dir string, version int, prefix []byte) (*iavl.MutableTree, error)
 		return nil, err
 	}
 	ver, err := tree.LoadVersion(int64(version))
-	fmt.Printf("Got version: %d\n", ver)
+	fmt.Printf("Tree %s version: %d\n", prefix, ver)
 	return tree, err
 }
 
-func PrintKeys(tree *iavl.MutableTree) {
-	fmt.Println("Printing all keys with hashed values (to detect diff)")
+func PrintTree(tree *iavl.MutableTree, prefix string) error {
+	fmt.Printf("Tree %s data:\n", prefix)
 	tree.Iterate(func(key []byte, value []byte) bool { //nolint:errcheck
 		printKey := parseWeaveKey(key)
 		digest := sha256.Sum256(value)
 		fmt.Printf("  %s\n    %X\n", printKey, digest)
+		if treeUnmarshallerRegistry, ok := unmarshallerRegistry[prefix]; ok {
+			for keyPrefix, unmarshaller := range treeUnmarshallerRegistry {
+				if strings.HasPrefix(string(key), keyPrefix) {
+					str := unmarshaller(value)
+					fmt.Printf("    %s\n", str)
+					break
+				}
+			}
+		}
 		return false
 	})
+	hash, err := tree.Hash()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Tree %s Hash: %X\n", prefix, hash)
+	fmt.Printf("Tree %s Size: %X\n", prefix, tree.Size())
+	return nil
 }
 
 // parseWeaveKey assumes a separating : where all in front should be ascii,

--- a/protocol/scripts/iaviewer/iaviewer.go
+++ b/protocol/scripts/iaviewer/iaviewer.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -30,7 +31,10 @@ var rootCmd = &cobra.Command{
 }
 
 func main() {
-	rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "iaviewer got error: '%s'", err)
+		os.Exit(1)
+	}
 }
 
 func init() {
@@ -42,12 +46,16 @@ func init() {
 
 func AddPathFlag(cmd *cobra.Command) {
 	cmd.Flags().String("path", "", "path to leveldb dir")
-	cmd.MarkFlagRequired("path")
+	if err := cmd.MarkFlagRequired("path"); err != nil {
+		panic(err)
+	}
 }
 
 func AddPrefixFlag(cmd *cobra.Command) {
 	cmd.Flags().String("prefix", "", "prefix of the db e.g. \"s/k:gov/\"")
-	cmd.MarkFlagRequired("prefix")
+	if err := cmd.MarkFlagRequired("prefix"); err != nil {
+		panic(err)
+	}
 }
 
 func AddVersionFlag(cmd *cobra.Command) {

--- a/protocol/scripts/iaviewer/unmarshaller.go
+++ b/protocol/scripts/iaviewer/unmarshaller.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"reflect"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	app "github.com/dydxprotocol/v4-chain/protocol/app"
+	clob "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+)
+
+func protoUnmarshaller[M codec.ProtoMarshaler](b []byte) string {
+	cdc := app.GetEncodingConfig().Codec
+	var m M
+	// TODO: avoid reflection?
+	msgType := reflect.TypeOf(m).Elem()
+	m = reflect.New(msgType).Interface().(M)
+	cdc.MustUnmarshal(b, m)
+	return m.String()
+}
+
+var unmarshallerRegistry = map[string]map[string]func([]byte) string{
+	"s/k:clob/": {
+		"Clob:":      protoUnmarshaller[*clob.ClobPair],
+		"EqTierCfg":  protoUnmarshaller[*clob.EquityTierLimitConfiguration],
+		"LiqCfg":     protoUnmarshaller[*clob.LiquidationsConfig],
+		"RateLimCfg": protoUnmarshaller[*clob.BlockRateLimitConfiguration],
+	},
+}

--- a/protocol/scripts/iaviewer/unmarshaller.go
+++ b/protocol/scripts/iaviewer/unmarshaller.go
@@ -18,6 +18,10 @@ func protoUnmarshaller[M codec.ProtoMarshaler](b []byte) string {
 	return m.String()
 }
 
+// Maps prefix names for modules to an inner registry map of type map[string]func([]byte) string.
+// For iavl key-value pair (K_i, V_i) and registry map key-value pair (K_r, V_r), V_r will be used
+// to unmarshal V_i if K_r is a prefix of K_i.
+// Thus, keys each inner registry map should not be prefixes of each other.
 var unmarshallerRegistry = map[string]map[string]func([]byte) string{
 	"s/k:clob/": {
 		"Clob:":      protoUnmarshaller[*clob.ClobPair],


### PR DESCRIPTION
### Changelist
- Migrate cli to use cobra
- Add `data-all` command to list iavl tree for all modules
- Unmarshal proto values and output human readable strings if they are in the registry

### Test Plan
- Manually tried all commands on a db from localnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
