### PR TITLE
Disallow order removal reason fully filled

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -180,7 +180,7 @@ const (
 	Status                                       = "status"
 	SubaccountPendingMatches                     = "subaccount_pending_matches"
 	TimeInForce                                  = "time_in_force"
-	TotalOrdersClobPair                          = "total_orders_in_clob"
+	TotalOrdersInClob                            = "total_orders_in_clob"
 	TotalQuoteQuantums                           = "total_quote_quantums"
 	Unfilled                                     = "unfilled"
 	UnfilledLiquidationOrders                    = "unfilled_liquidation_orders"

--- a/protocol/testutil/constants/clob_pair.go
+++ b/protocol/testutil/constants/clob_pair.go
@@ -91,7 +91,7 @@ var (
 		QuantumConversionExponent: -8,
 		Status:                    clobtypes.ClobPair_STATUS_ACTIVE,
 	}
-	ClobPair_Btc_Init = clobtypes.ClobPair{
+	ClobPair_Btc_Initializing = clobtypes.ClobPair{
 		Id: 0,
 		Metadata: &clobtypes.ClobPair_PerpetualClobMetadata{
 			PerpetualClobMetadata: &clobtypes.PerpetualClobMetadata{

--- a/protocol/x/clob/keeper/clob_pair_test.go
+++ b/protocol/x/clob/keeper/clob_pair_test.go
@@ -896,7 +896,7 @@ func TestIsPerpetualClobPairActive(t *testing.T) {
 			perpetualIdToClobPairId: map[uint32][]types.ClobPairId{
 				0: {types.ClobPairId(0)},
 			},
-			clobPair: &constants.ClobPair_Btc_Init,
+			clobPair: &constants.ClobPair_Btc_Initializing,
 			resp:     false,
 		},
 		"Succeeds when clob pair is active": {

--- a/protocol/x/clob/keeper/get_price_premium_test.go
+++ b/protocol/x/clob/keeper/get_price_premium_test.go
@@ -142,7 +142,7 @@ func TestGetPricePremiumForPerpetual(t *testing.T) {
 		"Success, premium is zeroed for initializing clob pair": {
 			perpetualId: 0,
 			args: testMemClobMethodArgs{
-				clobPair: constants.ClobPair_Btc_Init,
+				clobPair: constants.ClobPair_Btc_Initializing,
 			},
 			setUpMockMemClob: func(mck *mocks.MemClob, args testMemClobMethodArgs) {},
 		},

--- a/protocol/x/clob/keeper/process_operations_test.go
+++ b/protocol/x/clob/keeper/process_operations_test.go
@@ -1358,7 +1358,7 @@ func TestProcessProposerOperations(t *testing.T) {
 			},
 			perpetualFeeParams: &constants.PerpetualFeeParams,
 			clobPairs: []types.ClobPair{
-				constants.ClobPair_Btc_Init,
+				constants.ClobPair_Btc_Initializing,
 			},
 			rawOperations: []types.OperationRaw{
 				clobtest.NewMatchOperationRaw(
@@ -1379,7 +1379,7 @@ func TestProcessProposerOperations(t *testing.T) {
 			},
 			perpetualFeeParams: &constants.PerpetualFeeParams,
 			clobPairs: []types.ClobPair{
-				constants.ClobPair_Btc_Init,
+				constants.ClobPair_Btc_Initializing,
 			},
 			rawOperations: []types.OperationRaw{
 				clobtest.NewShortTermOrderPlacementOperationRaw(
@@ -1394,7 +1394,7 @@ func TestProcessProposerOperations(t *testing.T) {
 			},
 			perpetualFeeParams: &constants.PerpetualFeeParams,
 			clobPairs: []types.ClobPair{
-				constants.ClobPair_Btc_Init,
+				constants.ClobPair_Btc_Initializing,
 			},
 			preExistingStatefulOrders: []types.Order{
 				constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10,
@@ -1406,6 +1406,25 @@ func TestProcessProposerOperations(t *testing.T) {
 				),
 			},
 			expectedError: types.ErrOperationConflictsWithClobPairStatus,
+		},
+		"Fails with order removal reason fully filled": {
+			perpetuals: []*perptypes.Perpetual{
+				&constants.BtcUsd_100PercentMarginRequirement,
+			},
+			perpetualFeeParams: &constants.PerpetualFeeParams,
+			clobPairs: []types.ClobPair{
+				constants.ClobPair_Btc,
+			},
+			preExistingStatefulOrders: []types.Order{
+				constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10,
+			},
+			rawOperations: []types.OperationRaw{
+				clobtest.NewOrderRemovalOperationRaw(
+					constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10.OrderId,
+					types.OrderRemoval_REMOVAL_REASON_FULLY_FILLED,
+				),
+			},
+			expectedError: types.ErrInvalidOrderRemoval,
 		},
 	}
 

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -1828,7 +1828,7 @@ func (m *MemClobPriceTimePriority) SetMemclobGauges(
 		telemetry.SetGaugeWithLabels(
 			[]string{
 				types.ModuleName,
-				metrics.TotalOrdersClobPair,
+				metrics.TotalOrdersInClob,
 			},
 			float32(orderbook.TotalOpenOrders),
 			[]gometrics.Label{

--- a/protocol/x/clob/types/message_proposed_operations.go
+++ b/protocol/x/clob/types/message_proposed_operations.go
@@ -114,7 +114,10 @@ func ValidateAndTransformRawOperations(
 			if err := orderRemoval.OrderId.Validate(); err != nil {
 				return nil, err
 			}
-			if orderRemoval.RemovalReason == OrderRemoval_REMOVAL_REASON_UNSPECIFIED {
+			// Order removal reason fully filled is only used by indexer and should not be
+			// placed in the operations queue.
+			if orderRemoval.RemovalReason == OrderRemoval_REMOVAL_REASON_UNSPECIFIED ||
+				orderRemoval.RemovalReason == OrderRemoval_REMOVAL_REASON_FULLY_FILLED {
 				return nil, errorsmod.Wrapf(
 					ErrInvalidOrderRemoval,
 					"Invalid order removal reason: %+v",


### PR DESCRIPTION
slack thread [here](https://dydx-team.slack.com/archives/C03SLFHC3L7/p1699473001736049?thread_ts=1699415363.029589&cid=C03SLFHC3L7).

order removal reason Fully filled is only used within indexer services, thus it is not a valid removal reason for process operations.