### PR TITLE
Fix flaky TestQueryPremiumSamples test

### DIFF
--- a/protocol/x/perpetuals/client/cli/query_premiums_test.go
+++ b/protocol/x/perpetuals/client/cli/query_premiums_test.go
@@ -25,8 +25,8 @@ func TestQueryPremiumSamples(t *testing.T) {
 	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 
 	// In CI, we see that PremiumSamples may have NumPremiums set to a non-zero value. Waiting for a block height before
-	// the query does not seem to allow us to reproduce this locally, so we just check that the PremiumSamples are
-	// non-nil and AllMarketPremiums is empty.
+	// the query does not reproduce this locally, so we just check that the response PremiumSamples are non-nil the rest
+	// of the struct is as expected.
 	require.NotNil(t, resp.PremiumSamples)
 	require.Len(t, resp.PremiumSamples.AllMarketPremiums, 0)
 }

--- a/protocol/x/perpetuals/client/cli/query_premiums_test.go
+++ b/protocol/x/perpetuals/client/cli/query_premiums_test.go
@@ -23,9 +23,12 @@ func TestQueryPremiumSamples(t *testing.T) {
 
 	var resp types.QueryPremiumSamplesResponse
 	require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-	require.Equal(t, types.PremiumStore{
-		AllMarketPremiums: []types.MarketPremiums{},
-	}, resp.PremiumSamples)
+
+	// In CI, we see that PremiumSamples may have NumPremiums set to a non-zero value. Waiting for a block height before
+	// the query does not seem to allow us to reproduce this locally, so we just check that the PremiumSamples are
+	// non-nil and AllMarketPremiums is empty.
+	require.NotNil(t, resp.PremiumSamples)
+	require.Len(t, resp.PremiumSamples.AllMarketPremiums, 0)
 }
 
 func TestQueryPremiumVotes(t *testing.T) {


### PR DESCRIPTION
See [bug report](https://dydx-team.slack.com/archives/GTGEVSCUU/p1699386424785019)

### Changelist
The flakiness seems to depend on how long the test takes to run, but I was unable to reproduce the unexpected (NumPremiums occasionally nonzero) by waiting for a specific block ,and I did not want to extend the test case runtime by waiting for a block with a specific timeout. So here, I de-tune query response check to reduce test flakes.

### Test Plan


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
