### PR TITLE
Fix CLOB flag parsing for MEV telemetry hosts

### DIFF
--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -118,8 +118,10 @@ func GetClobFlagValuesFromOptions(
 		}
 	}
 
-	if v, ok := appOpts.Get(MevTelemetryHosts).(string); ok {
-		result.MevTelemetryHosts = strings.Split(v, ",")
+	if option := appOpts.Get(MevTelemetryHosts); option != nil {
+		if v, err := cast.ToStringE(option); err == nil {
+			result.MevTelemetryHosts = strings.Split(v, ",")
+		}
 	}
 
 	if option := appOpts.Get(MevTelemetryIdentifier); option != nil {


### PR DESCRIPTION
### Changelist
[Causing error logs in `dev`](https://app.datadoghq.com/logs?query=env%3Adev%20status%3Aerror%20&cols=host%2Cservice&event=AgAAAYxaQNyGckFdyAAAAAAAAAAYAAAAAEFZeGFRTl81QUFEcjJjXzU1QVZsendBRQAAACQAAAAAMDE4YzVhNDAtZTE5MS00ZGZjLTk2YzYtODVhNmVlMGE1YTFm&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&from_ts=1702304471302&to_ts=1702318871302&live=true) since this flag is being [parsed as a list of length 1 with the element being th empty string](https://app.datadoghq.com/logs?query=env%3Adev%20Parsed%20CLOB%20flags%20&cols=host%2Cservice&event=AgAAAYxaELhzcMGBxAAAAAAAAAAYAAAAAEFZeGFFTHFFQUFBTmdPNEVselE5TVFBSwAAACQAAAAAMDE4YzVhMTQtMDAzOS00MGQ3LTgzZTEtZmI1N2ViMGVmZGE0&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&from_ts=1702304471302&to_ts=1702318871302&live=true).

### Test Plan
Tested by running this locally and verifying MEV telemetry hosts list is length 1 before the fix, and length 0 after the fix.

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
