### PR TITLE
[IND-489] Update order side when replacing. Fix liquidations side bug.

### DIFF
--- a/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
@@ -80,16 +80,17 @@ BEGIN
                                   power(10, perpetual_market_record."quantumConversionExponent" +
                                             asset_record."atomicResolution" -
                                             perpetual_market_record."atomicResolution")::numeric);
-    order_side = dydx_from_protocol_order_side(order_->'side');
 
     IF field = 'makerOrder' THEN
         order_uuid = dydx_uuid_from_order_id(order_->'orderId');
         subaccount_uuid = dydx_uuid_from_subaccount_id(jsonb_extract_path(order_, 'orderId', 'subaccountId'));
         order_client_metadata = (order_->'clientMetadata')::bigint;
+        order_side = dydx_from_protocol_order_side(order_->'side');
     ELSE
         order_uuid = NULL;
         subaccount_uuid = dydx_uuid_from_subaccount_id(jsonb_extract_path(order_, 'liquidated'));
         order_client_metadata = NULL;
+        order_side = CASE WHEN (order_->'isBuy')::bool THEN 'BUY' ELSE 'SELL' END;
     END IF;
 
     IF field = 'makerOrder' THEN
@@ -98,6 +99,7 @@ BEGIN
 
         /** Upsert the order, populating the order_record fields with what will be in the database. */
         SELECT * INTO order_record FROM orders WHERE "id" = order_uuid;
+        order_record."side" = order_side;
         order_record."size" = order_size;
         order_record."price" = order_price;
         order_record."timeInForce" = dydx_from_protocol_time_in_force(order_->'timeInForce');
@@ -115,6 +117,7 @@ BEGIN
 
             UPDATE orders
             SET
+                "side" = order_record."side",
                 "size" = order_record."size",
                 "totalFilled" = order_record."totalFilled",
                 "price" = order_record."price",

--- a/indexer/services/ender/src/scripts/dydx_order_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/dydx_order_fill_handler_per_order.sql
@@ -84,6 +84,7 @@ BEGIN
 
     /** Upsert the order, populating the order_record fields with what will be in the database. */
     SELECT * INTO order_record FROM orders WHERE "id" = order_uuid;
+    order_record."side" = order_side;
     order_record."size" = order_size;
     order_record."price" = order_price;
     order_record."timeInForce" = dydx_from_protocol_time_in_force(order_->'timeInForce');
@@ -101,6 +102,7 @@ BEGIN
 
         UPDATE orders
         SET
+            "side" = order_record."side",
             "size" = order_record."size",
             "totalFilled" = order_record."totalFilled",
             "price" = order_record."price",


### PR DESCRIPTION
### Changelist

- Update SQL handlers to update the order side when replacing an order
- Update SQL handlers for liquidations, fixing bug where liquidation fills always have side `SELL`

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
