### PR TITLE
Fix unsettled funding sign

### DIFF
--- a/indexer/packages/postgres/__tests__/db/helpers.test.ts
+++ b/indexer/packages/postgres/__tests__/db/helpers.test.ts
@@ -45,7 +45,7 @@ describe('helpers', () => {
             [defaultFundingIndexUpdate.perpetualId]: Big('10050'),
           },
         ),
-      ).toEqual(Big('20000'));  // 10 * (12050-10050)
+      ).toEqual(Big('-20000'));  // 10 * (10050-12050). longs pay shorts when funding index is increasing.
     });
 
     it('compute unsettled funding for short position', () => {
@@ -64,7 +64,7 @@ describe('helpers', () => {
             [defaultFundingIndexUpdate.perpetualId]: Big('10050'),
           },
         ),
-      ).toEqual(Big('-20000'));  // -10 * (12050-10050)
+      ).toEqual(Big('20000'));  // -10 * (10050-12050). longs pay shorts when funding index is increasing.
     });
 
     it('compute unsettled funding for decimal position', () => {
@@ -82,7 +82,7 @@ describe('helpers', () => {
             [defaultFundingIndexUpdate.perpetualId]: Big('10050'),
           },
         ),
-      ).toEqual(Big('2700.1674'));  // 1.35 * (12050.124-10050)
+      ).toEqual(Big('-2700.1674'));  // 1.35 * (10050-12050.124). longs pay shorts when funding index is increasing.
     });
   });
 

--- a/indexer/packages/postgres/src/db/helpers.ts
+++ b/indexer/packages/postgres/src/db/helpers.ts
@@ -40,8 +40,13 @@ export function getMaintenanceMarginPpm(
  * Computes the unsettled funding for a position.
  *
  * To compute the net USDC balance for a subaccount, sum the result of this function for all
- * open perpetual positions, and subtract the sum from the latest USDC asset position for
+ * open perpetual positions, and add it to the latest USDC asset position for
  * this subaccount.
+ *
+ * When funding index is increasing, shorts get paid & unsettled funding for shorts should
+ * be positive, vice versa for longs.
+ * When funding index is decreasing, longs get paid & unsettled funding for longs should
+ * be positive, vice versa for shorts.
  *
  * @param position
  * @param latestFundingIndex
@@ -53,8 +58,8 @@ export function getUnsettledFunding(
   lastUpdateFundingIndexMap: FundingIndexMap,
 ): Big {
   return Big(position.size).times(
-    latestFundingIndexMap[position.perpetualId].minus(
-      lastUpdateFundingIndexMap[position.perpetualId],
+    lastUpdateFundingIndexMap[position.perpetualId].minus(
+      latestFundingIndexMap[position.perpetualId],
     ),
   );
 }

--- a/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
@@ -89,12 +89,12 @@ describe('addresses-controller#V4', () => {
                 testConstants.defaultPerpetualPosition.entryPrice!,
               ),
               maxSize: testConstants.defaultPerpetualPosition.maxSize,
-              // 200000 + 10*(10050-10000)=200500
-              netFunding: getFixedRepresentation('200500'),
+              // 200000 + 10*(10000-10050)=199500
+              netFunding: getFixedRepresentation('199500'),
               // sumClose=0, so realized Pnl is the same as the net funding of the position.
               // Unsettled funding is funding payments that already "happened" but not reflected
               // in the subaccount's balance yet, so it's considered a part of realizedPnl.
-              realizedPnl: getFixedRepresentation('200500'),
+              realizedPnl: getFixedRepresentation('199500'),
               // size * (index-entry) = 10*(15000-20000) = -50000
               unrealizedPnl: getFixedRepresentation(-50000),
               status: testConstants.defaultPerpetualPosition.status,
@@ -246,12 +246,12 @@ describe('addresses-controller#V4', () => {
                   testConstants.defaultPerpetualPosition.entryPrice!,
                 ),
                 maxSize: testConstants.defaultPerpetualPosition.maxSize,
-                // 200000 + 10*(10050-10000)=200500
-                netFunding: getFixedRepresentation('200500'),
+                // 200000 + 10*(10000-10050)=199500
+                netFunding: getFixedRepresentation('199500'),
                 // sumClose=0, so realized Pnl is the same as the net funding of the position.
                 // Unsettled funding is funding payments that already "happened" but not reflected
                 // in the subaccount's balance yet, so it's considered a part of realizedPnl.
-                realizedPnl: getFixedRepresentation('200500'),
+                realizedPnl: getFixedRepresentation('199500'),
                 // size * (index-entry) = 10*(15000-20000) = -50000
                 unrealizedPnl: getFixedRepresentation(-50000),
                 status: testConstants.defaultPerpetualPosition.status,

--- a/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-positions-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-positions-controller.test.ts
@@ -75,12 +75,12 @@ describe('perpetual-positions-controller#V4', () => {
         // For the calculation of the net funding (long position):
         // settled funding on position = 200_000, size = 10, latest funding index = 10050
         // last updated funding index = 10000
-        // total funding = 200_000 + (10 * (10050 - 10000)) = 200_500
-        netFunding: getFixedRepresentation('200500'),
+        // total funding = 200_000 + (10 * (10000 - 10050)) = 199_500
+        netFunding: getFixedRepresentation('199500'),
         // sumClose=0, so realized Pnl is the same as the net funding of the position.
         // Unsettled funding is funding payments that already "happened" but not reflected
         // in the subaccount's balance yet, so it's considered a part of realizedPnl.
-        realizedPnl: getFixedRepresentation('200500'),
+        realizedPnl: getFixedRepresentation('199500'),
         // For the calculation of the unrealized pnl (long position):
         // index price = 15_000, entry price = 20_000, size = 10
         // unrealizedPnl = size * (index price - entry price)
@@ -126,12 +126,12 @@ describe('perpetual-positions-controller#V4', () => {
         // For the calculation of the net funding (short position):
         // settled funding on position = 200_000, size = -10, latest funding index = 10050
         // last updated funding index = 10000
-        // total funding = 200_000 + (-10 * (10050 - 10000)) = 199_500
-        netFunding: getFixedRepresentation('199500'),
+        // total funding = 200_000 + (-10 * (10000 - 10050)) = 200_500
+        netFunding: getFixedRepresentation('200500'),
         // sumClose=0, so realized Pnl is the same as the net funding of the position.
         // Unsettled funding is funding payments that already "happened" but not reflected
         // in the subaccount's balance yet, so it's considered a part of realizedPnl.
-        realizedPnl: getFixedRepresentation('199500'),
+        realizedPnl: getFixedRepresentation('200500'),
         // For the calculation of the unrealized pnl (short position):
         // index price = 15_000, entry price = 20_000, size = -10
         // unrealizedPnl = size * (index price - entry price)

--- a/indexer/services/comlink/__tests__/lib/helpers.test.ts
+++ b/indexer/services/comlink/__tests__/lib/helpers.test.ts
@@ -405,8 +405,8 @@ describe('helpers', () => {
       );
 
       expect(unsettledFunding).toEqual(
-        Big(perpetualPosition.size).times('100').plus(
-          Big(perpetualPosition2.size).times('1000'),
+        Big(perpetualPosition.size).times('-100').plus(
+          Big(perpetualPosition2.size).times('-1000'),
         ),
       );
     });
@@ -414,8 +414,8 @@ describe('helpers', () => {
 
   describe('adjustUSDCAssetPosition', () => {
     it.each([
-      ['long', PositionSide.LONG, '700', '700'],
-      ['short', PositionSide.SHORT, '1300', '-1300'],
+      ['long', PositionSide.LONG, '1300', '1300'],
+      ['short', PositionSide.SHORT, '700', '-700'],
     ])('adjusts USDC position size in returned map, size: [%s]', (
       _name: string,
       side: PositionSide,
@@ -476,8 +476,8 @@ describe('helpers', () => {
     });
 
     it.each([
-      ['long', 'short', PositionSide.LONG, PositionSide.SHORT, '300', '500', '200', '-200'],
-      ['short', 'long', PositionSide.SHORT, PositionSide.LONG, '300', '-500', '200', '200'],
+      ['long', 'short', PositionSide.LONG, PositionSide.LONG, '300', '500', '800', '800'],
+      ['short', 'long', PositionSide.SHORT, PositionSide.SHORT, '300', '-500', '800', '-800'],
     ])('flips USDC position side, original side [%s], flipped side [%s]', (
       _name: string,
       _secondName: string,
@@ -541,13 +541,12 @@ describe('helpers', () => {
     });
 
     it.each([
-      ['long', PositionSide.LONG, '300', '300'],
-      ['short', PositionSide.SHORT, '300', '-300'],
+      ['long', '300', PositionSide.LONG],
+      ['short', '-300', PositionSide.SHORT],
     ])('adjusts USDC position when USDC position doesn\'t exist, side [%s]', (
       _name: string,
+      funding: string,
       expectedSide: PositionSide,
-      expectedPositionSize: string,
-      expectedAdjustedPositionSize: string,
     ) => {
       const assetPositions: AssetPositionsMap = {
         BTC: {
@@ -564,7 +563,7 @@ describe('helpers', () => {
       }: {
         assetPositionsMap: AssetPositionsMap,
         adjustedUSDCAssetPositionSize: string
-      } = adjustUSDCAssetPosition(assetPositions, Big(-expectedAdjustedPositionSize));
+      } = adjustUSDCAssetPosition(assetPositions, Big(funding));
 
       // Original asset positions object should be unchanged
       expect(assetPositions).toEqual({
@@ -579,7 +578,7 @@ describe('helpers', () => {
         [USDC_SYMBOL]: {
           ...ZERO_USDC_POSITION,
           side: expectedSide,
-          size: expectedPositionSize,
+          size: Big(funding).abs().toString(),
         },
         BTC: {
           symbol: 'BTC',
@@ -588,12 +587,12 @@ describe('helpers', () => {
           size: '1',
         },
       });
-      expect(adjustedUSDCAssetPositionSize).toEqual(expectedAdjustedPositionSize);
+      expect(adjustedUSDCAssetPositionSize).toEqual(funding);
     });
 
     it.each([
-      ['long', PositionSide.LONG, '300', '300'],
-      ['short', PositionSide.SHORT, '300', '-300'],
+      ['long', PositionSide.LONG, '300', '-300'],
+      ['short', PositionSide.SHORT, '300', '300'],
     ])('removes USDC position when resulting USDC position size is 0, side [%s]', (
       _name: string,
       side: PositionSide,

--- a/indexer/services/comlink/src/lib/helpers.ts
+++ b/indexer/services/comlink/src/lib/helpers.ts
@@ -456,7 +456,7 @@ export function adjustUSDCAssetPosition(
   } else {
     signedUsdcPositionSize = ZERO;
   }
-  const adjustedSize: Big = signedUsdcPositionSize.minus(unsettledFunding);
+  const adjustedSize: Big = signedUsdcPositionSize.plus(unsettledFunding);
   // Update the USDC position in the map if the adjusted size is non-zero
   if (!adjustedSize.eq(ZERO)) {
     _.set(

--- a/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
+++ b/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
@@ -361,7 +361,7 @@ export function calculateEquity(
     ZERO,
   );
 
-  return signedPositionNotional.plus(usdcPositionSize).minus(totalUnsettledFundingPayment);
+  return signedPositionNotional.plus(usdcPositionSize).plus(totalUnsettledFundingPayment);
 }
 
 /**


### PR DESCRIPTION
### Changelist
Fix unsettled funding sign

Since the sign was changed in the shared `getUnsettledFunding` function, updated minus -> plus in roundtable pnl calculation task. Pnl unit tests are still passing.

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
