### PR TITLE
[IND-526] Block subscribing to subaccounts from restricted regions for read-only mode.

### DIFF
--- a/indexer/packages/compliance/src/constants.ts
+++ b/indexer/packages/compliance/src/constants.ts
@@ -1,2 +1,4 @@
-export const INDEXER_GEOBLOCKED_PAYLOAD = 'Because you appear to be a resident of, or trading from, a jurisdiction that violates our terms of use, or have engaged in activity that violates our terms of use, you have been blocked. You may withdraw your funds from the protocol at any time.';
-export const INDEXER_COMPLIANCE_BLOCKED_PAYLOAD = 'Because this address appears to be a resident of, or trading from, a jurisdiction that violates our terms of use, or has engaged in activity that violates our terms of use, this address has been blocked.';
+export const INDEXER_GEOBLOCKED_PAYLOAD: string = 'Because you appear to be a resident of, or trading from, a jurisdiction that violates our terms of use, or have engaged in activity that violates our terms of use, you have been blocked. You may withdraw your funds from the protocol at any time.';
+export const INDEXER_COMPLIANCE_BLOCKED_PAYLOAD: string = 'Because this address appears to be a resident of, or trading from, a jurisdiction that violates our terms of use, or has engaged in activity that violates our terms of use, this address has been blocked.';
+
+export const COUNTRY_HEADER_KEY: string = 'cf-ipcountry';

--- a/indexer/packages/compliance/src/constants.ts
+++ b/indexer/packages/compliance/src/constants.ts
@@ -1,4 +1,6 @@
 export const INDEXER_GEOBLOCKED_PAYLOAD: string = 'Because you appear to be a resident of, or trading from, a jurisdiction that violates our terms of use, or have engaged in activity that violates our terms of use, you have been blocked. You may withdraw your funds from the protocol at any time.';
 export const INDEXER_COMPLIANCE_BLOCKED_PAYLOAD: string = 'Because this address appears to be a resident of, or trading from, a jurisdiction that violates our terms of use, or has engaged in activity that violates our terms of use, this address has been blocked.';
 
+// For use by other services packages, can't be used to index on the actual requests
+// object as that needs to be a string literal.
 export const COUNTRY_HEADER_KEY: string = 'cf-ipcountry';

--- a/indexer/services/socks/__tests__/websocket/index.test.ts
+++ b/indexer/services/socks/__tests__/websocket/index.test.ts
@@ -15,7 +15,7 @@ import {
 import { InvalidMessageHandler } from '../../src/lib/invalid-message';
 import { PingHandler } from '../../src/lib/ping';
 import config from '../../src/config';
-import { isRestrictedCountryHeaders } from '@dydxprotocol-indexer/compliance';
+import { isRestrictedCountryHeaders, COUNTRY_HEADER_KEY } from '@dydxprotocol-indexer/compliance';
 
 jest.mock('uuid');
 jest.mock('../../src/helpers/wss');
@@ -38,6 +38,7 @@ describe('Index', () => {
 
   const connectionId: string = 'conId';
   const defaultGeoblockingEnabled: boolean = config.INDEXER_LEVEL_GEOBLOCKING_ENABLED;
+  const countryCode: string = 'AR';
 
   beforeAll(() => {
     jest.useFakeTimers();
@@ -142,7 +143,9 @@ describe('Index', () => {
     beforeEach(() => {
       // Connect to the index before starting each test.
       (v4 as unknown as jest.Mock).mockReturnValueOnce(connectionId);
-      mockConnect(websocket, new IncomingMessage(new Socket()));
+      const incomingMessage: IncomingMessage = new IncomingMessage(new Socket());
+      incomingMessage.headers[COUNTRY_HEADER_KEY] = countryCode;
+      mockConnect(websocket, incomingMessage);
     });
 
     describe('message', () => {
@@ -257,6 +260,7 @@ describe('Index', () => {
           index.connections[connectionId].messageId,
           id,
           isBatched,
+          countryCode,
         );
       });
 

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -3,6 +3,7 @@ import {
   logger,
   stats,
 } from '@dydxprotocol-indexer/base';
+import { isRestrictedCountry } from '@dydxprotocol-indexer/compliance';
 import { CandleResolution, perpetualMarketRefresher } from '@dydxprotocol-indexer/postgres';
 import WebSocket from 'ws';
 
@@ -77,6 +78,7 @@ export class Subscriptions {
     messageId: number,
     id?: string,
     batched?: boolean,
+    country?: string,
   ): Promise<void> {
     if (this.forwardMessage === undefined) {
       throw new Error('Unexpected error, subscription object is uninitialized.');
@@ -129,7 +131,7 @@ export class Subscriptions {
     let initialResponse: string;
     const startGetInitialResponse: number = Date.now();
     try {
-      initialResponse = await this.getInitialResponsesForChannels(channel, id);
+      initialResponse = await this.getInitialResponsesForChannels(channel, id, country);
     } catch (error) {
       logger.info({
         at: 'Subscription#subscribe',
@@ -481,9 +483,19 @@ export class Subscriptions {
     }
   }
 
-  private async getInitialResponseForSubaccountSubscription(id?: string): Promise<string> {
+  private async getInitialResponseForSubaccountSubscription(
+    id?: string,
+    country?: string,
+  ): Promise<string> {
     if (id === undefined) {
       throw new Error('Invalid undefined id');
+    }
+
+    // TODO(IND-508): Change this to match technical spec for persistent geo-blocking. This may
+    // either have to replicate any blocking logic added on comlink, or re-direct to comlink to
+    // determine if subscribing to a specific subaccount is blocked. 
+    if (country !== undefined && isRestrictedCountry(country)) {
+      throw new BlockedError();
     }
 
     try {
@@ -567,9 +579,13 @@ export class Subscriptions {
    * @param id Id fo the subscription to get the initial response for.
    * @returns The initial response for the channel.
    */
-  private async getInitialResponsesForChannels(channel: Channel, id?: string): Promise<string> {
+  private async getInitialResponsesForChannels(
+    channel: Channel,
+    id?: string,
+    country?: string,
+  ): Promise<string> {
     if (channel === Channel.V4_ACCOUNTS) {
-      return this.getInitialResponseForSubaccountSubscription(id);
+      return this.getInitialResponseForSubaccountSubscription(id, country);
     }
     const endpoint: string | undefined = this.getInitialEndpointForSubscription(channel, id);
     // If no endpoint exists, return an empty initial response.

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -493,7 +493,7 @@ export class Subscriptions {
 
     // TODO(IND-508): Change this to match technical spec for persistent geo-blocking. This may
     // either have to replicate any blocking logic added on comlink, or re-direct to comlink to
-    // determine if subscribing to a specific subaccount is blocked. 
+    // determine if subscribing to a specific subaccount is blocked.
     if (country !== undefined && isRestrictedCountry(country)) {
       throw new BlockedError();
     }

--- a/indexer/services/socks/src/types.ts
+++ b/indexer/services/socks/src/types.ts
@@ -119,6 +119,7 @@ export interface Connection {
   messageId: number;
   heartbeat?: NodeJS.Timeout;
   disconnect?: NodeJS.Timeout;
+  countryCode?: string;
 }
 
 export interface MessageToForward {

--- a/indexer/services/socks/src/websocket/index.ts
+++ b/indexer/services/socks/src/websocket/index.ts
@@ -109,6 +109,7 @@ export class Index {
     this.connections[connectionId] = {
       ws,
       messageId: 0,
+      countryCode: this.countryRestrictor.getCountry(req),
     };
 
     const numConcurrentConnections: number = Object.keys(this.connections).length;
@@ -287,6 +288,7 @@ export class Index {
           this.connections[connectionId].messageId,
           subscribeMessage.id,
           subscribeMessage.batched,
+          this.connections[connectionId].countryCode,
         ).catch((error: Error) => logger.error({
           at: 'Subscription#subscribe',
           message: `Subscribing threw error: ${error.message}`,

--- a/indexer/services/socks/src/websocket/restrict-countries.ts
+++ b/indexer/services/socks/src/websocket/restrict-countries.ts
@@ -13,4 +13,9 @@ export class CountryRestrictor {
 
     return false;
   }
+
+  public getCountry(req: IncomingMessage): string | undefined {
+    const countryHeaders: CountryHeaders = req.headers as CountryHeaders;
+    return countryHeaders['cf-ipcountry'];
+  }
 }


### PR DESCRIPTION
### Changelist
Update `socks` to return a blocked error message when subscribing to subaccounts channel from a restricted region. This is done by storing additional metadata per websocket connection indicating which country the connection was made from.
In the case where no country exists, this blocking logic fails-open (allows subscribing to subaccounts).

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
