### PR TITLE
[CORE-538] Remove DB shutdown, Cosmos 0.50 SDK does this now in BaseApp

### DIFF
--- a/protocol/app/simulation_test.go
+++ b/protocol/app/simulation_test.go
@@ -218,7 +218,6 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 			return app.New(
 				logger,
 				db,
-				dbm.NewMemDB(),
 				nil,
 				true,
 				appOptions,
@@ -291,7 +290,6 @@ func TestFullAppSimulation(t *testing.T) {
 			return app.New(
 				logger,
 				db,
-				dbm.NewMemDB(),
 				nil,
 				true,
 				appOptions,
@@ -364,7 +362,6 @@ func TestAppStateDeterminism(t *testing.T) {
 					return app.New(
 						logger,
 						db,
-						dbm.NewMemDB(),
 						nil,
 						true,
 						appOptions,

--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -314,7 +314,6 @@ func (a appCreator) newApp(
 	return dydxapp.New(
 		logger,
 		db,
-		snapshotDB,
 		traceStore,
 		true,
 		appOpts,
@@ -354,7 +353,6 @@ func (a appCreator) appExport(
 	dydxApp := dydxapp.New(
 		logger,
 		db,
-		dbm.NewMemDB(),
 		traceStore,
 		height == -1, // -1: no height provided
 		appOpts,

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -151,11 +151,9 @@ func DefaultTestApp(customFlags map[string]interface{}, baseAppOptions ...func(*
 		logger, _ = testlog.TestLogger()
 	}
 	db := dbm.NewMemDB()
-	snapshotsDB := dbm.NewMemDB()
 	dydxApp := app.New(
 		logger,
 		db,
-		snapshotsDB,
 		nil,
 		true,
 		appOptions,
@@ -1274,9 +1272,6 @@ func launchValidatorInDir(
 	case a = <-appCaptor:
 		shutdownFn = func() error {
 			cancelFn()
-			// TODO(CORE-538): Remove this explicit app.Close() invocation since wrapCPUProfile doesn't actually
-			// wait till the Cosmos app shuts down.
-			a.Close()
 			return <-done
 		}
 		return a, shutdownFn, nil

--- a/protocol/testutil/network/network.go
+++ b/protocol/testutil/network/network.go
@@ -146,7 +146,6 @@ func DefaultConfig(options *NetworkConfigOptions) network.Config {
 			return app.New(
 				val.GetCtx().Logger,
 				dbm.NewMemDB(),
-				dbm.NewMemDB(),
 				nil,
 				true,
 				appOptions,
@@ -177,7 +176,6 @@ func NewTestNetworkFixture() network.TestFixture {
 	dydxApp := app.New(
 		log.NewNopLogger(),
 		dbm.NewMemDB(),
-		dbm.NewMemDB(),
 		nil,
 		true,
 		appOptions,
@@ -186,7 +184,6 @@ func NewTestNetworkFixture() network.TestFixture {
 	appCtr := func(val network.ValidatorI) servertypes.Application {
 		return app.New(
 			val.GetCtx().Logger,
-			dbm.NewMemDB(),
 			dbm.NewMemDB(),
 			nil,
 			true,


### PR DESCRIPTION
### Changelist
[CORE-538] Remove DB shutdown, Cosmos 0.50 SDK does this now.

### Test Plan
Crashing app tests would discover that we are using the db while it is still open.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
