### PR TITLE
[CORE-837] - Emit daemon health metrics for monitoring

### DIFF
--- a/protocol/daemons/server/types/health_checker_test.go
+++ b/protocol/daemons/server/types/health_checker_test.go
@@ -83,6 +83,7 @@ func TestHealthChecker(t *testing.T) {
 			checkable := &mocks.HealthCheckable{}
 			for _, response := range test.healthCheckResponses {
 				checkable.On("HealthCheck").Return(response).Once()
+				checkable.On("ServiceName").Return("test-service")
 			}
 
 			// Set up time provider to return a sequence of timestamps one second apart starting at Time0.

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -211,6 +211,11 @@ const (
 	EpochNumber   = "epoch_number"
 	IsEpochOne    = "is_epoch_one"
 
+	// Health Monitor
+	HealthMonitor    = "health_monitor"
+	ServiceIsHealthy = "service_is_healthy"
+	ServiceName      = "service_name"
+
 	// Perpetuals.
 	AddPremiumSamples            = "add_premium_samples"
 	AddPremiumVotes              = "add_premium_votes"


### PR DESCRIPTION
### Changelist
Add a guage metric to have some visibility into daemon health from the dashboards.

### Test Plan
Existing tests pass

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
