### PR TITLE
Deflake test-sim-nondeterminism 

### DIFF
--- a/protocol/app/simulation_test.go
+++ b/protocol/app/simulation_test.go
@@ -326,7 +326,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	config.ChainID = simChainId
 
 	numSeeds := 3
-	numTimesToRunPerSeed := 5
+	numTimesToRunPerSeed := 3
 	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
 
 	appOptions := defaultAppOptionsForSimulation()


### PR DESCRIPTION
### Changelist
Make the test run 9 instead of 15 apps. Maybe excessive memory usage is causing github to shut these down? I ran CI on this quite a few times and it seems to not flake anymore.

### Test Plan
Run CI a bunch of times

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
