### PR TITLE
refactor: remove ValidateBasic in cli

### DIFF
--- a/protocol/x/clob/client/cli/tx_cancel_order.go
+++ b/protocol/x/clob/client/cli/tx_cancel_order.go
@@ -49,9 +49,6 @@ func CmdCancelOrder() *cobra.Command {
 				argGoodTilBlock,
 			)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/protocol/x/clob/client/cli/tx_place_order.go
+++ b/protocol/x/clob/client/cli/tx_place_order.go
@@ -74,9 +74,7 @@ func CmdPlaceOrder() *cobra.Command {
 					GoodTilOneof: &types.Order_GoodTilBlock{GoodTilBlock: argGoodTilBlock},
 				},
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/protocol/x/sending/client/cli/tx_create_transfer.go
+++ b/protocol/x/sending/client/cli/tx_create_transfer.go
@@ -62,9 +62,6 @@ func CmdCreateTransfer() *cobra.Command {
 				},
 			)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/protocol/x/sending/client/cli/tx_deposit_to_subaccount.go
+++ b/protocol/x/sending/client/cli/tx_deposit_to_subaccount.go
@@ -57,9 +57,6 @@ Note, the '--from' flag is ignored as it is implied from [sender_key_or_address]
 				argAmount,
 			)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/protocol/x/sending/client/cli/tx_withdraw_from_subaccount.go
+++ b/protocol/x/sending/client/cli/tx_withdraw_from_subaccount.go
@@ -57,9 +57,6 @@ Note, the '--from' flag is ignored as it is implied from [sender_key_or_address]
 				argAmount,
 			)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}


### PR DESCRIPTION
### Changelist
The `ValidateBasic` function has been called in the `GenerateOrBroadcastTxWithFactory` function, so we no longer need to add the `ValidateBasic` function when writing Cli. Related PRs can be viewed at: https://github.com/cosmos/cosmos-sdk/pull/9236#discussion_r623803504

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
