### PR TITLE
[IND-468] Push ender market modify logic to use a single SQL function

### DIFF
--- a/indexer/services/ender/src/config.ts
+++ b/indexer/services/ender/src/config.ts
@@ -32,6 +32,9 @@ export const configSchema = {
   USE_MARKET_CREATE_HANDLER_SQL_FUNCTION: parseBoolean({
     default: true,
   }),
+  USE_MARKET_MODIFY_HANDLER_SQL_FUNCTION: parseBoolean({
+    default: true,
+  }),
   USE_SUBACCOUNT_UPDATE_SQL_FUNCTION: parseBoolean({
     default: true,
   }),

--- a/indexer/services/ender/src/handlers/markets/market-modify-handler.ts
+++ b/indexer/services/ender/src/handlers/markets/market-modify-handler.ts
@@ -19,7 +19,7 @@ export class MarketModifyHandler extends Handler<MarketEventV1> {
 
   public async internalHandle(): Promise<ConsolidatedKafkaEvent[]> {
     logger.info({
-      at: 'MarketCreateHandler#handle',
+      at: 'MarketModifyHandler#handle',
       message: 'Received MarketEvent with MarketCreate.',
       event: this.event,
     });

--- a/indexer/services/ender/src/handlers/markets/market-modify-handler.ts
+++ b/indexer/services/ender/src/handlers/markets/market-modify-handler.ts
@@ -1,9 +1,11 @@
 import { logger } from '@dydxprotocol-indexer/base';
 import {
-  MarketFromDatabase, MarketUpdateObject, MarketTable, marketRefresher,
+  MarketFromDatabase, MarketUpdateObject, MarketTable, marketRefresher, storeHelpers, MarketModel,
 } from '@dydxprotocol-indexer/postgres';
 import { MarketEventV1 } from '@dydxprotocol-indexer/v4-protos';
+import * as pg from 'pg';
 
+import config from '../../config';
 import { ConsolidatedKafkaEvent, MarketModifyEventMessage } from '../../lib/types';
 import { Handler } from '../handler';
 
@@ -17,6 +19,18 @@ export class MarketModifyHandler extends Handler<MarketEventV1> {
 
   public async internalHandle(): Promise<ConsolidatedKafkaEvent[]> {
     logger.info({
+      at: 'MarketCreateHandler#handle',
+      message: 'Received MarketEvent with MarketCreate.',
+      event: this.event,
+    });
+    if (config.USE_MARKET_MODIFY_HANDLER_SQL_FUNCTION) {
+      return this.handleViaSqlFunction();
+    }
+    return this.handleViaKnexQueries();
+  }
+
+  private async handleViaKnexQueries(): Promise<ConsolidatedKafkaEvent[]> {
+    logger.info({
       at: 'MarketModifyHandler#handle',
       message: 'Received MarketEvent with MarketModify.',
       event: this.event,
@@ -29,6 +43,42 @@ export class MarketModifyHandler extends Handler<MarketEventV1> {
       this.updateMarketFromEvent(castedMarketModifyMessage),
       this.generateTimingStatsOptions('update_market'),
     );
+    return [];
+  }
+
+  private async handleViaSqlFunction(): Promise<ConsolidatedKafkaEvent[]> {
+    const eventDataBinary: Uint8Array = this.indexerTendermintEvent.dataBytes;
+    const result: pg.QueryResult = await storeHelpers.rawQuery(
+      `SELECT dydx_market_modify_handler(
+        '${JSON.stringify(MarketEventV1.decode(eventDataBinary))}' 
+      ) AS result;`,
+      { txId: this.txId },
+    ).catch((error: Error) => {
+      logger.error({
+        at: 'MarketModifyHandler#handleViaSqlFunction',
+        message: 'Failed to handle MarketEventV1',
+        error,
+      });
+
+      const castedMarketModifyMessage:
+      MarketModifyEventMessage = this.event as MarketModifyEventMessage;
+
+      if (error.message.includes('Market in MarketModify doesn\'t exist')) {
+        this.logAndThrowParseMessageError(
+          'Market in MarketModify doesn\'t exist',
+          { castedMarketModifyMessage },
+        );
+      }
+
+      this.logAndThrowParseMessageError(
+        'Failed to update market in markets table',
+        { castedMarketModifyMessage },
+      );
+    });
+
+    const market: MarketFromDatabase = MarketModel.fromJson(
+      result.rows[0].result.market) as MarketFromDatabase;
+    marketRefresher.updateMarket(market);
     return [];
   }
 

--- a/indexer/services/ender/src/helpers/postgres/postgres-functions.ts
+++ b/indexer/services/ender/src/helpers/postgres/postgres-functions.ts
@@ -30,6 +30,7 @@ const scripts: string[] = [
   'create_extension_pg_stat_statements.sql',
   'create_extension_uuid_ossp.sql',
   'dydx_market_create_handler.sql',
+  'dydx_market_modify_handler.sql',
   'dydx_event_id_from_parts.sql',
   'dydx_event_to_transaction_index.sql',
   'dydx_from_jsonlib_long.sql',

--- a/indexer/services/ender/src/scripts/dydx_market_modify_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_market_modify_handler.sql
@@ -1,0 +1,34 @@
+/**
+  Parameters:
+    - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-proto/blob/8d35c86/dydxprotocol/indexer/indexer_manager/event.proto#L25)
+        converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
+  Returns: JSON object containing fields:
+    - market: The updated market in market-model format (https://github.com/dydxprotocol/indexer/blob/cc70982/packages/postgres/src/models/market-model.ts).
+*/
+CREATE OR REPLACE FUNCTION dydx_market_modify_handler(event_data jsonb) RETURNS jsonb AS $$
+DECLARE
+    market_record_id integer;
+    market_record markets%ROWTYPE;
+BEGIN
+    market_record_id = (event_data->'marketId')::integer;
+    SELECT * INTO market_record FROM markets WHERE "id" = market_record_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION E'Market in MarketModify doesn\'t exist. Id: %', market_record_id;
+    END IF;
+
+    market_record."pair" = event_data->'marketModify'->'base'->>'pair';
+    market_record."minPriceChangePpm" = (event_data->'marketModify'->'base'->'minPriceChangePpm')::integer;
+
+    UPDATE markets
+    SET
+        "pair" = market_record."pair",
+        "minPriceChangePpm" = market_record."minPriceChangePpm"
+    WHERE id = market_record."id";
+
+    RETURN jsonb_build_object(
+        'market',
+        dydx_to_jsonb(market_record)
+    );
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
### Changelist
[IND-468] Push ender market modify logic to use a single SQL function

### Test Plan
Updated existing tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
