### PR TITLE
Implement `GetNegativeTncSubaccountSeenAtBlock` and `SetNegativeTncSubaccountSeenAtBlock` [CLOB-1026]

### DIFF
--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -202,7 +202,7 @@ func (k Keeper) GetStatefulOrdersTimeSlice(ctx sdk.Context, goodTilBlockTime tim
 }
 
 // GetNextStatefulOrderTransactionIndex returns the next stateful order block transaction index
-// to be used, defeaulting to zero if not set. It then increments the transaction index by one.
+// to be used, defaulting to zero if not set. It then increments the transaction index by one.
 func (k Keeper) GetNextStatefulOrderTransactionIndex(ctx sdk.Context) uint32 {
 	// Get the existing value
 	nextTransactionIndexTransientStore := k.getTransientStore(ctx)

--- a/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
+++ b/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
@@ -1,0 +1,63 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	gogotypes "github.com/cosmos/gogoproto/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+)
+
+// GetNegativeTncSubaccountSeenAtBlock gets the last block height a negative TNC subaccount was
+// seen in state. Note this defaults to 0 if it has not been set.
+func (k Keeper) GetNegativeTncSubaccountSeenAtBlock(
+	ctx sdk.Context,
+) uint32 {
+	store := ctx.KVStore(k.storeKey)
+	return k.getNegativeTncSubaccountSeenAtBlock(store)
+}
+
+// getNegativeTncSubaccountSeenAtBlock is a helper function that takes a store and returns the last
+// block height a negative TNC subaccount was seen in state.
+func (k Keeper) getNegativeTncSubaccountSeenAtBlock(
+	store sdk.KVStore,
+) uint32 {
+	b := store.Get(
+		[]byte(types.NegativeTncSubaccountSeenAtBlockKey),
+	)
+	blockHeight := gogotypes.UInt32Value{Value: 0}
+	if b != nil {
+		k.cdc.MustUnmarshal(b, &blockHeight)
+	}
+
+	return blockHeight.Value
+}
+
+// SetNegativeTncSubaccountSeenAtBlock sets a block number in state where a negative TNC subaccount
+// was seen. This function will overwrite previous values at this key.
+// This function will panic if the old block heigh is greater than the new block height.
+func (k Keeper) SetNegativeTncSubaccountSeenAtBlock(
+	ctx sdk.Context,
+	blockHeight uint32,
+) {
+	store := ctx.KVStore(k.storeKey)
+
+	// Panic if the new block height is less than the current block height.
+	currentValue := k.getNegativeTncSubaccountSeenAtBlock(store)
+	if blockHeight < currentValue {
+		panic(
+			fmt.Sprintf(
+				"SetNegativeTncSubaccountSeenAtBlock: new block height (%d) is less than the current block height (%d)",
+				blockHeight,
+				currentValue,
+			),
+		)
+	}
+
+	blockHeightValue := gogotypes.UInt32Value{Value: 0}
+	blockHeightValue.Value = blockHeight
+	store.Set(
+		[]byte(types.NegativeTncSubaccountSeenAtBlockKey),
+		k.cdc.MustMarshal(&blockHeightValue),
+	)
+}

--- a/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
+++ b/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
@@ -35,7 +35,7 @@ func (k Keeper) getNegativeTncSubaccountSeenAtBlock(
 
 // SetNegativeTncSubaccountSeenAtBlock sets a block number in state where a negative TNC subaccount
 // was seen. This function will overwrite previous values at this key.
-// This function will panic if the old block heigh is greater than the new block height.
+// This function will panic if the old block height is greater than the new block height.
 func (k Keeper) SetNegativeTncSubaccountSeenAtBlock(
 	ctx sdk.Context,
 	blockHeight uint32,

--- a/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
+++ b/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
@@ -54,8 +54,7 @@ func (k Keeper) SetNegativeTncSubaccountSeenAtBlock(
 		)
 	}
 
-	blockHeightValue := gogotypes.UInt32Value{Value: 0}
-	blockHeightValue.Value = blockHeight
+	blockHeightValue := gogotypes.UInt32Value{Value: blockHeight}
 	store.Set(
 		[]byte(types.NegativeTncSubaccountSeenAtBlockKey),
 		k.cdc.MustMarshal(&blockHeightValue),

--- a/protocol/x/subaccounts/keeper/negative_tnc_subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/negative_tnc_subaccount_test.go
@@ -7,6 +7,7 @@ import (
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/tracer"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +22,6 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 		"Block height defaults to zero if not set": {
 			setupTestAndPerformAssertions: func(ctx sdk.Context, k keeper.Keeper) {
 				require.Equal(
-
 					t,
 					uint32(0),
 					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
@@ -34,7 +34,6 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 			setupTestAndPerformAssertions: func(ctx sdk.Context, k keeper.Keeper) {
 				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 1)
 				require.Equal(
-
 					t,
 					uint32(1),
 					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
@@ -42,14 +41,13 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 			},
 
 			expectedMultiStoreWrites: []string{
-				"NegSA:",
+				types.NegativeTncSubaccountSeenAtBlockKey,
 			},
 		},
 		"Block height can be updated more than once": {
 			setupTestAndPerformAssertions: func(ctx sdk.Context, k keeper.Keeper) {
 				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 1)
 				require.Equal(
-
 					t,
 					uint32(1),
 					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
@@ -57,7 +55,6 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 
 				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 2)
 				require.Equal(
-
 					t,
 					uint32(2),
 					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
@@ -65,7 +62,6 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 
 				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 3)
 				require.Equal(
-
 					t,
 					uint32(3),
 					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
@@ -73,7 +69,6 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 
 				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 10)
 				require.Equal(
-
 					t,
 					uint32(10),
 					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
@@ -81,17 +76,16 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 			},
 
 			expectedMultiStoreWrites: []string{
-				"NegSA:",
-				"NegSA:",
-				"NegSA:",
-				"NegSA:",
+				types.NegativeTncSubaccountSeenAtBlockKey,
+				types.NegativeTncSubaccountSeenAtBlockKey,
+				types.NegativeTncSubaccountSeenAtBlockKey,
+				types.NegativeTncSubaccountSeenAtBlockKey,
 			},
 		},
 		"Block height can be updated to same block height": {
 			setupTestAndPerformAssertions: func(ctx sdk.Context, k keeper.Keeper) {
 				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 0)
 				require.Equal(
-
 					t,
 					uint32(0),
 					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
@@ -99,7 +93,6 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 
 				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 0)
 				require.Equal(
-
 					t,
 					uint32(0),
 					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
@@ -107,8 +100,8 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 			},
 
 			expectedMultiStoreWrites: []string{
-				"NegSA:",
-				"NegSA:",
+				types.NegativeTncSubaccountSeenAtBlockKey,
+				types.NegativeTncSubaccountSeenAtBlockKey,
 			},
 		},
 	}

--- a/protocol/x/subaccounts/keeper/negative_tnc_subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/negative_tnc_subaccount_test.go
@@ -1,0 +1,146 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/tracer"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
+	tests := map[string]struct {
+		// Setup.
+		setupTestAndPerformAssertions func(ctx sdk.Context, s keeper.Keeper)
+
+		// Expectations.
+		expectedMultiStoreWrites []string
+	}{
+		"Block height defaults to zero if not set": {
+			setupTestAndPerformAssertions: func(ctx sdk.Context, k keeper.Keeper) {
+				require.Equal(
+
+					t,
+					uint32(0),
+					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
+				)
+			},
+
+			expectedMultiStoreWrites: []string{},
+		},
+		"Block height can be updated": {
+			setupTestAndPerformAssertions: func(ctx sdk.Context, k keeper.Keeper) {
+				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 1)
+				require.Equal(
+
+					t,
+					uint32(1),
+					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
+				)
+			},
+
+			expectedMultiStoreWrites: []string{
+				"NegSA:",
+			},
+		},
+		"Block height can be updated more than once": {
+			setupTestAndPerformAssertions: func(ctx sdk.Context, k keeper.Keeper) {
+				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 1)
+				require.Equal(
+
+					t,
+					uint32(1),
+					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
+				)
+
+				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 2)
+				require.Equal(
+
+					t,
+					uint32(2),
+					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
+				)
+
+				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 3)
+				require.Equal(
+
+					t,
+					uint32(3),
+					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
+				)
+
+				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 10)
+				require.Equal(
+
+					t,
+					uint32(10),
+					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
+				)
+			},
+
+			expectedMultiStoreWrites: []string{
+				"NegSA:",
+				"NegSA:",
+				"NegSA:",
+				"NegSA:",
+			},
+		},
+		"Block height can be updated to same block height": {
+			setupTestAndPerformAssertions: func(ctx sdk.Context, k keeper.Keeper) {
+				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 0)
+				require.Equal(
+
+					t,
+					uint32(0),
+					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
+				)
+
+				k.SetNegativeTncSubaccountSeenAtBlock(ctx, 0)
+				require.Equal(
+
+					t,
+					uint32(0),
+					k.GetNegativeTncSubaccountSeenAtBlock(ctx),
+				)
+			},
+
+			expectedMultiStoreWrites: []string{
+				"NegSA:",
+				"NegSA:",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Setup keeper state and test parameters.
+			ctx, subaccountsKeeper, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
+
+			// Set the tracer on the multistore to verify the performed writes are correct.
+			traceDecoder := &tracer.TraceDecoder{}
+			ctx.MultiStore().SetTracer(traceDecoder)
+
+			tc.setupTestAndPerformAssertions(
+				ctx,
+				*subaccountsKeeper,
+			)
+
+			// Verify the writes were done in the expected order.
+			traceDecoder.RequireKeyPrefixWrittenInSequence(t, tc.expectedMultiStoreWrites)
+		})
+	}
+}
+
+func TestGetSetNegativeTncSubaccountSeenAtBlock_PanicsOnDecreasingBlock(t *testing.T) {
+	// Setup keeper state and test parameters.
+	ctx, subaccountsKeeper, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
+
+	subaccountsKeeper.SetNegativeTncSubaccountSeenAtBlock(ctx, 2)
+	require.PanicsWithValue(
+		t,
+		"SetNegativeTncSubaccountSeenAtBlock: new block height (1) is less than the current block height (2)",
+		func() { subaccountsKeeper.SetNegativeTncSubaccountSeenAtBlock(ctx, 1) },
+	)
+}

--- a/protocol/x/subaccounts/types/keys.go
+++ b/protocol/x/subaccounts/types/keys.go
@@ -11,6 +11,9 @@ const (
 
 // State
 const (
-	// SubaccountKeyPrefix is the prefix to retrieve all Subaccount
+	// SubaccountKeyPrefix is the prefix to retrieve all Subaccounts
 	SubaccountKeyPrefix = "SA:"
+	// NegativeTncSubaccountSeenAtBlockKey is the store key that stores the last
+	// block a negative TNC subaccount was seen in state.
+	NegativeTncSubaccountSeenAtBlockKey = "NegSA:"
 )


### PR DESCRIPTION
### Changelist
Implement `GetNegativeTncSubaccountSeenAtBlock` and `SetNegativeTncSubaccountSeenAtBlock`.

### Test Plan
Unit tests only, didn't write E2E tests since this isn't used in any top-level functionality yet.

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
