### PR TITLE
[feat][protocol] Write block number to state when encountering zero-fill deleveraging op [CLOB-1030]

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -334,6 +334,7 @@ const (
 	NotEnoughPositionToFullyOffset = "not_enough_position_to_fully_offset"
 	NonOverlappingBankruptcyPrices = "non_overlapping_bankruptcy_prices"
 	NoOpenPositionOnOppositeSide   = "no_open_position_on_opposite_side"
+	NegativeTncSubaccountSeen      = "negative_tnc_subaccount_seen"
 
 	// Pricefeed Daemon.
 	Exchange                                = "exchange"

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -334,7 +334,6 @@ const (
 	NotEnoughPositionToFullyOffset = "not_enough_position_to_fully_offset"
 	NonOverlappingBankruptcyPrices = "non_overlapping_bankruptcy_prices"
 	NoOpenPositionOnOppositeSide   = "no_open_position_on_opposite_side"
-	NegativeTncSubaccountSeen      = "negative_tnc_subaccount_seen"
 
 	// Pricefeed Daemon.
 	Exchange                                = "exchange"

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -20,6 +20,7 @@ const (
 	LiquidationsPlacePerpetualLiquidationQuoteQuantums = "liquidations_place_perpetual_liquidation_quote_quantums"
 	LiquidationsLiquidationMatchNegativeTNC            = "liquidations_liquidation_match_negative_tnc"
 	ClobMevErrorCount                                  = "clob_mev_error_count"
+	SubaccountsNegativeTncSubaccountSeen               = "negative_tnc_subaccount_seen"
 
 	// Gauges
 	InsuranceFundBalance = "insurance_fund_balance"

--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -675,6 +675,14 @@ func (k Keeper) PersistMatchDeleveragingToState(
 	}
 	deltaBaseQuantumsIsNegative := position.GetIsLong()
 
+	// TODO: This logic assumes that the subaccount is negative equity. Should account for final settlement markets.
+	// If there are zero-deleveraging fills, this is a sentinel value to indicate a subaccount could not be liquidated or deleveraged
+	// and still has negative equity. Mark the current block number in state to indicate a negative TNC subaccount was seen.
+	if len(matchDeleveraging.GetFills()) == 0 {
+		k.subaccountsKeeper.SetNegativeTncSubaccountSeenAtBlock(ctx, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
+		return nil
+	}
+
 	for _, fill := range matchDeleveraging.GetFills() {
 		deltaBaseQuantums := new(big.Int).SetUint64(fill.FillAmount)
 		if deltaBaseQuantumsIsNegative {

--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -691,13 +691,11 @@ func (k Keeper) PersistMatchDeleveragingToState(
 			)
 		}
 
-		telemetry.IncrCounterWithLabels(
-			[]string{types.ModuleName, metrics.ProcessOperations, metrics.NegativeTncSubaccountSeen, metrics.Count},
-			1,
-			[]metrics.Label{
-				metrics.GetLabelForIntValue(metrics.PerpetualId, int(perpetualId)),
-				metrics.GetLabelForBoolValue(metrics.IsLong, position.GetIsLong()),
-			},
+		metrics.IncrCountMetricWithLabels(
+			types.ModuleName,
+			metrics.SubaccountsNegativeTncSubaccountSeen,
+			metrics.GetLabelForIntValue(metrics.PerpetualId, int(perpetualId)),
+			metrics.GetLabelForBoolValue(metrics.IsLong, position.GetIsLong()),
 		)
 		k.subaccountsKeeper.SetNegativeTncSubaccountSeenAtBlock(ctx, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
 		return nil

--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -676,8 +676,9 @@ func (k Keeper) PersistMatchDeleveragingToState(
 	deltaBaseQuantumsIsNegative := position.GetIsLong()
 
 	// TODO: This logic assumes that the subaccount is negative equity. Should account for final settlement markets.
-	// If there are zero-deleveraging fills, this is a sentinel value to indicate a subaccount could not be liquidated or deleveraged
-	// and still has negative equity. Mark the current block number in state to indicate a negative TNC subaccount was seen.
+	// If there are zero-deleveraging fills, this is a sentinel value to indicate a subaccount could not be liquidated
+	// or deleveraged and still has negative equity. Mark the current block number in state to indicate a negative TNC
+	// subaccount was seen.
 	if len(matchDeleveraging.GetFills()) == 0 {
 		k.subaccountsKeeper.SetNegativeTncSubaccountSeenAtBlock(ctx, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
 		return nil

--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -680,6 +680,17 @@ func (k Keeper) PersistMatchDeleveragingToState(
 	// or deleveraged and still has negative equity. Mark the current block number in state to indicate a negative TNC
 	// subaccount was seen.
 	if len(matchDeleveraging.GetFills()) == 0 {
+		if !shouldDeleverageAtBankruptcyPrice {
+			panic(
+				fmt.Sprintf(
+					"PersistMatchDeleveragingToState: zero-fill deleveraging operation included for subaccount %+v"+
+						" and perpetual %d but cannot be be deleveraged at bankruptcy price",
+					liquidatedSubaccountId,
+					perpetualId,
+				),
+			)
+		}
+
 		k.subaccountsKeeper.SetNegativeTncSubaccountSeenAtBlock(ctx, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
 		return nil
 	}

--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -675,10 +675,9 @@ func (k Keeper) PersistMatchDeleveragingToState(
 	}
 	deltaBaseQuantumsIsNegative := position.GetIsLong()
 
-	// TODO: This logic assumes that the subaccount is negative equity. Should account for final settlement markets.
-	// If there are zero-deleveraging fills, this is a sentinel value to indicate a subaccount could not be liquidated
-	// or deleveraged and still has negative equity. Mark the current block number in state to indicate a negative TNC
-	// subaccount was seen.
+	// If there are zero-fill deleveraging operations, this is a sentinel value to indicate a subaccount could not be
+	// liquidated or deleveraged and still has negative equity. Mark the current block number in state to indicate a
+	// negative TNC subaccount was seen.
 	if len(matchDeleveraging.GetFills()) == 0 {
 		if !shouldDeleverageAtBankruptcyPrice {
 			panic(

--- a/protocol/x/clob/keeper/process_operations_test.go
+++ b/protocol/x/clob/keeper/process_operations_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -1465,11 +1464,7 @@ func TestProcessProposerOperations(t *testing.T) {
 				constants.Carl_Num0: constants.Carl_Num0_1BTC_Short_100000USD.GetPerpetualPositions(),
 				constants.Dave_Num0: constants.Dave_Num0_1BTC_Long_50000USD.GetPerpetualPositions(),
 			},
-			expectedPanics: fmt.Sprintf(
-				"PersistMatchDeleveragingToState: zero-fill deleveraging operation included for subaccount %+v"+
-					" and perpetual 0 but cannot be be deleveraged at bankruptcy price",
-				constants.Carl_Num0,
-			),
+			expectedError: types.ErrZeroFillDeleveragingForNonNegativeTncSubaccount,
 		},
 		"Fails with clob match for market in initializing mode": {
 			perpetuals: []*perptypes.Perpetual{

--- a/protocol/x/clob/types/errors.go
+++ b/protocol/x/clob/types/errors.go
@@ -443,7 +443,7 @@ var (
 	ErrZeroFillDeleveragingForNonNegativeTncSubaccount = errorsmod.Register(
 		ModuleName,
 		4008,
-		"Deleveraging fill is invalid",
+		"Zero-fill deleveraging operation included in block for non-negative TNC subaccount",
 	)
 
 	// Block rate limit errors.

--- a/protocol/x/clob/types/errors.go
+++ b/protocol/x/clob/types/errors.go
@@ -283,11 +283,7 @@ var (
 		1015,
 		"Invalid delta base and/or quote quantums for insurance fund delta calculation",
 	)
-	ErrEmptyDeleveragingFills = errorsmod.Register(
-		ModuleName,
-		1016,
-		"Deleveraging fills length must be greater than 0",
-	)
+	// TODO: Should the error code be skipped or re-assigned?
 	ErrDeleveragingAgainstSelf = errorsmod.Register(
 		ModuleName,
 		1017,

--- a/protocol/x/clob/types/errors.go
+++ b/protocol/x/clob/types/errors.go
@@ -440,6 +440,11 @@ var (
 		4007,
 		"Order Removal reason is invalid",
 	)
+	ErrZeroFillDeleveragingForNonNegativeTncSubaccount = errorsmod.Register(
+		ModuleName,
+		4008,
+		"Deleveraging fill is invalid",
+	)
 
 	// Block rate limit errors.
 	ErrInvalidBlockRateLimitConfig = errorsmod.Register(

--- a/protocol/x/clob/types/expected_keepers.go
+++ b/protocol/x/clob/types/expected_keepers.go
@@ -59,6 +59,10 @@ type SubaccountsKeeper interface {
 		successPerUpdate []satypes.UpdateResult,
 		err error,
 	)
+	SetNegativeTncSubaccountSeenAtBlock(
+		ctx sdk.Context,
+		blockHeight uint32,
+	)
 	TransferFeesToFeeCollectorModule(
 		ctx sdk.Context,
 		assetId uint32,

--- a/protocol/x/clob/types/match_perpetual_deleveraging.go
+++ b/protocol/x/clob/types/match_perpetual_deleveraging.go
@@ -7,7 +7,6 @@ import (
 // Validate performs stateless validation on a `MatchPerpetualDeleveraging` object.
 // It checks the following conditions to be true:
 // - Validation for all subaccount Ids
-// - length of fills to be greater than zero
 // - For each fill, fill amount must be greater than zero
 // - Subaccount ids in fills are all unique
 // - Subaccount ids in fills cannot be the same as the liquidated subaccount id
@@ -17,10 +16,8 @@ func (match *MatchPerpetualDeleveraging) Validate() error {
 		return err
 	}
 
+	// Note that zero-fill deleveraging operations are valid, iff the subaccount is negative equity.
 	fills := match.GetFills()
-	if len(fills) == 0 {
-		return ErrEmptyDeleveragingFills
-	}
 	seenOffsettingSubacountIds := map[satypes.SubaccountId]struct{}{}
 	for _, fill := range fills {
 		offsettingSubaccountId := fill.GetOffsettingSubaccountId()

--- a/protocol/x/clob/types/match_perpetual_deleveraging_test.go
+++ b/protocol/x/clob/types/match_perpetual_deleveraging_test.go
@@ -34,7 +34,7 @@ func TestPerformStatelessMatchPerpetualDeleveragingValidation(t *testing.T) {
 				PerpetualId: constants.ClobPair_Eth.MustGetPerpetualId(),
 				Fills:       []types.MatchPerpetualDeleveraging_Fill{},
 			},
-			expectedError: types.ErrEmptyDeleveragingFills,
+			expectedError: nil,
 		},
 		"Deleveraging fill subaccount id the same as liquidation subaccount id": {
 			match: types.MatchPerpetualDeleveraging{

--- a/protocol/x/clob/types/message_proposed_operations_test.go
+++ b/protocol/x/clob/types/message_proposed_operations_test.go
@@ -474,7 +474,7 @@ func TestValidateAndTransformRawOperations(t *testing.T) {
 					},
 				),
 			},
-			expectedError: types.ErrEmptyDeleveragingFills,
+			expectedError: nil,
 		},
 
 		// Tests for byte functionality


### PR DESCRIPTION
### Changelist
When encountering a zero-fill deleveraging operation in `DeliverTx`, write the current block number to state.

Note the zero-fill deleveraging operation is meant to be a sentinel value to indicate a negative TNC subaccount exists in state at the time of processing the deleveraging operation.

### Test Plan
Unit tests. Will add E2E tests when the feature is fully implemented.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
