### PR TITLE
[IND-546] Prevent IOC/FOK orders from changing order book levels / sending updates.

### DIFF
--- a/indexer/packages/redis/__tests__/helpers/constants.ts
+++ b/indexer/packages/redis/__tests__/helpers/constants.ts
@@ -73,7 +73,7 @@ export const defaultOrder: IndexerOrder = {
   subticks: Long.fromValue(2_000_000, true),
   goodTilBlock: 1150,
   goodTilBlockTime: undefined,
-  timeInForce: IndexerOrder_TimeInForce.TIME_IN_FORCE_FILL_OR_KILL,
+  timeInForce: IndexerOrder_TimeInForce.TIME_IN_FORCE_POST_ONLY,
   reduceOnly: false,
   clientMetadata: 0,
   conditionType: IndexerOrder_ConditionType.CONDITION_TYPE_UNSPECIFIED,
@@ -90,6 +90,14 @@ export const defaultConditionalOrder: IndexerOrder = {
   orderId: defaultOrderIdConditional,
   conditionType: IndexerOrder_ConditionType.CONDITION_TYPE_STOP_LOSS,
   conditionalOrderTriggerSubticks: Long.fromValue(190_000_000, true),
+};
+export const defaultOrderFok: IndexerOrder = {
+  ...defaultOrder,
+  timeInForce: IndexerOrder_TimeInForce.TIME_IN_FORCE_FILL_OR_KILL,
+};
+export const defaultOrderIoc: IndexerOrder = {
+  ...defaultOrder,
+  timeInForce: IndexerOrder_TimeInForce.TIME_IN_FORCE_IOC,
 };
 
 export const defaultOrderUuid: string = OrderTable.orderIdToUuid(defaultOrderId);
@@ -125,6 +133,14 @@ export const defaultRedisOrderConditional: RedisOrder = {
   ...defaultRedisOrder,
   id: defaultOrderUuidConditional,
   order: defaultConditionalOrder,
+};
+export const defaultRedisOrderFok: RedisOrder = {
+  ...defaultRedisOrder,
+  order: defaultOrderFok,
+};
+export const defaultRedisOrderIoc: RedisOrder = {
+  ...defaultRedisOrder,
+  order: defaultOrderIoc,
 };
 
 export const orderPlace: OffChainUpdateOrderPlaceUpdateMessage = {

--- a/indexer/packages/v4-proto-parser/src/order-helpers.ts
+++ b/indexer/packages/v4-proto-parser/src/order-helpers.ts
@@ -24,7 +24,7 @@ export function isStatefulOrder(orderFlag: number | String): boolean {
   return numberOrderFlag === ORDER_FLAG_CONDITIONAL || numberOrderFlag === ORDER_FLAG_LONG_TERM;
 }
 
-export function isIOC(tif: IndexerOrder_TimeInForce): boolean {
+export function requiresImmediateExecution(tif: IndexerOrder_TimeInForce): boolean {
   return (
     tif === IndexerOrder_TimeInForce.TIME_IN_FORCE_FILL_OR_KILL ||
     tif === IndexerOrder_TimeInForce.TIME_IN_FORCE_IOC

--- a/indexer/packages/v4-proto-parser/src/order-helpers.ts
+++ b/indexer/packages/v4-proto-parser/src/order-helpers.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto';
 
-import { IndexerOrderId } from '@dydxprotocol-indexer/v4-protos';
+import { IndexerOrderId, IndexerOrder_TimeInForce } from '@dydxprotocol-indexer/v4-protos';
 
 import { ORDER_FLAG_CONDITIONAL, ORDER_FLAG_LONG_TERM } from './constants';
 
@@ -22,4 +22,11 @@ export function isStatefulOrder(orderFlag: number | String): boolean {
     return false;
   }
   return numberOrderFlag === ORDER_FLAG_CONDITIONAL || numberOrderFlag === ORDER_FLAG_LONG_TERM;
+}
+
+export function isIOC(tif: IndexerOrder_TimeInForce): boolean {
+  return (
+    tif === IndexerOrder_TimeInForce.TIME_IN_FORCE_FILL_OR_KILL ||
+    tif === IndexerOrder_TimeInForce.TIME_IN_FORCE_IOC
+  );
 }

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -27,7 +27,7 @@ import {
   StatefulOrderUpdatesCache,
 } from '@dydxprotocol-indexer/redis';
 import {
-  ORDER_FLAG_SHORT_TERM, getOrderIdHash, isStatefulOrder, isIOC,
+  ORDER_FLAG_SHORT_TERM, getOrderIdHash, isStatefulOrder, requiresImmediateExecution,
 } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   OffChainUpdateV1,
@@ -191,7 +191,7 @@ export class OrderPlaceHandler extends Handler {
     if (
       result.replaced !== true ||
       result.restingOnBook !== true ||
-      isIOC(result.oldOrder!.order!.timeInForce)
+      requiresImmediateExecution(result.oldOrder!.order!.timeInForce)
     ) {
       return undefined;
     }

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -26,7 +26,9 @@ import {
   CanceledOrdersCache,
   StatefulOrderUpdatesCache,
 } from '@dydxprotocol-indexer/redis';
-import { ORDER_FLAG_SHORT_TERM, getOrderIdHash, isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
+import {
+  ORDER_FLAG_SHORT_TERM, getOrderIdHash, isStatefulOrder, isIOC,
+} from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   OffChainUpdateV1,
   IndexerOrder,
@@ -186,7 +188,11 @@ export class OrderPlaceHandler extends Handler {
   ): Promise<number | undefined> {
     // TODO(DEC-1339): Update price levels based on if the order is reduce-only and if the replaced
     // order is reduce-only.
-    if (result.replaced !== true || result.restingOnBook !== true) {
+    if (
+      result.replaced !== true ||
+      result.restingOnBook !== true ||
+      isIOC(result.oldOrder!.order!.timeInForce)
+    ) {
       return undefined;
     }
 

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -23,7 +23,7 @@ import {
   removeOrder,
   CanceledOrdersCache,
 } from '@dydxprotocol-indexer/redis';
-import { ORDER_FLAG_SHORT_TERM, isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
+import { ORDER_FLAG_SHORT_TERM, isStatefulOrder, isIOC } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   OffChainUpdateV1,
   IndexerOrder,
@@ -231,7 +231,10 @@ export class OrderRemoveHandler extends Handler {
 
     // If an order was removed from the Orders cache and was resting on the book, update the
     // orderbook levels cache
-    if (removeOrderResult.removed && removeOrderResult.restingOnBook === true) {
+    if (
+      removeOrderResult.removed &&
+      removeOrderResult.restingOnBook === true &&
+      !isIOC(removeOrderResult.removedOrder!.order!.timeInForce)) {
       await this.updateOrderbook(removeOrderResult, perpetualMarket);
     }
 
@@ -309,7 +312,10 @@ export class OrderRemoveHandler extends Handler {
     ));
     // Do not update orderbook if order being cancelled has no remaining quantums or is
     // resting on book
-    if (!remainingQuantums.eq('0') && removeOrderResult.restingOnBook !== false) {
+    if (
+      !remainingQuantums.eq('0') &&
+      removeOrderResult.restingOnBook !== false &&
+      !isIOC(removeOrderResult.removedOrder!.order!.timeInForce)) {
       await this.updateOrderbook(removeOrderResult, perpetualMarket);
     }
     // TODO: consolidate remove handler logic into a single lua script.

--- a/indexer/services/vulcan/src/handlers/order-update-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-update-handler.ts
@@ -17,7 +17,7 @@ import {
   OpenOrdersCache,
   StatefulOrderUpdatesCache,
 } from '@dydxprotocol-indexer/redis';
-import { isStatefulOrder, isIOC } from '@dydxprotocol-indexer/v4-proto-parser';
+import { isStatefulOrder, requiresImmediateExecution } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   OffChainUpdateV1,
   OrderUpdateV1,
@@ -146,7 +146,9 @@ export class OrderUpdateHandler extends Handler {
       return;
     }
 
-    if (!isIOC(updateResult.order!.order!.timeInForce)) {
+    // Orders that require immediate execution do not rest on the order book and will not lead to
+    // a change in the order book level for the order's price
+    if (!requiresImmediateExecution(updateResult.order!.order!.timeInForce)) {
       const updatedQuantums: number = await this.updatePriceLevel(
         updateResult,
         sizeDeltaInQuantums,

--- a/indexer/services/vulcan/src/handlers/order-update-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-update-handler.ts
@@ -17,7 +17,7 @@ import {
   OpenOrdersCache,
   StatefulOrderUpdatesCache,
 } from '@dydxprotocol-indexer/redis';
-import { isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
+import { isStatefulOrder, isIOC } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   OffChainUpdateV1,
   OrderUpdateV1,
@@ -145,27 +145,33 @@ export class OrderUpdateHandler extends Handler {
       stats.increment(`${config.SERVICE_NAME}.order_update_with_zero_delta.count`, 1);
       return;
     }
-    const updatedQuantums: number = await this.updatePriceLevel(updateResult, sizeDeltaInQuantums);
 
-    const perpetualMarket: PerpetualMarketFromDatabase | undefined = perpetualMarketRefresher
-      .getPerpetualMarketFromTicker(updateResult.order!.ticker);
-    if (perpetualMarket === undefined) {
-      logger.error({
-        at: 'OrderUpdateHandler#handle',
-        message: `Received order update for order with unknown perpetual market, ticker ${
-          updateResult.order!.ticker}`,
-      });
-      return;
+    if (!isIOC(updateResult.order!.order!.timeInForce)) {
+      const updatedQuantums: number = await this.updatePriceLevel(
+        updateResult,
+        sizeDeltaInQuantums,
+      );
+
+      const perpetualMarket: PerpetualMarketFromDatabase | undefined = perpetualMarketRefresher
+        .getPerpetualMarketFromTicker(updateResult.order!.ticker);
+      if (perpetualMarket === undefined) {
+        logger.error({
+          at: 'OrderUpdateHandler#handle',
+          message: `Received order update for order with unknown perpetual market, ticker ${
+            updateResult.order!.ticker}`,
+        });
+        return;
+      }
+
+      const orderbookMessage: Message = {
+        value: this.createOrderbookWebsocketMessage(
+          updateResult.order!,
+          perpetualMarket,
+          updatedQuantums,
+        ),
+      };
+      sendMessageWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
     }
-
-    const orderbookMessage: Message = {
-      value: this.createOrderbookWebsocketMessage(
-        updateResult.order!,
-        perpetualMarket,
-        updatedQuantums,
-      ),
-    };
-    sendMessageWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
   }
 
   /**


### PR DESCRIPTION
### Changelist
Previously, it was possible that an IOC/FOK order is updated to have non-zero remaining amount, and the logic in the order handlers would then add a price level for that IOC/FOK order (e.g. a buy order with price $50 would lead to the creation of a $50 price level on the buy side). This is incorrect as the IOC/FOK order should never lead to the order book having a new price level as it never rests on the book.

This change update the `order-update-handler` to not change orderbook price levels when the remaining amount of FOK/IOC orders change. Logic around decreasing price levels when orders are removed which exist in the `order-place-handler` (for replacing orders) and `order-remove-handler` also needed to be changed to exclude FOK/IOC orders.
This will require some clean-up of orderbook levels that are affected by IOC/FOK orders after upgrading to a version with this change, as there may be some crossed orderbooks.

### Test Plan
Unit tests, will test in dev/staging.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
