### PR TITLE
feat(mev): enable using multiple mev telemetry hosts

### DIFF
--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"fmt"
+	"strings"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/spf13/cast"
@@ -15,7 +16,7 @@ type ClobFlags struct {
 	MaxDeleveragingSubaccountsToIterate uint32
 
 	MevTelemetryEnabled    bool
-	MevTelemetryHost       string
+	MevTelemetryHosts      []string
 	MevTelemetryIdentifier string
 }
 
@@ -28,20 +29,23 @@ const (
 
 	// Mev.
 	MevTelemetryEnabled    = "mev-telemetry-enabled"
-	MevTelemetryHost       = "mev-telemetry-host"
+	MevTelemetryHosts      = "mev-telemetry-hosts"
 	MevTelemetryIdentifier = "mev-telemetry-identifier"
 )
 
 // Default values.
+
 const (
 	DefaultMaxLiquidationAttemptsPerBlock      = 50
 	DefaultMaxDeleveragingAttemptsPerBlock     = 10
 	DefaultMaxDeleveragingSubaccountsToIterate = 500
 
 	DefaultMevTelemetryEnabled    = false
-	DefaultMevTelemetryHost       = ""
+	DefaultMevTelemetryHostsFlag  = ""
 	DefaultMevTelemetryIdentifier = ""
 )
+
+var DefaultMevTelemetryHosts = []string{}
 
 // AddFlagsToCmd adds flags to app initialization.
 // These flags should be applied to the `start` command of the V4 Cosmos application.
@@ -77,14 +81,14 @@ func AddClobFlagsToCmd(cmd *cobra.Command) {
 		"Runs the MEV Telemetry collection agent if true.",
 	)
 	cmd.Flags().String(
-		MevTelemetryHost,
-		DefaultMevTelemetryHost,
-		"Sets the address to connect to for the MEV Telemetry collection agent.",
+		MevTelemetryHosts,
+		DefaultMevTelemetryHostsFlag,
+		"Sets the addresses (comma-delimited) to connect to the MEV Telemetry collection agents.",
 	)
 	cmd.Flags().String(
 		MevTelemetryIdentifier,
 		DefaultMevTelemetryIdentifier,
-		"Sets the identifier to use for MEV Telemetry collection agent.",
+		"Sets the identifier to use for MEV Telemetry collection agents.",
 	)
 }
 
@@ -94,7 +98,7 @@ func GetDefaultClobFlags() ClobFlags {
 		MaxDeleveragingAttemptsPerBlock:     DefaultMaxDeleveragingAttemptsPerBlock,
 		MaxDeleveragingSubaccountsToIterate: DefaultMaxDeleveragingSubaccountsToIterate,
 		MevTelemetryEnabled:                 DefaultMevTelemetryEnabled,
-		MevTelemetryHost:                    DefaultMevTelemetryHost,
+		MevTelemetryHosts:                   DefaultMevTelemetryHosts,
 		MevTelemetryIdentifier:              DefaultMevTelemetryIdentifier,
 	}
 }
@@ -114,10 +118,8 @@ func GetClobFlagValuesFromOptions(
 		}
 	}
 
-	if option := appOpts.Get(MevTelemetryHost); option != nil {
-		if v, err := cast.ToStringE(option); err == nil {
-			result.MevTelemetryHost = v
-		}
+	if v, ok := appOpts.Get(MevTelemetryHosts).(string); ok {
+		result.MevTelemetryHosts = strings.Split(v, ",")
 	}
 
 	if option := appOpts.Get(MevTelemetryIdentifier); option != nil {

--- a/protocol/x/clob/flags/flags_test.go
+++ b/protocol/x/clob/flags/flags_test.go
@@ -24,12 +24,13 @@ func TestAddFlagsToCommand(t *testing.T) {
 		fmt.Sprintf("Has %s flag", flags.MaxDeleveragingAttemptsPerBlock): {
 			flagName: flags.MaxDeleveragingAttemptsPerBlock,
 		},
-		fmt.Sprintf("Has %s flag", flags.MevTelemetryHost): {
-			flagName: flags.MevTelemetryHost,
+		fmt.Sprintf("Has %s flag", flags.MevTelemetryHosts): {
+			flagName: flags.MevTelemetryHosts,
 		},
 		fmt.Sprintf("Has %s flag", flags.MevTelemetryIdentifier): {
 			flagName: flags.MevTelemetryIdentifier,
-		}}
+		},
+	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -47,28 +48,28 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 		expectedMaxLiquidationAttemptsPerBlock      uint32
 		expectedMaxDeleveragingAttemptsPerBlock     uint32
 		expectedMaxDeleveragingSubaccountsToIterate uint32
-		expectedMevTelemetryHost                    string
+		expectedMevTelemetryHosts                   []string
 		expectedMevTelemetryIdentifier              string
 	}{
 		"Sets to default if unset": {
 			expectedMaxLiquidationAttemptsPerBlock:      flags.DefaultMaxLiquidationAttemptsPerBlock,
 			expectedMaxDeleveragingAttemptsPerBlock:     flags.DefaultMaxDeleveragingAttemptsPerBlock,
 			expectedMaxDeleveragingSubaccountsToIterate: flags.DefaultMaxDeleveragingSubaccountsToIterate,
-			expectedMevTelemetryHost:                    flags.DefaultMevTelemetryHost,
+			expectedMevTelemetryHosts:                   flags.DefaultMevTelemetryHosts,
 			expectedMevTelemetryIdentifier:              flags.DefaultMevTelemetryIdentifier,
 		},
-		"Sets values from options": {
+		"Sets values from options with one host": {
 			optsMap: map[string]any{
 				flags.MaxLiquidationAttemptsPerBlock:      uint32(50),
 				flags.MaxDeleveragingAttemptsPerBlock:     uint32(25),
 				flags.MaxDeleveragingSubaccountsToIterate: uint32(100),
-				flags.MevTelemetryHost:                    "https://localhost:13137",
+				flags.MevTelemetryHosts:                   "https://localhost:13137",
 				flags.MevTelemetryIdentifier:              "node-agent-01",
 			},
 			expectedMaxLiquidationAttemptsPerBlock:      uint32(50),
 			expectedMaxDeleveragingAttemptsPerBlock:     uint32(25),
 			expectedMaxDeleveragingSubaccountsToIterate: uint32(100),
-			expectedMevTelemetryHost:                    "https://localhost:13137",
+			expectedMevTelemetryHosts:                   []string{"https://localhost:13137"},
 			expectedMevTelemetryIdentifier:              "node-agent-01",
 		},
 	}
@@ -84,8 +85,8 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 			flags := flags.GetClobFlagValuesFromOptions(&mockOpts)
 			require.Equal(
 				t,
-				tc.expectedMevTelemetryHost,
-				flags.MevTelemetryHost,
+				tc.expectedMevTelemetryHosts,
+				flags.MevTelemetryHosts,
 			)
 			require.Equal(
 				t,

--- a/protocol/x/clob/flags/flags_test.go
+++ b/protocol/x/clob/flags/flags_test.go
@@ -72,6 +72,20 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 			expectedMevTelemetryHosts:                   []string{"https://localhost:13137"},
 			expectedMevTelemetryIdentifier:              "node-agent-01",
 		},
+		"Sets values from options with mulitple hosts": {
+			optsMap: map[string]any{
+				flags.MaxLiquidationAttemptsPerBlock:      uint32(50),
+				flags.MaxDeleveragingAttemptsPerBlock:     uint32(25),
+				flags.MaxDeleveragingSubaccountsToIterate: uint32(100),
+				flags.MevTelemetryHosts:                   "https://localhost:13137,https://example.dev:443",
+				flags.MevTelemetryIdentifier:              "node-agent-01",
+			},
+			expectedMaxLiquidationAttemptsPerBlock:      uint32(50),
+			expectedMaxDeleveragingAttemptsPerBlock:     uint32(25),
+			expectedMaxDeleveragingSubaccountsToIterate: uint32(100),
+			expectedMevTelemetryHosts:                   []string{"https://localhost:13137", "https://example.dev:443"},
+			expectedMevTelemetryIdentifier:              "node-agent-01",
+		},
 	}
 
 	for name, tc := range tests {

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -59,8 +59,10 @@ type (
 	}
 )
 
-var _ types.ClobKeeper = &Keeper{}
-var _ types.MemClobKeeper = &Keeper{}
+var (
+	_ types.ClobKeeper    = &Keeper{}
+	_ types.MemClobKeeper = &Keeper{}
+)
 
 func NewKeeper(
 	cdc codec.BinaryCodec,
@@ -105,7 +107,7 @@ func NewKeeper(
 		txDecoder:                    txDecoder,
 		mevTelemetryConfig: MevTelemetryConfig{
 			Enabled:    clobFlags.MevTelemetryEnabled,
-			Host:       clobFlags.MevTelemetryHost,
+			Hosts:      clobFlags.MevTelemetryHosts,
 			Identifier: clobFlags.MevTelemetryIdentifier,
 		},
 		Flags:                  clobFlags,

--- a/protocol/x/clob/keeper/mev.go
+++ b/protocol/x/clob/keeper/mev.go
@@ -20,7 +20,7 @@ import (
 
 type MevTelemetryConfig struct {
 	Enabled    bool
-	Host       string
+	Hosts      []string
 	Identifier string
 }
 
@@ -302,7 +302,7 @@ func (k Keeper) RecordMevMetrics(
 		mevPerMarket[clobPairId] = mev
 	}
 
-	if k.mevTelemetryConfig.Host != "" {
+	if len(k.mevTelemetryConfig.Hosts) != 0 {
 		mevClobMidPrices := make([]types.ClobMidPrice, 0, len(clobPairs))
 		for _, clobPair := range clobPairs {
 			mevClobMidPrices = append(
@@ -315,7 +315,7 @@ func (k Keeper) RecordMevMetrics(
 		}
 		go mev_telemetry.SendDatapoints(
 			ctx,
-			k.mevTelemetryConfig.Host,
+			k.mevTelemetryConfig.Hosts,
 			types.MevMetrics{
 				MevDatapoint: types.MEVDatapoint{
 					Height:              lib.MustConvertIntegerToUint32(ctx.BlockHeight()),


### PR DESCRIPTION
### Changelist
Enables using multiple MEV telemetry hosts instead of defining just one. This is useful in cases of mirroring traffic to a local indexer or multiple indexer environments.

### Test Plan
* Unit tests
* Running nodes with these changes both on testnet and mainnet (1-4 telemetry hosts)

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
