### PR TITLE
[IND-399] Fix line numbers in SQL function stack traces

### DIFF
--- a/indexer/services/ender/src/scripts/dydx_asset_create_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_asset_create_handler.sql
@@ -1,11 +1,13 @@
+CREATE OR REPLACE FUNCTION dydx_asset_create_handler(event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-proto/blob/8d35c86/dydxprotocol/indexer/indexer_manager/event.proto#L25)
         converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
   Returns: JSON object containing fields:
     - asset: The created asset in asset-model format (https://github.com/dydxprotocol/indexer/blob/cc70982/packages/postgres/src/models/asset-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_asset_create_handler(event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     market_record_id integer;
     asset_record assets%ROWTYPE;

--- a/indexer/services/ender/src/scripts/dydx_clob_pair_status_to_market_status.sql
+++ b/indexer/services/ender/src/scripts/dydx_clob_pair_status_to_market_status.sql
@@ -1,3 +1,5 @@
+CREATE OR REPLACE FUNCTION dydx_clob_pair_status_to_market_status(status jsonb)
+    RETURNS text AS $$
 /**
   Returns the market status (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/types/perpetual-market-types.ts#L60)
   from the clob pair status (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L157).
@@ -5,9 +7,9 @@
 
   Parameters:
     - status: the ClobPairStatus (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L157)
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_clob_pair_status_to_market_status(status jsonb)
-    RETURNS text AS $$
 BEGIN
     CASE status
         WHEN '1'::jsonb THEN RETURN 'ACTIVE'; /** CLOB_PAIR_STATUS_ACTIVE */

--- a/indexer/services/ender/src/scripts/dydx_create_initial_rows_for_tendermint_block.sql
+++ b/indexer/services/ender/src/scripts/dydx_create_initial_rows_for_tendermint_block.sql
@@ -1,3 +1,5 @@
+CREATE OR REPLACE FUNCTION dydx_create_initial_rows_for_tendermint_block(
+    block_height text, block_time text, tx_hashes text[], events jsonb[]) RETURNS void AS $$
 /**
   Parameters:
     - block_height: the height of the block being processed.
@@ -5,9 +7,9 @@
     - tx_hashes: Array of transaction hashes from the IndexerTendermintBlock.
     - events: Array of IndexerTendermintEvent objects.
   Returns: void.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_create_initial_rows_for_tendermint_block(
-    block_height text, block_time text, tx_hashes text[], events jsonb[]) RETURNS void AS $$
 BEGIN
     -- Create block.
     INSERT INTO blocks ("blockHeight", "time") VALUES (block_height::bigint, block_time::timestamp);

--- a/indexer/services/ender/src/scripts/dydx_create_tendermint_event.sql
+++ b/indexer/services/ender/src/scripts/dydx_create_tendermint_event.sql
@@ -1,12 +1,14 @@
+CREATE OR REPLACE FUNCTION dydx_create_tendermint_event(
+    event jsonb, block_height text
+) RETURNS jsonb AS $$
 /**
   Parameters:
     - event: The IndexerTendermintEvent object.
     - block_height: the height of the block being processed.
   Returns: The inserted event.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_create_tendermint_event(
-    event jsonb, block_height text
-) RETURNS jsonb AS $$
 DECLARE
     transaction_idx int;
     event_id bytea;

--- a/indexer/services/ender/src/scripts/dydx_create_transaction.sql
+++ b/indexer/services/ender/src/scripts/dydx_create_transaction.sql
@@ -1,13 +1,15 @@
+CREATE OR REPLACE FUNCTION dydx_create_transaction(
+    transaction_hash text, block_height text, transaction_index int
+) RETURNS jsonb AS $$
 /**
   Parameters:
     - transaction_hash: the hash of the transaction being processed.
     - block_height: the height of the block being processed.
     - transaction_index: the index of the transaction in the block.
   Returns: The inserted transaction.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_create_transaction(
-    transaction_hash text, block_height text, transaction_index int
-) RETURNS jsonb AS $$
 DECLARE
     inserted_transaction jsonb;
 BEGIN

--- a/indexer/services/ender/src/scripts/dydx_deleveraging_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_deleveraging_handler.sql
@@ -1,3 +1,6 @@
+CREATE OR REPLACE FUNCTION dydx_deleveraging_handler(
+    block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int,
+    transaction_hash text) RETURNS jsonb AS $$
 /**
   Parameters:
     - block_height: the height of the block being processing.
@@ -14,10 +17,9 @@
     - perpetual_market: The perpetual market for the deleveraging in perpetual-market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-market-model.ts).
     - liquidated_perpetual_position: The updated liquidated perpetual position in perpetual-position-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-position-model.ts).
     - offsetting_perpetual_position: The updated offsetting perpetual position in perpetual-position-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-position-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_deleveraging_handler(
-    block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int,
-    transaction_hash text) RETURNS jsonb AS $$
 DECLARE
     QUOTE_CURRENCY_ATOMIC_RESOLUTION constant numeric = -6;
     FEE constant numeric = 0;

--- a/indexer/services/ender/src/scripts/dydx_event_id_from_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_event_id_from_parts.sql
@@ -1,3 +1,4 @@
+CREATE OR REPLACE FUNCTION dydx_event_id_from_parts(block_height int, transaction_index int, event_index int) RETURNS bytea AS $$
 /**
   Returns an event id from parts.
 
@@ -6,8 +7,9 @@
     - transaction_index: The transaction_index of the IndexerTendermintEvent after the conversion that takes into
         account the block_event (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/services/ender/src/lib/helper.ts#L41)
     - event_index: The 'event_index' of the IndexerTendermintEvent.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_event_id_from_parts(block_height int, transaction_index int, event_index int) RETURNS bytea AS $$
 BEGIN
     /*
     int4send converts to network order (which is also big endian order).

--- a/indexer/services/ender/src/scripts/dydx_from_jsonlib_long.sql
+++ b/indexer/services/ender/src/scripts/dydx_from_jsonlib_long.sql
@@ -1,3 +1,4 @@
+CREATE OR REPLACE FUNCTION dydx_from_jsonlib_long(long_value jsonb) RETURNS numeric AS $$
 /**
   Converts JSON objects of the form (https://www.npmjs.com/package/long):
     {
@@ -7,8 +8,9 @@
     }
   and converts it to a numeric. Note that this is the format used to convert Long types when converted using
   JSON.stringify.
- */
-CREATE OR REPLACE FUNCTION dydx_from_jsonlib_long(long_value jsonb) RETURNS numeric AS $$
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
+*/
 DECLARE
     POWER_2_32 constant numeric = power(2::numeric, 32::numeric);
 BEGIN

--- a/indexer/services/ender/src/scripts/dydx_from_protocol_order_side.sql
+++ b/indexer/services/ender/src/scripts/dydx_from_protocol_order_side.sql
@@ -1,8 +1,10 @@
-/**
- Converts the 'Side' enum from the IndexerOrder protobuf (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L56)
- to the 'OrderSide' enum in postgres.
- */
 CREATE OR REPLACE FUNCTION dydx_from_protocol_order_side(order_side jsonb) RETURNS text AS $$
+/**
+  Converts the 'Side' enum from the IndexerOrder protobuf (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L56)
+  to the 'OrderSide' enum in postgres.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
+*/
 BEGIN
     CASE order_side
         WHEN '1'::jsonb THEN RETURN 'BUY'; /** SIDE_BUY */

--- a/indexer/services/ender/src/scripts/dydx_from_protocol_time_in_force.sql
+++ b/indexer/services/ender/src/scripts/dydx_from_protocol_time_in_force.sql
@@ -1,10 +1,12 @@
+CREATE OR REPLACE FUNCTION dydx_from_protocol_time_in_force(tif jsonb) RETURNS text AS $$
 /**
- Converts the TimeInForce field from an IndexerOrder proto (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L94)
- to a TimeInForce enum in postgres.
+  Converts the TimeInForce field from an IndexerOrder proto (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L94)
+  to a TimeInForce enum in postgres.
 
   Raise an exception if the input TimeInForce enum is not in the known enum values for TimeInForce.
- */
-CREATE OR REPLACE FUNCTION dydx_from_protocol_time_in_force(tif jsonb) RETURNS text AS $$
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
+*/
 BEGIN
     CASE tif
         WHEN '-1'::jsonb THEN RETURN 'GTT'; /** Default behavior with UNRECOGNIZED = GTT (Good-Til-Time) */

--- a/indexer/services/ender/src/scripts/dydx_from_serializable_int.sql
+++ b/indexer/services/ender/src/scripts/dydx_from_serializable_int.sql
@@ -1,3 +1,4 @@
+CREATE OR REPLACE FUNCTION dydx_from_serializable_int(serializable_int jsonb) RETURNS numeric AS $$
 /**
   Converts a JSON.stringify byte array representing a SerializableInt
   (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/protocol/dtypes/serializable_int.go#L84) to a numeric.
@@ -5,8 +6,9 @@
   (https://github.com/golang/go/blob/886fba5/src/math/big/intmarsh.go#L18)
   which is represented as [versionAndSignByte bigEndianByte0 bigEndianByte1 ... bigEndianByte2]
   byte array.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_from_serializable_int(serializable_int jsonb) RETURNS numeric AS $$
 DECLARE
     rval numeric = 0;
     version_and_sign int;

--- a/indexer/services/ender/src/scripts/dydx_funding_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_funding_handler.sql
@@ -1,3 +1,5 @@
+CREATE OR REPLACE FUNCTION dydx_funding_handler(
+    block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int) RETURNS jsonb AS $$
 /**
   Parameters:
     - block_height: the height of the block being processing.
@@ -10,9 +12,9 @@
   Returns: JSON object containing fields:
     - perpetual_markets: A mapping from perpetual market id to the associated perpetual market in perpetual-market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-market-model.ts).
     - errors: An array containing an error string (or NULL if no error occurred) for each FundingEventUpdate.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_funding_handler(
-    block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int) RETURNS jsonb AS $$
 DECLARE
     PPM_EXPONENT constant numeric = -6;
     FUNDING_RATE_FROM_PROTOCOL_IN_HOURS constant numeric = 8;

--- a/indexer/services/ender/src/scripts/dydx_get_fee_from_liquidity.sql
+++ b/indexer/services/ender/src/scripts/dydx_get_fee_from_liquidity.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_get_fee(fill_liquidity text, event_data jsonb) RETURNS numeric AS $$
 /**
   Returns the fee given the liquidity side.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_get_fee(fill_liquidity text, event_data jsonb) RETURNS numeric AS $$
 BEGIN
     IF fill_liquidity = 'TAKER' THEN
         RETURN dydx_from_jsonlib_long(event_data->'takerFee');

--- a/indexer/services/ender/src/scripts/dydx_get_order_status.sql
+++ b/indexer/services/ender/src/scripts/dydx_get_order_status.sql
@@ -1,3 +1,5 @@
+CREATE OR REPLACE FUNCTION dydx_get_order_status(total_filled numeric, size numeric, order_canceled_status text, order_flags bigint, time_in_force text)
+RETURNS text AS $$
 /**
   Computes the order status given a set of order parameters.
 
@@ -21,9 +23,9 @@
     - order_canceled_status - The status of the order.
     - order_flags - The flags of the order.
   Returns the order status.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_get_order_status(total_filled numeric, size numeric, order_canceled_status text, order_flags bigint, time_in_force text)
-RETURNS text AS $$
 BEGIN
     IF total_filled >= size THEN
         RETURN 'FILLED';

--- a/indexer/services/ender/src/scripts/dydx_get_perpetual_market_for_clob_pair.sql
+++ b/indexer/services/ender/src/scripts/dydx_get_perpetual_market_for_clob_pair.sql
@@ -1,13 +1,15 @@
+CREATE OR REPLACE FUNCTION dydx_get_perpetual_market_for_clob_pair(
+    clob_pair_id bigint
+) RETURNS perpetual_markets AS $$
 /**
   Returns the perpetual market record for the provided clob pair.
 
   Parameters:
     - clob_pair_id: The clob pair id.
   Returns: the only perpetual market for the clob pair. Throws an exception if not exactly one row is found.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_get_perpetual_market_for_clob_pair(
-    clob_pair_id bigint
-) RETURNS perpetual_markets AS $$
 DECLARE
     perpetual_market_record perpetual_markets%ROWTYPE;
 BEGIN

--- a/indexer/services/ender/src/scripts/dydx_get_total_filled_from_liquidity.sql
+++ b/indexer/services/ender/src/scripts/dydx_get_total_filled_from_liquidity.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_get_total_filled(fill_liquidity text, event_data jsonb) RETURNS numeric AS $$
 /**
   Returns the order total filled amount given the liquidity side.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_get_total_filled(fill_liquidity text, event_data jsonb) RETURNS numeric AS $$
 BEGIN
     IF fill_liquidity = 'TAKER' THEN
         RETURN dydx_from_jsonlib_long(event_data->'totalFilledTaker');

--- a/indexer/services/ender/src/scripts/dydx_get_weighted_average.sql
+++ b/indexer/services/ender/src/scripts/dydx_get_weighted_average.sql
@@ -1,3 +1,4 @@
+CREATE OR REPLACE FUNCTION dydx_get_weighted_average(first_price numeric, first_weight numeric, second_price numeric, second_weight numeric) RETURNS numeric AS $$
 /**
   Returns the weighted average between two prices.
 
@@ -9,8 +10,9 @@
     - first_weight: The weight of the first price.
     - second_price: The second price. Defaults to 0 if null.
     - second_weight: The weight of the second price.
- */
-CREATE OR REPLACE FUNCTION dydx_get_weighted_average(first_price numeric, first_weight numeric, second_price numeric, second_weight numeric) RETURNS numeric AS $$
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
+*/
 BEGIN
     RETURN dydx_trim_scale((coalesce(first_price, 0::numeric) * first_weight +
                             coalesce(second_price, 0::numeric) * second_weight)::numeric(256, 20)

--- a/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/dydx_liquidation_fill_handler_per_order.sql
@@ -1,24 +1,3 @@
-/**
-  Parameters:
-    - field: the field storing the order to process.
-    - block_height: the height of the block being processing.
-    - block_time: the time of the block being processed.
-    - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25)
-        converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
-    - event_index: The 'event_index' of the IndexerTendermintEvent.
-    - transaction_index: The transaction_index of the IndexerTendermintEvent after the conversion that takes into
-        account the block_event (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/services/ender/src/lib/helper.ts#L41)
-    - transaction_hash: The transaction hash corresponding to this event from the IndexerTendermintBlock 'tx_hashes'.
-    - fill_liquidity: The liquidity for the fill record.
-    - fill_type: The type for the fill record.
-    - usdc_asset_id: The USDC asset id.
-  Returns: JSON object containing fields:
-    - order: The updated order in order-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/order-model.ts).
-        Only returned if field == 'makerOrder'.
-    - fill: The updated fill in fill-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/fill-model.ts).
-    - perpetual_market: The perpetual market for the order in perpetual-market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-market-model.ts).
-    - perpetual_position: The updated perpetual position in perpetual-position-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-position-model.ts).
-*/
 CREATE OR REPLACE FUNCTION dydx_liquidation_fill_handler_per_order(
     field text, block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int,
     transaction_hash text, fill_liquidity text, fill_type text, usdc_asset_id text) RETURNS jsonb AS $$
@@ -42,6 +21,29 @@ DECLARE
     total_filled numeric;
     maker_price numeric;
     event_id bytea;
+/**
+  Parameters:
+    - field: the field storing the order to process.
+    - block_height: the height of the block being processing.
+    - block_time: the time of the block being processed.
+    - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25)
+        converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
+    - event_index: The 'event_index' of the IndexerTendermintEvent.
+    - transaction_index: The transaction_index of the IndexerTendermintEvent after the conversion that takes into
+        account the block_event (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/services/ender/src/lib/helper.ts#L41)
+    - transaction_hash: The transaction hash corresponding to this event from the IndexerTendermintBlock 'tx_hashes'.
+    - fill_liquidity: The liquidity for the fill record.
+    - fill_type: The type for the fill record.
+    - usdc_asset_id: The USDC asset id.
+  Returns: JSON object containing fields:
+    - order: The updated order in order-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/order-model.ts).
+        Only returned if field == 'makerOrder'.
+    - fill: The updated fill in fill-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/fill-model.ts).
+    - perpetual_market: The perpetual market for the order in perpetual-market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-market-model.ts).
+    - perpetual_position: The updated perpetual position in perpetual-position-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-position-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
+*/
 BEGIN
     order_ = event_data->field;
     maker_order = event_data->'makerOrder';

--- a/indexer/services/ender/src/scripts/dydx_liquidity_tier_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_liquidity_tier_handler.sql
@@ -1,11 +1,13 @@
+CREATE OR REPLACE FUNCTION dydx_liquidity_tier_handler(event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25)
         converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
   Returns: JSON object containing fields:
     - liquidy_tier: The upserted liquidity tier in liquidity-tiers-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/liquidity-tiers-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_liquidity_tier_handler(event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     liquidity_tier_record liquidity_tiers%ROWTYPE;
 BEGIN

--- a/indexer/services/ender/src/scripts/dydx_market_create_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_market_create_handler.sql
@@ -1,11 +1,13 @@
+CREATE OR REPLACE FUNCTION dydx_market_create_handler(event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25)
         converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
   Returns: JSON object containing fields:
     - market: The created market in market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/market-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_market_create_handler(event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     market_record_id integer;
     market_record markets%ROWTYPE;

--- a/indexer/services/ender/src/scripts/dydx_market_modify_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_market_modify_handler.sql
@@ -1,11 +1,13 @@
+CREATE OR REPLACE FUNCTION dydx_market_modify_handler(event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25)
         converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
   Returns: JSON object containing fields:
     - market: The updated market in market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/market-model.ts).
+
+  (Note that all comments must be after the declaration of the function to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_market_modify_handler(event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     market_record_id integer;
     market_record markets%ROWTYPE;

--- a/indexer/services/ender/src/scripts/dydx_market_price_update_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_market_price_update_handler.sql
@@ -1,3 +1,4 @@
+CREATE OR REPLACE FUNCTION dydx_market_price_update_handler(block_height int, block_time timestamp, event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - block_height: the height of the block being processing.
@@ -7,8 +8,9 @@
   Returns: JSON object containing fields:
     - market: The updated market in market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/market-model.ts).
     - oracle_price: The created oracle price in oracle-price-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/oracle-price-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_market_price_update_handler(block_height int, block_time timestamp, event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     market_record_id integer;
     market_record markets%ROWTYPE;

--- a/indexer/services/ender/src/scripts/dydx_order_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/dydx_order_fill_handler_per_order.sql
@@ -1,3 +1,6 @@
+CREATE OR REPLACE FUNCTION dydx_order_fill_handler_per_order(
+    field text, block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int,
+    transaction_hash text, fill_liquidity text, fill_type text, usdc_asset_id text, order_canceled_status text) RETURNS jsonb AS $$
 /**
   Parameters:
     - field: the field storing the order to process.
@@ -18,10 +21,9 @@
     - fill: The updated fill in fill-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/fill-model.ts).
     - perpetual_market: The perpetual market for the order in perpetual-market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-market-model.ts).
     - perpetual_position: The updated perpetual position in perpetual-position-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-position-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_order_fill_handler_per_order(
-    field text, block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int,
-    transaction_hash text, fill_liquidity text, fill_type text, usdc_asset_id text, order_canceled_status text) RETURNS jsonb AS $$
 DECLARE
     order_ jsonb;
     maker_order jsonb;

--- a/indexer/services/ender/src/scripts/dydx_perpetual_market_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_perpetual_market_handler.sql
@@ -1,11 +1,13 @@
+CREATE OR REPLACE FUNCTION dydx_perpetual_market_handler(event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25)
         converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
   Returns: JSON object containing fields:
     - perpetual_market: The updated perpetual market in perpetual-market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-market-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_perpetual_market_handler(event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     perpetual_market_record perpetual_markets%ROWTYPE;
 BEGIN

--- a/indexer/services/ender/src/scripts/dydx_perpetual_position_and_order_side_matching.sql
+++ b/indexer/services/ender/src/scripts/dydx_perpetual_position_and_order_side_matching.sql
@@ -1,9 +1,11 @@
+CREATE OR REPLACE FUNCTION dydx_perpetual_position_and_order_side_matching(
+    perpetual_position_side text, order_side text) RETURNS boolean AS $$
 /**
   Returns true iff perpetual_position_side is LONG and order_side is BUY or if perpetual_position_side is SHORT and
   order_side is SELL.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_perpetual_position_and_order_side_matching(
-    perpetual_position_side text, order_side text) RETURNS boolean AS $$
 BEGIN
     RETURN (perpetual_position_side = 'LONG' AND order_side = 'BUY') OR
            (perpetual_position_side = 'SHORT' AND order_side = 'SELL');

--- a/indexer/services/ender/src/scripts/dydx_protocol_condition_type_to_order_type.sql
+++ b/indexer/services/ender/src/scripts/dydx_protocol_condition_type_to_order_type.sql
@@ -1,8 +1,10 @@
-/**
- Converts the 'ConditionType' enum from the IndexerOrder protobuf (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L130)
- to the 'OrderType' enum in postgres.
- */
 CREATE OR REPLACE FUNCTION dydx_protocol_condition_type_to_order_type(condition_type jsonb) RETURNS text AS $$
+/**
+  Converts the 'ConditionType' enum from the IndexerOrder protobuf (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L130)
+  to the 'OrderType' enum in postgres.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
+*/
 BEGIN
     CASE condition_type
         WHEN '-1'::jsonb THEN RETURN 'LIMIT'; /** UNRECOGNIZED */

--- a/indexer/services/ender/src/scripts/dydx_stateful_order_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_stateful_order_handler.sql
@@ -1,3 +1,5 @@
+CREATE OR REPLACE FUNCTION dydx_stateful_order_handler(
+    block_height int, block_time timestamp, event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - block_height: the height of the block being processing.
@@ -6,9 +8,9 @@
         converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
   Returns: JSON object containing fields:
     - order: The upserted order in order-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/order-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_stateful_order_handler(
-    block_height int, block_time timestamp, event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     QUOTE_CURRENCY_ATOMIC_RESOLUTION constant numeric = -6;
 

--- a/indexer/services/ender/src/scripts/dydx_subaccount_update_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_subaccount_update_handler.sql
@@ -1,3 +1,6 @@
+CREATE OR REPLACE FUNCTION dydx_subaccount_update_handler(
+    block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int)
+    RETURNS jsonb AS $$
 /**
   Parameters:
     - block_height: the height of the block being processing.
@@ -11,10 +14,9 @@
     - subaccount: The upserted subaccount in subaccount-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/subaccount-model.ts).
     - perpetual_positions: A JSON array of upserted perpetual positions in perpetual-position-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-position-model.ts).
     - asset_positions: A JSON array of upserted asset positions in asset-position-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/asset-position-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_subaccount_update_handler(
-    block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int)
-    RETURNS jsonb AS $$
 DECLARE
     QUOTE_CURRENCY_ATOMIC_RESOLUTION constant numeric = -6;
     event_id bytea;

--- a/indexer/services/ender/src/scripts/dydx_tendermint_event_to_transaction_index.sql
+++ b/indexer/services/ender/src/scripts/dydx_tendermint_event_to_transaction_index.sql
@@ -1,11 +1,13 @@
+CREATE OR REPLACE FUNCTION dydx_tendermint_event_to_transaction_index(event jsonb) RETURNS int AS $$
 /**
   Gets the transaction index from the IndexerTendermint event.
 
   Parameters:
     - event: The JSON.stringify of a IndexerTendermintEvent object (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25).
   Returns: int.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_tendermint_event_to_transaction_index(event jsonb) RETURNS int AS $$
 BEGIN
     IF event->'transactionIndex' IS NOT NULL THEN
         RETURN (event->'transactionIndex')::int;

--- a/indexer/services/ender/src/scripts/dydx_transfer_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_transfer_handler.sql
@@ -1,3 +1,6 @@
+CREATE OR REPLACE FUNCTION dydx_transfer_handler(
+    block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int,
+    transaction_hash text) RETURNS jsonb AS $$
 /**
   Parameters:
     - block_height: the height of the block being processing.
@@ -11,10 +14,9 @@
   Returns: JSON object containing fields:
     - asset: The existing asset in asset-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/asset-model.ts).
     - transfer: The new transfer in transfer-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/transfer-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_transfer_handler(
-    block_height int, block_time timestamp, event_data jsonb, event_index int, transaction_index int,
-    transaction_hash text) RETURNS jsonb AS $$
 DECLARE
     asset_record assets%ROWTYPE;
     recipient_subaccount_record subaccounts%ROWTYPE;

--- a/indexer/services/ender/src/scripts/dydx_trim_scale.sql
+++ b/indexer/services/ender/src/scripts/dydx_trim_scale.sql
@@ -1,8 +1,10 @@
+CREATE OR REPLACE FUNCTION dydx_trim_scale(value numeric) RETURNS numeric AS $$
 /**
   Returns a numeric with the zeros after the decimal point removed. Note that this function should be replaced by
   trim_scale which has become available with Postgres 13 (https://www.postgresql.org/docs/current/functions-math.html).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_trim_scale(value numeric) RETURNS numeric AS $$
 DECLARE
     trimmed_text text;
     trimmed_num numeric;

--- a/indexer/services/ender/src/scripts/dydx_update_clob_pair_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_update_clob_pair_handler.sql
@@ -1,11 +1,13 @@
+CREATE OR REPLACE FUNCTION dydx_update_clob_pair_handler(event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25)
         converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
   Returns: JSON object containing fields:
     - perpetual_market: The updated perpetual market in perpetual-market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-market-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_update_clob_pair_handler(event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     clob_pair_id bigint;
     perpetual_market_record perpetual_markets%ROWTYPE;

--- a/indexer/services/ender/src/scripts/dydx_update_perpetual_handler.sql
+++ b/indexer/services/ender/src/scripts/dydx_update_perpetual_handler.sql
@@ -1,11 +1,13 @@
+CREATE OR REPLACE FUNCTION dydx_update_perpetual_handler(event_data jsonb) RETURNS jsonb AS $$
 /**
   Parameters:
     - event_data: The 'data' field of the IndexerTendermintEvent (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/indexer_manager/event.proto#L25)
         converted to JSON format. Conversion to JSON is expected to be done by JSON.stringify.
   Returns: JSON object containing fields:
     - perpetual_market: The updated perpetual market in perpetual-market-model format (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/models/perpetual-market-model.ts).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_update_perpetual_handler(event_data jsonb) RETURNS jsonb AS $$
 DECLARE
     perpetual_market_id bigint;
     perpetual_market_record perpetual_markets%ROWTYPE;

--- a/indexer/services/ender/src/scripts/dydx_update_perpetual_position_aggregate_fields.sql
+++ b/indexer/services/ender/src/scripts/dydx_update_perpetual_position_aggregate_fields.sql
@@ -1,3 +1,10 @@
+CREATE OR REPLACE FUNCTION dydx_update_perpetual_position_aggregate_fields(
+    subaccount_uuid uuid,
+    perpetual_id bigint,
+    side text,
+    size numeric,
+    price numeric
+) RETURNS perpetual_positions AS $$
 /**
   Parameters:
     - subaccount_uuid: The subaccount uuid of the updated perpetual position.
@@ -6,14 +13,9 @@
     - size: The size of the fill.
     - price: The price of the fill.
   Returns: the updated perpetual position.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_update_perpetual_position_aggregate_fields(
-    subaccount_uuid uuid,
-    perpetual_id bigint,
-    side text,
-    size numeric,
-    price numeric
-) RETURNS perpetual_positions AS $$
 DECLARE
     perpetual_position_record perpetual_positions%ROWTYPE;
     sum_open numeric;

--- a/indexer/services/ender/src/scripts/dydx_uuid.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid.sql
@@ -1,10 +1,12 @@
+CREATE OR REPLACE FUNCTION dydx_uuid(name text) RETURNS uuid AS $$
 /**
   Computes a UUID using a well known namespace.
 
   The namespace must match the well known constant defined in
   https://github.com/dydxprotocol/indexer/blob/6aafb97/packages/postgres/src/helpers/uuid.ts#L4.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid(name text) RETURNS uuid AS $$
 BEGIN
     RETURN uuid_generate_v5('0f9da948-a6fb-4c45-9edc-4685c3f3317d', name);
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_asset_position_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_asset_position_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_asset_position_parts(subaccount_uuid uuid, asset_id text) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of an asset position.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_asset_position_parts(subaccount_uuid uuid, asset_id text) RETURNS uuid AS $$
 BEGIN
     return dydx_uuid(concat(subaccount_uuid, '-', asset_id));
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_fill_event_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_fill_event_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_fill_event_parts(event_id bytea, liquidity text) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of a fill event.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_fill_event_parts(event_id bytea, liquidity text) RETURNS uuid AS $$
 BEGIN
     return dydx_uuid(concat(encode(event_id, 'hex'), '-', liquidity));
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_funding_index_update_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_funding_index_update_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_funding_index_update_parts(block_height int, event_id bytea, perpetual_id bigint) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of a funding index update.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_funding_index_update_parts(block_height int, event_id bytea, perpetual_id bigint) RETURNS uuid AS $$
 BEGIN
     return dydx_uuid(concat(block_height, '-', encode(event_id, 'hex'), '-', perpetual_id));
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_oracle_price_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_oracle_price_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_oracle_price_parts(market_id int, block_height int) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of an OraclePrice (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/indexer/packages/postgres/src/stores/oracle-price-table.ts#L24).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_oracle_price_parts(market_id int, block_height int) RETURNS uuid AS $$
 BEGIN
     return dydx_uuid(concat(market_id, '-', block_height));
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_order_id.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_order_id.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_order_id(order_id jsonb) RETURNS uuid AS $$
 /**
   Returns a UUID using the JSON.stringify format of an IndexerOrderId (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L15).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_order_id(order_id jsonb) RETURNS uuid AS $$
 BEGIN
     return dydx_uuid_from_order_id_parts(
         dydx_uuid_from_subaccount_id(order_id->'subaccountId'),

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_order_id_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_order_id_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_order_id_parts(subaccount_id uuid, client_id text, clob_pair_id text, order_flags text) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of an IndexerOrderId (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/clob.proto#L15).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_order_id_parts(subaccount_id uuid, client_id text, clob_pair_id text, order_flags text) RETURNS uuid AS $$
 BEGIN
     return dydx_uuid(concat(subaccount_id, '-', client_id, '-', clob_pair_id, '-', order_flags));
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_perpetual_position_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_perpetual_position_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_perpetual_position_parts(subaccount_uuid uuid, open_event_id bytea) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of a perpetual position.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_perpetual_position_parts(subaccount_uuid uuid, open_event_id bytea) RETURNS uuid AS $$
 BEGIN
     return dydx_uuid(concat(subaccount_uuid, '-', encode(open_event_id, 'hex')));
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_subaccount_id.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_subaccount_id.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_subaccount_id(subaccount_id jsonb) RETURNS uuid AS $$
 /**
   Returns a UUID using the JSON.stringify format of an IndexerSubaccountId (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/subaccount.proto#L15).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_subaccount_id(subaccount_id jsonb) RETURNS uuid AS $$
 BEGIN
     RETURN dydx_uuid_from_subaccount_id_parts(subaccount_id->>'owner', subaccount_id->>'number');
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_subaccount_id_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_subaccount_id_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_subaccount_id_parts(address text, subaccount_number text) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of an IndexerSubaccountId (https://github.com/dydxprotocol/v4-chain/blob/9ed26bd/proto/dydxprotocol/indexer/protocol/v1/subaccount.proto#L15).
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_subaccount_id_parts(address text, subaccount_number text) RETURNS uuid AS $$
 BEGIN
     RETURN dydx_uuid(concat(address, '-', subaccount_number));
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_transaction_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_transaction_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_transaction_parts(block_height text, transaction_index text) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of a transaction.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_transaction_parts(block_height text, transaction_index text) RETURNS uuid AS $$
 BEGIN
     return dydx_uuid(concat(block_height, '-', transaction_index));
 END;

--- a/indexer/services/ender/src/scripts/dydx_uuid_from_transfer_parts.sql
+++ b/indexer/services/ender/src/scripts/dydx_uuid_from_transfer_parts.sql
@@ -1,7 +1,9 @@
+CREATE OR REPLACE FUNCTION dydx_uuid_from_transfer_parts(event_id bytea, asset_id text, sender_subaccount_id uuid, recipient_subaccount_id uuid, sender_wallet_address text, recipient_wallet_address text) RETURNS uuid AS $$
 /**
   Returns a UUID using the parts of a transfer.
+
+  (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
-CREATE OR REPLACE FUNCTION dydx_uuid_from_transfer_parts(event_id bytea, asset_id text, sender_subaccount_id uuid, recipient_subaccount_id uuid, sender_wallet_address text, recipient_wallet_address text) RETURNS uuid AS $$
 DECLARE
     sender_subaccount_id_or_undefined text;
     recipient_subaccount_id_or_undefined text;


### PR DESCRIPTION
### Changelist
[IND-399] Fix line numbers in SQL function stack traces

This makes so that the PG_EXCEPTION_CONTEXT contains the correct line numbers giving a stack like: PL/pgSQL function dydx_market_modify_handler(jsonb) line 17 at RAISE PL/pgSQL function dydx_block_processor(jsonb) line 85 at assignment

### Test Plan
No functional changes.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
