### PR TITLE
[bugfix][protocol] make funding payment event ordering deterministic

### DIFF
--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -281,8 +281,8 @@ func (k Keeper) UpdateSubaccounts(
 		// payment. Note that `fundingPaid` is positive if the subaccount paid funding,
 		// and negative if the subaccount received funding.
 		// Note the perpetual IDs are sorted first to ensure event emission determinism.
-		sortedPerpsWithFunding := lib.GetSortedKeys[lib.Sortable[uint32]](fundingPayments)
-		for _, perpetualId := range sortedPerpsWithFunding {
+		sortedPerpIds := lib.GetSortedKeys[lib.Sortable[uint32]](fundingPayments)
+		for _, perpetualId := range sortedPerpIds {
 			fundingPaid := fundingPayments[perpetualId]
 			ctx.EventManager().EmitEvent(
 				types.NewCreateSettledFundingEvent(

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	"sort"
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
@@ -282,14 +281,8 @@ func (k Keeper) UpdateSubaccounts(
 		// payment. Note that `fundingPaid` is positive if the subaccount paid funding,
 		// and negative if the subaccount received funding.
 		// Note the perpetual IDs are sorted first to ensure event emission determinism.
-		perpsWithFunding := make([]uint32, 0, len(fundingPayments))
-		for perpetualId := range fundingPayments {
-			perpsWithFunding = append(perpsWithFunding, perpetualId)
-		}
-		sort.Slice(perpsWithFunding, func(i, j int) bool {
-			return perpsWithFunding[i] < perpsWithFunding[j]
-		})
-		for _, perpetualId := range perpsWithFunding {
+		sortedPerpsWithFunding := lib.GetSortedKeys[lib.Sortable[uint32]](fundingPayments)
+		for _, perpetualId := range sortedPerpsWithFunding {
 			fundingPaid := fundingPayments[perpetualId]
 			ctx.EventManager().EmitEvent(
 				types.NewCreateSettledFundingEvent(


### PR DESCRIPTION
### Changelist
Make the funding payment event ordering deterministic. Should address [this Github issue](https://github.com/dydxprotocol/v4-chain/issues/895).
### Test Plan
Not tested since the change is fairly simple and doesn't affect anything in state (only events).

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
