### PR TITLE
Add empty string check to string flag parsing

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -836,7 +836,7 @@ func New(
 	)
 
 	clobFlags := clobflags.GetClobFlagValuesFromOptions(appOpts)
-	logger.Info("Parsed CLOB flags", "Flags", clobFlags, "NumHosts", len(clobFlags.MevTelemetryHosts))
+	logger.Info("Parsed CLOB flags", "Flags", clobFlags)
 
 	memClob := clobmodulememclob.NewMemClobPriceTimePriority(app.IndexerEventManager.Enabled())
 

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -13,8 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/configs"
-
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
 	dbm "github.com/cometbft/cometbft-db"
@@ -108,6 +106,7 @@ import (
 
 	// Daemons
 	bridgeclient "github.com/dydxprotocol/v4-chain/protocol/daemons/bridge/client"
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/configs"
 	daemonflags "github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	liquidationclient "github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/client"
 	metricsclient "github.com/dydxprotocol/v4-chain/protocol/daemons/metrics/client"

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/dydxprotocol/v4-chain/protocol/daemons/configs"
 	"io"
 	"math/big"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"runtime/debug"
 	"sync"
 	"time"
+
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/configs"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
@@ -835,7 +836,7 @@ func New(
 	)
 
 	clobFlags := clobflags.GetClobFlagValuesFromOptions(appOpts)
-	logger.Info("Parsed CLOB flags", "Flags", clobFlags)
+	logger.Info("Parsed CLOB flags", "Flags", clobFlags, "NumHosts", len(clobFlags.MevTelemetryHosts))
 
 	memClob := clobmodulememclob.NewMemClobPriceTimePriority(app.IndexerEventManager.Enabled())
 

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/spf13/cast"
@@ -102,7 +103,7 @@ func GetFlagValuesFromOptions(
 	}
 
 	if option := appOpts.Get(DdAgentHost); option != nil {
-		if v, err := cast.ToStringE(option); err == nil {
+		if v, err := cast.ToStringE(option); err == nil && len(v) > 0 {
 			result.DdAgentHost = v
 		}
 	}
@@ -120,7 +121,7 @@ func GetFlagValuesFromOptions(
 	}
 
 	if option := appOpts.Get(GrpcAddress); option != nil {
-		if v, err := cast.ToStringE(option); err == nil {
+		if v, err := cast.ToStringE(option); err == nil && len(v) > 0 {
 			result.GrpcAddress = v
 		}
 	}

--- a/protocol/daemons/flags/flags.go
+++ b/protocol/daemons/flags/flags.go
@@ -192,7 +192,7 @@ func GetDaemonFlagValuesFromOptions(
 
 	// Shared Flags
 	if option := appOpts.Get(FlagUnixSocketAddress); option != nil {
-		if v, err := cast.ToStringE(option); err == nil {
+		if v, err := cast.ToStringE(option); err == nil && len(v) > 0 {
 			result.Shared.SocketAddress = v
 		}
 	}
@@ -219,7 +219,7 @@ func GetDaemonFlagValuesFromOptions(
 		}
 	}
 	if option := appOpts.Get(FlagBridgeDaemonEthRpcEndpoint); option != nil {
-		if v, err := cast.ToStringE(option); err == nil {
+		if v, err := cast.ToStringE(option); err == nil && len(v) > 0 {
 			result.Bridge.EthRpcEndpoint = v
 		}
 	}

--- a/protocol/x/clob/flags/flags.go
+++ b/protocol/x/clob/flags/flags.go
@@ -119,13 +119,13 @@ func GetClobFlagValuesFromOptions(
 	}
 
 	if option := appOpts.Get(MevTelemetryHosts); option != nil {
-		if v, err := cast.ToStringE(option); err == nil {
+		if v, err := cast.ToStringE(option); err == nil && len(v) > 0 {
 			result.MevTelemetryHosts = strings.Split(v, ",")
 		}
 	}
 
 	if option := appOpts.Get(MevTelemetryIdentifier); option != nil {
-		if v, err := cast.ToStringE(option); err == nil {
+		if v, err := cast.ToStringE(option); err == nil && len(v) > 0 {
 			result.MevTelemetryIdentifier = v
 		}
 	}


### PR DESCRIPTION
### Changelist
Add special casing for empty string when parsing string flags. This will run into an error when the default value is not the empty string.

Note this special casing already exists with other string flag parsing, such as [parsing the Kafka connection string](https://github.com/dydxprotocol/v4-chain/blob/316473cf115ee901a1371151512a8e97987f66da/protocol/indexer/flags.go#L81).

### Test Plan
Ran this locally and verified that the empty string flag is parsed out, therefore requiring the empty string check.

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
