### PR TITLE
Fix false positive race tests by gating all R/W access to timers behind synchronization

### DIFF
--- a/protocol/daemons/server/types/health_checker.go
+++ b/protocol/daemons/server/types/health_checker.go
@@ -112,7 +112,8 @@ func (u *healthCheckerMutableState) SchedulePoll(nextPollDelay time.Duration) {
 	u.timer.Reset(nextPollDelay)
 }
 
-// InitializePolling schedules the first poll for the health-checkable service. This method is synchronized.
+// InitializePolling schedules the first poll for the health-checkable service. This method is meant to be called
+// immediately after initializing the health checker mutable state. This method is synchronized.
 func (u *healthCheckerMutableState) InitializePolling(firstPollDelay time.Duration, pollFunc func()) {
 	u.lock.Lock()
 	defer u.lock.Unlock()
@@ -218,6 +219,8 @@ func StartNewHealthChecker(
 	}
 
 	// The first poll is scheduled after the startup grace period to allow the service to initialize.
+	// We initialize the timer and schedule a poll outside of object creation in order to avoid data races for
+	// extremely short startup grace periods.
 	checker.mutableState.InitializePolling(startupGracePeriod, checker.Poll)
 
 	return checker


### PR DESCRIPTION
### Changelist
Race tests are detecting potential conflict in the initialization of the health checker mutable state timer, and updates to the timer after polling starts. This race is logically impossible, but to prevent the false positive I moved the initialization of the timer to a method where it isgated behind the lock on the mutable state object.

### Test Plan
Existing tests should continue to pass + no more race failures.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
