### PR TITLE
[IND-450]: Prevent orders transitioning from canceled to best effort canceled

### DIFF
--- a/indexer/packages/redis/src/caches/canceled-orders-cache.ts
+++ b/indexer/packages/redis/src/caches/canceled-orders-cache.ts
@@ -100,7 +100,7 @@ export async function addCanceledOrderId(
 }
 
 /**
- * addCanceledOrderId adds the order id to the canceled orders cache.
+ * addCanceledOrderId adds the order id to the cacheKey's cache.
  *
  * @param orderId
  * @param timestamp

--- a/indexer/packages/redis/src/caches/canceled-orders-cache.ts
+++ b/indexer/packages/redis/src/caches/canceled-orders-cache.ts
@@ -1,9 +1,11 @@
 import { Callback, RedisClient } from 'redis';
 
 import { zRemAsync, zScoreAsync } from '../helpers/redis';
+import { CanceledOrderStatus } from '../types';
 import { addCanceledOrderIdScript } from './scripts';
 // Cache of cancelled orders
 export const CANCELED_ORDERS_CACHE_KEY: string = 'v4/cancelled_orders';
+export const BEST_EFFORT_CANCELED_ORDERS_CACHE_KEY: string = 'v4/best_effort_cancelled_orders';
 // 10 seconds in milliseconds
 export const CANCELED_ORDER_WINDOW_SIZE: number = 30 * 1000;
 
@@ -24,16 +26,62 @@ export async function isOrderCanceled(
   orderId: string,
   client: RedisClient,
 ): Promise<boolean> {
-  const score: string | null = await
-  zScoreAsync({ hash: CANCELED_ORDERS_CACHE_KEY, key: orderId }, client);
-  return score !== null;
+  const [
+    canceledScore,
+    bestEffortCanceledScore,
+  ]: (string | null)[] = await Promise.all([
+    zScoreAsync({ hash: CANCELED_ORDERS_CACHE_KEY, key: orderId }, client),
+    zScoreAsync({ hash: BEST_EFFORT_CANCELED_ORDERS_CACHE_KEY, key: orderId }, client),
+  ]);
+  return canceledScore !== null || bestEffortCanceledScore !== null;
 }
 
-export async function removeOrderFromCache(
+export async function getOrderCanceledStatus(
   orderId: string,
   client: RedisClient,
+): Promise<CanceledOrderStatus> {
+  const [
+    canceledScore,
+    bestEffortCanceledScore,
+  ]: (string | null)[] = await Promise.all([
+    zScoreAsync({ hash: CANCELED_ORDERS_CACHE_KEY, key: orderId }, client),
+    zScoreAsync({ hash: BEST_EFFORT_CANCELED_ORDERS_CACHE_KEY, key: orderId }, client),
+  ]);
+
+  if (canceledScore !== null) {
+    return CanceledOrderStatus.CANCELED;
+  }
+
+  if (bestEffortCanceledScore !== null) {
+    return CanceledOrderStatus.BEST_EFFORT_CANCELED;
+  }
+
+  return CanceledOrderStatus.NOT_CANCELED;
+}
+
+export async function removeOrderFromCaches(
+  orderId: string,
+  client: RedisClient,
+): Promise<void> {
+  await Promise.all([
+    zRemAsync({ hash: CANCELED_ORDERS_CACHE_KEY, key: orderId }, client),
+    zRemAsync({ hash: BEST_EFFORT_CANCELED_ORDERS_CACHE_KEY, key: orderId }, client),
+  ]);
+}
+
+/**
+ * addCanceledOrderId adds the order id to the best effort canceled orders cache.
+ *
+ * @param orderId
+ * @param timestamp
+ * @param client
+ */
+export async function addBestEffortCanceledOrderId(
+  orderId: string,
+  timestamp: number,
+  client: RedisClient,
 ): Promise<number> {
-  return zRemAsync({ hash: CANCELED_ORDERS_CACHE_KEY, key: orderId }, client);
+  return addOrderIdtoCache(orderId, timestamp, client, BEST_EFFORT_CANCELED_ORDERS_CACHE_KEY);
 }
 
 /**
@@ -47,6 +95,22 @@ export async function addCanceledOrderId(
   orderId: string,
   timestamp: number,
   client: RedisClient,
+): Promise<number> {
+  return addOrderIdtoCache(orderId, timestamp, client, CANCELED_ORDERS_CACHE_KEY);
+}
+
+/**
+ * addCanceledOrderId adds the order id to the canceled orders cache.
+ *
+ * @param orderId
+ * @param timestamp
+ * @param client
+ */
+export async function addOrderIdtoCache(
+  orderId: string,
+  timestamp: number,
+  client: RedisClient,
+  cacheKey: string,
 ): Promise<number> {
   const numKeys: number = 2;
   let evalAsync: (
@@ -69,7 +133,7 @@ export async function addCanceledOrderId(
       client.evalsha(
         addCanceledOrderIdScript.hash,
         numKeys,
-        CANCELED_ORDERS_CACHE_KEY,
+        cacheKey,
         CANCELED_ORDER_WINDOW_SIZE,
         canceledOrderId,
         currentTimestampMs,

--- a/indexer/packages/redis/src/types.ts
+++ b/indexer/packages/redis/src/types.ts
@@ -67,6 +67,12 @@ export type LuaScript = {
   readonly hash: string;
 };
 
+export enum CanceledOrderStatus {
+  CANCELED = 'CANCELED',
+  BEST_EFFORT_CANCELED = 'BEST_EFFORT_CANCELED',
+  NOT_CANCELED = 'NOT_CANCELED',
+}
+
 /* ------- PNL Creation TYPES ------- */
 export type PnlTickForSubaccounts = {
   // Stores a PnlTicksCreateObject for the most recent pnl tick for each subaccount.

--- a/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
@@ -1511,7 +1511,7 @@ describe('OrderHandler', () => {
     useSqlFunction: boolean,
     timeInForce: IndexerOrder_TimeInForce,
     // either BEST_EFFORT_CANCELED or CANCELED
-    status: OrderStatus = OrderStatus.BEST_EFFORT_CANCELED, 
+    status: OrderStatus = OrderStatus.BEST_EFFORT_CANCELED,
   ) => {
     config.USE_ORDER_HANDLER_SQL_FUNCTION = useSqlFunction;
     const transactionIndex: number = 0;

--- a/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
@@ -1472,35 +1472,30 @@ describe('OrderHandler', () => {
       'via knex',
       false,
       IndexerOrder_TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
-      true,
     ],
     [
       'limit',
       'via SQL function',
       true,
       IndexerOrder_TimeInForce.TIME_IN_FORCE_UNSPECIFIED,
-      true,
     ],
     [
       'post-only best effort canceled',
       'via knex',
       false,
       IndexerOrder_TimeInForce.TIME_IN_FORCE_POST_ONLY,
-      true,
     ],
     [
       'post-only best effort canceled',
       'via SQL function',
       true,
       IndexerOrder_TimeInForce.TIME_IN_FORCE_POST_ONLY,
-      true,
     ],
     [
       'post-only canceled',
       'via knex',
       false,
       IndexerOrder_TimeInForce.TIME_IN_FORCE_POST_ONLY,
-      false,
       OrderStatus.CANCELED,
     ],
     [
@@ -1508,7 +1503,6 @@ describe('OrderHandler', () => {
       'via SQL function',
       true,
       IndexerOrder_TimeInForce.TIME_IN_FORCE_POST_ONLY,
-      false,
       OrderStatus.CANCELED,
     ],
   ])('correctly sets status for short term %s orders (%s)', async (
@@ -1516,8 +1510,8 @@ describe('OrderHandler', () => {
     _name: string,
     useSqlFunction: boolean,
     timeInForce: IndexerOrder_TimeInForce,
-    isBestEffortCanceled: boolean, // either best effort canceled or canceled
-    status: OrderStatus = OrderStatus.BEST_EFFORT_CANCELED,
+    // either BEST_EFFORT_CANCELED or CANCELED
+    status: OrderStatus = OrderStatus.BEST_EFFORT_CANCELED, 
   ) => {
     config.USE_ORDER_HANDLER_SQL_FUNCTION = useSqlFunction;
     const transactionIndex: number = 0;
@@ -1560,9 +1554,9 @@ describe('OrderHandler', () => {
     });
 
     const makerOrderId: string = OrderTable.orderIdToUuid(makerOrderProto.orderId!);
-    if (isBestEffortCanceled === true) {
+    if (status === OrderStatus.BEST_EFFORT_CANCELED) {
       await CanceledOrdersCache.addBestEffortCanceledOrderId(makerOrderId, Date.now(), redisClient);
-    } else {
+    } else { // Status is only over CANCELED or BEST_EFFORT_CANCELED
       await CanceledOrdersCache.addCanceledOrderId(makerOrderId, Date.now(), redisClient);
     }
 

--- a/indexer/services/ender/src/handlers/order-fills/liquidation-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/liquidation-handler.ts
@@ -16,6 +16,7 @@ import {
   USDC_ASSET_ID,
   OrderStatus, FillType,
 } from '@dydxprotocol-indexer/postgres';
+import { CanceledOrderStatus } from '@dydxprotocol-indexer/redis';
 import { isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   LiquidationOrderV1, IndexerOrderId, OrderFillEventV1,
@@ -209,7 +210,7 @@ export class LiquidationHandler extends AbstractOrderFillHandler<OrderFillWithLi
           perpetualMarket,
           castedLiquidationFillEventMessage.makerOrder,
           this.getTotalFilled(castedLiquidationFillEventMessage),
-          false,
+          CanceledOrderStatus.NOT_CANCELED,
         ), this.generateTimingStatsOptions('upsert_maker_order'));
     }
 

--- a/indexer/services/ender/src/scripts/dydx_get_order_status.sql
+++ b/indexer/services/ender/src/scripts/dydx_get_order_status.sql
@@ -1,37 +1,36 @@
 /**
-  Returns the order status given the total filled amount, the order size, whether the order was
-  cancelled, order flags, and time in force.
   * The obvious case is if totalFilled >= size, then the order status should always be `FILLED`.
   * The difficult case is if totalFilled < size after a fill, then we need to keep the following
   * cases in mind:
-  * 1. Stateful Orders - All cancelations are on-chain events, so the order can be `OPEN` or 
-  *    `BEST_EFFORT_CANCELED` if the order is in the CanceledOrdersCache.
+  * 1. Stateful Orders - All cancelations are on-chain events, so the will be `OPEN`. The
+  *     CanceledOrdersCache does not store any stateful orders and we never send
+  *     BEST_EFFORT_CANCELED notifications for stateful orders.
   * 2. Short-term FOK - FOK orders can never be `OPEN`, since they don't rest on the orderbook, so
   *    totalFilled cannot be < size. By the end of the block, the order will be filled, so we mark
   *    it as `FILLED`.
   * 3. Short-term IOC - Protocol guarantees that an IOC order will only ever be filled in a single
   *    block, so status should be `CANCELED`.
   * 4. Short-term Limit & Post-only - If the order is in the CanceledOrdersCache, then it should be
-  *    set to `BEST_EFFORT_CANCELED`, otherwise `OPEN`.
-*/
-CREATE OR REPLACE FUNCTION dydx_get_order_status(total_filled numeric, size numeric, is_cancelled boolean, order_flags bigint, time_in_force text)
+  *    set to the corresponding CanceledOrderStatus, otherwise `OPEN`.
+  * @param isCanceled - if the order is in the CanceledOrderCache, always false for liquidiation
+  * orders
+  */
+CREATE OR REPLACE FUNCTION dydx_get_order_status(total_filled numeric, size numeric, order_canceled_status text, order_flags bigint, time_in_force text)
 RETURNS text AS $$
 BEGIN
     IF total_filled >= size THEN
         RETURN 'FILLED';
     /** Order flag of 64 is a stateful term order */
     ELSIF order_flags = 64 THEN /** 1. Stateful Order */
-        IF is_cancelled THEN
-            RETURN 'BEST_EFFORT_CANCELED';
-        ELSE
-            RETURN 'OPEN';
-        END IF;
+        RETURN 'OPEN';
     ELSIF time_in_force = 'FOK' THEN /** 2. Short-term FOK */
         RETURN 'FILLED';
     ELSIF time_in_force = 'IOC' THEN /** 3. Short-term IOC */
         RETURN 'CANCELED';
-    ELSIF is_cancelled THEN /** 4. Short-term Limit & Postonly */
+    ELSIF order_canceled_status = 'BEST_EFFORT_CANCELED' THEN /** 4. Short-term Limit & Postonly */
         RETURN 'BEST_EFFORT_CANCELED';
+    ELSIF order_canceled_status = 'CANCELED' THEN
+        RETURN 'CANCELED';
     ELSE
         RETURN 'OPEN';
     END IF;

--- a/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
@@ -119,7 +119,7 @@ BEGIN
 
         IF FOUND THEN
             order_record."totalFilled" = total_filled;
-            order_record."status" = dydx_get_order_status(total_filled, order_record.size, false, order_record."orderFlags", order_record."timeInForce");
+            order_record."status" = dydx_get_order_status(total_filled, order_record.size, 'NOT_CANCELED', order_record."orderFlags", order_record."timeInForce");
 
             UPDATE orders
             SET
@@ -145,7 +145,7 @@ BEGIN
             order_record."type" = 'LIMIT';
 
             order_record."totalFilled" = fill_amount;
-            order_record."status" = dydx_get_order_status(fill_amount, order_size, false, order_record."orderFlags", order_record."timeInForce");
+            order_record."status" = dydx_get_order_status(fill_amount, order_size, 'NOT_CANCELED', order_record."orderFlags", order_record."timeInForce");
             order_record."createdAtHeight" = block_height;
             INSERT INTO orders
             ("id", "subaccountId", "clientId", "clobPairId", "side", "size", "totalFilled", "price", "type",

--- a/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
@@ -39,6 +39,7 @@ import {
   redisTestConstants,
   SubaccountOrderIdsCache,
   updateOrder,
+  CanceledOrderStatus,
 } from '@dydxprotocol-indexer/redis';
 import {
   OffChainUpdateV1,
@@ -58,8 +59,7 @@ import { OrderRemoveHandler } from '../../src/handlers/order-remove-handler';
 import { OrderbookSide } from '../../src/lib/types';
 import { redisClient } from '../../src/helpers/redis/redis-controller';
 import {
-  expectCanceledOrdersCacheEmpty,
-  expectCanceledOrdersCacheFound,
+  expectCanceledOrderStatus,
   expectOpenOrderIds,
   expectOrderbookLevelCache,
   handleOrderUpdate,
@@ -308,7 +308,7 @@ describe('OrderRemoveHandler', () => {
         expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
         // Check order is removed from open orders cache
         expectOpenOrderIds(testConstants.defaultPerpetualMarket.clobPairId, []),
-        expectCanceledOrdersCacheFound(expectedOrderUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.CANCELED),
       ]);
 
       // Subaccounts message is sent first followed by orderbooks message
@@ -442,6 +442,7 @@ describe('OrderRemoveHandler', () => {
         expectOrdersCacheEmpty(expectedOrderUuid),
         expectOrdersDataCacheEmpty(removedOrderId),
         expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.BEST_EFFORT_CANCELED),
       ]);
 
       // Subaccounts message is sent first followed by orderbooks message
@@ -577,6 +578,7 @@ describe('OrderRemoveHandler', () => {
           expectOrdersCacheEmpty(expectedOrderUuid),
           expectOrdersDataCacheEmpty(removedOrderId),
           expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+          expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.CANCELED),
         ]);
 
         // Subaccounts message is sent first followed by orderbooks message
@@ -711,6 +713,7 @@ describe('OrderRemoveHandler', () => {
           expectOrdersCacheEmpty(expectedOrderUuid),
           expectOrdersDataCacheEmpty(removedOrderId),
           expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+          expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.CANCELED),
         ]);
 
         // Subaccounts message is sent first followed by orderbooks message
@@ -846,6 +849,7 @@ describe('OrderRemoveHandler', () => {
           expectOrdersCacheEmpty(expectedOrderUuid),
           expectOrdersDataCacheEmpty(removedOrderId),
           expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+          expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.BEST_EFFORT_CANCELED),
         ]);
 
         // no orderbook message because no change in orderbook levels
@@ -928,6 +932,7 @@ describe('OrderRemoveHandler', () => {
           expectOrdersCacheEmpty(expectedOrderUuid),
           expectOrdersDataCacheEmpty(removedOrderId),
           expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+          expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED),
         ]);
 
         // no orderbook message because no change in orderbook levels
@@ -1107,7 +1112,7 @@ describe('OrderRemoveHandler', () => {
         expectOrdersCacheEmpty(expectedOrderUuid),
         expectOrdersDataCacheEmpty(removedOrderId),
         expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
-        expectCanceledOrdersCacheEmpty(expectedOrderUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED),
       ]);
 
       // Subaccounts message is sent first followed by orderbooks message
@@ -1226,6 +1231,7 @@ describe('OrderRemoveHandler', () => {
         expectOrdersCacheEmpty(expectedOrderUuid),
         expectOrdersDataCacheEmpty(removedOrderId),
         expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED),
       ]);
 
       // Subaccounts message is sent first followed by orderbooks message
@@ -1360,6 +1366,7 @@ describe('OrderRemoveHandler', () => {
         expectOrdersCacheEmpty(expectedOrderUuid),
         expectOrdersDataCacheEmpty(removedOrderId),
         expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED),
       ]);
 
       // Subaccounts message is sent first followed by orderbooks message
@@ -1485,6 +1492,7 @@ describe('OrderRemoveHandler', () => {
         expectOrdersCacheEmpty(expectedOrderUuid),
         expectOrdersDataCacheEmpty(removedOrderId),
         expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.CANCELED),
       ]);
 
       // Subaccounts message is sent first followed by orderbooks message
@@ -1602,6 +1610,7 @@ describe('OrderRemoveHandler', () => {
         expectOrdersCacheEmpty(expectedOrderUuid),
         expectOrdersDataCacheEmpty(removedOrderId),
         expectSubaccountsOrderIdsCacheEmpty(redisTestConstants.defaultSubaccountUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.CANCELED),
       ]);
       expectNoWebsocketMessagesSent(producerSendSpy);
       expectTimingStats(true, true);
@@ -1663,6 +1672,7 @@ describe('OrderRemoveHandler', () => {
           expectOrdersCacheFound(expectedOrderUuid),
           expectOrdersDataCacheFound(removedOrderId),
           expectSubaccountsOrderIdsCacheFound(redisTestConstants.defaultSubaccountUuid),
+          expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED),
         ]);
 
         expectTimingStats(false, false, false, false, true);
@@ -1725,6 +1735,7 @@ describe('OrderRemoveHandler', () => {
           expectOrdersCacheFound(expectedOrderUuid),
           expectOrdersDataCacheFound(removedOrderId),
           expectSubaccountsOrderIdsCacheFound(redisTestConstants.defaultSubaccountUuid),
+          expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED),
         ]);
 
         expectTimingStats(false, false, false, false, true, true);
@@ -1804,6 +1815,7 @@ describe('OrderRemoveHandler', () => {
         expectOrdersCacheFound(expectedOrderUuid),
         expectOrdersDataCacheFound(removedOrderId),
         expectSubaccountsOrderIdsCacheFound(redisTestConstants.defaultSubaccountUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED),
       ]);
 
       expectTimingStats(false, false, false, false, true, true);
@@ -1860,6 +1872,7 @@ describe('OrderRemoveHandler', () => {
         expectOrdersCacheFound(expectedOrderUuid),
         expectOrdersDataCacheFound(removedOrderId),
         expectSubaccountsOrderIdsCacheFound(redisTestConstants.defaultSubaccountUuid),
+        expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED),
       ]);
 
       expectTimingStats(false, false, false, false, true, true);

--- a/indexer/services/vulcan/__tests__/helpers/helpers.ts
+++ b/indexer/services/vulcan/__tests__/helpers/helpers.ts
@@ -5,6 +5,7 @@ import {
   redisTestConstants,
   OrderbookLevelsCache,
   CanceledOrdersCache,
+  CanceledOrderStatus,
 } from '@dydxprotocol-indexer/redis';
 import { OffChainUpdateV1 } from '@dydxprotocol-indexer/v4-protos';
 import { KafkaMessage } from 'kafkajs';
@@ -80,16 +81,11 @@ export function setTransactionHash(
   return messageWithTxhash;
 }
 
-export async function expectCanceledOrdersCacheFound(
+export async function expectCanceledOrderStatus(
   orderId: string,
-): Promise<void> {
-  const orderExists: boolean = await CanceledOrdersCache.isOrderCanceled(orderId, redisClient);
-  expect(orderExists).toEqual(true);
-}
-
-export async function expectCanceledOrdersCacheEmpty(
-  orderId: string,
-): Promise<void> {
-  const orderExists: boolean = await CanceledOrdersCache.isOrderCanceled(orderId, redisClient);
-  expect(orderExists).toEqual(false);
+  canceledOrderStatus: CanceledOrderStatus,
+) {
+  expect(await CanceledOrdersCache.getOrderCanceledStatus(orderId, redisClient)).toEqual(
+    canceledOrderStatus,
+  );
 }

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -364,7 +364,7 @@ export class OrderPlaceHandler extends Handler {
     orderId: string,
   ): Promise<void> {
     await runFuncWithTimingStat(
-      CanceledOrdersCache.removeOrderFromCache(orderId, redisClient),
+      CanceledOrdersCache.removeOrderFromCaches(orderId, redisClient),
       this.generateTimingStatsOptions('remove_order_from_cancel_cache'),
     );
   }

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -300,7 +300,7 @@ export class OrderRemoveHandler extends Handler {
     }
     // TODO: consolidate remove handler logic into a single lua script.
     await this.addOrderToCanceledOrdersCache(
-      OrderTable.orderIdToUuid(orderRemove.removedOrderId!),
+      orderRemove,
       Date.now(),
     );
   }
@@ -338,13 +338,28 @@ export class OrderRemoveHandler extends Handler {
    * @protected
    */
   protected async addOrderToCanceledOrdersCache(
-    orderId: string,
+    orderRemove: OrderRemoveV1,
     timestampMs: number,
   ): Promise<void> {
-    await runFuncWithTimingStat(
-      CanceledOrdersCache.addCanceledOrderId(orderId, timestampMs, redisClient),
-      this.generateTimingStatsOptions('add_order_to_canceled_order_cache'),
-    );
+    const orderId: string = OrderTable.orderIdToUuid(orderRemove.removedOrderId!);
+
+    if (
+      orderRemove.removalStatus ===
+      OrderRemoveV1_OrderRemovalStatus.ORDER_REMOVAL_STATUS_BEST_EFFORT_CANCELED
+    ) {
+      await runFuncWithTimingStat(
+        CanceledOrdersCache.addBestEffortCanceledOrderId(orderId, timestampMs, redisClient),
+        this.generateTimingStatsOptions('add_order_to_canceled_order_cache'),
+      );
+    } else if (
+      orderRemove.removalStatus ===
+      OrderRemoveV1_OrderRemovalStatus.ORDER_REMOVAL_STATUS_CANCELED
+    ) {
+      await runFuncWithTimingStat(
+        CanceledOrdersCache.addCanceledOrderId(orderId, timestampMs, redisClient),
+        this.generateTimingStatsOptions('add_order_to_canceled_order_cache'),
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
### Changelist
- Convert CanceledOrdersCache to have a cache for `BEST_EFFORT_CANCELED` and `CANCELED`
- Update vulcan `remove-order-handler.ts` to update CanceledOrdersCache with status
- Update ender's `abstract-order-fill-handler.ts` to update short term GTT and short term post-only orders to the correct status
- Fix bug in ender's `abstract-order-fill-handler.ts` to never set stateful orders to `BEST_EFFORT_CANCELED` because stateful orders are never added to the CanceledOrdersCache in vulcan, and because we never send `BEST_EFFORT_CANCELED` for stateful orders

### Test Plan
Tested in unit tests, verified previous behavior in dev

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
