### PR TITLE
[CORE-668,CORE-669] - Add health monitor flags

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -612,7 +612,7 @@ func New(
 			go func() {
 				app.RegisterDaemonWithHealthMonitor(
 					app.LiquidationsClient,
-					time.Duration(daemonFlags.Shared.MaximumDaemonUnhealthySeconds)*time.Second,
+					time.Duration(daemonFlags.Shared.MaxDaemonUnhealthySeconds)*time.Second,
 				)
 				if err := app.LiquidationsClient.Start(
 					// The client will use `context.Background` so that it can have a different context from
@@ -647,7 +647,7 @@ func New(
 			)
 			app.RegisterDaemonWithHealthMonitor(
 				app.PriceFeedClient,
-				time.Duration(daemonFlags.Shared.MaximumDaemonUnhealthySeconds)*time.Second,
+				time.Duration(daemonFlags.Shared.MaxDaemonUnhealthySeconds)*time.Second,
 			)
 		}
 
@@ -658,7 +658,7 @@ func New(
 			go func() {
 				app.RegisterDaemonWithHealthMonitor(
 					app.BridgeClient,
-					time.Duration(daemonFlags.Shared.MaximumDaemonUnhealthySeconds)*time.Second,
+					time.Duration(daemonFlags.Shared.MaxDaemonUnhealthySeconds)*time.Second,
 				)
 				if err := app.BridgeClient.Start(
 					// The client will use `context.Background` so that it can have a different context from

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -183,10 +183,6 @@ import (
 var (
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
-
-	// MaximumDaemonUnhealthyDuration is the maximum amount of time that a daemon can be unhealthy before the
-	// application panics.
-	MaximumDaemonUnhealthyDuration = 5 * time.Minute
 )
 
 var (
@@ -599,6 +595,7 @@ func New(
 		daemonservertypes.DaemonStartupGracePeriod,
 		daemonservertypes.HealthCheckPollFrequency,
 		app.Logger(),
+		daemonFlags.Shared.PanicOnDaemonFailureEnabled,
 	)
 	// Create a closure for starting daemons and daemon server. Daemon services are delayed until after the gRPC
 	// service is started because daemons depend on the gRPC service being available. If a node is initialized
@@ -613,7 +610,10 @@ func New(
 		if daemonFlags.Liquidation.Enabled {
 			app.LiquidationsClient = liquidationclient.NewClient(logger)
 			go func() {
-				app.RegisterDaemonWithHealthMonitor(app.LiquidationsClient, MaximumDaemonUnhealthyDuration)
+				app.RegisterDaemonWithHealthMonitor(
+					app.LiquidationsClient,
+					time.Duration(daemonFlags.Shared.MaximumDaemonUnhealthySeconds)*time.Second,
+				)
 				if err := app.LiquidationsClient.Start(
 					// The client will use `context.Background` so that it can have a different context from
 					// the main application.
@@ -645,17 +645,21 @@ func New(
 				constants.StaticExchangeDetails,
 				&pricefeedclient.SubTaskRunnerImpl{},
 			)
-			app.RegisterDaemonWithHealthMonitor(app.PriceFeedClient, MaximumDaemonUnhealthyDuration)
+			app.RegisterDaemonWithHealthMonitor(
+				app.PriceFeedClient,
+				time.Duration(daemonFlags.Shared.MaximumDaemonUnhealthySeconds)*time.Second,
+			)
 		}
 
 		// Start Bridge Daemon.
 		// Non-validating full-nodes have no need to run the bridge daemon.
 		if !appFlags.NonValidatingFullNode && daemonFlags.Bridge.Enabled {
-			// TODO(CORE-582): Re-enable bridge daemon registration once the bridge daemon is fixed in local / CI
-			// environments.
 			app.BridgeClient = bridgeclient.NewClient(logger)
 			go func() {
-				app.RegisterDaemonWithHealthMonitor(app.BridgeClient, MaximumDaemonUnhealthyDuration)
+				app.RegisterDaemonWithHealthMonitor(
+					app.BridgeClient,
+					time.Duration(daemonFlags.Shared.MaximumDaemonUnhealthySeconds)*time.Second,
+				)
 				if err := app.BridgeClient.Start(
 					// The client will use `context.Background` so that it can have a different context from
 					// the main application.

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"fmt"
-
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/spf13/cast"

--- a/protocol/daemons/flags/flags.go
+++ b/protocol/daemons/flags/flags.go
@@ -125,6 +125,11 @@ func AddDaemonFlagsToCmd(
 		df.Shared.PanicOnDaemonFailureEnabled,
 		"Enables panicking when a daemon fails.",
 	)
+	cmd.Flags().Uint32(
+		FlagMaximumDaemonUnhealthySeconds,
+		df.Shared.MaximumDaemonUnhealthySeconds,
+		"Maximum allowable duration for which a daemon can be unhealthy.",
+	)
 
 	// Bridge Daemon.
 	cmd.Flags().Bool(

--- a/protocol/daemons/flags/flags.go
+++ b/protocol/daemons/flags/flags.go
@@ -82,7 +82,7 @@ func GetDefaultDaemonFlags() DaemonFlags {
 			Shared: SharedFlags{
 				SocketAddress:               "/tmp/daemons.sock",
 				PanicOnDaemonFailureEnabled: true,
-				MaxDaemonUnhealthySeconds:   5 * 60,
+				MaxDaemonUnhealthySeconds:   5 * 60, // 5 minutes.
 			},
 			Bridge: BridgeFlags{
 				Enabled:        true,

--- a/protocol/daemons/flags/flags.go
+++ b/protocol/daemons/flags/flags.go
@@ -9,9 +9,9 @@ import (
 // List of CLI flags for Server and Client.
 const (
 	// Flag names
-	FlagUnixSocketAddress             = "unix-socket-address"
-	FlagPanicOnDaemonFailureEnabled   = "panic-on-daemon-failure-enabled"
-	FlagMaximumDaemonUnhealthySeconds = "maximum-daemon-unhealthy-seconds"
+	FlagUnixSocketAddress           = "unix-socket-address"
+	FlagPanicOnDaemonFailureEnabled = "panic-on-daemon-failure-enabled"
+	FlagMaxDaemonUnhealthySeconds   = "max-daemon-unhealthy-seconds"
 
 	FlagPriceDaemonEnabled     = "price-daemon-enabled"
 	FlagPriceDaemonLoopDelayMs = "price-daemon-loop-delay-ms"
@@ -32,8 +32,8 @@ type SharedFlags struct {
 	SocketAddress string
 	// PanicOnDaemonFailureEnabled toggles whether the daemon should panic on failure.
 	PanicOnDaemonFailureEnabled bool
-	// MaximumDaemonUnhealthySeconds is the maximum allowable duration for which a daemon can be unhealthy.
-	MaximumDaemonUnhealthySeconds uint32
+	// MaxDaemonUnhealthySeconds is the maximum allowable duration for which a daemon can be unhealthy.
+	MaxDaemonUnhealthySeconds uint32
 }
 
 // BridgeFlags contains configuration flags for the Bridge Daemon.
@@ -80,9 +80,9 @@ func GetDefaultDaemonFlags() DaemonFlags {
 	if defaultDaemonFlags == nil {
 		defaultDaemonFlags = &DaemonFlags{
 			Shared: SharedFlags{
-				SocketAddress:                 "/tmp/daemons.sock",
-				PanicOnDaemonFailureEnabled:   true,
-				MaximumDaemonUnhealthySeconds: 5 * 60,
+				SocketAddress:               "/tmp/daemons.sock",
+				PanicOnDaemonFailureEnabled: true,
+				MaxDaemonUnhealthySeconds:   5 * 60,
 			},
 			Bridge: BridgeFlags{
 				Enabled:        true,
@@ -126,8 +126,8 @@ func AddDaemonFlagsToCmd(
 		"Enables panicking when a daemon fails.",
 	)
 	cmd.Flags().Uint32(
-		FlagMaximumDaemonUnhealthySeconds,
-		df.Shared.MaximumDaemonUnhealthySeconds,
+		FlagMaxDaemonUnhealthySeconds,
+		df.Shared.MaxDaemonUnhealthySeconds,
 		"Maximum allowable duration for which a daemon can be unhealthy.",
 	)
 
@@ -201,9 +201,9 @@ func GetDaemonFlagValuesFromOptions(
 			result.Shared.PanicOnDaemonFailureEnabled = v
 		}
 	}
-	if option := appOpts.Get(FlagMaximumDaemonUnhealthySeconds); option != nil {
+	if option := appOpts.Get(FlagMaxDaemonUnhealthySeconds); option != nil {
 		if v, err := cast.ToUint32E(option); err == nil {
-			result.Shared.MaximumDaemonUnhealthySeconds = v
+			result.Shared.MaxDaemonUnhealthySeconds = v
 		}
 	}
 

--- a/protocol/daemons/flags/flags.go
+++ b/protocol/daemons/flags/flags.go
@@ -9,7 +9,9 @@ import (
 // List of CLI flags for Server and Client.
 const (
 	// Flag names
-	FlagUnixSocketAddress = "unix-socket-address"
+	FlagUnixSocketAddress             = "unix-socket-address"
+	FlagPanicOnDaemonFailureEnabled   = "panic-on-daemon-failure-enabled"
+	FlagMaximumDaemonUnhealthySeconds = "maximum-daemon-unhealthy-seconds"
 
 	FlagPriceDaemonEnabled     = "price-daemon-enabled"
 	FlagPriceDaemonLoopDelayMs = "price-daemon-loop-delay-ms"
@@ -28,6 +30,10 @@ const (
 type SharedFlags struct {
 	// SocketAddress is the location of the unix socket to communicate with the daemon gRPC service.
 	SocketAddress string
+	// PanicOnDaemonFailureEnabled toggles whether the daemon should panic on failure.
+	PanicOnDaemonFailureEnabled bool
+	// MaximumDaemonUnhealthySeconds is the maximum allowable duration for which a daemon can be unhealthy.
+	MaximumDaemonUnhealthySeconds uint32
 }
 
 // BridgeFlags contains configuration flags for the Bridge Daemon.
@@ -74,7 +80,9 @@ func GetDefaultDaemonFlags() DaemonFlags {
 	if defaultDaemonFlags == nil {
 		defaultDaemonFlags = &DaemonFlags{
 			Shared: SharedFlags{
-				SocketAddress: "/tmp/daemons.sock",
+				SocketAddress:                 "/tmp/daemons.sock",
+				PanicOnDaemonFailureEnabled:   true,
+				MaximumDaemonUnhealthySeconds: 5 * 60,
 			},
 			Bridge: BridgeFlags{
 				Enabled:        true,
@@ -109,8 +117,13 @@ func AddDaemonFlagsToCmd(
 	cmd.Flags().String(
 		FlagUnixSocketAddress,
 		df.Shared.SocketAddress,
-		"Socket address for the price daemon to send updates to, if not set "+
-			"will establish default location to ingest price updates from",
+		"Socket address for the daemons to send updates to, if not set "+
+			"will establish default location to ingest daemon updates from",
+	)
+	cmd.Flags().Bool(
+		FlagPanicOnDaemonFailureEnabled,
+		df.Shared.PanicOnDaemonFailureEnabled,
+		"Enables panicking when a daemon fails.",
 	)
 
 	// Bridge Daemon.
@@ -176,6 +189,16 @@ func GetDaemonFlagValuesFromOptions(
 	if option := appOpts.Get(FlagUnixSocketAddress); option != nil {
 		if v, err := cast.ToStringE(option); err == nil {
 			result.Shared.SocketAddress = v
+		}
+	}
+	if option := appOpts.Get(FlagPanicOnDaemonFailureEnabled); option != nil {
+		if v, err := cast.ToBoolE(option); err == nil {
+			result.Shared.PanicOnDaemonFailureEnabled = v
+		}
+	}
+	if option := appOpts.Get(FlagMaximumDaemonUnhealthySeconds); option != nil {
+		if v, err := cast.ToUint32E(option); err == nil {
+			result.Shared.MaximumDaemonUnhealthySeconds = v
 		}
 	}
 

--- a/protocol/daemons/flags/flags_test.go
+++ b/protocol/daemons/flags/flags_test.go
@@ -18,7 +18,7 @@ func TestAddDaemonFlagsToCmd(t *testing.T) {
 	tests := []string{
 		flags.FlagUnixSocketAddress,
 		flags.FlagPanicOnDaemonFailureEnabled,
-		flags.FlagMaximumDaemonUnhealthySeconds,
+		flags.FlagMaxDaemonUnhealthySeconds,
 
 		flags.FlagBridgeDaemonEnabled,
 		flags.FlagBridgeDaemonLoopDelayMs,
@@ -44,7 +44,7 @@ func TestGetDaemonFlagValuesFromOptions_Custom(t *testing.T) {
 
 	optsMap[flags.FlagUnixSocketAddress] = "test-socket-address"
 	optsMap[flags.FlagPanicOnDaemonFailureEnabled] = false
-	optsMap[flags.FlagMaximumDaemonUnhealthySeconds] = uint32(1234)
+	optsMap[flags.FlagMaxDaemonUnhealthySeconds] = uint32(1234)
 
 	optsMap[flags.FlagBridgeDaemonEnabled] = true
 	optsMap[flags.FlagBridgeDaemonLoopDelayMs] = uint32(1111)
@@ -71,8 +71,8 @@ func TestGetDaemonFlagValuesFromOptions_Custom(t *testing.T) {
 	require.Equal(t, optsMap[flags.FlagPanicOnDaemonFailureEnabled], r.Shared.PanicOnDaemonFailureEnabled)
 	require.Equal(
 		t,
-		optsMap[flags.FlagMaximumDaemonUnhealthySeconds],
-		r.Shared.MaximumDaemonUnhealthySeconds,
+		optsMap[flags.FlagMaxDaemonUnhealthySeconds],
+		r.Shared.MaxDaemonUnhealthySeconds,
 	)
 
 	// Bridge Daemon.

--- a/protocol/daemons/flags/flags_test.go
+++ b/protocol/daemons/flags/flags_test.go
@@ -17,6 +17,8 @@ func TestAddDaemonFlagsToCmd(t *testing.T) {
 	flags.AddDaemonFlagsToCmd(&cmd)
 	tests := []string{
 		flags.FlagUnixSocketAddress,
+		flags.FlagPanicOnDaemonFailureEnabled,
+		flags.FlagMaximumDaemonUnhealthySeconds,
 
 		flags.FlagBridgeDaemonEnabled,
 		flags.FlagBridgeDaemonLoopDelayMs,
@@ -41,6 +43,8 @@ func TestGetDaemonFlagValuesFromOptions_Custom(t *testing.T) {
 	optsMap := make(map[string]interface{})
 
 	optsMap[flags.FlagUnixSocketAddress] = "test-socket-address"
+	optsMap[flags.FlagPanicOnDaemonFailureEnabled] = false
+	optsMap[flags.FlagMaximumDaemonUnhealthySeconds] = uint32(1234)
 
 	optsMap[flags.FlagBridgeDaemonEnabled] = true
 	optsMap[flags.FlagBridgeDaemonLoopDelayMs] = uint32(1111)
@@ -64,6 +68,12 @@ func TestGetDaemonFlagValuesFromOptions_Custom(t *testing.T) {
 
 	// Shared.
 	require.Equal(t, optsMap[flags.FlagUnixSocketAddress], r.Shared.SocketAddress)
+	require.Equal(t, optsMap[flags.FlagPanicOnDaemonFailureEnabled], r.Shared.PanicOnDaemonFailureEnabled)
+	require.Equal(
+		t,
+		optsMap[flags.FlagMaximumDaemonUnhealthySeconds],
+		r.Shared.MaximumDaemonUnhealthySeconds,
+	)
 
 	// Bridge Daemon.
 	require.Equal(t, optsMap[flags.FlagBridgeDaemonEnabled], r.Bridge.Enabled)
@@ -81,7 +91,7 @@ func TestGetDaemonFlagValuesFromOptions_Custom(t *testing.T) {
 	require.Equal(t, optsMap[flags.FlagPriceDaemonLoopDelayMs], r.Price.LoopDelayMs)
 }
 
-func TestGetDaemonFlagValuesFromOptions_Defaul(t *testing.T) {
+func TestGetDaemonFlagValuesFromOptions_Default(t *testing.T) {
 	mockOpts := mocks.AppOptions{}
 	mockOpts.On("Get", mock.Anything).
 		Return(func(key string) interface{} {

--- a/protocol/daemons/pricefeed/client/client_integration_test.go
+++ b/protocol/daemons/pricefeed/client/client_integration_test.go
@@ -5,7 +5,6 @@ package client_test
 import (
 	"fmt"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/dydxprotocol/v4-chain/protocol/app"
 	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client"
@@ -285,6 +284,7 @@ func (s *PriceDaemonIntegrationTestSuite) SetupTest() {
 		servertypes.DaemonStartupGracePeriod,
 		servertypes.HealthCheckPollFrequency,
 		log.TestingLogger(),
+		flags.GetDefaultDaemonFlags().Shared.PanicOnDaemonFailureEnabled, // Use default behavior for testing
 	)
 
 	s.exchangePriceCache = pricefeedserver_types.NewMarketToExchangePrices(pricefeed_types.MaxPriceAge)
@@ -337,7 +337,10 @@ func (s *PriceDaemonIntegrationTestSuite) startClient() {
 		testExchangeToQueryDetails,
 		&client.SubTaskRunnerImpl{},
 	)
-	err := s.healthMonitor.RegisterService(s.pricefeedDaemon, app.MaximumDaemonUnhealthyDuration)
+	err := s.healthMonitor.RegisterService(
+		s.pricefeedDaemon,
+		time.Duration(s.daemonFlags.Shared.MaximumDaemonUnhealthySeconds)*time.Second,
+	)
 	s.Require().NoError(err)
 }
 

--- a/protocol/daemons/pricefeed/client/client_integration_test.go
+++ b/protocol/daemons/pricefeed/client/client_integration_test.go
@@ -339,7 +339,7 @@ func (s *PriceDaemonIntegrationTestSuite) startClient() {
 	)
 	err := s.healthMonitor.RegisterService(
 		s.pricefeedDaemon,
-		time.Duration(s.daemonFlags.Shared.MaximumDaemonUnhealthySeconds)*time.Second,
+		time.Duration(s.daemonFlags.Shared.MaxDaemonUnhealthySeconds)*time.Second,
 	)
 	s.Require().NoError(err)
 }

--- a/protocol/daemons/server/types/health_monitor.go
+++ b/protocol/daemons/server/types/health_monitor.go
@@ -123,9 +123,9 @@ type HealthMonitor struct {
 
 	// These fields are initialized in NewHealthMonitor and are not modified after initialization.
 	logger log.Logger
-	// startupGracePeriod is the grace period before the monitor starts polling the health checkable services.
+	// startupGracePeriod is the grace period before the monitor starts polling the health-checkable services.
 	startupGracePeriod time.Duration
-	// pollingFrequency is the frequency at which the health checkable services are polled.
+	// pollingFrequency is the frequency at which the health-checkable services are polled.
 	pollingFrequency time.Duration
 	// enablePanics is used to toggle between panics or error logs when a daemon sustains an unhealthy state past the
 	// maximum allowable duration.
@@ -160,15 +160,15 @@ func (hm *HealthMonitor) DisableForTesting() {
 // health-checkable service before returning.
 func (hm *HealthMonitor) RegisterServiceWithCallback(
 	hc types.HealthCheckable,
-	maximumAcceptableUnhealthyDuration time.Duration,
+	maxUnhealthyDuration time.Duration,
 	callback func(error),
 ) error {
-	if maximumAcceptableUnhealthyDuration <= 0 {
+	if maxUnhealthyDuration <= 0 {
 		return fmt.Errorf(
 			"health check registration failure for service %v: "+
-				"maximum acceptable unhealthy duration %v must be positive",
+				"maximum unhealthy duration %v must be positive",
 			hc.ServiceName(),
-			maximumAcceptableUnhealthyDuration,
+			maxUnhealthyDuration,
 		)
 	}
 
@@ -178,7 +178,7 @@ func (hm *HealthMonitor) RegisterServiceWithCallback(
 			hm.pollingFrequency,
 			callback,
 			&libtime.TimeProviderImpl{},
-			maximumAcceptableUnhealthyDuration,
+			maxUnhealthyDuration,
 			hm.startupGracePeriod,
 			hm.logger,
 		)
@@ -216,7 +216,7 @@ func LogErrorServiceNotResponding(hc types.HealthCheckable, logger log.Logger) f
 // service before returning.
 func (hm *HealthMonitor) RegisterService(
 	hc types.HealthCheckable,
-	maximumAcceptableUnhealthyDuration time.Duration,
+	maxDaemonUnhealthyDuration time.Duration,
 ) error {
 	// If the monitor is configured to panic, use the panic callback. Otherwise, use the error log callback.
 	// This behavior is configured via flag and defaults to panicking on daemon failure.
@@ -227,7 +227,7 @@ func (hm *HealthMonitor) RegisterService(
 
 	return hm.RegisterServiceWithCallback(
 		hc,
-		maximumAcceptableUnhealthyDuration,
+		maxDaemonUnhealthyDuration,
 		callback,
 	)
 }

--- a/protocol/daemons/server/types/health_monitor.go
+++ b/protocol/daemons/server/types/health_monitor.go
@@ -122,9 +122,14 @@ type HealthMonitor struct {
 	mutableState *healthMonitorMutableState
 
 	// These fields are initialized in NewHealthMonitor and are not modified after initialization.
-	logger             log.Logger
+	logger log.Logger
+	// startupGracePeriod is the grace period before the monitor starts polling the health checkable services.
 	startupGracePeriod time.Duration
-	pollingFrequency   time.Duration
+	// pollingFrequency is the frequency at which the health checkable services are polled.
+	pollingFrequency time.Duration
+	// enablePanics is used to toggle between panics or error logs when a daemon sustains an unhealthy state past the
+	// maximum allowable duration.
+	enablePanics bool
 }
 
 // NewHealthMonitor creates a new health monitor.
@@ -132,12 +137,14 @@ func NewHealthMonitor(
 	startupGracePeriod time.Duration,
 	pollingFrequency time.Duration,
 	logger log.Logger,
+	enablePanics bool,
 ) *HealthMonitor {
 	return &HealthMonitor{
 		mutableState:       newHealthMonitorMutableState(),
 		logger:             logger.With(cosmoslog.ModuleKey, HealthMonitorLogModuleName),
 		startupGracePeriod: startupGracePeriod,
 		pollingFrequency:   pollingFrequency,
+		enablePanics:       enablePanics,
 	}
 }
 
@@ -202,7 +209,8 @@ func LogErrorServiceNotResponding(hc types.HealthCheckable, logger log.Logger) f
 
 // RegisterService registers a new health-checkable service with the health check monitor. If the service
 // is unhealthy every time it is polled for a duration greater than or equal to the maximum acceptable unhealthy
-// duration, the monitor will panic.
+// duration, the monitor will panic or log an error, depending on the app configuration via the
+// `panic-on-daemon-failure-enabled` flag.
 // This method is synchronized. It returns an error if the service was already registered or the monitor has
 // already been stopped. If the monitor has been stopped, this method will proactively stop the health-checkable
 // service before returning.
@@ -210,10 +218,17 @@ func (hm *HealthMonitor) RegisterService(
 	hc types.HealthCheckable,
 	maximumAcceptableUnhealthyDuration time.Duration,
 ) error {
+	// If the monitor is configured to panic, use the panic callback. Otherwise, use the error log callback.
+	// This behavior is configured via flag and defaults to panicking on daemon failure.
+	callback := LogErrorServiceNotResponding(hc, hm.logger)
+	if hm.enablePanics {
+		callback = PanicServiceNotResponding(hc)
+	}
+
 	return hm.RegisterServiceWithCallback(
 		hc,
 		maximumAcceptableUnhealthyDuration,
-		PanicServiceNotResponding(hc),
+		callback,
 	)
 }
 

--- a/protocol/daemons/server/types/health_monitor_test.go
+++ b/protocol/daemons/server/types/health_monitor_test.go
@@ -160,8 +160,8 @@ func TestHealthMonitor_DisablePanics_DoesNotPanic(t *testing.T) {
 
 	// Assert.
 	// This test is confirmed to panic when panics are not disabled - but because the panic occurs in a separate
-	// go-routine, it cannot be easily captured with an assert. Instead, we assert that the logger was called with
-	// the expected arguments.
+	// go-routine, it cannot be easily captured with an assert. Instead, we do not try to capture the panic, but
+	// assert that the logger was called with the expected arguments.
 	mock.AssertExpectationsForObjects(t, logger)
 }
 

--- a/protocol/daemons/server/types/health_monitor_test.go
+++ b/protocol/daemons/server/types/health_monitor_test.go
@@ -242,7 +242,7 @@ func TestRegisterValidResponseWithCallback_NegativeUnhealthyDuration(t *testing.
 	ufm, _ := createTestMonitor()
 	hc := mockFailingHealthCheckerWithError("test-service", TestError1)
 	err := ufm.RegisterServiceWithCallback(hc, -50*time.Millisecond, func(error) {})
-	require.ErrorContains(t, err, "maximum acceptable unhealthy duration -50ms must be positive")
+	require.ErrorContains(t, err, "maximum unhealthy duration -50ms must be positive")
 }
 
 func TestPanicServiceNotResponding(t *testing.T) {

--- a/protocol/daemons/server/types/health_monitor_test.go
+++ b/protocol/daemons/server/types/health_monitor_test.go
@@ -129,7 +129,7 @@ func TestRegisterServiceWithCallback_Mixed(t *testing.T) {
 
 func TestHealthMonitor_DisablePanics_DoesNotPanic(t *testing.T) {
 	logger := &mocks.Logger{}
-	logger.On("With", "module", "health-monitor").Return(logger).Once()
+	logger.On("With", "module", "daemon-health-monitor").Return(logger).Once()
 	logger.On(
 		"Error",
 		"health-checked service is unhealthy",

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - --bridge-daemon-eth-rpc-endpoint
       - "${ETH_RPC_ENDPOINT}"
       - --maximum-daemon-unhealthy-seconds
-      - "4294967295"
+      - "4294967295" # Effectively disable the daemon monitor because bridge daemon is flaky in localnet.
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -10,13 +10,15 @@ services:
       - --log_level
       # Note that only this validator has a log-level of `info`; other validators use `error` by default.
       # Change to `debug` for more verbose log-level.
-      - info 
+      - info
       - --home
       - /dydxprotocol/chain/.alice
-      - --p2p.persistent_peers 
+      - --p2p.persistent_peers
       - "17e5e45691f0d01449c84fd4ae87279578cdd7ec@dydxprotocold0:26656,b69182310be02559483e42c77b7b104352713166@dydxprotocold1:26656,47539956aaa8e624e0f1d926040e54908ad0eb44@dydxprotocold2:26656,5882428984d83b03d0c907c1f0af343534987052@dydxprotocold3:26656"
       - --bridge-daemon-eth-rpc-endpoint
       - "${ETH_RPC_ENDPOINT}"
+      - --maximum-daemon-unhealthy-seconds
+      - "4294967295"
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}
@@ -28,7 +30,7 @@ services:
       - "26657:26657"
       - "9090:9090"
       - "1317:1317"
-  
+
   dydxprotocold1:
     image: local:dydxprotocol
     entrypoint:
@@ -39,10 +41,12 @@ services:
        - error
        - --home
        - /dydxprotocol/chain/.bob
-       - --p2p.persistent_peers 
+       - --p2p.persistent_peers
        - "17e5e45691f0d01449c84fd4ae87279578cdd7ec@dydxprotocold0:26656,b69182310be02559483e42c77b7b104352713166@dydxprotocold1:26656,47539956aaa8e624e0f1d926040e54908ad0eb44@dydxprotocold2:26656,5882428984d83b03d0c907c1f0af343534987052@dydxprotocold3:26656"
        - --bridge-daemon-eth-rpc-endpoint
        - "${ETH_RPC_ENDPOINT}"
+       - --maximum-daemon-unhealthy-seconds
+       - "4294967295"
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}
@@ -52,7 +56,7 @@ services:
       - ./localnet/dydxprotocol1:/dydxprotocol/chain/.bob/data
     ports:
       - "26658:26657"
- 
+
   dydxprotocold2:
     image: local:dydxprotocol
     entrypoint:
@@ -67,6 +71,8 @@ services:
        - "17e5e45691f0d01449c84fd4ae87279578cdd7ec@dydxprotocold0:26656,b69182310be02559483e42c77b7b104352713166@dydxprotocold1:26656,47539956aaa8e624e0f1d926040e54908ad0eb44@dydxprotocold2:26656,5882428984d83b03d0c907c1f0af343534987052@dydxprotocold3:26656"
        - --bridge-daemon-eth-rpc-endpoint
        - "${ETH_RPC_ENDPOINT}"
+       - --maximum-daemon-unhealthy-seconds
+       - "4294967295"
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}
@@ -74,7 +80,7 @@ services:
       - DAEMON_HOME=/dydxprotocol/chain/.carl
     volumes:
       - ./localnet/dydxprotocol2:/dydxprotocol/chain/.carl/data
-  
+
   dydxprotocold3:
     image: local:dydxprotocol
     entrypoint:
@@ -85,10 +91,12 @@ services:
        - error
        - --home
        - /dydxprotocol/chain/.dave
-       - --p2p.persistent_peers 
+       - --p2p.persistent_peers
        - "17e5e45691f0d01449c84fd4ae87279578cdd7ec@dydxprotocold0:26656,b69182310be02559483e42c77b7b104352713166@dydxprotocold1:26656,47539956aaa8e624e0f1d926040e54908ad0eb44@dydxprotocold2:26656,5882428984d83b03d0c907c1f0af343534987052@dydxprotocold3:26656"
        - --bridge-daemon-eth-rpc-endpoint
        - "${ETH_RPC_ENDPOINT}"
+       - --maximum-daemon-unhealthy-seconds
+       - "4294967295"
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
       - DD_ENV=localnet_${USER}

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "17e5e45691f0d01449c84fd4ae87279578cdd7ec@dydxprotocold0:26656,b69182310be02559483e42c77b7b104352713166@dydxprotocold1:26656,47539956aaa8e624e0f1d926040e54908ad0eb44@dydxprotocold2:26656,5882428984d83b03d0c907c1f0af343534987052@dydxprotocold3:26656"
       - --bridge-daemon-eth-rpc-endpoint
       - "${ETH_RPC_ENDPOINT}"
-      - --maximum-daemon-unhealthy-seconds
+      - --max-daemon-unhealthy-seconds
       - "4294967295" # Effectively disable the daemon monitor because bridge daemon is flaky in localnet.
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
@@ -45,7 +45,7 @@ services:
        - "17e5e45691f0d01449c84fd4ae87279578cdd7ec@dydxprotocold0:26656,b69182310be02559483e42c77b7b104352713166@dydxprotocold1:26656,47539956aaa8e624e0f1d926040e54908ad0eb44@dydxprotocold2:26656,5882428984d83b03d0c907c1f0af343534987052@dydxprotocold3:26656"
        - --bridge-daemon-eth-rpc-endpoint
        - "${ETH_RPC_ENDPOINT}"
-       - --maximum-daemon-unhealthy-seconds
+       - --max-daemon-unhealthy-seconds
        - "4294967295"
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
@@ -71,7 +71,7 @@ services:
        - "17e5e45691f0d01449c84fd4ae87279578cdd7ec@dydxprotocold0:26656,b69182310be02559483e42c77b7b104352713166@dydxprotocold1:26656,47539956aaa8e624e0f1d926040e54908ad0eb44@dydxprotocold2:26656,5882428984d83b03d0c907c1f0af343534987052@dydxprotocold3:26656"
        - --bridge-daemon-eth-rpc-endpoint
        - "${ETH_RPC_ENDPOINT}"
-       - --maximum-daemon-unhealthy-seconds
+       - --max-daemon-unhealthy-seconds
        - "4294967295"
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables
@@ -95,7 +95,7 @@ services:
        - "17e5e45691f0d01449c84fd4ae87279578cdd7ec@dydxprotocold0:26656,b69182310be02559483e42c77b7b104352713166@dydxprotocold1:26656,47539956aaa8e624e0f1d926040e54908ad0eb44@dydxprotocold2:26656,5882428984d83b03d0c907c1f0af343534987052@dydxprotocold3:26656"
        - --bridge-daemon-eth-rpc-endpoint
        - "${ETH_RPC_ENDPOINT}"
-       - --maximum-daemon-unhealthy-seconds
+       - --max-daemon-unhealthy-seconds
        - "4294967295"
     environment:
       # See https://docs.datadoghq.com/profiler/enabling/go/ for DD_ specific environment variables

--- a/protocol/x/clob/client/cli/cancel_order_cli_test.go
+++ b/protocol/x/clob/client/cli/cancel_order_cli_test.go
@@ -8,6 +8,7 @@ import (
 	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	daemonflags "github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/appoptions"
+	"math"
 	"math/big"
 	"testing"
 
@@ -72,6 +73,13 @@ func (s *CancelOrderIntegrationTestSuite) SetupTest() {
 			// Disable the Bridge and Price daemons in the integration tests.
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, false)
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
+
+			// Effectively disable the health monitor panic timeout for these tests. This is necessary
+			// because all clob cli tests are running in the same process and the total time to run is >> 5 minutes
+			// on CI, causing the panic to trigger for liquidations daemon go routines that haven't been properly
+			// cleaned up after a test run.
+			// TODO(CORE-29): Remove this once the liquidations daemon is refactored to be stoppable.
+			appOptions.Set(daemonflags.FlagMaxDaemonUnhealthySeconds, math.MaxUint32)
 
 			// Make sure the daemon is using the correct GRPC address.
 			appOptions.Set(appflags.GrpcAddress, testval.AppConfig.GRPC.Address)

--- a/protocol/x/clob/client/cli/liquidations_cli_test.go
+++ b/protocol/x/clob/client/cli/liquidations_cli_test.go
@@ -4,6 +4,7 @@ package cli_test
 
 import (
 	"fmt"
+	"math"
 
 	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"math/big"
@@ -73,6 +74,13 @@ func TestLiquidationOrderIntegrationTestSuite(t *testing.T) {
 			// Disable the Bridge and Price daemons in the integration tests.
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, false)
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
+
+			// Effectively disable the health monitor panic timeout for these tests. This is necessary
+			// because all clob cli tests are running in the same process and the total time to run is >> 5 minutes
+			// on CI, causing the panic to trigger for liquidations daemon go routines that haven't been properly
+			// cleaned up after a test run.
+			// TODO(CORE-29): Remove this once the liquidations daemon is refactored to be stoppable.
+			appOptions.Set(daemonflags.FlagMaxDaemonUnhealthySeconds, math.MaxUint32)
 
 			// Make sure the daemon is using the correct GRPC address.
 			appOptions.Set(appflags.GrpcAddress, testval.AppConfig.GRPC.Address)

--- a/protocol/x/clob/client/cli/place_order_cli_test.go
+++ b/protocol/x/clob/client/cli/place_order_cli_test.go
@@ -5,6 +5,7 @@ package cli_test
 import (
 	"fmt"
 	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	"math"
 	"math/big"
 	"testing"
 
@@ -67,6 +68,13 @@ func TestPlaceOrderIntegrationTestSuite(t *testing.T) {
 			// Disable the Bridge and Price daemons in the integration tests.
 			appOptions.Set(daemonflags.FlagPriceDaemonEnabled, false)
 			appOptions.Set(daemonflags.FlagBridgeDaemonEnabled, false)
+
+			// Effectively disable the health monitor panic timeout for these tests. This is necessary
+			// because all clob cli tests are running in the same process and the total time to run is >> 5 minutes
+			// on CI, causing the panic to trigger for liquidations daemon go routines that haven't been properly
+			// cleaned up after a test run.
+			// TODO(CORE-29): Remove this once the liquidations daemon is refactored to be stoppable.
+			appOptions.Set(daemonflags.FlagMaxDaemonUnhealthySeconds, math.MaxUint32)
 
 			// Make sure the daemon is using the correct GRPC address.
 			appOptions.Set(appflags.GrpcAddress, testval.AppConfig.GRPC.Address)


### PR DESCRIPTION
### Changelist
Add 2 flags:
- configure # of seconds before unhealthy daemon causes a panic
- enable panicking behavior or log error when daemon health check fails

### Test Plan
- unit tests for daemonFlags
- tested both flags with localnet.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
