### PR TITLE
[IND-465] Add support for liquidation handler to use a single SQL function.  Also fix fill and order models since clientMetadata is a nullable field.

### DIFF
--- a/indexer/packages/postgres/src/models/fill-model.ts
+++ b/indexer/packages/postgres/src/models/fill-model.ts
@@ -84,7 +84,7 @@ export default class FillModel extends Model {
         transactionHash: { type: 'string' },
         createdAt: { type: 'string', format: 'date-time' },
         createdAtHeight: { type: 'string', pattern: IntegerPattern },
-        clientMetadata: { type: 'string', pattern: IntegerPattern },
+        clientMetadata: { type: ['string', 'null'], pattern: IntegerPattern },
         fee: { type: 'string', pattern: NumericPattern },
       },
     };

--- a/indexer/packages/postgres/src/models/order-model.ts
+++ b/indexer/packages/postgres/src/models/order-model.ts
@@ -92,7 +92,7 @@ export default class OrderModel extends BaseModel {
         goodTilBlock: { type: ['string', 'null'], default: null, pattern: IntegerPattern },
         goodTilBlockTime: { type: ['string', 'null'], default: null, format: 'date-time' },
         createdAtHeight: { type: ['string', 'null'], default: null, pattern: IntegerPattern },
-        clientMetadata: { type: 'string', pattern: IntegerPattern },
+        clientMetadata: { type: ['string', 'null'], pattern: IntegerPattern },
         triggerPrice: { type: ['string', 'null'], default: null, pattern: NonNegativeNumericPattern },
         updatedAt: { type: 'string', format: 'date-time' },
         updatedAtHeight: { type: 'string', pattern: IntegerPattern },

--- a/indexer/packages/postgres/src/models/order-model.ts
+++ b/indexer/packages/postgres/src/models/order-model.ts
@@ -92,7 +92,7 @@ export default class OrderModel extends BaseModel {
         goodTilBlock: { type: ['string', 'null'], default: null, pattern: IntegerPattern },
         goodTilBlockTime: { type: ['string', 'null'], default: null, format: 'date-time' },
         createdAtHeight: { type: ['string', 'null'], default: null, pattern: IntegerPattern },
-        clientMetadata: { type: ['string', 'null'], pattern: IntegerPattern },
+        clientMetadata: { type: 'string', pattern: IntegerPattern },
         triggerPrice: { type: ['string', 'null'], default: null, pattern: NonNegativeNumericPattern },
         updatedAt: { type: 'string', format: 'date-time' },
         updatedAtHeight: { type: 'string', pattern: IntegerPattern },

--- a/indexer/services/ender/src/config.ts
+++ b/indexer/services/ender/src/config.ts
@@ -26,6 +26,9 @@ export const configSchema = {
   USE_ORDER_HANDLER_SQL_FUNCTION: parseBoolean({
     default: true,
   }),
+  USE_LIQUIDATION_HANDLER_SQL_FUNCTION: parseBoolean({
+    default: true,
+  }),
   USE_SUBACCOUNT_UPDATE_SQL_FUNCTION: parseBoolean({
     default: true,
   }),

--- a/indexer/services/ender/src/handlers/order-fills/liquidation-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/liquidation-handler.ts
@@ -1,24 +1,35 @@
 import { logger } from '@dydxprotocol-indexer/base';
 import {
   FillFromDatabase,
+  FillModel,
   Liquidity,
   OrderFromDatabase,
+  OrderModel,
   OrderTable,
   PerpetualMarketFromDatabase,
+  PerpetualMarketModel,
   perpetualMarketRefresher,
   PerpetualPositionFromDatabase,
+  PerpetualPositionModel,
+  storeHelpers,
   SubaccountTable,
-  OrderStatus,
+  USDC_ASSET_ID,
+  OrderStatus, FillType,
 } from '@dydxprotocol-indexer/postgres';
 import { isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
-  LiquidationOrderV1, IndexerOrderId,
+  LiquidationOrderV1, IndexerOrderId, OrderFillEventV1,
 } from '@dydxprotocol-indexer/v4-protos';
 import Long from 'long';
+import * as pg from 'pg';
 
+import config from '../../config';
 import { STATEFUL_ORDER_ORDER_FILL_EVENT_TYPE, SUBACCOUNT_ORDER_FILL_EVENT_TYPE } from '../../constants';
 import { convertPerpetualPosition } from '../../helpers/kafka-helper';
-import { orderFillWithLiquidityToOrderFillEventWithLiquidation } from '../../helpers/translation-helper';
+import {
+  orderFillWithLiquidityToOrderFillEventWithLiquidation,
+} from '../../helpers/translation-helper';
+import { indexerTendermintEventToTransactionIndex } from '../../lib/helper';
 import { OrderFillWithLiquidity } from '../../lib/translated-types';
 import {
   ConsolidatedKafkaEvent,
@@ -73,8 +84,99 @@ export class LiquidationHandler extends AbstractOrderFillHandler<OrderFillWithLi
       : castedOrderFillEventMessage.totalFilledMaker;
   }
 
+  public async handleViaSqlFunction(): Promise<ConsolidatedKafkaEvent[]> {
+    const eventDataBinary: Uint8Array = this.indexerTendermintEvent.dataBytes;
+    const transactionIndex: number = indexerTendermintEventToTransactionIndex(
+      this.indexerTendermintEvent,
+    );
+
+    const castedLiquidationFillEventMessage:
+    OrderFillEventWithLiquidation = orderFillWithLiquidityToOrderFillEventWithLiquidation(
+      this.event,
+    );
+    const field: string = this.event.liquidity === Liquidity.MAKER
+      ? 'makerOrder' : 'liquidationOrder';
+    const fillType: string = this.event.liquidity === Liquidity.MAKER
+      ? FillType.LIQUIDATION : FillType.LIQUIDATED;
+
+    const result: pg.QueryResult = await storeHelpers.rawQuery(
+      `SELECT dydx_liquidation_fill_handler_per_order(
+        '${field}', 
+        ${this.block.height}, 
+        '${this.block.time?.toISOString()}', 
+        '${JSON.stringify(OrderFillEventV1.decode(eventDataBinary))}', 
+        ${this.indexerTendermintEvent.eventIndex}, 
+        ${transactionIndex}, 
+        '${this.block.txHashes[transactionIndex]}', 
+        '${this.event.liquidity}', 
+        '${fillType}',
+        '${USDC_ASSET_ID}'
+      ) AS result;`,
+      { txId: this.txId },
+    ).catch((error) => {
+      logger.error({
+        at: 'orderHandler#handleViaSqlFunction',
+        message: 'Failed to handle OrderFillEventV1',
+        error,
+      });
+      throw error;
+    });
+
+    const fill: FillFromDatabase = FillModel.fromJson(
+      result.rows[0].result.fill) as FillFromDatabase;
+    const perpetualMarket: PerpetualMarketFromDatabase = PerpetualMarketModel.fromJson(
+      result.rows[0].result.perpetual_market) as PerpetualMarketFromDatabase;
+    const position: PerpetualPositionFromDatabase = PerpetualPositionModel.fromJson(
+      result.rows[0].result.perpetual_position) as PerpetualPositionFromDatabase;
+
+    if (this.event.liquidity === Liquidity.MAKER) {
+      // Must be done in this order, because fills refer to an order
+      // We do not create a taker order for liquidations.
+      const makerOrder: OrderFromDatabase = OrderModel.fromJson(
+        result.rows[0].result.order) as OrderFromDatabase;
+
+      const kafkaEvents: ConsolidatedKafkaEvent[] = [
+        this.generateConsolidatedKafkaEvent(
+          castedLiquidationFillEventMessage.makerOrder.orderId!.subaccountId!,
+          makerOrder,
+          convertPerpetualPosition(position),
+          fill,
+          perpetualMarket,
+        ),
+        // Update vulcan with the total filled amount of the maker order.
+        this.getOrderUpdateKafkaEvent(
+          castedLiquidationFillEventMessage.makerOrder!.orderId!,
+          castedLiquidationFillEventMessage.totalFilledMaker,
+        ),
+      ];
+
+      // If the order is stateful and fully-filled, send an order removal to vulcan. We only do this
+      // for stateful orders as we are guaranteed a stateful order cannot be replaced until the next
+      // block.
+      if (makerOrder?.status === OrderStatus.FILLED && isStatefulOrder(makerOrder?.orderFlags)) {
+        kafkaEvents.push(
+          this.getOrderRemoveKafkaEvent(castedLiquidationFillEventMessage.makerOrder!.orderId!),
+        );
+      }
+      return kafkaEvents;
+    } else {
+      return [
+        this.generateConsolidatedKafkaEvent(
+          castedLiquidationFillEventMessage.liquidationOrder.liquidated!,
+          undefined,
+          convertPerpetualPosition(position),
+          fill,
+          perpetualMarket,
+        ),
+        this.generateTradeKafkaEventFromTakerOrderFill(
+          fill,
+        ),
+      ];
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/require-await
-  public async internalHandle(): Promise<ConsolidatedKafkaEvent[]> {
+  public async handleViaKnexQueries(): Promise<ConsolidatedKafkaEvent[]> {
     const castedLiquidationFillEventMessage:
     OrderFillEventWithLiquidation = orderFillWithLiquidityToOrderFillEventWithLiquidation(
       this.event,
@@ -160,5 +262,12 @@ export class LiquidationHandler extends AbstractOrderFillHandler<OrderFillWithLi
         ),
       ];
     }
+  }
+
+  public async internalHandle(): Promise<ConsolidatedKafkaEvent[]> {
+    if (config.USE_LIQUIDATION_HANDLER_SQL_FUNCTION) {
+      return this.handleViaSqlFunction();
+    }
+    return this.handleViaKnexQueries();
   }
 }

--- a/indexer/services/ender/src/helpers/postgres/postgres-functions.ts
+++ b/indexer/services/ender/src/helpers/postgres/postgres-functions.ts
@@ -39,6 +39,7 @@ const scripts: string[] = [
   'dydx_get_order_status.sql',
   'dydx_get_total_filled_from_liquidity.sql',
   'dydx_get_weighted_average.sql',
+  'dydx_liquidation_fill_handler_per_order.sql',
   'dydx_order_fill_handler_per_order.sql',
   'dydx_perpetual_position_and_order_side_matching.sql',
   'dydx_subaccount_update_handler.sql',

--- a/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
@@ -1,0 +1,242 @@
+/**
+  Parameters:
+    - field: the field storing the order to process.
+    - block_height: the height of the block being processing.
+    - block_time: the time of the block being processed.
+    - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-proto/blob/8d35c86/dydxprotocol/indexer/indexer_manager/event.proto#L25)
+        converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
+    - event_index: The 'event_index' of the IndexerTendermintEvent.
+    - transaction_index: The transaction_index of the IndexerTendermintEvent after the conversion that takes into
+        account the block_event (https://github.com/dydxprotocol/indexer/blob/cc70982/services/ender/src/lib/helper.ts#L33)
+    - transaction_hash: The transaction hash corresponding to this event from the IndexerTendermintBlock 'tx_hashes'.
+    - fill_liquidity: The liquidity for the fill record.
+    - fill_type: The type for the fill record.
+    - usdc_asset_id: The USDC asset id.
+  Returns: JSON object containing fields:
+    - order: The updated order in order-model format (https://github.com/dydxprotocol/indexer/blob/cc70982/packages/postgres/src/models/order-model.ts).
+        Only returned if field == 'makerOrder'.
+    - fill: The updated fill in fill-model format (https://github.com/dydxprotocol/indexer/blob/cc70982/packages/postgres/src/models/fill-model.ts).
+    - perpetual_market: The perpetual market for the order in perpetual-market-model format (https://github.com/dydxprotocol/indexer/blob/cc70982/packages/postgres/src/models/perpetual-market-model.ts).
+    - perpetual_position: The updated perpetual position in perpetual-position-model format (https://github.com/dydxprotocol/indexer/blob/cc70982/packages/postgres/src/models/perpetual-position-model.ts).
+*/
+CREATE OR REPLACE FUNCTION dydx_liquidation_fill_handler_per_order(
+    field text, block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int,
+    transaction_hash text, fill_liquidity text, fill_type text, usdc_asset_id text) RETURNS jsonb AS $$
+DECLARE
+    order_ jsonb;
+    maker_order jsonb;
+    clob_pair_id bigint;
+    subaccount_uuid uuid;
+    perpetual_market_record perpetual_markets%ROWTYPE;
+    order_record orders%ROWTYPE;
+    fill_record fills%ROWTYPE;
+    perpetual_position_record perpetual_positions%ROWTYPE;
+    asset_record assets%ROWTYPE;
+    order_uuid uuid;
+    order_side text;
+    order_size numeric;
+    order_price numeric;
+    order_client_metadata bigint;
+    fee numeric;
+    fill_amount numeric;
+    total_filled numeric;
+    maker_price numeric;
+    event_id bytea;
+BEGIN
+    order_ = event_data->field;
+    maker_order = event_data->'makerOrder';
+
+    IF field = 'makerOrder' THEN
+        clob_pair_id = jsonb_extract_path(order_, 'orderId', 'clobPairId')::bigint;
+    ELSE
+        clob_pair_id = jsonb_extract_path(order_, 'clobPairId')::bigint;
+    END IF;
+
+    BEGIN
+        SELECT * INTO STRICT perpetual_market_record FROM perpetual_markets WHERE "clobPairId" = clob_pair_id;
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'Unable to find perpetual market with clobPairId %', clob_pair_id;
+        WHEN TOO_MANY_ROWS THEN
+            /** This should never happen and if it ever were to would indicate that the table has malformed data. */
+            RAISE EXCEPTION 'Found multiple perpetual markets with clobPairId %', clob_pair_id;
+    END;
+
+    BEGIN
+        SELECT * INTO STRICT asset_record FROM assets WHERE "id" = usdc_asset_id;
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'Unable to find asset with id %', usdc_asset_id;
+    END;
+
+    /**
+      Calculate sizes, prices, and fill amounts.
+
+      TODO(IND-238): Extract out calculation of quantums and subticks to their own SQL functions.
+    */
+    fill_amount = dydx_trim_scale(dydx_from_jsonlib_long(event_data->'fillAmount') *
+                                  power(10, perpetual_market_record."atomicResolution")::numeric);
+    maker_price = dydx_trim_scale(dydx_from_jsonlib_long(maker_order->'subticks') *
+                                  power(10, perpetual_market_record."quantumConversionExponent" +
+                                            asset_record."atomicResolution" -
+                                            perpetual_market_record."atomicResolution")::numeric);
+    total_filled = dydx_trim_scale(dydx_get_total_filled(fill_liquidity, event_data) *
+                                   power(10, perpetual_market_record."atomicResolution")::numeric);
+    fee = dydx_trim_scale(dydx_get_fee(fill_liquidity, event_data) *
+                          power(10, asset_record."atomicResolution")::numeric);
+    order_price = dydx_trim_scale(dydx_from_jsonlib_long(order_->'subticks') *
+                                  power(10, perpetual_market_record."quantumConversionExponent" +
+                                            asset_record."atomicResolution" -
+                                            perpetual_market_record."atomicResolution")::numeric);
+    order_side = dydx_from_protocol_order_side(order_->'side');
+
+    IF field = 'makerOrder' THEN
+        order_uuid = dydx_uuid_from_order_id(order_->'orderId');
+        subaccount_uuid = dydx_uuid_from_subaccount_id(jsonb_extract_path(order_, 'orderId', 'subaccountId'));
+        order_client_metadata = (order_->'clientMetadata')::bigint;
+    ELSE
+        order_uuid = NULL;
+        subaccount_uuid = dydx_uuid_from_subaccount_id(jsonb_extract_path(order_, 'liquidated'));
+        order_client_metadata = NULL;
+    END IF;
+
+    IF field = 'makerOrder' THEN
+        order_size = dydx_trim_scale(dydx_from_jsonlib_long(order_->'quantums') *
+                                     power(10, perpetual_market_record."atomicResolution")::numeric);
+
+        /** Upsert the order, populating the order_record fields with what will be in the database. */
+        SELECT * INTO order_record FROM orders WHERE "id" = order_uuid;
+        order_record."size" = order_size;
+        order_record."price" = order_price;
+        order_record."timeInForce" = dydx_from_protocol_time_in_force(order_->'timeInForce');
+        order_record."reduceOnly" = (order_->>'reduceOnly')::boolean;
+        order_record."orderFlags" = jsonb_extract_path(order_, 'orderId', 'orderFlags')::bigint;
+        order_record."goodTilBlock" = (order_->'goodTilBlock')::bigint;
+        order_record."goodTilBlockTime" = to_timestamp((order_->'goodTilBlockTime')::double precision);
+        order_record."clientMetadata" = order_client_metadata;
+        order_record."updatedAt" = block_time;
+        order_record."updatedAtHeight" = block_height;
+
+        IF FOUND THEN
+            order_record."totalFilled" = total_filled;
+            order_record."status" = dydx_get_order_status(total_filled, order_record.size, false, order_record."orderFlags", order_record."timeInForce");
+
+            UPDATE orders
+            SET
+                "size" = order_record."size",
+                "totalFilled" = order_record."totalFilled",
+                "price" = order_record."price",
+                "status" = order_record."status",
+                "orderFlags" = order_record."orderFlags",
+                "goodTilBlock" = order_record."goodTilBlock",
+                "goodTilBlockTime" = order_record."goodTilBlockTime",
+                "timeInForce" = order_record."timeInForce",
+                "reduceOnly" = order_record."reduceOnly",
+                "clientMetadata" = order_record."clientMetadata",
+                "updatedAt" = order_record."updatedAt",
+                "updatedAtHeight" = order_record."updatedAtHeight"
+            WHERE id = order_uuid;
+        ELSE
+            order_record."id" = order_uuid;
+            order_record."subaccountId" = subaccount_uuid;
+            order_record."clientId" = jsonb_extract_path_text(order_, 'orderId', 'clientId')::bigint;
+            order_record."clobPairId" = clob_pair_id;
+            order_record."side" = order_side;
+            order_record."type" = 'LIMIT';
+
+            order_record."totalFilled" = fill_amount;
+            order_record."status" = dydx_get_order_status(fill_amount, order_size, false, order_record."orderFlags", order_record."timeInForce");
+            order_record."createdAtHeight" = block_height;
+            INSERT INTO orders
+            ("id", "subaccountId", "clientId", "clobPairId", "side", "size", "totalFilled", "price", "type",
+             "status", "timeInForce", "reduceOnly", "orderFlags", "goodTilBlock", "goodTilBlockTime", "createdAtHeight",
+             "clientMetadata", "triggerPrice", "updatedAt", "updatedAtHeight")
+            VALUES (order_record.*);
+        END IF;
+    END IF;
+
+    /* Insert the associated fill record for this order_fill event. */
+    event_id = dydx_event_id_from_parts(
+            block_height, transaction_index, event_index);
+    INSERT INTO fills
+    ("id", "subaccountId", "side", "liquidity", "type", "clobPairId", "orderId", "size", "price", "quoteAmount",
+     "eventId", "transactionHash", "createdAt", "createdAtHeight", "clientMetadata", "fee")
+    VALUES (dydx_uuid_from_fill_event_parts(event_id, fill_liquidity),
+            subaccount_uuid,
+            order_side,
+            fill_liquidity,
+            fill_type,
+            clob_pair_id,
+            order_uuid,
+            fill_amount,
+            maker_price,
+            dydx_trim_scale(fill_amount * maker_price),
+            event_id,
+            transaction_hash,
+            block_time,
+            block_height,
+            order_client_metadata,
+            fee)
+    RETURNING * INTO fill_record;
+
+    /* Upsert the perpetual_position record for this order_fill event. */
+    SELECT * INTO perpetual_position_record FROM perpetual_positions WHERE "subaccountId" = subaccount_uuid
+                                                                       AND "perpetualId" = perpetual_market_record."id"
+    ORDER BY "createdAtHeight" DESC;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Unable to find existing perpetual position, subaccountId: %, perpetualId: %', subaccount_uuid, perpetual_market_record."id";
+    END IF;
+    DECLARE
+        sum_open numeric = perpetual_position_record."sumOpen";
+        entry_price numeric = perpetual_position_record."entryPrice";
+        sum_close numeric = perpetual_position_record."sumClose";
+        exit_price numeric = perpetual_position_record."exitPrice";
+    BEGIN
+        IF dydx_perpetual_position_and_order_side_matching(
+                perpetual_position_record."side", order_side) THEN
+            sum_open = dydx_trim_scale(perpetual_position_record."sumOpen" + fill_amount);
+            entry_price = dydx_get_weighted_average(
+                    perpetual_position_record."entryPrice", perpetual_position_record."sumOpen",
+                    maker_price, fill_amount);
+            perpetual_position_record."sumOpen" = sum_open;
+            perpetual_position_record."entryPrice" = entry_price;
+        ELSE
+            sum_close = dydx_trim_scale(perpetual_position_record."sumClose" + fill_amount);
+            exit_price = dydx_get_weighted_average(
+                    perpetual_position_record."exitPrice", perpetual_position_record."sumClose",
+                    maker_price, fill_amount);
+            perpetual_position_record."sumClose" = sum_close;
+            perpetual_position_record."exitPrice" = exit_price;
+        END IF;
+        UPDATE perpetual_positions
+        SET
+            "sumOpen" = sum_open,
+            "entryPrice" = entry_price,
+            "sumClose" = sum_close,
+            "exitPrice" = exit_price
+        WHERE "id" = perpetual_position_record.id;
+    END;
+
+    IF field = 'makerOrder' THEN
+        RETURN jsonb_build_object(
+                'order',
+                dydx_to_jsonb(order_record),
+                'fill',
+                dydx_to_jsonb(fill_record),
+                'perpetual_market',
+                dydx_to_jsonb(perpetual_market_record),
+                'perpetual_position',
+                dydx_to_jsonb(perpetual_position_record)
+            );
+    ELSE
+        RETURN jsonb_build_object(
+                'fill',
+                dydx_to_jsonb(fill_record),
+                'perpetual_market',
+                dydx_to_jsonb(perpetual_market_record),
+                'perpetual_position',
+                dydx_to_jsonb(perpetual_position_record)
+            );
+    END IF;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
### Changelist
[IND-465] Add support for liquidation handler to use a single SQL function.

Also fix fill and order models since clientMetadata is a nullable field.

### Test Plan
New tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
