### PR TITLE
[CLOB-1014] [CLOB-1004] Unify metrics library, un-modularize metrics keys

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -302,7 +302,6 @@ const (
 
 	// Liquidation.
 	ConstructLiquidationOrder             = "construct_liquidation_order"
-	InsuranceFundBalance                  = "insurance_fund_balance"
 	InsuranceFundDelta                    = "insurance_fund_delta"
 	Liquidations                          = "liquidations"
 	MaybeGetLiquidationOrder              = "maybe_get_liquidation_order"

--- a/protocol/lib/metrics/lib.go
+++ b/protocol/lib/metrics/lib.go
@@ -60,6 +60,8 @@ func AddSample(key string, val float32) {
 // ModuleMeasureSince provides a wrapper functionality for emitting a time measure
 // metric with global labels (if any).
 // Please try to use `AddSample` instead.
+// TODO(CLOB-1022) Roll our own calculations for timing on top of AddSample instead
+// of using MeasureSince.
 func ModuleMeasureSince(module string, key string, start time.Time) {
 	telemetry.ModuleMeasureSince(
 		module,
@@ -69,9 +71,10 @@ func ModuleMeasureSince(module string, key string, start time.Time) {
 }
 
 // ModuleMeasureSinceWithLabels provides a short hand method for emitting a time measure
-// metric for a module with labels. Global labels are not included
-// in this metric.
+// metric for a module with labels. Global labels are not included in this metric.
 // Please try to use `AddSampleWithLabels` instead.
+// TODO(CLOB-1022) Roll our own calculations for timing on top of AddSample instead
+// of using MeasureSince.
 func ModuleMeasureSinceWithLabels(
 	module string,
 	keys []string,

--- a/protocol/lib/metrics/lib.go
+++ b/protocol/lib/metrics/lib.go
@@ -50,7 +50,6 @@ func AddSampleWithLabels(key string, val float32, labels ...gometrics.Label) {
 // AddSample provides a wrapper functionality for emitting a sample
 // metric.
 func AddSample(key string, val float32) {
-	// TODO why the f is this a differnet library
 	gometrics.AddSampleWithLabels(
 		[]string{key},
 		val,

--- a/protocol/lib/metrics/lib.go
+++ b/protocol/lib/metrics/lib.go
@@ -7,42 +7,39 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 )
 
-// main entrypoint for logging in the v4 protocol
-// type Label struct {
-// 	Name  string
-// 	Value string
-// }
+// This file provides a main entrypoint for logging in the v4 protocol.
+// TODO(CLOB-1013) Drop both metrics libraries above for a library
+// that supports float64 (i.e hashicorp go-metrics)
 
 type Label = gometrics.Label
 
-// IncrCounter provides a wrapper functionality for emitting a counter
+// IncrCounterWithLabels provides a wrapper functionality for emitting a counter
 // metric with global labels (if any) along with the provided labels.
 func IncrCounterWithLabels(key string, val float32, labels ...Label) {
 	telemetry.IncrCounterWithLabels([]string{key}, val, labels)
 }
 
 // IncrCounter provides a wrapper functionality for emitting a counter
-// metric with global labels (if any) along with the provided labels.
+// metric with global labels (if any).
 func IncrCounter(key string, val float32) {
 	telemetry.IncrCounterWithLabels([]string{key}, val, []gometrics.Label{})
 }
 
-// Gauge provides a wrapper functionality for emitting a counter
+// SetGaugeWithLabels provides a wrapper functionality for emitting a gauge
 // metric with global labels (if any) along with the provided labels.
 func SetGaugeWithLabels(key string, val float32, labels ...gometrics.Label) {
 	telemetry.SetGaugeWithLabels([]string{key}, val, labels)
 }
 
-// Gauge provides a wrapper functionality for emitting a counter
-// metric with global labels (if any) along with the provided labels.
+// SetGauge provides a wrapper functionality for emitting a gauge
+// metric with global labels (if any).
 func SetGauge(key string, val float32) {
 	telemetry.SetGaugeWithLabels([]string{key}, val, []gometrics.Label{})
 }
 
-// Histogram provides a wrapper functionality for emitting a counter
-// metric with global labels (if any) along with the provided labels.
+// AddSampleWithLabels provides a wrapper functionality for emitting a sample
+// metric with the provided labels.
 func AddSampleWithLabels(key string, val float32, labels ...gometrics.Label) {
-	// TODO why the f is this a differnet library
 	gometrics.AddSampleWithLabels(
 		[]string{key},
 		val,
@@ -50,8 +47,8 @@ func AddSampleWithLabels(key string, val float32, labels ...gometrics.Label) {
 	)
 }
 
-// Histogram provides a wrapper functionality for emitting a counter
-// metric with global labels (if any) along with the provided labels.
+// AddSample provides a wrapper functionality for emitting a sample
+// metric.
 func AddSample(key string, val float32) {
 	// TODO why the f is this a differnet library
 	gometrics.AddSampleWithLabels(
@@ -61,6 +58,9 @@ func AddSample(key string, val float32) {
 	)
 }
 
+// ModuleMeasureSince provides a wrapper functionality for emitting a time measure
+// metric with global labels (if any).
+// Please try to use `AddSample` instead.
 func ModuleMeasureSince(module string, key string, start time.Time) {
 	telemetry.ModuleMeasureSince(
 		module,
@@ -70,8 +70,9 @@ func ModuleMeasureSince(module string, key string, start time.Time) {
 }
 
 // ModuleMeasureSinceWithLabels provides a short hand method for emitting a time measure
-// metric for a module with a given set of keys and labels.
-// NOTE: global labels are not included in this metric.
+// metric for a module with labels. Global labels are not included
+// in this metric.
+// Please try to use `AddSampleWithLabels` instead.
 func ModuleMeasureSinceWithLabels(
 	module string,
 	keys []string,

--- a/protocol/lib/metrics/lib.go
+++ b/protocol/lib/metrics/lib.go
@@ -1,0 +1,89 @@
+package metrics
+
+import (
+	"time"
+
+	gometrics "github.com/armon/go-metrics"
+	"github.com/cosmos/cosmos-sdk/telemetry"
+)
+
+// main entrypoint for logging in the v4 protocol
+// type Label struct {
+// 	Name  string
+// 	Value string
+// }
+
+type Label = gometrics.Label
+
+// IncrCounter provides a wrapper functionality for emitting a counter
+// metric with global labels (if any) along with the provided labels.
+func IncrCounterWithLabels(key string, val float32, labels ...Label) {
+	telemetry.IncrCounterWithLabels([]string{key}, val, labels)
+}
+
+// IncrCounter provides a wrapper functionality for emitting a counter
+// metric with global labels (if any) along with the provided labels.
+func IncrCounter(key string, val float32) {
+	telemetry.IncrCounterWithLabels([]string{key}, val, []gometrics.Label{})
+}
+
+// Gauge provides a wrapper functionality for emitting a counter
+// metric with global labels (if any) along with the provided labels.
+func SetGaugeWithLabels(key string, val float32, labels ...gometrics.Label) {
+	telemetry.SetGaugeWithLabels([]string{key}, val, labels)
+}
+
+// Gauge provides a wrapper functionality for emitting a counter
+// metric with global labels (if any) along with the provided labels.
+func SetGauge(key string, val float32) {
+	telemetry.SetGaugeWithLabels([]string{key}, val, []gometrics.Label{})
+}
+
+// Histogram provides a wrapper functionality for emitting a counter
+// metric with global labels (if any) along with the provided labels.
+func AddSampleWithLabels(key string, val float32, labels ...gometrics.Label) {
+	// TODO why the f is this a differnet library
+	gometrics.AddSampleWithLabels(
+		[]string{key},
+		val,
+		labels,
+	)
+}
+
+// Histogram provides a wrapper functionality for emitting a counter
+// metric with global labels (if any) along with the provided labels.
+func AddSample(key string, val float32) {
+	// TODO why the f is this a differnet library
+	gometrics.AddSampleWithLabels(
+		[]string{key},
+		val,
+		[]gometrics.Label{},
+	)
+}
+
+func ModuleMeasureSince(module string, key string, start time.Time) {
+	telemetry.ModuleMeasureSince(
+		module,
+		start,
+		key,
+	)
+}
+
+// ModuleMeasureSinceWithLabels provides a short hand method for emitting a time measure
+// metric for a module with a given set of keys and labels.
+// NOTE: global labels are not included in this metric.
+func ModuleMeasureSinceWithLabels(
+	module string,
+	keys []string,
+	start time.Time,
+	labels []gometrics.Label,
+) {
+	gometrics.MeasureSinceWithLabels(
+		keys,
+		start.UTC(),
+		append(
+			[]gometrics.Label{telemetry.NewLabel(telemetry.MetricLabelNameModule, module)},
+			labels...,
+		),
+	)
+}

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -6,17 +6,19 @@ package metrics
 // 3. Suffix keys with a unit of measurement
 // 4. Delimit with '_'
 // 5. Information such as callback type should be added as tags, not in key names.
+// Example: clob_place_order_count, clob_msg_place_order_latency_ms, clob_operations_queue_length
+// clob_expired_stateful_orders_count, clob_processed_orders_ms_total
 
 // Clob Metrics Keys
 const (
 	// Stats
-	ClobExpiredStatefulOrders                         = "clob_expired_stateful_order_removed"
-	ClobPrepareCheckStateCannotDeleverageSubaccount   = "clob_prepare_check_state_cannot_deleverage_subaccount"
-	ClobDeleverageSubaccountTotalQuoteQuantums        = "clob_deleverage_subaccount_total_quote_quantums"
-	ClobDeleverageSubaccount                          = "clob_deleverage_subaccount"
-	LiqidationsPlacePerpetualLiquidationQuoteQuantums = "liquidations_place_perpetual_liquidation_quote_quantums"
-	LiquidationsLiquidationMatchNegativeTNC           = "liquidations_liquidation_match_negative_tnc"
-	ClobMevErrorCount                                 = "clob_mev_error_count"
+	ClobExpiredStatefulOrders                          = "clob_expired_stateful_order_removed"
+	ClobPrepareCheckStateCannotDeleverageSubaccount    = "clob_prepare_check_state_cannot_deleverage_subaccount"
+	ClobDeleverageSubaccountTotalQuoteQuantums         = "clob_deleverage_subaccount_total_quote_quantums"
+	ClobDeleverageSubaccount                           = "clob_deleverage_subaccount"
+	LiquidationsPlacePerpetualLiquidationQuoteQuantums = "liquidations_place_perpetual_liquidation_quote_quantums"
+	LiquidationsLiquidationMatchNegativeTNC            = "liquidations_liquidation_match_negative_tnc"
+	ClobMevErrorCount                                  = "clob_mev_error_count"
 
 	// Gauges
 	InsuranceFundBalance = "insurance_fund_balance"

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -14,9 +14,11 @@ const (
 	ClobDeleverageSubaccount                          = "clob_deleverage_subaccount"
 	LiqidationsPlacePerpetualLiquidationQuoteQuantums = "liquidations_place_perpetual_liquidation_quote_quantums"
 	LiquidationsLiquidationMatchNegativeTNC           = "liquidations_liquidation_match_negative_tnc"
+	ClobMevErrorCount                                 = "clob_mev_error_count"
 
 	// gauge
 	InsuranceFundBalance = "insurance_fund_balance"
+	ClobMev              = "clob_mev"
 
 	// sample
 	ClobDeleverageSubaccountTotalQuoteQuantumsDistribution         = "clob_deleverage_subaccount_total_quote_quantums_distribution"
@@ -31,4 +33,5 @@ const (
 
 	// Measure since
 	ClobOffsettingSubaccountPerpetualPosition = "clob_offsetting_subaccount_perpetual_position"
+	MevLatency                                = "mev_latency"
 )

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -1,0 +1,29 @@
+package metrics
+
+// 1. do not make it too long
+// 2. prefix/suffix rules
+const (
+	// Clob metric keys
+	// Currently Sorted by type of metric.
+	// TODO make sure the metric type is clear.
+
+	// stat
+	ClobExpiredStatefulOrders                       = "clob_expired_stateful_order_removed"
+	ClobPrepareCheckStateCannotDeleverageSubaccount = "clob_prepare_check_state_cannot_deleverage_subaccount"
+	ClobDeleverageSubaccountTotalQuoteQuantums      = "clob_deleverage_subaccount_total_quote_quantums"
+	ClobDeleverageSubaccount                        = "clob_deleverage_subaccount"
+
+	// gauge
+	InsuranceFundBalance = "insurance_fund_balance"
+
+	// sample
+	ClobDeleverageSubaccountTotalQuoteQuantumsDistribution = "clob_deleverage_subaccount_total_quote_quantums_distribution"
+	DeleveragingPercentFilledDistribution                  = "deleveraging_percent_filled_distribution"
+	ClobDeleveragingNumSubaccountsIteratedCount            = "clob_deleveraging_num_subaccounts_iterated_count"
+	ClobDeleveragingNonOverlappingBankrupcyPricesCount     = "clob_deleveraging_non_overlapping_bankruptcy_prices_count"
+	ClobDeleveragingNoOpenPositionOnOppositeSideCount      = "clob_deleveraging_no_open_position_on_opposite_side_count"
+	ClobDeleverageSubaccountFilledQuoteQuantums            = "clob_deleverage_subaccount_filled_quote_quantums"
+
+	// Measure since
+	ClobOffsettingSubaccountPerpetualPosition = "clob_offsetting_subaccount_perpetual_position"
+)

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -1,3 +1,4 @@
+// nolint:lll
 package metrics
 
 // Metrics Keys Guidelines

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -1,13 +1,15 @@
 package metrics
 
-// 1. do not make it too long
-// 2. prefix/suffix rules
-const (
-	// Clob metric keys
-	// Currently Sorted by type of metric.
-	// TODO make sure the metric type is clear.
+// Metrics Keys Guidelines
+// 1. Be wary of length
+// 2. Prefix by module
+// 3. Suffix keys with a unit of measurement
+// 4. Delimit with '_'
+// 5. Information such as callback type should be added as tags, not in key names.
 
-	// stat
+// Clob Metrics Keys
+const (
+	// Stats
 	ClobExpiredStatefulOrders                         = "clob_expired_stateful_order_removed"
 	ClobPrepareCheckStateCannotDeleverageSubaccount   = "clob_prepare_check_state_cannot_deleverage_subaccount"
 	ClobDeleverageSubaccountTotalQuoteQuantums        = "clob_deleverage_subaccount_total_quote_quantums"
@@ -16,11 +18,11 @@ const (
 	LiquidationsLiquidationMatchNegativeTNC           = "liquidations_liquidation_match_negative_tnc"
 	ClobMevErrorCount                                 = "clob_mev_error_count"
 
-	// gauge
+	// Gauges
 	InsuranceFundBalance = "insurance_fund_balance"
 	ClobMev              = "clob_mev"
 
-	// sample
+	// Samples
 	ClobDeleverageSubaccountTotalQuoteQuantumsDistribution         = "clob_deleverage_subaccount_total_quote_quantums_distribution"
 	DeleveragingPercentFilledDistribution                          = "deleveraging_percent_filled_distribution"
 	ClobDeleveragingNumSubaccountsIteratedCount                    = "clob_deleveraging_num_subaccounts_iterated_count"
@@ -28,10 +30,10 @@ const (
 	ClobDeleveragingNoOpenPositionOnOppositeSideCount              = "clob_deleveraging_no_open_position_on_opposite_side_count"
 	ClobDeleverageSubaccountFilledQuoteQuantums                    = "clob_deleverage_subaccount_filled_quote_quantums"
 	LiquidationsLiquidatableSubaccountIdsCount                     = "liquidations_liquidatable_subaccount_ids_count"
-	LiquidationsPercentFilledDistribution                          = "liquidations_percent_filled_distribbution"
+	LiquidationsPercentFilledDistribution                          = "liquidations_percent_filled_distribution"
 	LiquidationsPlacePerpetualLiquidationQuoteQuantumsDistribution = "liquidations_place_perpetual_liquidation_quote_quantums_distribution"
 
-	// Measure since
+	// Measure Since
 	ClobOffsettingSubaccountPerpetualPosition = "clob_offsetting_subaccount_perpetual_position"
 	MevLatency                                = "mev_latency"
 )

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -8,21 +8,26 @@ const (
 	// TODO make sure the metric type is clear.
 
 	// stat
-	ClobExpiredStatefulOrders                       = "clob_expired_stateful_order_removed"
-	ClobPrepareCheckStateCannotDeleverageSubaccount = "clob_prepare_check_state_cannot_deleverage_subaccount"
-	ClobDeleverageSubaccountTotalQuoteQuantums      = "clob_deleverage_subaccount_total_quote_quantums"
-	ClobDeleverageSubaccount                        = "clob_deleverage_subaccount"
+	ClobExpiredStatefulOrders                         = "clob_expired_stateful_order_removed"
+	ClobPrepareCheckStateCannotDeleverageSubaccount   = "clob_prepare_check_state_cannot_deleverage_subaccount"
+	ClobDeleverageSubaccountTotalQuoteQuantums        = "clob_deleverage_subaccount_total_quote_quantums"
+	ClobDeleverageSubaccount                          = "clob_deleverage_subaccount"
+	LiqidationsPlacePerpetualLiquidationQuoteQuantums = "liquidations_place_perpetual_liquidation_quote_quantums"
+	LiquidationsLiquidationMatchNegativeTNC           = "liquidations_liquidation_match_negative_tnc"
 
 	// gauge
 	InsuranceFundBalance = "insurance_fund_balance"
 
 	// sample
-	ClobDeleverageSubaccountTotalQuoteQuantumsDistribution = "clob_deleverage_subaccount_total_quote_quantums_distribution"
-	DeleveragingPercentFilledDistribution                  = "deleveraging_percent_filled_distribution"
-	ClobDeleveragingNumSubaccountsIteratedCount            = "clob_deleveraging_num_subaccounts_iterated_count"
-	ClobDeleveragingNonOverlappingBankrupcyPricesCount     = "clob_deleveraging_non_overlapping_bankruptcy_prices_count"
-	ClobDeleveragingNoOpenPositionOnOppositeSideCount      = "clob_deleveraging_no_open_position_on_opposite_side_count"
-	ClobDeleverageSubaccountFilledQuoteQuantums            = "clob_deleverage_subaccount_filled_quote_quantums"
+	ClobDeleverageSubaccountTotalQuoteQuantumsDistribution         = "clob_deleverage_subaccount_total_quote_quantums_distribution"
+	DeleveragingPercentFilledDistribution                          = "deleveraging_percent_filled_distribution"
+	ClobDeleveragingNumSubaccountsIteratedCount                    = "clob_deleveraging_num_subaccounts_iterated_count"
+	ClobDeleveragingNonOverlappingBankrupcyPricesCount             = "clob_deleveraging_non_overlapping_bankruptcy_prices_count"
+	ClobDeleveragingNoOpenPositionOnOppositeSideCount              = "clob_deleveraging_no_open_position_on_opposite_side_count"
+	ClobDeleverageSubaccountFilledQuoteQuantums                    = "clob_deleverage_subaccount_filled_quote_quantums"
+	LiquidationsLiquidatableSubaccountIdsCount                     = "liquidations_liquidatable_subaccount_ids_count"
+	LiquidationsPercentFilledDistribution                          = "liquidations_percent_filled_distribbution"
+	LiquidationsPlacePerpetualLiquidationQuoteQuantumsDistribution = "liquidations_place_perpetual_liquidation_quote_quantums_distribution"
 
 	// Measure since
 	ClobOffsettingSubaccountPerpetualPosition = "clob_offsetting_subaccount_perpetual_position"

--- a/protocol/lib/metrics/util.go
+++ b/protocol/lib/metrics/util.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"math/big"
 	"strconv"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -66,25 +65,6 @@ func GetLabelForStringValue(labelName string, labelValue string) gometrics.Label
 func GetMetricValueFromBigInt(i *big.Int) float32 {
 	r, _ := new(big.Float).SetInt(i).Float32()
 	return r
-}
-
-// ModuleMeasureSinceWithLabels provides a short hand method for emitting a time measure
-// metric for a module with a given set of keys and labels.
-// NOTE: global labels are not included in this metric.
-func ModuleMeasureSinceWithLabels(
-	module string,
-	keys []string,
-	start time.Time,
-	labels []gometrics.Label,
-) {
-	gometrics.MeasureSinceWithLabels(
-		keys,
-		start.UTC(),
-		append(
-			[]gometrics.Label{telemetry.NewLabel(telemetry.MetricLabelNameModule, module)},
-			labels...,
-		),
-	)
 }
 
 // GetCallbackMetricFromCtx determines the callback metric based on the context. Note that DeliverTx is implied

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -65,7 +65,7 @@ func EndBlocker(
 		metrics.IncrCounterWithLabels(
 			metrics.ClobExpiredStatefulOrders,
 			1,
-			orderId.GetOrderIdLabels(),
+			orderId.GetOrderIdLabels()...,
 		)
 	}
 

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	gometrics "github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	liquidationtypes "github.com/dydxprotocol/v4-chain/protocol/daemons/server/types/liquidations"
@@ -63,8 +62,8 @@ func EndBlocker(
 				),
 			),
 		)
-		telemetry.IncrCounterWithLabels(
-			[]string{types.ModuleName, metrics.Expired, metrics.StatefulOrderRemoved, metrics.Count},
+		metrics.IncrCounterWithLabels(
+			metrics.ClobExpiredStatefulOrders,
 			1,
 			orderId.GetOrderIdLabels(),
 		)
@@ -108,10 +107,9 @@ func EndBlocker(
 	keeper.PruneRateLimits(ctx)
 
 	// Emit relevant metrics at the end of every block.
-	telemetry.SetGaugeWithLabels(
-		[]string{metrics.InsuranceFundBalance},
+	metrics.SetGauge(
+		metrics.InsuranceFundBalance,
 		metrics.GetMetricValueFromBigInt(keeper.GetInsuranceFundBalance(ctx)),
-		[]gometrics.Label{},
 	)
 }
 

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -198,7 +198,6 @@ func (k Keeper) OffsetSubaccountPerpetualPosition(
 	fills []types.MatchPerpetualDeleveraging_Fill,
 	deltaQuantumsRemaining *big.Int,
 ) {
-
 	defer metrics.ModuleMeasureSince(
 		types.ModuleName,
 		metrics.ClobOffsettingSubaccountPerpetualPosition,

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -321,7 +321,7 @@ func (k Keeper) PlacePerpetualLiquidation(
 		liquidationOrder.GetBaseQuantums().ToBigInt(),
 	); err == nil {
 		metrics.IncrCounterWithLabels(
-			metrics.LiqidationsPlacePerpetualLiquidationQuoteQuantums,
+			metrics.LiquidationsPlacePerpetualLiquidationQuoteQuantums,
 			metrics.GetMetricValueFromBigInt(totalQuoteQuantums),
 			labels...,
 		)

--- a/protocol/x/clob/keeper/mev.go
+++ b/protocol/x/clob/keeper/mev.go
@@ -6,8 +6,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	gometrics "github.com/armon/go-metrics"
-	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/app/process"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -60,7 +58,11 @@ func (k Keeper) RecordMevMetrics(
 	perpetualKeeper process.ProcessPerpetualKeeper,
 	msgProposedOperations *types.MsgProposedOperations,
 ) {
-	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), metrics.Mev, metrics.Latency)
+	defer metrics.ModuleMeasureSince(
+		types.ModuleName,
+		metrics.MevLatency,
+		time.Now(),
+	)
 
 	// Recover from any panics that occur during MEV calculation.
 	defer func() {
@@ -99,7 +101,10 @@ func (k Keeper) RecordMevMetrics(
 				msgProposedOperations.GetOperationsQueue(),
 			),
 		)
-		telemetry.IncrCounter(1, types.ModuleName, metrics.Mev, metrics.Error, metrics.Count)
+		metrics.IncrCounter(
+			metrics.ClobMevErrorCount,
+			1,
+		)
 		return
 	}
 	if err := k.CalculateSubaccountPnLForMevMatches(
@@ -114,7 +119,10 @@ func (k Keeper) RecordMevMetrics(
 				blockProposerMevMatches,
 			),
 		)
-		telemetry.IncrCounter(1, types.ModuleName, metrics.Mev, metrics.Error, metrics.Count)
+		metrics.IncrCounter(
+			metrics.ClobMevErrorCount,
+			1,
+		)
 		return
 	}
 
@@ -132,7 +140,10 @@ func (k Keeper) RecordMevMetrics(
 				k.GetOperations(ctx).GetOperationsQueue(),
 			),
 		)
-		telemetry.IncrCounter(1, types.ModuleName, metrics.Mev, metrics.Error, metrics.Count)
+		metrics.IncrCounter(
+			metrics.ClobMevErrorCount,
+			1,
+		)
 		return
 	}
 	if err := k.CalculateSubaccountPnLForMevMatches(
@@ -147,7 +158,10 @@ func (k Keeper) RecordMevMetrics(
 				validatorMevMatches,
 			),
 		)
-		telemetry.IncrCounter(1, types.ModuleName, metrics.Mev, metrics.Error, metrics.Count)
+		metrics.IncrCounter(
+			metrics.ClobMevErrorCount,
+			1,
+		)
 		return
 	}
 
@@ -220,7 +234,10 @@ func (k Keeper) RecordMevMetrics(
 	consensusRound, ok := ctx.Value(process.ConsensusRound).(int64)
 	if !ok {
 		k.Logger(ctx).Error("Failed to get consensus round")
-		telemetry.IncrCounter(1, types.ModuleName, metrics.Mev, metrics.Error, metrics.Count)
+		metrics.IncrCounter(
+			metrics.ClobMevErrorCount,
+			1,
+		)
 		return
 	}
 
@@ -233,7 +250,10 @@ func (k Keeper) RecordMevMetrics(
 			"proposer",
 			proposerConsAddress.String(),
 		)
-		telemetry.IncrCounter(1, types.ModuleName, metrics.Mev, metrics.Error, metrics.Count)
+		metrics.IncrCounter(
+			metrics.ClobMevErrorCount,
+			1,
+		)
 		return
 	}
 
@@ -280,19 +300,17 @@ func (k Keeper) RecordMevMetrics(
 			).String(),
 		)
 
-		telemetry.SetGaugeWithLabels(
-			[]string{types.ModuleName, metrics.Mev},
+		metrics.SetGaugeWithLabels(
+			metrics.ClobMev,
 			mev,
-			[]gometrics.Label{
-				metrics.GetLabelForStringValue(
-					metrics.Proposer,
-					proposer.Description.Moniker,
-				),
-				metrics.GetLabelForIntValue(
-					metrics.ClobPairId,
-					int(clobPairId.ToUint32()),
-				),
-			},
+			metrics.GetLabelForStringValue(
+				metrics.Proposer,
+				proposer.Description.Moniker,
+			),
+			metrics.GetLabelForIntValue(
+				metrics.ClobPairId,
+				int(clobPairId.ToUint32()),
+			),
 		)
 
 		validatorVolumeQuoteQuantumsPerMarket[clobPairId] = new(big.Int).Div(

--- a/protocol/x/clob/types/order_id.go
+++ b/protocol/x/clob/types/order_id.go
@@ -6,7 +6,6 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 
-	gometrics "github.com/armon/go-metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 )
 
@@ -174,8 +173,8 @@ func MustSortAndHaveNoDuplicates(orderIds []OrderId) {
 }
 
 // GetOrderIdLabels returns the telemetry labels of this order ID.
-func (o *OrderId) GetOrderIdLabels() []gometrics.Label {
-	return []gometrics.Label{
+func (o *OrderId) GetOrderIdLabels() []metrics.Label {
+	return []metrics.Label{
 		metrics.GetLabelForIntValue(metrics.OrderFlag, int(o.GetOrderFlags())),
 		metrics.GetLabelForIntValue(metrics.ClobPairId, int(o.GetClobPairId())),
 	}


### PR DESCRIPTION
Provide a standard for metrics going forward.

First step to do this is to create a singular entrypoint method that we report metrics through.

We currently have multiple different ways we report telemetry, using these two libraries across all files in the codebase:
```
	gometrics "github.com/armon/go-metrics"
	"github.com/cosmos/cosmos-sdk/telemetry"
```

Barrel everything through metric functions in `metrics/lib.go`.
Files should be migrated one by one, so here's a start with migrating a few libraries.

There should be _no_ change in how metrics are reported.

After everything goes through the singular entrypoint method, we can look at unifying the metrics libraries.

Also, un-modularize the metrics keys instead.
instead of passing in `[]string{"clob", "place_order", "count"}`, we should just pass in `metrics.ClobPlaceOrderCount` instead. This will make our metrics and the naming system a lot more clear because of the 1:1 metric:name:dashboard ratio.

Other files will need to be modified too later.
