### PR TITLE
[CORE-619] add e2e tests for subaccount transfers

### DIFF
--- a/protocol/x/sending/app_test.go
+++ b/protocol/x/sending/app_test.go
@@ -31,8 +31,12 @@ import (
 
 func TestMsgCreateTransfer(t *testing.T) {
 	tests := map[string]struct {
+		/* Setup */
 		// Initial balance of sender subaccount.
 		senderInitialBalance uint64
+
+		// Whether recipient subaccount exists.
+		recipientDoesNotExist bool
 
 		// Sender subaccount ID.
 		senderSubaccountId satypes.SubaccountId
@@ -72,8 +76,9 @@ func TestMsgCreateTransfer(t *testing.T) {
 		},
 		// Transfer to a non-existent subaccount will create that subaccount and succeed.
 		"Success: transfer from Alice subaccount to non-existent subaccount": {
-			senderInitialBalance: 10_000_000,
-			senderSubaccountId:   constants.Alice_Num0,
+			senderInitialBalance:  10_000_000,
+			recipientDoesNotExist: true,
+			senderSubaccountId:    constants.Alice_Num0,
 			recipientSubaccountId: satypes.SubaccountId{
 				Owner:  constants.BobAccAddress.String(),
 				Number: 104,
@@ -129,7 +134,7 @@ func TestMsgCreateTransfer(t *testing.T) {
 					func(genesisState *satypes.GenesisState) {
 						genesisState.Subaccounts = []satypes.Subaccount{
 							{
-								Id: &tc.senderSubaccountId,
+								Id: &(tc.senderSubaccountId),
 								AssetPositions: []*satypes.AssetPosition{
 									{
 										AssetId: constants.Usdc.Id,
@@ -140,6 +145,23 @@ func TestMsgCreateTransfer(t *testing.T) {
 									},
 								},
 							},
+						}
+						if !tc.recipientDoesNotExist {
+							genesisState.Subaccounts = append(
+								genesisState.Subaccounts,
+								satypes.Subaccount{
+									Id: &(tc.recipientSubaccountId),
+									AssetPositions: []*satypes.AssetPosition{
+										{
+											AssetId: constants.Usdc.Id,
+											Index:   0,
+											Quantums: dtypes.NewIntFromUint64(
+												rand.NewRand().Uint64(),
+											),
+										},
+									},
+								},
+							)
 						}
 					},
 				)


### PR DESCRIPTION
### Changelist
add e2e tests for `MsgCreateTransfer`, which transfers between subaccounts

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
