### PR TITLE
[CLOB-1046] populate negative tnc subaccounts in grpc request

### DIFF
--- a/protocol/daemons/liquidation/client/grpc_helper.go
+++ b/protocol/daemons/liquidation/client/grpc_helper.go
@@ -205,7 +205,9 @@ func (c *Client) GetAllSubaccounts(
 // subaccount ids to a gRPC server via `LiquidateSubaccounts`.
 func (c *Client) SendLiquidatableSubaccountIds(
 	ctx context.Context,
-	subaccountIds []satypes.SubaccountId,
+	blockHeight uint32,
+	liquidatableSubaccountIds []satypes.SubaccountId,
+	negativeTncSubaccountIds []satypes.SubaccountId,
 ) error {
 	defer telemetry.ModuleMeasureSince(
 		metrics.LiquidationDaemon,
@@ -216,13 +218,21 @@ func (c *Client) SendLiquidatableSubaccountIds(
 
 	telemetry.ModuleSetGauge(
 		metrics.LiquidationDaemon,
-		float32(len(subaccountIds)),
+		float32(len(liquidatableSubaccountIds)),
 		metrics.LiquidatableSubaccountIds,
+		metrics.Count,
+	)
+	telemetry.ModuleSetGauge(
+		metrics.LiquidationDaemon,
+		float32(len(negativeTncSubaccountIds)),
+		metrics.NegativeTncSubaccountIds,
 		metrics.Count,
 	)
 
 	request := &api.LiquidateSubaccountsRequest{
-		LiquidatableSubaccountIds: subaccountIds,
+		BlockHeight:               blockHeight,
+		LiquidatableSubaccountIds: liquidatableSubaccountIds,
+		NegativeTncSubaccountIds:  negativeTncSubaccountIds,
 	}
 
 	if _, err := c.LiquidationServiceClient.LiquidateSubaccounts(ctx, request); err != nil {

--- a/protocol/daemons/liquidation/client/grpc_helper.go
+++ b/protocol/daemons/liquidation/client/grpc_helper.go
@@ -10,8 +10,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/grpc"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/api"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	blocktimetypes "github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -208,6 +210,7 @@ func (c *Client) SendLiquidatableSubaccountIds(
 	blockHeight uint32,
 	liquidatableSubaccountIds []satypes.SubaccountId,
 	negativeTncSubaccountIds []satypes.SubaccountId,
+	openPositionInfoMap map[uint32]*clobtypes.SubaccountOpenPositionInfo,
 ) error {
 	defer telemetry.ModuleMeasureSince(
 		metrics.LiquidationDaemon,
@@ -229,10 +232,20 @@ func (c *Client) SendLiquidatableSubaccountIds(
 		metrics.Count,
 	)
 
+	// Convert the map to a slice.
+	// Note that sorting here is not strictly necessary but is done for safety and to avoid making
+	// any assumptions on the server side.
+	sortedPerpetualIds := lib.GetSortedKeys[lib.Sortable[uint32]](openPositionInfoMap)
+	subaccountOpenPositionInfo := make([]clobtypes.SubaccountOpenPositionInfo, 0)
+	for _, perpetualId := range sortedPerpetualIds {
+		subaccountOpenPositionInfo = append(subaccountOpenPositionInfo, *openPositionInfoMap[perpetualId])
+	}
+
 	request := &api.LiquidateSubaccountsRequest{
-		BlockHeight:               blockHeight,
-		LiquidatableSubaccountIds: liquidatableSubaccountIds,
-		NegativeTncSubaccountIds:  negativeTncSubaccountIds,
+		BlockHeight:                blockHeight,
+		LiquidatableSubaccountIds:  liquidatableSubaccountIds,
+		NegativeTncSubaccountIds:   negativeTncSubaccountIds,
+		SubaccountOpenPositionInfo: subaccountOpenPositionInfo,
 	}
 
 	if _, err := c.LiquidationServiceClient.LiquidateSubaccounts(ctx, request); err != nil {
@@ -241,7 +254,6 @@ func (c *Client) SendLiquidatableSubaccountIds(
 	return nil
 }
 
-// nolint:unused
 func newContextWithQueryBlockHeight(
 	ctx context.Context,
 	blockHeight uint32,

--- a/protocol/daemons/liquidation/client/grpc_helper_test.go
+++ b/protocol/daemons/liquidation/client/grpc_helper_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/grpc"
 	blocktimetypes "github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -452,31 +453,33 @@ func TestGetAllMarketPrices(t *testing.T) {
 func TestSendLiquidatableSubaccountIds(t *testing.T) {
 	tests := map[string]struct {
 		// mocks
-		setupMocks func(
-			context.Context,
-			*mocks.QueryClient,
-			uint32,
-			[]satypes.SubaccountId,
-			[]satypes.SubaccountId,
-		)
-		liquidatableSubaccountIds []satypes.SubaccountId
-		negativeTncSubaccountIds  []satypes.SubaccountId
+		setupMocks                 func(context.Context, *mocks.QueryClient)
+		liquidatableSubaccountIds  []satypes.SubaccountId
+		negativeTncSubaccountIds   []satypes.SubaccountId
+		subaccountOpenPositionInfo map[uint32]*clobtypes.SubaccountOpenPositionInfo
 
 		// expectations
 		expectedError error
 	}{
 		"Success": {
-			setupMocks: func(
-				ctx context.Context,
-				mck *mocks.QueryClient,
-				blockHeight uint32,
-				liquidatableSubaccountIds []satypes.SubaccountId,
-				negativeTncSubaccountIds []satypes.SubaccountId,
-			) {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
 				req := &api.LiquidateSubaccountsRequest{
-					BlockHeight:               blockHeight,
-					LiquidatableSubaccountIds: liquidatableSubaccountIds,
-					NegativeTncSubaccountIds:  negativeTncSubaccountIds,
+					BlockHeight:               uint32(50),
+					LiquidatableSubaccountIds: []satypes.SubaccountId{constants.Alice_Num0, constants.Bob_Num0},
+					NegativeTncSubaccountIds:  []satypes.SubaccountId{constants.Carl_Num0, constants.Dave_Num0},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId: 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{
+								constants.Alice_Num0,
+								constants.Carl_Num0,
+							},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{
+								constants.Bob_Num0,
+								constants.Dave_Num0,
+							},
+						},
+					},
 				}
 				response := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response, nil)
@@ -489,55 +492,56 @@ func TestSendLiquidatableSubaccountIds(t *testing.T) {
 				constants.Carl_Num0,
 				constants.Dave_Num0,
 			},
+			subaccountOpenPositionInfo: map[uint32]*clobtypes.SubaccountOpenPositionInfo{
+				0: {
+					PerpetualId: 0,
+					SubaccountsWithLongPosition: []satypes.SubaccountId{
+						constants.Alice_Num0,
+						constants.Carl_Num0,
+					},
+					SubaccountsWithShortPosition: []satypes.SubaccountId{
+						constants.Bob_Num0,
+						constants.Dave_Num0,
+					},
+				},
+			},
 		},
 		"Success Empty": {
-			setupMocks: func(
-				ctx context.Context,
-				mck *mocks.QueryClient,
-				blockHeight uint32,
-				liquidatableSubaccountIds []satypes.SubaccountId,
-				negativeTncSubaccountIds []satypes.SubaccountId,
-			) {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
 				req := &api.LiquidateSubaccountsRequest{
-					BlockHeight:               blockHeight,
-					LiquidatableSubaccountIds: liquidatableSubaccountIds,
-					NegativeTncSubaccountIds:  negativeTncSubaccountIds,
+					BlockHeight:                uint32(50),
+					LiquidatableSubaccountIds:  []satypes.SubaccountId{},
+					NegativeTncSubaccountIds:   []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{},
 				}
 				response := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response, nil)
 			},
-			liquidatableSubaccountIds: []satypes.SubaccountId{},
+			liquidatableSubaccountIds:  []satypes.SubaccountId{},
+			negativeTncSubaccountIds:   []satypes.SubaccountId{},
+			subaccountOpenPositionInfo: map[uint32]*clobtypes.SubaccountOpenPositionInfo{},
 		},
 		"Errors are propagated": {
-			setupMocks: func(
-				ctx context.Context,
-				mck *mocks.QueryClient,
-				blockHeight uint32,
-				liquidatableSubaccountIds []satypes.SubaccountId,
-				negativeTncSubaccountIds []satypes.SubaccountId,
-			) {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
 				req := &api.LiquidateSubaccountsRequest{
-					BlockHeight:               blockHeight,
-					LiquidatableSubaccountIds: liquidatableSubaccountIds,
-					NegativeTncSubaccountIds:  negativeTncSubaccountIds,
+					BlockHeight:                uint32(50),
+					LiquidatableSubaccountIds:  []satypes.SubaccountId{},
+					NegativeTncSubaccountIds:   []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{},
 				}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(nil, errors.New("test error"))
 			},
-			liquidatableSubaccountIds: []satypes.SubaccountId{},
-			expectedError:             errors.New("test error"),
+			liquidatableSubaccountIds:  []satypes.SubaccountId{},
+			negativeTncSubaccountIds:   []satypes.SubaccountId{},
+			subaccountOpenPositionInfo: map[uint32]*clobtypes.SubaccountOpenPositionInfo{},
+			expectedError:              errors.New("test error"),
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			queryClientMock := &mocks.QueryClient{}
-			tc.setupMocks(
-				grpc.Ctx,
-				queryClientMock,
-				uint32(50),
-				tc.liquidatableSubaccountIds,
-				tc.negativeTncSubaccountIds,
-			)
+			tc.setupMocks(grpc.Ctx, queryClientMock)
 
 			daemon := client.NewClient(log.NewNopLogger())
 			daemon.LiquidationServiceClient = queryClientMock
@@ -547,6 +551,7 @@ func TestSendLiquidatableSubaccountIds(t *testing.T) {
 				uint32(50),
 				tc.liquidatableSubaccountIds,
 				tc.negativeTncSubaccountIds,
+				tc.subaccountOpenPositionInfo,
 			)
 			require.Equal(t, tc.expectedError, err)
 		})

--- a/protocol/daemons/liquidation/client/sub_task_runner.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	assetstypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	clobkeeper "github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	perpkeeper "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/keeper"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
@@ -80,12 +81,16 @@ func (s *SubTaskRunnerImpl) RunLiquidationDaemonTaskLoop(
 		return err
 	}
 
+	// Build a map of perpetual id to subaccounts with open positions in that perpetual.
+	subaccountOpenPositionInfo := daemonClient.GetSubaccountOpenPositionInfo(subaccounts)
+
 	// 3. Send the list of liquidatable subaccount ids to the daemon server.
 	err = daemonClient.SendLiquidatableSubaccountIds(
 		ctx,
 		lastCommittedBlockHeight,
 		liquidatableSubaccountIds,
 		negativeTncSubaccountIds,
+		subaccountOpenPositionInfo,
 	)
 	if err != nil {
 		return err
@@ -176,7 +181,6 @@ func (c *Client) GetLiquidatableSubaccountIds(
 		metrics.Latency,
 	)
 
-	numSubaccountsWithOpenPositions := 0
 	liquidatableSubaccountIds = make([]satypes.SubaccountId, 0)
 	negativeTncSubaccountIds = make([]satypes.SubaccountId, 0)
 	for _, subaccount := range subaccounts {
@@ -203,6 +207,57 @@ func (c *Client) GetLiquidatableSubaccountIds(
 		if hasNegativeTnc {
 			negativeTncSubaccountIds = append(negativeTncSubaccountIds, *subaccount.Id)
 		}
+	}
+
+	return liquidatableSubaccountIds, negativeTncSubaccountIds, nil
+}
+
+// GetSubaccountOpenPositionInfo iterates over the given subaccounts and returns a map of
+// perpetual id to open position info.
+func (c *Client) GetSubaccountOpenPositionInfo(
+	subaccounts []satypes.Subaccount,
+) (
+	subaccountOpenPositionInfo map[uint32]*clobtypes.SubaccountOpenPositionInfo,
+) {
+	defer telemetry.ModuleMeasureSince(
+		metrics.LiquidationDaemon,
+		time.Now(),
+		metrics.GetSubaccountOpenPositionInfo,
+		metrics.Latency,
+	)
+
+	numSubaccountsWithOpenPositions := 0
+	subaccountOpenPositionInfo = make(map[uint32]*clobtypes.SubaccountOpenPositionInfo)
+	for _, subaccount := range subaccounts {
+		// Skip subaccounts with no open positions.
+		if len(subaccount.PerpetualPositions) == 0 {
+			continue
+		}
+
+		for _, perpetualPosition := range subaccount.PerpetualPositions {
+			openPositionInfo, ok := subaccountOpenPositionInfo[perpetualPosition.PerpetualId]
+			if !ok {
+				openPositionInfo = &clobtypes.SubaccountOpenPositionInfo{
+					PerpetualId:                  perpetualPosition.PerpetualId,
+					SubaccountsWithLongPosition:  make([]satypes.SubaccountId, 0),
+					SubaccountsWithShortPosition: make([]satypes.SubaccountId, 0),
+				}
+				subaccountOpenPositionInfo[perpetualPosition.PerpetualId] = openPositionInfo
+			}
+
+			if perpetualPosition.GetIsLong() {
+				openPositionInfo.SubaccountsWithLongPosition = append(
+					openPositionInfo.SubaccountsWithLongPosition,
+					*subaccount.Id,
+				)
+			} else {
+				openPositionInfo.SubaccountsWithShortPosition = append(
+					openPositionInfo.SubaccountsWithShortPosition,
+					*subaccount.Id,
+				)
+			}
+		}
+
 		numSubaccountsWithOpenPositions++
 	}
 
@@ -213,7 +268,7 @@ func (c *Client) GetLiquidatableSubaccountIds(
 		metrics.Count,
 	)
 
-	return liquidatableSubaccountIds, negativeTncSubaccountIds, nil
+	return subaccountOpenPositionInfo
 }
 
 // CheckSubaccountCollateralization performs the same collateralization check as the application

--- a/protocol/daemons/liquidation/client/sub_task_runner.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner.go
@@ -68,7 +68,9 @@ func (s *SubTaskRunnerImpl) RunLiquidationDaemonTaskLoop(
 	}
 
 	// 2. Check collateralization statuses of subaccounts with at least one open position.
-	liquidatableSubaccountIds, err := daemonClient.GetLiquidatableSubaccountIds(
+	liquidatableSubaccountIds,
+		negativeTncSubaccountIds,
+		err := daemonClient.GetLiquidatableSubaccountIds(
 		subaccounts,
 		marketPrices,
 		perpetuals,
@@ -79,7 +81,12 @@ func (s *SubTaskRunnerImpl) RunLiquidationDaemonTaskLoop(
 	}
 
 	// 3. Send the list of liquidatable subaccount ids to the daemon server.
-	err = daemonClient.SendLiquidatableSubaccountIds(ctx, liquidatableSubaccountIds)
+	err = daemonClient.SendLiquidatableSubaccountIds(
+		ctx,
+		lastCommittedBlockHeight,
+		liquidatableSubaccountIds,
+		negativeTncSubaccountIds,
+	)
 	if err != nil {
 		return err
 	}
@@ -159,6 +166,7 @@ func (c *Client) GetLiquidatableSubaccountIds(
 	liquidityTiers map[uint32]perptypes.LiquidityTier,
 ) (
 	liquidatableSubaccountIds []satypes.SubaccountId,
+	negativeTncSubaccountIds []satypes.SubaccountId,
 	err error,
 ) {
 	defer telemetry.ModuleMeasureSince(
@@ -170,6 +178,7 @@ func (c *Client) GetLiquidatableSubaccountIds(
 
 	numSubaccountsWithOpenPositions := 0
 	liquidatableSubaccountIds = make([]satypes.SubaccountId, 0)
+	negativeTncSubaccountIds = make([]satypes.SubaccountId, 0)
 	for _, subaccount := range subaccounts {
 		// Skip subaccounts with no open positions.
 		if len(subaccount.PerpetualPositions) == 0 {
@@ -177,7 +186,7 @@ func (c *Client) GetLiquidatableSubaccountIds(
 		}
 
 		// Check if the subaccount is liquidatable.
-		isLiquidatable, err := c.CheckSubaccountCollateralization(
+		isLiquidatable, hasNegativeTnc, err := c.CheckSubaccountCollateralization(
 			subaccount,
 			marketPrices,
 			perpetuals,
@@ -185,11 +194,14 @@ func (c *Client) GetLiquidatableSubaccountIds(
 		)
 		if err != nil {
 			c.logger.Error("Error checking collateralization status", "error", err)
-			return nil, err
+			return nil, nil, err
 		}
 
 		if isLiquidatable {
 			liquidatableSubaccountIds = append(liquidatableSubaccountIds, *subaccount.Id)
+		}
+		if hasNegativeTnc {
+			negativeTncSubaccountIds = append(negativeTncSubaccountIds, *subaccount.Id)
 		}
 		numSubaccountsWithOpenPositions++
 	}
@@ -201,7 +213,7 @@ func (c *Client) GetLiquidatableSubaccountIds(
 		metrics.Count,
 	)
 
-	return liquidatableSubaccountIds, nil
+	return liquidatableSubaccountIds, negativeTncSubaccountIds, nil
 }
 
 // CheckSubaccountCollateralization performs the same collateralization check as the application
@@ -216,6 +228,7 @@ func (c *Client) CheckSubaccountCollateralization(
 	liquidityTiers map[uint32]perptypes.LiquidityTier,
 ) (
 	isLiquidatable bool,
+	hasNegativeTnc bool,
 	err error,
 ) {
 	defer telemetry.ModuleMeasureSince(
@@ -232,7 +245,7 @@ func (c *Client) CheckSubaccountCollateralization(
 		perpetuals,
 	)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	bigTotalNetCollateral := big.NewInt(0)
@@ -242,7 +255,7 @@ func (c *Client) CheckSubaccountCollateralization(
 	// Note that we only expect USDC before multi-collateral support is added.
 	for _, assetPosition := range settledSubaccount.AssetPositions {
 		if assetPosition.AssetId != assetstypes.AssetUsdc.Id {
-			return false, errorsmod.Wrapf(
+			return false, false, errorsmod.Wrapf(
 				assetstypes.ErrNotImplementedMulticollateral,
 				"Asset %d is not supported",
 				assetPosition.AssetId,
@@ -257,7 +270,7 @@ func (c *Client) CheckSubaccountCollateralization(
 	for _, perpetualPosition := range settledSubaccount.PerpetualPositions {
 		perpetual, ok := perpetuals[perpetualPosition.PerpetualId]
 		if !ok {
-			return false, errorsmod.Wrapf(
+			return false, false, errorsmod.Wrapf(
 				perptypes.ErrPerpetualDoesNotExist,
 				"Perpetual not found for perpetual id %d",
 				perpetualPosition.PerpetualId,
@@ -266,7 +279,7 @@ func (c *Client) CheckSubaccountCollateralization(
 
 		marketPrice, ok := marketPrices[perpetual.Params.MarketId]
 		if !ok {
-			return false, errorsmod.Wrapf(
+			return false, false, errorsmod.Wrapf(
 				pricestypes.ErrMarketPriceDoesNotExist,
 				"MarketPrice not found for perpetual %+v",
 				perpetual,
@@ -281,7 +294,7 @@ func (c *Client) CheckSubaccountCollateralization(
 
 		liquidityTier, ok := liquidityTiers[perpetual.Params.LiquidityTier]
 		if !ok {
-			return false, errorsmod.Wrapf(
+			return false, false, errorsmod.Wrapf(
 				perptypes.ErrLiquidityTierDoesNotExist,
 				"LiquidityTier not found for perpetual %+v",
 				perpetual,
@@ -298,5 +311,7 @@ func (c *Client) CheckSubaccountCollateralization(
 		bigTotalMaintenanceMargin.Add(bigTotalMaintenanceMargin, bigMaintenanceMarginQuoteQuantums)
 	}
 
-	return clobkeeper.CanLiquidateSubaccount(bigTotalNetCollateral, bigTotalMaintenanceMargin), nil
+	return clobkeeper.CanLiquidateSubaccount(bigTotalNetCollateral, bigTotalMaintenanceMargin),
+		bigTotalNetCollateral.Sign() == -1,
+		nil
 }

--- a/protocol/daemons/liquidation/client/sub_task_runner_test.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner_test.go
@@ -70,9 +70,11 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight: uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{
 						constants.Carl_Num0,
 					},
+					NegativeTncSubaccountIds: []satypes.SubaccountId{},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -119,9 +121,11 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight: uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{
 						constants.Dave_Num0,
 					},
+					NegativeTncSubaccountIds: []satypes.SubaccountId{},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -169,7 +173,9 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight:               uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{},
+					NegativeTncSubaccountIds:  []satypes.SubaccountId{},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -216,7 +222,9 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight:               uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{},
+					NegativeTncSubaccountIds:  []satypes.SubaccountId{},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -283,9 +291,11 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight: uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{
 						constants.Carl_Num0,
 					},
+					NegativeTncSubaccountIds: []satypes.SubaccountId{},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -352,9 +362,11 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight: uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{
 						constants.Dave_Num0,
 					},
+					NegativeTncSubaccountIds: []satypes.SubaccountId{},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -421,7 +433,9 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight:               uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{},
+					NegativeTncSubaccountIds:  []satypes.SubaccountId{},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -488,7 +502,117 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight:               uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{},
+					NegativeTncSubaccountIds:  []satypes.SubaccountId{},
+				}
+				response3 := &api.LiquidateSubaccountsResponse{}
+				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
+			},
+		},
+		"Can get negative tnc subaccount with short position": {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
+				// Block height.
+				res := &blocktimetypes.QueryPreviousBlockInfoResponse{
+					Info: &blocktimetypes.BlockInfo{
+						Height:    uint32(50),
+						Timestamp: constants.TimeTen,
+					},
+				}
+				mck.On("PreviousBlockInfo", mock.Anything, mock.Anything).Return(res, nil)
+
+				// Subaccount.
+				res2 := &satypes.QuerySubaccountAllResponse{
+					Subaccount: []satypes.Subaccount{
+						// Carl has TNC of -$1.
+						constants.Carl_Num0_1BTC_Short_49999USD,
+					},
+				}
+				mck.On("SubaccountAll", mock.Anything, mock.Anything).Return(res2, nil)
+
+				// Market prices.
+				res3 := &pricestypes.QueryAllMarketPricesResponse{
+					MarketPrices: constants.TestMarketPrices,
+				}
+				mck.On("AllMarketPrices", mock.Anything, mock.Anything).Return(res3, nil)
+
+				// Perpetuals.
+				res4 := &perptypes.QueryAllPerpetualsResponse{
+					Perpetual: []perptypes.Perpetual{
+						constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+					},
+				}
+				mck.On("AllPerpetuals", mock.Anything, mock.Anything).Return(res4, nil)
+
+				// Liquidity tiers.
+				res5 := &perptypes.QueryAllLiquidityTiersResponse{
+					LiquidityTiers: constants.LiquidityTiers,
+				}
+				mck.On("AllLiquidityTiers", mock.Anything, mock.Anything).Return(res5, nil)
+
+				// Sends liquidatable subaccount ids to the server.
+				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight: uint32(50),
+					LiquidatableSubaccountIds: []satypes.SubaccountId{
+						constants.Carl_Num0,
+					},
+					NegativeTncSubaccountIds: []satypes.SubaccountId{
+						constants.Carl_Num0,
+					},
+				}
+				response3 := &api.LiquidateSubaccountsResponse{}
+				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
+			},
+		},
+		"Can get negative tnc subaccount with long position": {
+			setupMocks: func(ctx context.Context, mck *mocks.QueryClient) {
+				// Block height.
+				res := &blocktimetypes.QueryPreviousBlockInfoResponse{
+					Info: &blocktimetypes.BlockInfo{
+						Height:    uint32(50),
+						Timestamp: constants.TimeTen,
+					},
+				}
+				mck.On("PreviousBlockInfo", mock.Anything, mock.Anything).Return(res, nil)
+
+				// Subaccount.
+				res2 := &satypes.QuerySubaccountAllResponse{
+					Subaccount: []satypes.Subaccount{
+						// Dave has TNC of -$1.
+						constants.Dave_Num0_1BTC_Long_50001USD_Short,
+					},
+				}
+				mck.On("SubaccountAll", mock.Anything, mock.Anything).Return(res2, nil)
+
+				// Market prices.
+				res3 := &pricestypes.QueryAllMarketPricesResponse{
+					MarketPrices: constants.TestMarketPrices,
+				}
+				mck.On("AllMarketPrices", mock.Anything, mock.Anything).Return(res3, nil)
+
+				// Perpetuals.
+				res4 := &perptypes.QueryAllPerpetualsResponse{
+					Perpetual: []perptypes.Perpetual{
+						constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+					},
+				}
+				mck.On("AllPerpetuals", mock.Anything, mock.Anything).Return(res4, nil)
+
+				// Liquidity tiers.
+				res5 := &perptypes.QueryAllLiquidityTiersResponse{
+					LiquidityTiers: constants.LiquidityTiers,
+				}
+				mck.On("AllLiquidityTiers", mock.Anything, mock.Anything).Return(res5, nil)
+
+				// Sends liquidatable subaccount ids to the server.
+				req := &api.LiquidateSubaccountsRequest{
+					BlockHeight: uint32(50),
+					LiquidatableSubaccountIds: []satypes.SubaccountId{
+						constants.Dave_Num0,
+					},
+					NegativeTncSubaccountIds: []satypes.SubaccountId{
+						constants.Dave_Num0,
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)

--- a/protocol/daemons/liquidation/client/sub_task_runner_test.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/grpc"
 	blocktimetypes "github.com/dydxprotocol/v4-chain/protocol/x/blocktime/types"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -75,6 +76,15 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 						constants.Carl_Num0,
 					},
 					NegativeTncSubaccountIds: []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId:                 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{
+								constants.Carl_Num0,
+							},
+						},
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -126,6 +136,15 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 						constants.Dave_Num0,
 					},
 					NegativeTncSubaccountIds: []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId: 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{
+								constants.Dave_Num0,
+							},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{},
+						},
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -176,6 +195,17 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 					BlockHeight:               uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{},
 					NegativeTncSubaccountIds:  []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId: 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{
+								constants.Dave_Num0,
+							},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{
+								constants.Carl_Num0,
+							},
+						},
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -222,9 +252,10 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 
 				// Sends liquidatable subaccount ids to the server.
 				req := &api.LiquidateSubaccountsRequest{
-					BlockHeight:               uint32(50),
-					LiquidatableSubaccountIds: []satypes.SubaccountId{},
-					NegativeTncSubaccountIds:  []satypes.SubaccountId{},
+					BlockHeight:                uint32(50),
+					LiquidatableSubaccountIds:  []satypes.SubaccountId{},
+					NegativeTncSubaccountIds:   []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -296,6 +327,15 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 						constants.Carl_Num0,
 					},
 					NegativeTncSubaccountIds: []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId:                 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{
+								constants.Carl_Num0,
+							},
+						},
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -367,6 +407,15 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 						constants.Dave_Num0,
 					},
 					NegativeTncSubaccountIds: []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId: 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{
+								constants.Dave_Num0,
+							},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{},
+						},
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -436,6 +485,15 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 					BlockHeight:               uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{},
 					NegativeTncSubaccountIds:  []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId:                 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{
+								constants.Carl_Num0,
+							},
+						},
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -505,6 +563,15 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 					BlockHeight:               uint32(50),
 					LiquidatableSubaccountIds: []satypes.SubaccountId{},
 					NegativeTncSubaccountIds:  []satypes.SubaccountId{},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId: 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{
+								constants.Dave_Num0,
+							},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{},
+						},
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -559,6 +626,15 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 					NegativeTncSubaccountIds: []satypes.SubaccountId{
 						constants.Carl_Num0,
 					},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId:                 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{
+								constants.Carl_Num0,
+							},
+						},
+					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}
 				mck.On("LiquidateSubaccounts", ctx, req).Return(response3, nil)
@@ -612,6 +688,15 @@ func TestRunLiquidationDaemonTaskLoop(t *testing.T) {
 					},
 					NegativeTncSubaccountIds: []satypes.SubaccountId{
 						constants.Dave_Num0,
+					},
+					SubaccountOpenPositionInfo: []clobtypes.SubaccountOpenPositionInfo{
+						{
+							PerpetualId: 0,
+							SubaccountsWithLongPosition: []satypes.SubaccountId{
+								constants.Dave_Num0,
+							},
+							SubaccountsWithShortPosition: []satypes.SubaccountId{},
+						},
 					},
 				}
 				response3 := &api.LiquidateSubaccountsResponse{}

--- a/protocol/daemons/server/liquidation.go
+++ b/protocol/daemons/server/liquidation.go
@@ -45,6 +45,7 @@ func (s *Server) LiquidateSubaccounts(
 	s.daemonLiquidationInfo.UpdateBlockHeight(req.BlockHeight)
 	s.daemonLiquidationInfo.UpdateLiquidatableSubaccountIds(req.LiquidatableSubaccountIds)
 	s.daemonLiquidationInfo.UpdateNegativeTncSubaccountIds(req.NegativeTncSubaccountIds)
+	s.daemonLiquidationInfo.UpdateSubaccountsWithPositions(req.SubaccountOpenPositionInfo)
 
 	// Capture valid responses in metrics.
 	s.reportValidResponse(types.LiquidationsDaemonServiceName)

--- a/protocol/daemons/server/liquidation.go
+++ b/protocol/daemons/server/liquidation.go
@@ -42,7 +42,9 @@ func (s *Server) LiquidateSubaccounts(
 		metrics.Count,
 	)
 
+	s.daemonLiquidationInfo.UpdateBlockHeight(req.BlockHeight)
 	s.daemonLiquidationInfo.UpdateLiquidatableSubaccountIds(req.LiquidatableSubaccountIds)
+	s.daemonLiquidationInfo.UpdateNegativeTncSubaccountIds(req.NegativeTncSubaccountIds)
 
 	// Capture valid responses in metrics.
 	s.reportValidResponse(types.LiquidationsDaemonServiceName)

--- a/protocol/daemons/server/types/liquidations/daemon_liquidation_info.go
+++ b/protocol/daemons/server/types/liquidations/daemon_liquidation_info.go
@@ -80,20 +80,20 @@ func (ls *DaemonLiquidationInfo) GetNegativeTncSubaccountIds() []satypes.Subacco
 
 // UpdateSubaccountsWithPositions updates the struct with the given a list of subaccount ids with open positions.
 func (ls *DaemonLiquidationInfo) UpdateSubaccountsWithPositions(
-	subaccountsWithPositions map[uint32]*clobtypes.SubaccountOpenPositionInfo,
+	subaccountsWithPositions []clobtypes.SubaccountOpenPositionInfo,
 ) {
 	ls.Lock()
 	defer ls.Unlock()
 	ls.subaccountsWithPositions = make(map[uint32]*clobtypes.SubaccountOpenPositionInfo)
-	for perpetualId, info := range subaccountsWithPositions {
+	for _, info := range subaccountsWithPositions {
 		clone := &clobtypes.SubaccountOpenPositionInfo{
-			PerpetualId:                  perpetualId,
+			PerpetualId:                  info.PerpetualId,
 			SubaccountsWithLongPosition:  make([]satypes.SubaccountId, len(info.SubaccountsWithLongPosition)),
 			SubaccountsWithShortPosition: make([]satypes.SubaccountId, len(info.SubaccountsWithShortPosition)),
 		}
 		copy(clone.SubaccountsWithLongPosition, info.SubaccountsWithLongPosition)
 		copy(clone.SubaccountsWithShortPosition, info.SubaccountsWithShortPosition)
-		ls.subaccountsWithPositions[perpetualId] = clone
+		ls.subaccountsWithPositions[info.PerpetualId] = clone
 	}
 }
 

--- a/protocol/daemons/server/types/liquidations/daemon_liquidation_info_test.go
+++ b/protocol/daemons/server/types/liquidations/daemon_liquidation_info_test.go
@@ -49,18 +49,22 @@ func TestSubaccountsWithOpenPositions_Multiple_Reads(t *testing.T) {
 	ls := liquidationstypes.NewDaemonLiquidationInfo()
 	require.Empty(t, ls.GetNegativeTncSubaccountIds())
 
-	expected := map[uint32]*clobtypes.SubaccountOpenPositionInfo{
-		0: {
-			PerpetualId: 0,
-			SubaccountsWithLongPosition: []satypes.SubaccountId{
-				constants.Alice_Num1,
-			},
-			SubaccountsWithShortPosition: []satypes.SubaccountId{
-				constants.Bob_Num0,
-			},
+	info := clobtypes.SubaccountOpenPositionInfo{
+		PerpetualId: 0,
+		SubaccountsWithLongPosition: []satypes.SubaccountId{
+			constants.Alice_Num1,
+		},
+		SubaccountsWithShortPosition: []satypes.SubaccountId{
+			constants.Bob_Num0,
 		},
 	}
-	ls.UpdateSubaccountsWithPositions(expected)
+
+	input := []clobtypes.SubaccountOpenPositionInfo{info}
+	ls.UpdateSubaccountsWithPositions(input)
+
+	expected := map[uint32]*clobtypes.SubaccountOpenPositionInfo{
+		0: &info,
+	}
 	require.Equal(t, expected, ls.GetSubaccountsWithPositions())
 	require.Equal(t, expected, ls.GetSubaccountsWithPositions())
 	require.Equal(t, expected, ls.GetSubaccountsWithPositions())
@@ -116,46 +120,55 @@ func TestSubaccountsWithOpenPositions_Multiple_Writes(t *testing.T) {
 	ls := liquidationstypes.NewDaemonLiquidationInfo()
 	require.Empty(t, ls.GetSubaccountsWithPositions())
 
+	info := clobtypes.SubaccountOpenPositionInfo{
+		PerpetualId: 0,
+		SubaccountsWithLongPosition: []satypes.SubaccountId{
+			constants.Alice_Num1,
+		},
+		SubaccountsWithShortPosition: []satypes.SubaccountId{
+			constants.Bob_Num0,
+		},
+	}
+
+	input := []clobtypes.SubaccountOpenPositionInfo{info}
+	ls.UpdateSubaccountsWithPositions(input)
 	expected := map[uint32]*clobtypes.SubaccountOpenPositionInfo{
-		0: {
-			PerpetualId: 0,
-			SubaccountsWithLongPosition: []satypes.SubaccountId{
-				constants.Alice_Num1,
-			},
-			SubaccountsWithShortPosition: []satypes.SubaccountId{
-				constants.Bob_Num0,
-			},
-		},
+		0: &info,
 	}
-	ls.UpdateSubaccountsWithPositions(expected)
 	require.Equal(t, expected, ls.GetSubaccountsWithPositions())
 
-	expected = map[uint32]*clobtypes.SubaccountOpenPositionInfo{
-		0: {
-			PerpetualId: 0,
-			SubaccountsWithLongPosition: []satypes.SubaccountId{
-				constants.Carl_Num0,
-			},
-			SubaccountsWithShortPosition: []satypes.SubaccountId{
-				constants.Dave_Num0,
-			},
+	info2 := clobtypes.SubaccountOpenPositionInfo{
+		PerpetualId: 0,
+		SubaccountsWithLongPosition: []satypes.SubaccountId{
+			constants.Carl_Num0,
+		},
+		SubaccountsWithShortPosition: []satypes.SubaccountId{
+			constants.Dave_Num0,
 		},
 	}
-	ls.UpdateSubaccountsWithPositions(expected)
+
+	input2 := []clobtypes.SubaccountOpenPositionInfo{info2}
+	ls.UpdateSubaccountsWithPositions(input2)
+	expected = map[uint32]*clobtypes.SubaccountOpenPositionInfo{
+		0: &info2,
+	}
 	require.Equal(t, expected, ls.GetSubaccountsWithPositions())
 
-	expected = map[uint32]*clobtypes.SubaccountOpenPositionInfo{
-		0: {
-			PerpetualId: 0,
-			SubaccountsWithLongPosition: []satypes.SubaccountId{
-				constants.Dave_Num1,
-			},
-			SubaccountsWithShortPosition: []satypes.SubaccountId{
-				constants.Alice_Num1,
-			},
+	info3 := clobtypes.SubaccountOpenPositionInfo{
+		PerpetualId: 0,
+		SubaccountsWithLongPosition: []satypes.SubaccountId{
+			constants.Dave_Num1,
+		},
+		SubaccountsWithShortPosition: []satypes.SubaccountId{
+			constants.Alice_Num1,
 		},
 	}
-	ls.UpdateSubaccountsWithPositions(expected)
+
+	input3 := []clobtypes.SubaccountOpenPositionInfo{info3}
+	ls.UpdateSubaccountsWithPositions(input3)
+	expected = map[uint32]*clobtypes.SubaccountOpenPositionInfo{
+		0: &info3,
+	}
 	require.Equal(t, expected, ls.GetSubaccountsWithPositions())
 }
 
@@ -193,21 +206,23 @@ func TestSubaccountsWithOpenPosition_Empty_Update(t *testing.T) {
 	ls := liquidationstypes.NewDaemonLiquidationInfo()
 	require.Empty(t, ls.GetSubaccountsWithPositions())
 
-	expected := map[uint32]*clobtypes.SubaccountOpenPositionInfo{
-		0: {
-			PerpetualId: 0,
-			SubaccountsWithLongPosition: []satypes.SubaccountId{
-				constants.Alice_Num1,
-			},
-			SubaccountsWithShortPosition: []satypes.SubaccountId{
-				constants.Bob_Num0,
-			},
+	info := clobtypes.SubaccountOpenPositionInfo{
+		PerpetualId: 0,
+		SubaccountsWithLongPosition: []satypes.SubaccountId{
+			constants.Alice_Num1,
+		},
+		SubaccountsWithShortPosition: []satypes.SubaccountId{
+			constants.Bob_Num0,
 		},
 	}
-	ls.UpdateSubaccountsWithPositions(expected)
+	input := []clobtypes.SubaccountOpenPositionInfo{info}
+	ls.UpdateSubaccountsWithPositions(input)
+	expected := map[uint32]*clobtypes.SubaccountOpenPositionInfo{
+		0: &info,
+	}
 	require.Equal(t, expected, ls.GetSubaccountsWithPositions())
 
-	expected = map[uint32]*clobtypes.SubaccountOpenPositionInfo{}
-	ls.UpdateSubaccountsWithPositions(expected)
+	input2 := []clobtypes.SubaccountOpenPositionInfo{}
+	ls.UpdateSubaccountsWithPositions(input2)
 	require.Empty(t, ls.GetSubaccountsWithPositions())
 }

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -299,6 +299,7 @@ const (
 	GetSubaccountsFromKey                = "get_subaccounts_from_key"
 	LiquidatableSubaccountIds            = "liquidatable_subaccount_ids"
 	LiquidationDaemon                    = "liquidation_daemon"
+	NegativeTncSubaccountIds             = "negative_tnc_subaccount_ids"
 	PageLimit                            = "page_limit"
 	SendLiquidatableSubaccountIds        = "send_liquidatable_subaccount_ids"
 	SubaccountsWithOpenPositions         = "subaccounts_with_open_positions"

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -296,6 +296,7 @@ const (
 	FetchApplicationStateAtBlockHeight   = "fetch_application_state_at_block_height"
 	GetAllSubaccounts                    = "get_all_subaccounts"
 	GetLiquidatableSubaccountIds         = "get_liquidatable_subaccount_ids"
+	GetSubaccountOpenPositionInfo        = "get_subaccount_open_position_info"
 	GetSubaccountsFromKey                = "get_subaccounts_from_key"
 	LiquidatableSubaccountIds            = "liquidatable_subaccount_ids"
 	LiquidationDaemon                    = "liquidation_daemon"

--- a/protocol/testutil/constants/subaccounts.go
+++ b/protocol/testutil/constants/subaccounts.go
@@ -403,8 +403,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(100_000_000), // 1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}


### PR DESCRIPTION
### Changelist
- populate block height and negative tnc subaccounts in liquidation daemon grpc request.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
