### PR TITLE
[IND-485]: Query for PerpetualPositions by openEventId

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -287,6 +287,11 @@ export const defaultTendermintEvent3: TendermintEventCreateObject = {
   transactionIndex: 0,
   eventIndex: 0,
 };
+export const defaultTendermintEvent4: TendermintEventCreateObject = {
+  blockHeight: '2',
+  transactionIndex: 1,
+  eventIndex: 1,
+};
 export const defaultTendermintEventId: Buffer = TendermintEventTable.createEventId(
   defaultTendermintEvent.blockHeight,
   defaultTendermintEvent.transactionIndex,
@@ -301,6 +306,11 @@ export const defaultTendermintEventId3: Buffer = TendermintEventTable.createEven
   defaultTendermintEvent3.blockHeight,
   defaultTendermintEvent3.transactionIndex,
   defaultTendermintEvent3.eventIndex,
+);
+export const defaultTendermintEventId4: Buffer = TendermintEventTable.createEventId(
+  defaultTendermintEvent4.blockHeight,
+  defaultTendermintEvent4.transactionIndex,
+  defaultTendermintEvent4.eventIndex,
 );
 
 // ============== Transactions ==============

--- a/indexer/packages/postgres/__tests__/helpers/mock-generators.ts
+++ b/indexer/packages/postgres/__tests__/helpers/mock-generators.ts
@@ -24,6 +24,7 @@ import {
   defaultTendermintEvent,
   defaultTendermintEvent2,
   defaultTendermintEvent3,
+  defaultTendermintEvent4,
 } from './constants';
 
 export async function seedData() {
@@ -53,6 +54,7 @@ export async function seedData() {
     TendermintEventTable.create(defaultTendermintEvent),
     TendermintEventTable.create(defaultTendermintEvent2),
     TendermintEventTable.create(defaultTendermintEvent3),
+    TendermintEventTable.create(defaultTendermintEvent4),
   ]);
   await Promise.all([
     AssetTable.create(defaultAsset),

--- a/indexer/packages/postgres/src/stores/perpetual-position-table.ts
+++ b/indexer/packages/postgres/src/stores/perpetual-position-table.ts
@@ -124,7 +124,7 @@ export async function findAll(
       PerpetualPositionColumns.subaccountId,
       Ordering.ASC,
     ).orderBy(
-      PerpetualPositionColumns.createdAtHeight,
+      PerpetualPositionColumns.openEventId,
       Ordering.DESC,
     );
   }

--- a/indexer/services/ender/__tests__/handlers/order-fills/liquidation-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/liquidation-handler.test.ts
@@ -141,8 +141,8 @@ describe('LiquidationHandler', () => {
     entryPrice: '15000',
     createdAt: DateTime.utc().toISO(),
     createdAtHeight: '1',
-    openEventId: testConstants.defaultTendermintEventId,
-    lastEventId: testConstants.defaultTendermintEventId,
+    openEventId: testConstants.defaultTendermintEventId4,
+    lastEventId: testConstants.defaultTendermintEventId4,
     settledFunding: '200000',
   };
 
@@ -234,7 +234,7 @@ describe('LiquidationHandler', () => {
     ],
   ])(
     'creates fills and orders (with %s), sends vulcan message for maker order update and updates ' +
-    ' perpetualPosition',
+    'perpetualPosition',
     async (
       _name: string,
       goodTilOneof: Partial<IndexerOrder>,
@@ -297,8 +297,7 @@ describe('LiquidationHandler', () => {
         // older perpetual position to ensure that the correct perpetual position is being updated
         PerpetualPositionTable.create({
           ...defaultPerpetualPosition,
-          createdAtHeight: '0',
-          openEventId: testConstants.defaultTendermintEventId2,
+          openEventId: testConstants.defaultTendermintEventId,
         }),
       ]);
 

--- a/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
@@ -143,8 +143,8 @@ describe('OrderHandler', () => {
     entryPrice: '15000',
     createdAt: DateTime.utc().toISO(),
     createdAtHeight: '10',
-    openEventId: testConstants.defaultTendermintEventId,
-    lastEventId: testConstants.defaultTendermintEventId,
+    openEventId: testConstants.defaultTendermintEventId4,
+    lastEventId: testConstants.defaultTendermintEventId4,
     settledFunding: '200000',
   };
 
@@ -314,7 +314,6 @@ describe('OrderHandler', () => {
         // older perpetual position to ensure that the correct perpetual position is being updated
         PerpetualPositionTable.create({
           ...defaultPerpetualPosition,
-          createdAtHeight: '0',
           openEventId: testConstants.defaultTendermintEventId2,
         }),
       ]);
@@ -915,19 +914,17 @@ describe('OrderHandler', () => {
       // previous position for subaccount 1
       PerpetualPositionTable.create({
         ...defaultPerpetualPosition,
-        createdAtHeight: '1',
         size: '0',
         status: PerpetualPositionStatus.CLOSED,
-        openEventId: testConstants.defaultTendermintEventId2,
+        openEventId: testConstants.defaultTendermintEventId,
       }),
       // previous position for subaccount 2
       PerpetualPositionTable.create({
         ...defaultPerpetualPosition,
         subaccountId: testConstants.defaultSubaccountId2,
-        createdAtHeight: '1',
         size: '0',
         status: PerpetualPositionStatus.CLOSED,
-        openEventId: testConstants.defaultTendermintEventId2,
+        openEventId: testConstants.defaultTendermintEventId,
       }),
       // initial position for subaccount 2
       PerpetualPositionTable.create(defaultPerpetualPosition),
@@ -1129,20 +1126,18 @@ describe('OrderHandler', () => {
       PerpetualPositionTable.create({
         ...defaultPerpetualPosition,
         perpetualId: testConstants.defaultPerpetualMarket3.id,
-        createdAtHeight: '1',
         size: '0',
         status: PerpetualPositionStatus.CLOSED,
-        openEventId: testConstants.defaultTendermintEventId2,
+        openEventId: testConstants.defaultTendermintEventId,
       }),
       // previous position for subaccount 2
       PerpetualPositionTable.create({
         ...defaultPerpetualPosition,
         perpetualId: testConstants.defaultPerpetualMarket3.id,
         subaccountId: testConstants.defaultSubaccountId2,
-        createdAtHeight: '1',
         size: '0',
         status: PerpetualPositionStatus.CLOSED,
-        openEventId: testConstants.defaultTendermintEventId2,
+        openEventId: testConstants.defaultTendermintEventId,
       }),
       // initial position for subaccount 2
       PerpetualPositionTable.create({

--- a/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
@@ -182,7 +182,7 @@ BEGIN
     /* Upsert the perpetual_position record for this order_fill event. */
     SELECT * INTO perpetual_position_record FROM perpetual_positions WHERE "subaccountId" = subaccount_uuid
                                                                        AND "perpetualId" = perpetual_market_record."id"
-    ORDER BY "createdAtHeight" DESC;
+    ORDER BY "openEventId" DESC;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'Unable to find existing perpetual position, subaccountId: %, perpetualId: %', subaccount_uuid, perpetual_market_record."id";
     END IF;

--- a/indexer/services/ender/src/scripts/dydx_update_perpetual_position_aggregate_fields.sql
+++ b/indexer/services/ender/src/scripts/dydx_update_perpetual_position_aggregate_fields.sql
@@ -22,12 +22,11 @@ DECLARE
     exit_price numeric;
 BEGIN
     -- Retrieve the latest perpetual position record.
-    -- TODO(IND-485): Order by openEventId instead of createdAtHeight.
     SELECT * INTO perpetual_position_record
     FROM perpetual_positions
     WHERE "subaccountId" = subaccount_uuid
       AND "perpetualId" = perpetual_id
-    ORDER BY "createdAtHeight" DESC
+    ORDER BY "openEventId" DESC
     LIMIT 1;
 
     IF NOT FOUND THEN


### PR DESCRIPTION
### Changelist
Change existing queries to `perpetual_positions` to order by `openEventId` rather than `createdAtHeight` and change the corresponding SQL statement in Ender to also use `opentEventId`

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
