### PR TITLE
Emit TradingRewardEventV1 events in rewards module

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -811,6 +811,7 @@ func New(
 		app.BankKeeper,
 		app.FeeTiersKeeper,
 		app.PricesKeeper,
+		app.IndexerEventManager,
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades
 		[]string{
 			lib.GovModuleAddress.String(),

--- a/protocol/indexer/events/constants.go
+++ b/protocol/indexer/events/constants.go
@@ -17,6 +17,7 @@ const (
 	SubtypeUpdatePerpetual  = "update_perpetual"
 	SubtypeUpdateClobPair   = "update_clob_pair"
 	SubtypeDeleveraging     = "deleveraging"
+	SubtypeTradingReward    = "trading_reward"
 )
 
 const (
@@ -33,6 +34,7 @@ const (
 	UpdatePerpetualEventVersion  uint32 = 1
 	UpdateClobPairEventVersion   uint32 = 1
 	DeleveragingEventVersion     uint32 = 1
+	TradingRewardVersion         uint32 = 1
 )
 
 var OnChainEventSubtypes = []string{
@@ -48,4 +50,5 @@ var OnChainEventSubtypes = []string{
 	SubtypeUpdatePerpetual,
 	SubtypeUpdateClobPair,
 	SubtypeDeleveraging,
+	SubtypeTradingReward,
 }

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -310,10 +310,10 @@ func NewTestAppBuilder(t testing.TB) TestAppBuilder {
 		panic("t must not be nil")
 	}
 	return TestAppBuilder{
-		genesisDocFn:               DefaultGenesis,
-		usesDefaultAppConfig:       true,
-		appOptions:                 make(map[string]interface{}),
-		enableNonDeterminismChecks: true,
+		genesisDocFn:                   DefaultGenesis,
+		disableHealthMonitorForTesting: true,
+		appOptions:                     make(map[string]interface{}),
+		enableNonDeterminismChecks:     true,
 		enableCrashingAppCheckTxNonDeterminismChecks: true,
 		executeCheckTxs: func(ctx sdk.Context, app *app.App) (stop bool) {
 			return true
@@ -328,7 +328,7 @@ func NewTestAppBuilder(t testing.TB) TestAppBuilder {
 // immutable.
 type TestAppBuilder struct {
 	genesisDocFn                                 GenesisDocCreatorFn
-	usesDefaultAppConfig                         bool
+	disableHealthMonitorForTesting               bool
 	appOptions                                   map[string]interface{}
 	executeCheckTxs                              ExecuteCheckTxs
 	enableNonDeterminismChecks                   bool
@@ -340,6 +340,12 @@ type TestAppBuilder struct {
 // the genesis doc.
 func (tApp TestAppBuilder) WithGenesisDocFn(fn GenesisDocCreatorFn) TestAppBuilder {
 	tApp.genesisDocFn = fn
+	return tApp
+}
+
+// WithHealthMonitorDisabledForTesting controls whether the daemon server health monitor is disabled for testing.
+func (tApp TestAppBuilder) WithHealthMonitorDisabledForTesting(disableHealthMonitorForTesting bool) TestAppBuilder {
+	tApp.disableHealthMonitorForTesting = disableHealthMonitorForTesting
 	return tApp
 }
 
@@ -375,7 +381,6 @@ func (tApp TestAppBuilder) WithAppOptions(
 	appOptions map[string]interface{},
 ) TestAppBuilder {
 	tApp.appOptions = appOptions
-	tApp.usesDefaultAppConfig = false
 	return tApp
 }
 
@@ -489,7 +494,7 @@ func (tApp *TestApp) initChainIfNeeded() {
 		})
 	}
 
-	if tApp.builder.usesDefaultAppConfig {
+	if tApp.builder.disableHealthMonitorForTesting {
 		tApp.App.DisableHealthMonitorForTesting()
 	}
 

--- a/protocol/testutil/keeper/clob.go
+++ b/protocol/testutil/keeper/clob.go
@@ -1,8 +1,9 @@
 package keeper
 
 import (
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
@@ -119,6 +120,7 @@ func NewClobKeepersTestContextWithUninitializedMemStore(
 			bankKeeper,
 			ks.FeeTiersKeeper,
 			ks.PricesKeeper,
+			indexerEventManager,
 			db,
 			cdc,
 		)

--- a/protocol/x/rewards/module_test.go
+++ b/protocol/x/rewards/module_test.go
@@ -3,6 +3,10 @@ package rewards_test
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -13,9 +17,6 @@ import (
 	rewards_keeper "github.com/dydxprotocol/v4-chain/protocol/x/rewards/keeper"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 // Returns the keeper and context along with the AppModule.
@@ -25,7 +26,7 @@ func createAppModuleWithKeeper(t *testing.T) (rewards.AppModule, *rewards_keeper
 	interfaceRegistry := types.NewInterfaceRegistry()
 	appCodec := codec.NewProtoCodec(interfaceRegistry)
 
-	ctx, keeper, _, _, _, _, _ := keepertest.RewardsKeepers(t)
+	ctx, keeper, _, _, _, _, _, _ := keepertest.RewardsKeepers(t)
 
 	return rewards.NewAppModule(
 		appCodec,


### PR DESCRIPTION
### Changelist
- Emit TradingRewardEventV1 for indexer to process trading rewards
- Decouple usage of appOpts and disabling update monitor for testing in `TestApp`. Sometimes, like in this PR, we might want to have appOpts and also still disable the update monitor.

### Test Plan
- Extended existing e2e test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
