### PR TITLE
[CORE-666] - Implement liquidations healthcheck

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -603,7 +603,7 @@ func New(
 			app.Server.ExpectLiquidationsDaemon(
 				daemonservertypes.MaximumAcceptableUpdateDelay(daemonFlags.Liquidation.LoopDelayMs),
 			)
-			app.LiquidationsClient = liquidationclient.NewClient()
+			app.LiquidationsClient = liquidationclient.NewClient(logger)
 			go func() {
 				if err := app.LiquidationsClient.Start(
 					// The client will use `context.Background` so that it can have a different context from
@@ -611,7 +611,6 @@ func New(
 					context.Background(),
 					daemonFlags,
 					appFlags,
-					logger,
 					&daemontypes.GrpcClientImpl{},
 				); err != nil {
 					panic(err)

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -288,7 +288,8 @@ type App struct {
 	// can correctly operate.
 	startDaemons func()
 
-	PriceFeedClient *pricefeedclient.Client
+	PriceFeedClient    *pricefeedclient.Client
+	LiquidationsClient *liquidationclient.Client
 }
 
 // assertAppPreconditions assert invariants required for an application to start.
@@ -602,8 +603,9 @@ func New(
 			app.Server.ExpectLiquidationsDaemon(
 				daemonservertypes.MaximumAcceptableUpdateDelay(daemonFlags.Liquidation.LoopDelayMs),
 			)
+			app.LiquidationsClient = liquidationclient.NewClient()
 			go func() {
-				if err := liquidationclient.Start(
+				if err := app.LiquidationsClient.Start(
 					// The client will use `context.Background` so that it can have a different context from
 					// the main application.
 					context.Background(),

--- a/protocol/app/app_test.go
+++ b/protocol/app/app_test.go
@@ -97,11 +97,17 @@ func TestAppIsFullyInitialized(t *testing.T) {
 			tApp.InitChain()
 			uninitializedFields := getUninitializedStructFields(reflect.ValueOf(*tApp.App))
 
-			// Note that the PriceFeedClient is currently hard coded as disabled in GetDefaultTestAppOptions.
-			// Normally it would be only disabled for non-validating full nodes or for nodes where the
-			// price feed client is explicitly disabled.
-			if idx := slices.Index(uninitializedFields, "PriceFeedClient"); idx >= 0 {
-				slices.Remove(&uninitializedFields, idx)
+			// Note that the daemon clients are currently hard coded as disabled in GetDefaultTestAppOptions.
+			// Normally they would be only disabled for non-validating full nodes or for nodes where any
+			// daemon is explicitly disabled.
+			expectedUninitializedFields := []string{
+				"PriceFeedClient",
+				"LiquidationsClient",
+			}
+			for _, field := range expectedUninitializedFields {
+				if idx := slices.Index(uninitializedFields, field); idx >= 0 {
+					slices.Remove(&uninitializedFields, idx)
+				}
 			}
 
 			require.Len(

--- a/protocol/daemons/liquidation/client/client.go
+++ b/protocol/daemons/liquidation/client/client.go
@@ -35,6 +35,7 @@ func NewClient(logger log.Logger) *Client {
 			&timelib.TimeProviderImpl{},
 			logger,
 		),
+		logger: logger,
 	}
 }
 
@@ -117,6 +118,7 @@ func StartLiquidationsDaemonTaskLoop(
 		select {
 		case <-ticker.C:
 			if err := s.RunLiquidationDaemonTaskLoop(
+				client,
 				ctx,
 				flags.Liquidation,
 				subaccountQueryClient,

--- a/protocol/daemons/liquidation/client/client.go
+++ b/protocol/daemons/liquidation/client/client.go
@@ -2,28 +2,43 @@ package client
 
 import (
 	"context"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/server/types"
+	timelib "github.com/dydxprotocol/v4-chain/protocol/lib/time"
 	"time"
 
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
-
-	gometrics "github.com/armon/go-metrics"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/cosmos/cosmos-sdk/telemetry"
-	"github.com/cosmos/cosmos-sdk/types/query"
 	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/api"
 	daemontypes "github.com/dydxprotocol/v4-chain/protocol/daemons/types"
-	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
+
+// Client implements a daemon service client that periodically queries a gRPC server for all liquidatable subaccounts
+// and reports them back to the protocol via the daemon server.
+type Client struct {
+	// include HealthCheckable to track the health of the daemon.
+	daemontypes.HealthCheckable
+}
+
+// Ensure Client implements the HealthCheckable interface.
+var _ daemontypes.HealthCheckable = (*Client)(nil)
+
+func NewClient() *Client {
+	return &Client{
+		HealthCheckable: daemontypes.NewTimeBoundedHealthCheckable(
+			types.LiquidationsDaemonServiceName,
+			&timelib.TimeProviderImpl{},
+		),
+	}
+}
 
 // Start begins a job that periodically:
 // 1) Queries a gRPC server for all subaccounts including their open positions.
 // 2) Checks collateralization statuses of subaccounts with at least one open position.
 // 3) Sends a list of subaccount ids that potentially need to be liquidated to the application.
-func Start(
+func (c *Client) Start(
 	ctx context.Context,
 	flags flags.DaemonFlags,
 	appFlags appflags.Flags,
@@ -65,262 +80,56 @@ func Start(
 	liquidationServiceClient := api.NewLiquidationServiceClient(daemonConn)
 
 	ticker := time.NewTicker(time.Duration(flags.Liquidation.LoopDelayMs) * time.Millisecond)
-	for ; true; <-ticker.C {
-		if err := RunLiquidationDaemonTaskLoop(
-			ctx,
-			flags.Liquidation,
-			subaccountQueryClient,
-			clobQueryClient,
-			liquidationServiceClient,
-		); err != nil {
-			// TODO(DEC-947): Move daemon shutdown to application.
-			logger.Error("Liquidations daemon returned error", "error", err)
-		}
-	}
+	done := make(chan bool)
+
+	s := &SubTaskRunnerImpl{}
+	StartLiquidationsDaemonTaskLoop(
+		c,
+		ctx,
+		s,
+		flags,
+		ticker,
+		done,
+		subaccountQueryClient,
+		clobQueryClient,
+		liquidationServiceClient,
+		logger,
+	)
 
 	return nil
 }
 
-// RunLiquidationDaemonTaskLoop contains the logic to communicate with various gRPC services
-// to find the liquidatable subaccount ids.
-func RunLiquidationDaemonTaskLoop(
+// StartLiquidationsDaemonTaskLoop contains the logic to periodically run the liquidations daemon task.
+func StartLiquidationsDaemonTaskLoop(
+	client *Client,
 	ctx context.Context,
-	liqFlags flags.LiquidationFlags,
+	s SubTaskRunner,
+	flags flags.DaemonFlags,
+	ticker *time.Ticker,
+	done <-chan bool,
 	subaccountQueryClient satypes.QueryClient,
 	clobQueryClient clobtypes.QueryClient,
 	liquidationServiceClient api.LiquidationServiceClient,
-) error {
-	defer telemetry.ModuleMeasureSince(
-		metrics.LiquidationDaemon,
-		time.Now(),
-		metrics.MainTaskLoop,
-		metrics.Latency,
-	)
-
-	// 1. Fetch all subaccounts from query service.
-	subaccounts, err := GetAllSubaccounts(
-		ctx,
-		subaccountQueryClient,
-		liqFlags.SubaccountPageLimit,
-	)
-	if err != nil {
-		return err
-	}
-
-	// 2. Check collateralization statuses of subaccounts with at least one open position.
-	liquidatableSubaccountIds, err := GetLiquidatableSubaccountIds(
-		ctx,
-		clobQueryClient,
-		liqFlags,
-		subaccounts,
-	)
-	if err != nil {
-		return err
-	}
-
-	// 3. Send the list of liquidatable subaccount ids to the daemon server.
-	err = SendLiquidatableSubaccountIds(
-		ctx,
-		liquidationServiceClient,
-		liquidatableSubaccountIds,
-	)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// GetAllSubaccounts queries a gRPC server and returns a list of subaccounts and
-// their balances and open positions.
-func GetAllSubaccounts(
-	ctx context.Context,
-	client satypes.QueryClient,
-	limit uint64,
-) (
-	subaccounts []satypes.Subaccount,
-	err error,
+	logger log.Logger,
 ) {
-	defer telemetry.ModuleMeasureSince(metrics.LiquidationDaemon, time.Now(), metrics.GetAllSubaccounts, metrics.Latency)
-	subaccounts = make([]satypes.Subaccount, 0)
-
-	var nextKey []byte
 	for {
-		subaccountsFromKey, next, err := getSubaccountsFromKey(
-			ctx,
-			client,
-			limit,
-			nextKey,
-		)
-
-		if err != nil {
-			return nil, err
-		}
-
-		subaccounts = append(subaccounts, subaccountsFromKey...)
-		nextKey = next
-
-		if len(nextKey) == 0 {
-			break
-		}
-	}
-
-	telemetry.ModuleSetGauge(
-		metrics.LiquidationDaemon,
-		float32(len(subaccounts)),
-		metrics.GetAllSubaccounts,
-		metrics.Count,
-	)
-
-	return subaccounts, nil
-}
-
-// GetLiquidatableSubaccountIds verifies collateralization statuses of subaccounts with
-// at least one open position and returns a list of unique and potentially liquidatable subaccount ids.
-func GetLiquidatableSubaccountIds(
-	ctx context.Context,
-	client clobtypes.QueryClient,
-	liqFlags flags.LiquidationFlags,
-	subaccounts []satypes.Subaccount,
-) (
-	liquidatableSubaccountIds []satypes.SubaccountId,
-	err error,
-) {
-	defer telemetry.ModuleMeasureSince(
-		metrics.LiquidationDaemon,
-		time.Now(),
-		metrics.GetLiquidatableSubaccountIds,
-		metrics.Latency,
-	)
-
-	// Filter out subaccounts with no open positions.
-	subaccountsToCheck := make([]satypes.SubaccountId, 0)
-	for _, subaccount := range subaccounts {
-		if len(subaccount.PerpetualPositions) > 0 {
-			subaccountsToCheck = append(subaccountsToCheck, *subaccount.Id)
-		}
-	}
-
-	telemetry.ModuleSetGauge(
-		metrics.LiquidationDaemon,
-		float32(len(subaccountsToCheck)),
-		metrics.SubaccountsWithOpenPositions,
-		metrics.Count,
-	)
-
-	// Query the gRPC server in chunks of size `liqFlags.RequestChunkSize`.
-	liquidatableSubaccountIds = make([]satypes.SubaccountId, 0)
-	for start := 0; start < len(subaccountsToCheck); start += int(liqFlags.RequestChunkSize) {
-		end := lib.Min(start+int(liqFlags.RequestChunkSize), len(subaccountsToCheck))
-
-		results, err := CheckCollateralizationForSubaccounts(
-			ctx,
-			client,
-			subaccountsToCheck[start:end],
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, result := range results {
-			if result.IsLiquidatable {
-				liquidatableSubaccountIds = append(liquidatableSubaccountIds, result.SubaccountId)
+		select {
+		case <-ticker.C:
+			if err := s.RunLiquidationDaemonTaskLoop(
+				ctx,
+				flags.Liquidation,
+				subaccountQueryClient,
+				clobQueryClient,
+				liquidationServiceClient,
+			); err != nil {
+				// TODO(DEC-947): Move daemon shutdown to application.
+				logger.Error("Liquidations daemon returned error", "error", err)
+				client.ReportFailure(err)
+			} else {
+				client.ReportSuccess()
 			}
+		case <-done:
+			return
 		}
 	}
-	return liquidatableSubaccountIds, nil
-}
-
-// CheckCollateralizationForSubaccounts queries a gRPC server using `AreSubaccountsLiquidatable`
-// and returns a list of collateralization statuses for the given list of subaccount ids.
-func CheckCollateralizationForSubaccounts(
-	ctx context.Context,
-	client clobtypes.QueryClient,
-	subaccountIds []satypes.SubaccountId,
-) (
-	results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
-	err error,
-) {
-	defer telemetry.ModuleMeasureSince(
-		metrics.LiquidationDaemon,
-		time.Now(),
-		metrics.CheckCollateralizationForSubaccounts,
-		metrics.Latency,
-	)
-
-	query := &clobtypes.AreSubaccountsLiquidatableRequest{
-		SubaccountIds: subaccountIds,
-	}
-	response, err := client.AreSubaccountsLiquidatable(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	return response.Results, nil
-}
-
-// SendLiquidatableSubaccountIds sends a list of unique and potentially liquidatable
-// subaccount ids to a gRPC server via `LiquidateSubaccounts`.
-func SendLiquidatableSubaccountIds(
-	ctx context.Context,
-	client api.LiquidationServiceClient,
-	subaccountIds []satypes.SubaccountId,
-) error {
-	defer telemetry.ModuleMeasureSince(
-		metrics.LiquidationDaemon,
-		time.Now(),
-		metrics.SendLiquidatableSubaccountIds,
-		metrics.Latency,
-	)
-
-	telemetry.ModuleSetGauge(
-		metrics.LiquidationDaemon,
-		float32(len(subaccountIds)),
-		metrics.LiquidatableSubaccountIds,
-		metrics.Count,
-	)
-
-	request := &api.LiquidateSubaccountsRequest{
-		SubaccountIds: subaccountIds,
-	}
-
-	if _, err := client.LiquidateSubaccounts(ctx, request); err != nil {
-		return err
-	}
-	return nil
-}
-
-func getSubaccountsFromKey(
-	ctx context.Context,
-	client satypes.QueryClient,
-	limit uint64,
-	pageRequestKey []byte,
-) (
-	subaccounts []satypes.Subaccount,
-	nextKey []byte,
-	err error,
-) {
-	defer metrics.ModuleMeasureSinceWithLabels(
-		metrics.LiquidationDaemon,
-		[]string{metrics.GetSubaccountsFromKey, metrics.Latency},
-		time.Now(),
-		[]gometrics.Label{
-			metrics.GetLabelForIntValue(metrics.PageLimit, int(limit)),
-		},
-	)
-
-	query := &satypes.QueryAllSubaccountRequest{
-		Pagination: &query.PageRequest{
-			Key:   pageRequestKey,
-			Limit: limit,
-		},
-	}
-
-	response, err := client.SubaccountAll(ctx, query)
-	if err != nil {
-		return nil, nil, err
-	}
-	if response.Pagination != nil {
-		nextKey = response.Pagination.NextKey
-	}
-	return response.Subaccount, nextKey, nil
 }

--- a/protocol/daemons/liquidation/client/client.go
+++ b/protocol/daemons/liquidation/client/client.go
@@ -84,7 +84,7 @@ func (c *Client) Start(
 	liquidationServiceClient := api.NewLiquidationServiceClient(daemonConn)
 
 	ticker := time.NewTicker(time.Duration(flags.Liquidation.LoopDelayMs) * time.Millisecond)
-	done := make(chan bool)
+	stop := make(chan bool)
 
 	s := &SubTaskRunnerImpl{}
 	StartLiquidationsDaemonTaskLoop(
@@ -93,7 +93,7 @@ func (c *Client) Start(
 		s,
 		flags,
 		ticker,
-		done,
+		stop,
 		subaccountQueryClient,
 		clobQueryClient,
 		liquidationServiceClient,
@@ -109,7 +109,7 @@ func StartLiquidationsDaemonTaskLoop(
 	s SubTaskRunner,
 	flags flags.DaemonFlags,
 	ticker *time.Ticker,
-	done <-chan bool,
+	stop <-chan bool,
 	subaccountQueryClient satypes.QueryClient,
 	clobQueryClient clobtypes.QueryClient,
 	liquidationServiceClient api.LiquidationServiceClient,
@@ -131,7 +131,7 @@ func StartLiquidationsDaemonTaskLoop(
 			} else {
 				client.ReportSuccess()
 			}
-		case <-done:
+		case <-stop:
 			return
 		}
 	}

--- a/protocol/daemons/liquidation/client/client.go
+++ b/protocol/daemons/liquidation/client/client.go
@@ -15,8 +15,8 @@ import (
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
-// Client implements a daemon service client that periodically queries a gRPC server for all liquidatable subaccounts
-// and reports them back to the protocol via the daemon server.
+// Client implements a daemon service client that periodically calculates and reports liquidatable subaccounts
+// to the protocol.
 type Client struct {
 	// include HealthCheckable to track the health of the daemon.
 	daemontypes.HealthCheckable

--- a/protocol/daemons/liquidation/client/client_test.go
+++ b/protocol/daemons/liquidation/client/client_test.go
@@ -272,7 +272,7 @@ func (f *FakeSubTaskRunner) RunLiquidationDaemonTaskLoop(
 	return f.err
 }
 
-func TestTopLevelHealthCheck_Mixed(t *testing.T) {
+func TestHealthCheck_Mixed(t *testing.T) {
 	tests := map[string]struct {
 		// taskLoopResponses is a list of errors returned by the task loop. If the error is nil, the task loop is
 		// considered to have succeeded.

--- a/protocol/daemons/liquidation/client/client_test.go
+++ b/protocol/daemons/liquidation/client/client_test.go
@@ -29,14 +29,13 @@ func TestStart_TcpConnectionFails(t *testing.T) {
 	mockGrpcClient := &mocks.GrpcClient{}
 	mockGrpcClient.On("NewTcpConnection", grpc.Ctx, d_constants.DefaultGrpcEndpoint).Return(nil, errors.New(errorMsg))
 
-	liquidationsClient := client.NewClient()
+	liquidationsClient := client.NewClient(log.NewNopLogger())
 	require.EqualError(
 		t,
 		liquidationsClient.Start(
 			grpc.Ctx,
 			flags.GetDefaultDaemonFlags(),
 			appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
-			log.NewNopLogger(),
 			mockGrpcClient,
 		),
 		errorMsg,
@@ -54,14 +53,13 @@ func TestStart_UnixSocketConnectionFails(t *testing.T) {
 	mockGrpcClient.On("NewGrpcConnection", grpc.Ctx, grpc.SocketPath).Return(nil, errors.New(errorMsg))
 	mockGrpcClient.On("CloseConnection", grpc.GrpcConn).Return(nil)
 
-	liquidationsClient := client.NewClient()
+	liquidationsClient := client.NewClient(log.NewNopLogger())
 	require.EqualError(
 		t,
 		liquidationsClient.Start(
 			grpc.Ctx,
 			flags.GetDefaultDaemonFlags(),
 			appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
-			log.NewNopLogger(),
 			mockGrpcClient,
 		),
 		errorMsg,
@@ -300,7 +298,7 @@ func TestHealthCheck_Mixed(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Setup.
-			c := client.NewClient()
+			c := client.NewClient(log.NewNopLogger())
 
 			// Sanity check - the client should be unhealthy before the first successful update.
 			require.ErrorContains(
@@ -324,7 +322,6 @@ func TestHealthCheck_Mixed(t *testing.T) {
 					&mocks.QueryClient{},
 					&mocks.QueryClient{},
 					&mocks.QueryClient{},
-					log.NewNopLogger(),
 				)
 			}
 

--- a/protocol/daemons/liquidation/client/client_test.go
+++ b/protocol/daemons/liquidation/client/client_test.go
@@ -226,7 +226,10 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 			tc.setupMocks(grpc.Ctx, queryClientMock)
 			s := client.SubTaskRunnerImpl{}
 
+			c := client.NewClient(log.NewNopLogger())
+
 			err := s.RunLiquidationDaemonTaskLoop(
+				c,
 				grpc.Ctx,
 				flags.GetDefaultDaemonFlags().Liquidation,
 				queryClientMock,
@@ -258,6 +261,7 @@ func NewFakeSubTaskRunnerWithError(err error) *FakeSubTaskRunner {
 // RunLiquidationDaemonTaskLoop is a mock implementation of the SubTaskRunner interface. It records the
 // call as a sanity check, and returns the error set by NewFakeSubTaskRunnerWithError.
 func (f *FakeSubTaskRunner) RunLiquidationDaemonTaskLoop(
+	_ *client.Client,
 	_ context.Context,
 	_ flags.LiquidationFlags,
 	_ satypes.QueryClient,
@@ -268,7 +272,7 @@ func (f *FakeSubTaskRunner) RunLiquidationDaemonTaskLoop(
 	return f.err
 }
 
-func TestHealthCheck_Mixed(t *testing.T) {
+func TestTopLevelHealthCheck_Mixed(t *testing.T) {
 	tests := map[string]struct {
 		// taskLoopResponses is a list of errors returned by the task loop. If the error is nil, the task loop is
 		// considered to have succeeded.

--- a/protocol/daemons/liquidation/client/client_test.go
+++ b/protocol/daemons/liquidation/client/client_test.go
@@ -3,23 +3,24 @@ package client_test
 import (
 	"context"
 	"errors"
-	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/appoptions"
-	"testing"
-
+	"fmt"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	d_constants "github.com/dydxprotocol/v4-chain/protocol/daemons/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/api"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/client"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/appoptions"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	daemontestutils "github.com/dydxprotocol/v4-chain/protocol/testutil/daemons"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/grpc"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestStart_TcpConnectionFails(t *testing.T) {
@@ -28,9 +29,10 @@ func TestStart_TcpConnectionFails(t *testing.T) {
 	mockGrpcClient := &mocks.GrpcClient{}
 	mockGrpcClient.On("NewTcpConnection", grpc.Ctx, d_constants.DefaultGrpcEndpoint).Return(nil, errors.New(errorMsg))
 
+	liquidationsClient := client.NewClient()
 	require.EqualError(
 		t,
-		client.Start(
+		liquidationsClient.Start(
 			grpc.Ctx,
 			flags.GetDefaultDaemonFlags(),
 			appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
@@ -52,9 +54,10 @@ func TestStart_UnixSocketConnectionFails(t *testing.T) {
 	mockGrpcClient.On("NewGrpcConnection", grpc.Ctx, grpc.SocketPath).Return(nil, errors.New(errorMsg))
 	mockGrpcClient.On("CloseConnection", grpc.GrpcConn).Return(nil)
 
+	liquidationsClient := client.NewClient()
 	require.EqualError(
 		t,
-		client.Start(
+		liquidationsClient.Start(
 			grpc.Ctx,
 			flags.GetDefaultDaemonFlags(),
 			appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
@@ -223,8 +226,9 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			queryClientMock := &mocks.QueryClient{}
 			tc.setupMocks(grpc.Ctx, queryClientMock)
+			s := client.SubTaskRunnerImpl{}
 
-			err := client.RunLiquidationDaemonTaskLoop(
+			err := s.RunLiquidationDaemonTaskLoop(
 				grpc.Ctx,
 				flags.GetDefaultDaemonFlags().Liquidation,
 				queryClientMock,
@@ -241,245 +245,94 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 	}
 }
 
-func TestGetAllSubaccounts(t *testing.T) {
-	df := flags.GetDefaultDaemonFlags()
-	tests := map[string]struct {
-		// mocks
-		setupMocks func(ctx context.Context, mck *mocks.QueryClient)
+// FakeSubTaskRunner is a mock implementation of the SubTaskRunner interface for testing.
+type FakeSubTaskRunner struct {
+	err    error
+	called bool
+}
 
-		// expectations
-		expectedSubaccounts []satypes.Subaccount
-		expectedError       error
-	}{
-		"Success": {
-			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
-				req := &satypes.QueryAllSubaccountRequest{
-					Pagination: &query.PageRequest{
-						Limit: df.Liquidation.SubaccountPageLimit,
-					},
-				}
-				response := &satypes.QuerySubaccountAllResponse{
-					Subaccount: []satypes.Subaccount{
-						constants.Carl_Num0_599USD,
-						constants.Dave_Num0_599USD,
-					},
-				}
-				mck.On("SubaccountAll", ctx, req).Return(response, nil)
-			},
-			expectedSubaccounts: []satypes.Subaccount{
-				constants.Carl_Num0_599USD,
-				constants.Dave_Num0_599USD,
-			},
-		},
-		"Success Paginated": {
-			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
-				req := &satypes.QueryAllSubaccountRequest{
-					Pagination: &query.PageRequest{
-						Limit: df.Liquidation.SubaccountPageLimit,
-					},
-				}
-				nextKey := []byte("next key")
-				response := &satypes.QuerySubaccountAllResponse{
-					Subaccount: []satypes.Subaccount{
-						constants.Carl_Num0_599USD,
-					},
-					Pagination: &query.PageResponse{
-						NextKey: nextKey,
-					},
-				}
-				mck.On("SubaccountAll", ctx, req).Return(response, nil)
-				req2 := &satypes.QueryAllSubaccountRequest{
-					Pagination: &query.PageRequest{
-						Key:   nextKey,
-						Limit: df.Liquidation.SubaccountPageLimit,
-					},
-				}
-				response2 := &satypes.QuerySubaccountAllResponse{
-					Subaccount: []satypes.Subaccount{
-						constants.Dave_Num0_599USD,
-					},
-				}
-				mck.On("SubaccountAll", ctx, req2).Return(response2, nil)
-			},
-			expectedSubaccounts: []satypes.Subaccount{
-				constants.Carl_Num0_599USD,
-				constants.Dave_Num0_599USD,
-			},
-		},
-		"Errors are propagated": {
-			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
-				req := &satypes.QueryAllSubaccountRequest{
-					Pagination: &query.PageRequest{
-						Limit: df.Liquidation.SubaccountPageLimit,
-					},
-				}
-				mck.On("SubaccountAll", ctx, req).Return(nil, errors.New("test error"))
-			},
-			expectedError: errors.New("test error"),
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			queryClientMock := &mocks.QueryClient{}
-			tc.setupMocks(grpc.Ctx, queryClientMock)
-
-			actual, err := client.GetAllSubaccounts(grpc.Ctx, queryClientMock, df.Liquidation.SubaccountPageLimit)
-			if err != nil {
-				require.EqualError(t, err, tc.expectedError.Error())
-			} else {
-				require.Equal(t, tc.expectedSubaccounts, actual)
-			}
-		})
+func NewFakeSubTaskRunnerWithError(err error) *FakeSubTaskRunner {
+	return &FakeSubTaskRunner{
+		err: err,
 	}
 }
 
-func TestCheckCollateralizationForSubaccounts(t *testing.T) {
-	tests := map[string]struct {
-		// mocks
-		setupMocks func(
-			ctx context.Context,
-			mck *mocks.QueryClient,
-			results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
-		)
-		subaccountIds []satypes.SubaccountId
-
-		// expectations
-		expectedResults []clobtypes.AreSubaccountsLiquidatableResponse_Result
-		expectedError   error
-	}{
-		"Success": {
-			setupMocks: func(
-				ctx context.Context,
-				mck *mocks.QueryClient,
-				results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
-			) {
-				query := &clobtypes.AreSubaccountsLiquidatableRequest{
-					SubaccountIds: []satypes.SubaccountId{
-						constants.Alice_Num0,
-						constants.Bob_Num0,
-					},
-				}
-				response := &clobtypes.AreSubaccountsLiquidatableResponse{
-					Results: results,
-				}
-				mck.On("AreSubaccountsLiquidatable", ctx, query).Return(response, nil)
-			},
-			subaccountIds: []satypes.SubaccountId{
-				constants.Alice_Num0,
-				constants.Bob_Num0,
-			},
-			expectedResults: []clobtypes.AreSubaccountsLiquidatableResponse_Result{
-				{
-					SubaccountId:   constants.Alice_Num0,
-					IsLiquidatable: true,
-				},
-				{
-					SubaccountId:   constants.Bob_Num0,
-					IsLiquidatable: false,
-				},
-			},
-		},
-		"Success - Empty": {
-			setupMocks: func(
-				ctx context.Context,
-				mck *mocks.QueryClient,
-				results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
-			) {
-				query := &clobtypes.AreSubaccountsLiquidatableRequest{
-					SubaccountIds: []satypes.SubaccountId{},
-				}
-				response := &clobtypes.AreSubaccountsLiquidatableResponse{
-					Results: results,
-				}
-				mck.On("AreSubaccountsLiquidatable", ctx, query).Return(response, nil)
-			},
-			subaccountIds:   []satypes.SubaccountId{},
-			expectedResults: []clobtypes.AreSubaccountsLiquidatableResponse_Result{},
-		},
-		"Errors are propagated": {
-			setupMocks: func(
-				ctx context.Context,
-				mck *mocks.QueryClient,
-				results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
-			) {
-				query := &clobtypes.AreSubaccountsLiquidatableRequest{
-					SubaccountIds: []satypes.SubaccountId{},
-				}
-				mck.On("AreSubaccountsLiquidatable", ctx, query).Return(nil, errors.New("test error"))
-			},
-			subaccountIds:   []satypes.SubaccountId{},
-			expectedResults: []clobtypes.AreSubaccountsLiquidatableResponse_Result{},
-			expectedError:   errors.New("test error"),
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			queryClientMock := &mocks.QueryClient{}
-			tc.setupMocks(grpc.Ctx, queryClientMock, tc.expectedResults)
-
-			actual, err := client.CheckCollateralizationForSubaccounts(grpc.Ctx, queryClientMock, tc.subaccountIds)
-			if err != nil {
-				require.EqualError(t, err, tc.expectedError.Error())
-			} else {
-				require.Equal(t, tc.expectedResults, actual)
-			}
-		})
-	}
+// RunLiquidationDaemonTaskLoop is a mock implementation of the SubTaskRunner interface. It records the
+// call as a sanity check, and returns the error set by NewFakeSubTaskRunnerWithError.
+func (f *FakeSubTaskRunner) RunLiquidationDaemonTaskLoop(
+	_ context.Context,
+	_ flags.LiquidationFlags,
+	_ satypes.QueryClient,
+	_ clobtypes.QueryClient,
+	_ api.LiquidationServiceClient,
+) error {
+	f.called = true
+	return f.err
 }
 
-func TestSendLiquidatableSubaccountIds(t *testing.T) {
+func TestHealthCheck_Mixed(t *testing.T) {
 	tests := map[string]struct {
-		// mocks
-		setupMocks    func(ctx context.Context, mck *mocks.QueryClient, ids []satypes.SubaccountId)
-		subaccountIds []satypes.SubaccountId
-
-		// expectations
-		expectedError error
+		// taskLoopResponses is a list of errors returned by the task loop. If the error is nil, the task loop is
+		// considered to have succeeded.
+		taskLoopResponses    []error
+		expectedHealthStatus error
 	}{
-		"Success": {
-			setupMocks: func(ctx context.Context, mck *mocks.QueryClient, ids []satypes.SubaccountId) {
-				req := &api.LiquidateSubaccountsRequest{
-					SubaccountIds: ids,
-				}
-				response := &api.LiquidateSubaccountsResponse{}
-				mck.On("LiquidateSubaccounts", ctx, req).Return(response, nil)
+		"Healthy - successful update": {
+			taskLoopResponses: []error{
+				nil, // 1 successful update
 			},
-			subaccountIds: []satypes.SubaccountId{
-				constants.Alice_Num0,
-				constants.Bob_Num0,
-			},
+			expectedHealthStatus: nil, // healthy status
 		},
-		"Success Empty": {
-			setupMocks: func(ctx context.Context, mck *mocks.QueryClient, ids []satypes.SubaccountId) {
-				req := &api.LiquidateSubaccountsRequest{
-					SubaccountIds: ids,
-				}
-				response := &api.LiquidateSubaccountsResponse{}
-				mck.On("LiquidateSubaccounts", ctx, req).Return(response, nil)
+		"Unhealthy - failed update": {
+			taskLoopResponses: []error{
+				fmt.Errorf("failed to update"), // 1 failed update
 			},
-			subaccountIds: []satypes.SubaccountId{},
+			expectedHealthStatus: fmt.Errorf("no successful update has occurred"),
 		},
-		"Errors are propagated": {
-			setupMocks: func(ctx context.Context, mck *mocks.QueryClient, ids []satypes.SubaccountId) {
-				req := &api.LiquidateSubaccountsRequest{
-					SubaccountIds: ids,
-				}
-				mck.On("LiquidateSubaccounts", ctx, req).Return(nil, errors.New("test error"))
+		"Unhealthy - failed update after successful update": {
+			taskLoopResponses: []error{
+				nil,                            // 1 successful update
+				fmt.Errorf("failed to update"), // 1 failed update
 			},
-			subaccountIds: []satypes.SubaccountId{},
-			expectedError: errors.New("test error"),
+			expectedHealthStatus: fmt.Errorf("last update failed"),
 		},
 	}
-
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			queryClientMock := &mocks.QueryClient{}
-			tc.setupMocks(grpc.Ctx, queryClientMock, tc.subaccountIds)
+			// Setup.
+			c := client.NewClient()
 
-			err := client.SendLiquidatableSubaccountIds(grpc.Ctx, queryClientMock, tc.subaccountIds)
-			require.Equal(t, tc.expectedError, err)
+			// Sanity check - the client should be unhealthy before the first successful update.
+			require.ErrorContains(
+				t,
+				c.HealthCheck(),
+				"no successful update has occurred",
+			)
+
+			// Run the sequence of task loop responses.
+			for _, taskLoopError := range tc.taskLoopResponses {
+				ticker, stop := daemontestutils.SingleTickTickerAndStop()
+				// Start the daemon task loop. Since we created a single-tick ticker, this will run for one iteration and
+				// return.
+				client.StartLiquidationsDaemonTaskLoop(
+					c,
+					grpc.Ctx,
+					NewFakeSubTaskRunnerWithError(taskLoopError),
+					flags.GetDefaultDaemonFlags(),
+					ticker,
+					stop,
+					&mocks.QueryClient{},
+					&mocks.QueryClient{},
+					&mocks.QueryClient{},
+					log.NewNopLogger(),
+				)
+			}
+
+			if tc.expectedHealthStatus == nil {
+				require.NoError(t, c.HealthCheck())
+			} else {
+				require.ErrorContains(t, c.HealthCheck(), tc.expectedHealthStatus.Error())
+			}
 		})
 	}
 }

--- a/protocol/daemons/liquidation/client/sub_task_runner.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner.go
@@ -112,6 +112,10 @@ func CheckCollateralizationForSubaccounts(
 	}
 
 	// For the purposes of the health check, log the successful request as an indicator of daemon health.
+	// We log a success after every paginated call in order to provide a more granular view of daemon health.
+	// Request pagination ensures that these queries can be expected to complete in constant time and not
+	// O(# subaccounts), so reporting once per success for all paginated queries provides health update signals
+	// with a consistent frequency.
 	daemon.ReportSuccess()
 
 	return response.Results, nil
@@ -212,6 +216,10 @@ func GetAllSubaccounts(
 		}
 
 		// For the purposes of the health check, log the successful request as an indicator of daemon health.
+		// We log a success after every paginated call in order to provide a more granular view of daemon health.
+		// Request pagination ensures that these queries can be expected to complete in constant time and not
+		// O(# subaccounts), so reporting once per success for all paginated queries provides health update signals
+		// with a consistent frequency.
 		daemon.ReportSuccess()
 
 		subaccounts = append(subaccounts, subaccountsFromKey...)

--- a/protocol/daemons/liquidation/client/sub_task_runner.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner.go
@@ -111,13 +111,6 @@ func CheckCollateralizationForSubaccounts(
 		return nil, err
 	}
 
-	// For the purposes of the health check, log the successful request as an indicator of daemon health.
-	// We log a success after every paginated call in order to provide a more granular view of daemon health.
-	// Request pagination ensures that these queries can be expected to complete in constant time and not
-	// O(# subaccounts), so reporting once per success for all paginated queries provides health update signals
-	// with a consistent frequency.
-	daemon.ReportSuccess()
-
 	return response.Results, nil
 }
 
@@ -214,13 +207,6 @@ func GetAllSubaccounts(
 		if err != nil {
 			return nil, err
 		}
-
-		// For the purposes of the health check, log the successful request as an indicator of daemon health.
-		// We log a success after every paginated call in order to provide a more granular view of daemon health.
-		// Request pagination ensures that these queries can be expected to complete in constant time and not
-		// O(# subaccounts), so reporting once per success for all paginated queries provides health update signals
-		// with a consistent frequency.
-		daemon.ReportSuccess()
 
 		subaccounts = append(subaccounts, subaccountsFromKey...)
 		nextKey = next

--- a/protocol/daemons/liquidation/client/sub_task_runner.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner.go
@@ -1,0 +1,276 @@
+package client
+
+import (
+	"context"
+	gometrics "github.com/armon/go-metrics"
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/api"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"time"
+)
+
+// SubTaskRunner provides an interface that encapsulates the liquidations daemon logic to gather and report
+// potentially liquidatable subaccount ids. This interface is used to mock the daemon logic in tests.
+type SubTaskRunner interface {
+	RunLiquidationDaemonTaskLoop(
+		ctx context.Context,
+		liqFlags flags.LiquidationFlags,
+		subaccountQueryClient satypes.QueryClient,
+		clobQueryClient clobtypes.QueryClient,
+		liquidationServiceClient api.LiquidationServiceClient,
+	) error
+}
+
+type SubTaskRunnerImpl struct{}
+
+// Ensure SubTaskRunnerImpl implements the SubTaskRunner interface.
+var _ SubTaskRunner = (*SubTaskRunnerImpl)(nil)
+
+// RunLiquidationDaemonTaskLoop contains the logic to communicate with various gRPC services
+// to find the liquidatable subaccount ids.
+func (s *SubTaskRunnerImpl) RunLiquidationDaemonTaskLoop(
+	ctx context.Context,
+	liqFlags flags.LiquidationFlags,
+	subaccountQueryClient satypes.QueryClient,
+	clobQueryClient clobtypes.QueryClient,
+	liquidationServiceClient api.LiquidationServiceClient,
+) error {
+	defer telemetry.ModuleMeasureSince(
+		metrics.LiquidationDaemon,
+		time.Now(),
+		metrics.MainTaskLoop,
+		metrics.Latency,
+	)
+
+	// 1. Fetch all subaccounts from query service.
+	subaccounts, err := GetAllSubaccounts(
+		ctx,
+		subaccountQueryClient,
+		liqFlags.SubaccountPageLimit,
+	)
+	if err != nil {
+		return err
+	}
+
+	// 2. Check collateralization statuses of subaccounts with at least one open position.
+	liquidatableSubaccountIds, err := GetLiquidatableSubaccountIds(
+		ctx,
+		clobQueryClient,
+		liqFlags,
+		subaccounts,
+	)
+	if err != nil {
+		return err
+	}
+
+	// 3. Send the list of liquidatable subaccount ids to the daemon server.
+	err = SendLiquidatableSubaccountIds(
+		ctx,
+		liquidationServiceClient,
+		liquidatableSubaccountIds,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CheckCollateralizationForSubaccounts queries a gRPC server using `AreSubaccountsLiquidatable`
+// and returns a list of collateralization statuses for the given list of subaccount ids.
+func CheckCollateralizationForSubaccounts(
+	ctx context.Context,
+	client clobtypes.QueryClient,
+	subaccountIds []satypes.SubaccountId,
+) (
+	results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
+	err error,
+) {
+	defer telemetry.ModuleMeasureSince(
+		metrics.LiquidationDaemon,
+		time.Now(),
+		metrics.CheckCollateralizationForSubaccounts,
+		metrics.Latency,
+	)
+
+	query := &clobtypes.AreSubaccountsLiquidatableRequest{
+		SubaccountIds: subaccountIds,
+	}
+	response, err := client.AreSubaccountsLiquidatable(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return response.Results, nil
+}
+
+// SendLiquidatableSubaccountIds sends a list of unique and potentially liquidatable
+// subaccount ids to a gRPC server via `LiquidateSubaccounts`.
+func SendLiquidatableSubaccountIds(
+	ctx context.Context,
+	client api.LiquidationServiceClient,
+	subaccountIds []satypes.SubaccountId,
+) error {
+	defer telemetry.ModuleMeasureSince(
+		metrics.LiquidationDaemon,
+		time.Now(),
+		metrics.SendLiquidatableSubaccountIds,
+		metrics.Latency,
+	)
+
+	telemetry.ModuleSetGauge(
+		metrics.LiquidationDaemon,
+		float32(len(subaccountIds)),
+		metrics.LiquidatableSubaccountIds,
+		metrics.Count,
+	)
+
+	request := &api.LiquidateSubaccountsRequest{
+		SubaccountIds: subaccountIds,
+	}
+
+	if _, err := client.LiquidateSubaccounts(ctx, request); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getSubaccountsFromKey(
+	ctx context.Context,
+	client satypes.QueryClient,
+	limit uint64,
+	pageRequestKey []byte,
+) (
+	subaccounts []satypes.Subaccount,
+	nextKey []byte,
+	err error,
+) {
+	defer metrics.ModuleMeasureSinceWithLabels(
+		metrics.LiquidationDaemon,
+		[]string{metrics.GetSubaccountsFromKey, metrics.Latency},
+		time.Now(),
+		[]gometrics.Label{
+			metrics.GetLabelForIntValue(metrics.PageLimit, int(limit)),
+		},
+	)
+
+	query := &satypes.QueryAllSubaccountRequest{
+		Pagination: &query.PageRequest{
+			Key:   pageRequestKey,
+			Limit: limit,
+		},
+	}
+
+	response, err := client.SubaccountAll(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	if response.Pagination != nil {
+		nextKey = response.Pagination.NextKey
+	}
+	return response.Subaccount, nextKey, nil
+}
+
+// GetAllSubaccounts queries a gRPC server and returns a list of subaccounts and
+// their balances and open positions.
+func GetAllSubaccounts(
+	ctx context.Context,
+	client satypes.QueryClient,
+	limit uint64,
+) (
+	subaccounts []satypes.Subaccount,
+	err error,
+) {
+	defer telemetry.ModuleMeasureSince(metrics.LiquidationDaemon, time.Now(), metrics.GetAllSubaccounts, metrics.Latency)
+	subaccounts = make([]satypes.Subaccount, 0)
+
+	var nextKey []byte
+	for {
+		subaccountsFromKey, next, err := getSubaccountsFromKey(
+			ctx,
+			client,
+			limit,
+			nextKey,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		subaccounts = append(subaccounts, subaccountsFromKey...)
+		nextKey = next
+
+		if len(nextKey) == 0 {
+			break
+		}
+	}
+
+	telemetry.ModuleSetGauge(
+		metrics.LiquidationDaemon,
+		float32(len(subaccounts)),
+		metrics.GetAllSubaccounts,
+		metrics.Count,
+	)
+
+	return subaccounts, nil
+}
+
+// GetLiquidatableSubaccountIds verifies collateralization statuses of subaccounts with
+// at least one open position and returns a list of unique and potentially liquidatable subaccount ids.
+func GetLiquidatableSubaccountIds(
+	ctx context.Context,
+	client clobtypes.QueryClient,
+	liqFlags flags.LiquidationFlags,
+	subaccounts []satypes.Subaccount,
+) (
+	liquidatableSubaccountIds []satypes.SubaccountId,
+	err error,
+) {
+	defer telemetry.ModuleMeasureSince(
+		metrics.LiquidationDaemon,
+		time.Now(),
+		metrics.GetLiquidatableSubaccountIds,
+		metrics.Latency,
+	)
+
+	// Filter out subaccounts with no open positions.
+	subaccountsToCheck := make([]satypes.SubaccountId, 0)
+	for _, subaccount := range subaccounts {
+		if len(subaccount.PerpetualPositions) > 0 {
+			subaccountsToCheck = append(subaccountsToCheck, *subaccount.Id)
+		}
+	}
+
+	telemetry.ModuleSetGauge(
+		metrics.LiquidationDaemon,
+		float32(len(subaccountsToCheck)),
+		metrics.SubaccountsWithOpenPositions,
+		metrics.Count,
+	)
+
+	// Query the gRPC server in chunks of size `liqFlags.RequestChunkSize`.
+	liquidatableSubaccountIds = make([]satypes.SubaccountId, 0)
+	for start := 0; start < len(subaccountsToCheck); start += int(liqFlags.RequestChunkSize) {
+		end := lib.Min(start+int(liqFlags.RequestChunkSize), len(subaccountsToCheck))
+
+		results, err := CheckCollateralizationForSubaccounts(
+			ctx,
+			client,
+			subaccountsToCheck[start:end],
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, result := range results {
+			if result.IsLiquidatable {
+				liquidatableSubaccountIds = append(liquidatableSubaccountIds, result.SubaccountId)
+			}
+		}
+	}
+	return liquidatableSubaccountIds, nil
+}

--- a/protocol/daemons/liquidation/client/sub_task_runner_test.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner_test.go
@@ -17,6 +17,10 @@ import (
 	"testing"
 )
 
+const (
+	daemonInitializingErrorString = "no successful update has occurred"
+)
+
 func TestGetAllSubaccounts(t *testing.T) {
 	df := flags.GetDefaultDaemonFlags()
 	tests := map[string]struct {
@@ -111,7 +115,7 @@ func TestGetAllSubaccounts(t *testing.T) {
 				require.EqualError(t, err, tc.expectedError.Error())
 				// The daemon initializes as unhealthy.
 				// If a request fails, the daemon will not be toggled to healthy.
-				require.Error(t, daemonClient.HealthCheck())
+				require.ErrorContains(t, daemonClient.HealthCheck(), daemonInitializingErrorString)
 			} else {
 				require.Equal(t, tc.expectedSubaccounts, actual)
 				// If the request(s) succeeded, expect a healthy daemon.
@@ -218,7 +222,7 @@ func TestCheckCollateralizationForSubaccounts(t *testing.T) {
 				require.EqualError(t, err, tc.expectedError.Error())
 				// The daemon initializes as unhealthy.
 				// If a request fails, the daemon will not be toggled to healthy.
-				require.Error(t, daemon.HealthCheck())
+				require.ErrorContains(t, daemon.HealthCheck(), daemonInitializingErrorString)
 			} else {
 				require.Equal(t, tc.expectedResults, actual)
 				// If the request(s) succeeded, expect a healthy daemon.

--- a/protocol/daemons/liquidation/client/sub_task_runner_test.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner_test.go
@@ -17,10 +17,6 @@ import (
 	"testing"
 )
 
-const (
-	daemonInitializingErrorString = "no successful update has occurred"
-)
-
 func TestGetAllSubaccounts(t *testing.T) {
 	df := flags.GetDefaultDaemonFlags()
 	tests := map[string]struct {
@@ -113,13 +109,8 @@ func TestGetAllSubaccounts(t *testing.T) {
 			)
 			if err != nil {
 				require.EqualError(t, err, tc.expectedError.Error())
-				// The daemon initializes as unhealthy.
-				// If a request fails, the daemon will not be toggled to healthy.
-				require.ErrorContains(t, daemonClient.HealthCheck(), daemonInitializingErrorString)
 			} else {
 				require.Equal(t, tc.expectedSubaccounts, actual)
-				// If the request(s) succeeded, expect a healthy daemon.
-				require.NoError(t, daemonClient.HealthCheck())
 			}
 		})
 	}
@@ -220,13 +211,8 @@ func TestCheckCollateralizationForSubaccounts(t *testing.T) {
 
 			if err != nil {
 				require.EqualError(t, err, tc.expectedError.Error())
-				// The daemon initializes as unhealthy.
-				// If a request fails, the daemon will not be toggled to healthy.
-				require.ErrorContains(t, daemon.HealthCheck(), daemonInitializingErrorString)
 			} else {
 				require.Equal(t, tc.expectedResults, actual)
-				// If the request(s) succeeded, expect a healthy daemon.
-				require.NoError(t, daemon.HealthCheck())
 			}
 		})
 	}

--- a/protocol/daemons/liquidation/client/sub_task_runner_test.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner_test.go
@@ -1,0 +1,260 @@
+package client_test
+
+import (
+	"context"
+	"errors"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/api"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/client"
+	"github.com/dydxprotocol/v4-chain/protocol/mocks"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/grpc"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGetAllSubaccounts(t *testing.T) {
+	df := flags.GetDefaultDaemonFlags()
+	tests := map[string]struct {
+		// mocks
+		setupMocks func(ctx context.Context, mck *mocks.QueryClient)
+
+		// expectations
+		expectedSubaccounts []satypes.Subaccount
+		expectedError       error
+	}{
+		"Success": {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
+				req := &satypes.QueryAllSubaccountRequest{
+					Pagination: &query.PageRequest{
+						Limit: df.Liquidation.SubaccountPageLimit,
+					},
+				}
+				response := &satypes.QuerySubaccountAllResponse{
+					Subaccount: []satypes.Subaccount{
+						constants.Carl_Num0_599USD,
+						constants.Dave_Num0_599USD,
+					},
+				}
+				mck.On("SubaccountAll", ctx, req).Return(response, nil)
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				constants.Carl_Num0_599USD,
+				constants.Dave_Num0_599USD,
+			},
+		},
+		"Success Paginated": {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
+				req := &satypes.QueryAllSubaccountRequest{
+					Pagination: &query.PageRequest{
+						Limit: df.Liquidation.SubaccountPageLimit,
+					},
+				}
+				nextKey := []byte("next key")
+				response := &satypes.QuerySubaccountAllResponse{
+					Subaccount: []satypes.Subaccount{
+						constants.Carl_Num0_599USD,
+					},
+					Pagination: &query.PageResponse{
+						NextKey: nextKey,
+					},
+				}
+				mck.On("SubaccountAll", ctx, req).Return(response, nil)
+				req2 := &satypes.QueryAllSubaccountRequest{
+					Pagination: &query.PageRequest{
+						Key:   nextKey,
+						Limit: df.Liquidation.SubaccountPageLimit,
+					},
+				}
+				response2 := &satypes.QuerySubaccountAllResponse{
+					Subaccount: []satypes.Subaccount{
+						constants.Dave_Num0_599USD,
+					},
+				}
+				mck.On("SubaccountAll", ctx, req2).Return(response2, nil)
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				constants.Carl_Num0_599USD,
+				constants.Dave_Num0_599USD,
+			},
+		},
+		"Errors are propagated": {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
+				req := &satypes.QueryAllSubaccountRequest{
+					Pagination: &query.PageRequest{
+						Limit: df.Liquidation.SubaccountPageLimit,
+					},
+				}
+				mck.On("SubaccountAll", ctx, req).Return(nil, errors.New("test error"))
+			},
+			expectedError: errors.New("test error"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			queryClientMock := &mocks.QueryClient{}
+			tc.setupMocks(grpc.Ctx, queryClientMock)
+
+			actual, err := client.GetAllSubaccounts(grpc.Ctx, queryClientMock, df.Liquidation.SubaccountPageLimit)
+			if err != nil {
+				require.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				require.Equal(t, tc.expectedSubaccounts, actual)
+			}
+		})
+	}
+}
+
+func TestCheckCollateralizationForSubaccounts(t *testing.T) {
+	tests := map[string]struct {
+		// mocks
+		setupMocks func(
+			ctx context.Context,
+			mck *mocks.QueryClient,
+			results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
+		)
+		subaccountIds []satypes.SubaccountId
+
+		// expectations
+		expectedResults []clobtypes.AreSubaccountsLiquidatableResponse_Result
+		expectedError   error
+	}{
+		"Success": {
+			setupMocks: func(
+				ctx context.Context,
+				mck *mocks.QueryClient,
+				results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
+			) {
+				query := &clobtypes.AreSubaccountsLiquidatableRequest{
+					SubaccountIds: []satypes.SubaccountId{
+						constants.Alice_Num0,
+						constants.Bob_Num0,
+					},
+				}
+				response := &clobtypes.AreSubaccountsLiquidatableResponse{
+					Results: results,
+				}
+				mck.On("AreSubaccountsLiquidatable", ctx, query).Return(response, nil)
+			},
+			subaccountIds: []satypes.SubaccountId{
+				constants.Alice_Num0,
+				constants.Bob_Num0,
+			},
+			expectedResults: []clobtypes.AreSubaccountsLiquidatableResponse_Result{
+				{
+					SubaccountId:   constants.Alice_Num0,
+					IsLiquidatable: true,
+				},
+				{
+					SubaccountId:   constants.Bob_Num0,
+					IsLiquidatable: false,
+				},
+			},
+		},
+		"Success - Empty": {
+			setupMocks: func(
+				ctx context.Context,
+				mck *mocks.QueryClient,
+				results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
+			) {
+				query := &clobtypes.AreSubaccountsLiquidatableRequest{
+					SubaccountIds: []satypes.SubaccountId{},
+				}
+				response := &clobtypes.AreSubaccountsLiquidatableResponse{
+					Results: results,
+				}
+				mck.On("AreSubaccountsLiquidatable", ctx, query).Return(response, nil)
+			},
+			subaccountIds:   []satypes.SubaccountId{},
+			expectedResults: []clobtypes.AreSubaccountsLiquidatableResponse_Result{},
+		},
+		"Errors are propagated": {
+			setupMocks: func(
+				ctx context.Context,
+				mck *mocks.QueryClient,
+				results []clobtypes.AreSubaccountsLiquidatableResponse_Result,
+			) {
+				query := &clobtypes.AreSubaccountsLiquidatableRequest{
+					SubaccountIds: []satypes.SubaccountId{},
+				}
+				mck.On("AreSubaccountsLiquidatable", ctx, query).Return(nil, errors.New("test error"))
+			},
+			subaccountIds:   []satypes.SubaccountId{},
+			expectedResults: []clobtypes.AreSubaccountsLiquidatableResponse_Result{},
+			expectedError:   errors.New("test error"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			queryClientMock := &mocks.QueryClient{}
+			tc.setupMocks(grpc.Ctx, queryClientMock, tc.expectedResults)
+
+			actual, err := client.CheckCollateralizationForSubaccounts(grpc.Ctx, queryClientMock, tc.subaccountIds)
+			if err != nil {
+				require.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				require.Equal(t, tc.expectedResults, actual)
+			}
+		})
+	}
+}
+
+func TestSendLiquidatableSubaccountIds(t *testing.T) {
+	tests := map[string]struct {
+		// mocks
+		setupMocks    func(ctx context.Context, mck *mocks.QueryClient, ids []satypes.SubaccountId)
+		subaccountIds []satypes.SubaccountId
+
+		// expectations
+		expectedError error
+	}{
+		"Success": {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient, ids []satypes.SubaccountId) {
+				req := &api.LiquidateSubaccountsRequest{
+					SubaccountIds: ids,
+				}
+				response := &api.LiquidateSubaccountsResponse{}
+				mck.On("LiquidateSubaccounts", ctx, req).Return(response, nil)
+			},
+			subaccountIds: []satypes.SubaccountId{
+				constants.Alice_Num0,
+				constants.Bob_Num0,
+			},
+		},
+		"Success Empty": {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient, ids []satypes.SubaccountId) {
+				req := &api.LiquidateSubaccountsRequest{
+					SubaccountIds: ids,
+				}
+				response := &api.LiquidateSubaccountsResponse{}
+				mck.On("LiquidateSubaccounts", ctx, req).Return(response, nil)
+			},
+			subaccountIds: []satypes.SubaccountId{},
+		},
+		"Errors are propagated": {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient, ids []satypes.SubaccountId) {
+				req := &api.LiquidateSubaccountsRequest{
+					SubaccountIds: ids,
+				}
+				mck.On("LiquidateSubaccounts", ctx, req).Return(nil, errors.New("test error"))
+			},
+			subaccountIds: []satypes.SubaccountId{},
+			expectedError: errors.New("test error"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			queryClientMock := &mocks.QueryClient{}
+			tc.setupMocks(grpc.Ctx, queryClientMock, tc.subaccountIds)
+
+			err := client.SendLiquidatableSubaccountIds(grpc.Ctx, queryClientMock, tc.subaccountIds)
+			require.Equal(t, tc.expectedError, err)
+		})
+	}
+}

--- a/protocol/daemons/pricefeed/client/client_test.go
+++ b/protocol/daemons/pricefeed/client/client_test.go
@@ -237,12 +237,11 @@ func TestStart_InvalidConfig(t *testing.T) {
 			faketaskRunner.WaitGroup.Add(tc.expectedNumExchangeTasks * 2)
 
 			// Run Start.
-			client := newClient()
+			client := newClient(log.NewNopLogger())
 			err := client.start(
 				grpc_util.Ctx,
 				daemonflags.GetDefaultDaemonFlags(),
 				appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil)),
-				log.NewNopLogger(),
 				tc.mockGrpcClient,
 				tc.exchangeIdToQueryConfig,
 				tc.exchangeIdToExchangeDetails,
@@ -764,7 +763,7 @@ func TestHealthCheck_Mixed(t *testing.T) {
 				Return(nil, tc.updateMarketPricesError).Once()
 
 			ticker, stop := daemontestutils.SingleTickTickerAndStop()
-			client := newClient()
+			client := newClient(log.NewNopLogger())
 
 			// Act.
 			// Run the price updater for a single tick. Expect the daemon to toggle health state based on

--- a/protocol/daemons/pricefeed/client/client_test.go
+++ b/protocol/daemons/pricefeed/client/client_test.go
@@ -784,9 +784,6 @@ func TestHealthCheck_Mixed(t *testing.T) {
 			} else {
 				require.ErrorContains(t, client.HealthCheck(), tc.expectedError.Error())
 			}
-
-			// Cleanup.
-			close(stop)
 		})
 	}
 }

--- a/protocol/daemons/types/health_checkable.go
+++ b/protocol/daemons/types/health_checkable.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"github.com/cometbft/cometbft/libs/log"
 	libtime "github.com/dydxprotocol/v4-chain/protocol/lib/time"
 	"sync"
 	"time"
@@ -61,12 +62,20 @@ type timeBoundedHealthCheckable struct {
 	// timeProvider is the time provider used to determine the current time. This is used for timestamping
 	// creation and checking for update staleness during HealthCheck.
 	timeProvider libtime.TimeProvider
+
+	// logger is the logger used to log errors.
+	logger log.Logger
 }
 
 // NewTimeBoundedHealthCheckable creates a new HealthCheckable instance.
-func NewTimeBoundedHealthCheckable(serviceName string, timeProvider libtime.TimeProvider) HealthCheckable {
+func NewTimeBoundedHealthCheckable(
+	serviceName string,
+	timeProvider libtime.TimeProvider,
+	logger log.Logger,
+) HealthCheckable {
 	hc := &timeBoundedHealthCheckable{
 		timeProvider: timeProvider,
+		logger:       logger,
 	}
 	// Initialize the timeBoudnedHealthCheckable to an unhealthy state by reporting an error.
 	hc.ReportFailure(fmt.Errorf("%v is initializing", serviceName))
@@ -119,12 +128,15 @@ func (h *timeBoundedHealthCheckable) HealthCheck() error {
 
 	// If the last successful update was more than 5 minutes ago, report the specific error.
 	if h.timeProvider.Now().Sub(h.lastSuccessfulUpdate) > MaxAcceptableUpdateDelay {
-		return fmt.Errorf(
-			"last successful update occurred at %v, which is more than %v ago. Last failure occurred at %v with error '%w'",
-			h.lastSuccessfulUpdate,
-			MaxAcceptableUpdateDelay,
-			h.lastFailedUpdate.Timestamp(),
-			h.lastFailedUpdate.Error(),
+		h.logger.Error(
+			fmt.Sprintf(
+				"last successful update occurred at %v, which is more than %v ago. "+
+					"Last failure occurred at %v with error '%v'",
+				h.lastSuccessfulUpdate,
+				MaxAcceptableUpdateDelay,
+				h.lastFailedUpdate.Timestamp(),
+				h.lastFailedUpdate.Error(),
+			),
 		)
 	}
 

--- a/protocol/daemons/types/health_checkable.go
+++ b/protocol/daemons/types/health_checkable.go
@@ -126,7 +126,7 @@ func (h *timeBoundedHealthCheckable) HealthCheck() error {
 		)
 	}
 
-	// If the last successful update was more than 5 minutes ago, report the specific error.
+	// If the last successful update was more than 5 minutes ago, log the specific error.
 	if h.timeProvider.Now().Sub(h.lastSuccessfulUpdate) > MaxAcceptableUpdateDelay {
 		h.logger.Error(
 			fmt.Sprintf(

--- a/protocol/daemons/types/health_checkable_test.go
+++ b/protocol/daemons/types/health_checkable_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"fmt"
+	"github.com/cometbft/cometbft/libs/log"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/types"
 	libtime "github.com/dydxprotocol/v4-chain/protocol/lib/time"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
@@ -100,23 +101,6 @@ func TestHealthCheckableImpl_Mixed(t *testing.T) {
 			healthCheckTime:      Time3,
 			expectedHealthStatus: nil, // expect healthy
 		},
-		"unhealthy: last successful update was more than max delay": {
-			updates: []struct {
-				timestamp time.Time
-				err       error
-			}{
-				{Time1, nil}, // successful update
-			},
-			healthCheckTime: Time_5Minutes_And_2Seconds,
-			expectedHealthStatus: fmt.Errorf(
-				"last successful update occurred at %v, which is more than %v ago. "+
-					"Last failure occurred at %v with error '%w'",
-				Time1,
-				types.MaxAcceptableUpdateDelay,
-				Time0,
-				InitializingStatus,
-			),
-		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -138,6 +122,7 @@ func TestHealthCheckableImpl_Mixed(t *testing.T) {
 			hci := types.NewTimeBoundedHealthCheckable(
 				"test",
 				mockTimeProviderWithTimestamps(timestamps),
+				log.NewNopLogger(),
 			)
 
 			// Act.

--- a/protocol/testutil/daemons/common.go
+++ b/protocol/testutil/daemons/common.go
@@ -20,6 +20,7 @@ func SingleTickTickerAndStop() (*time.Ticker, chan bool) {
 			// Once the single tick is consumed, stop the ticker and signal the stop channel.
 			if len(ticker.C) == 0 {
 				stop <- true
+				close(stop)
 				ticker.Stop()
 				return
 			}


### PR DESCRIPTION
### Changelist
Implement the HealthCheck on the liquidations daemon, complete with refactors that both allow for easier mocking (for the sake of healthcheck unit tests) and prepare the daemon for implementing a Stop method in the future.

#### Daemon behavior
- daemon initializes to unhealthy
- daemon toggles to healthy whenever loop success occurs
 - daemon toggles to unhealthy whenever the task loop returns an error

#### Updates to timeBoundedHealthCheckable:
 - no change but FYI: this shared health tracking type still initializes as unhealthy and updates to healthy when the most recent report was successful
 - change: I removed the logic that toggles the HealthCheckable to unhealthy if the last success report was > 5 minutes old. We now log an error instead.

### Test Plan
Updated existing tests and added a new set of unit tests for health checks. Also added checks in unit tests for existing methods where health success is reported after a successful response of a paginated query.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
