### PR TITLE
[feat][protocol]: gate withdrawals if negative TNC subaccount encountered after liquidation and deleveraging steps

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -334,6 +334,7 @@ const (
 	NotEnoughPositionToFullyOffset = "not_enough_position_to_fully_offset"
 	NonOverlappingBankruptcyPrices = "non_overlapping_bankruptcy_prices"
 	NoOpenPositionOnOppositeSide   = "no_open_position_on_opposite_side"
+	NegativeTncSubaccountSeen      = "negative_tnc_subaccount_seen"
 
 	// Pricefeed Daemon.
 	Exchange                                = "exchange"

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -334,7 +334,6 @@ const (
 	NotEnoughPositionToFullyOffset = "not_enough_position_to_fully_offset"
 	NonOverlappingBankruptcyPrices = "non_overlapping_bankruptcy_prices"
 	NoOpenPositionOnOppositeSide   = "no_open_position_on_opposite_side"
-	NegativeTncSubaccountSeen      = "negative_tnc_subaccount_seen"
 
 	// Pricefeed Daemon.
 	Exchange                                = "exchange"

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -39,13 +39,14 @@ const (
 	LiquidationsPlacePerpetualLiquidationQuoteQuantumsDistribution = "liquidations_place_perpetual_liquidation_quote_quantums_distribution"
 
 	// Measure Since
-	ClobOffsettingSubaccountPerpetualPosition = "clob_offsetting_subaccount_perpetual_position"
-	DaemonGetPreviousBlockInfoLatency         = "daemon_get_previous_block_info_latency"
-	DaemonGetAllMarketPricesLatency           = "daemon_get_all_market_prices_latency"
-	DaemonGetMarketPricesPaginatedLatency     = "daemon_get_market_prices_paginated_latency"
-	DaemonGetAllLiquidityTiersLatency         = "daemon_get_all_liquidity_tiers_latency"
-	DaemonGetLiquidityTiersPaginatedLatency   = "daemon_get_liquidity_tiers_paginated_latency"
-	DaemonGetAllPerpetualsLatency             = "daemon_get_all_perpetuals_latency"
-	DaemonGetPerpetualsPaginatedLatency       = "daemon_get_perpetuals_paginated_latency"
-	MevLatency                                = "mev_latency"
+	ClobOffsettingSubaccountPerpetualPosition  = "clob_offsetting_subaccount_perpetual_position"
+	DaemonGetPreviousBlockInfoLatency          = "daemon_get_previous_block_info_latency"
+	DaemonGetAllMarketPricesLatency            = "daemon_get_all_market_prices_latency"
+	DaemonGetMarketPricesPaginatedLatency      = "daemon_get_market_prices_paginated_latency"
+	DaemonGetAllLiquidityTiersLatency          = "daemon_get_all_liquidity_tiers_latency"
+	DaemonGetLiquidityTiersPaginatedLatency    = "daemon_get_liquidity_tiers_paginated_latency"
+	DaemonGetAllPerpetualsLatency              = "daemon_get_all_perpetuals_latency"
+	DaemonGetPerpetualsPaginatedLatency        = "daemon_get_perpetuals_paginated_latency"
+	MevLatency                                 = "mev_latency"
+	GateWithdrawalsIfNegativeTncSubaccountSeen = "gate_withdrawals_if_negative_tnc_subaccount_seen"
 )

--- a/protocol/mocks/MemClob.go
+++ b/protocol/mocks/MemClob.go
@@ -25,10 +25,6 @@ func (_m *MemClob) CancelOrder(ctx types.Context, msgCancelOrder *clobtypes.MsgC
 	ret := _m.Called(ctx, msgCancelOrder)
 
 	var r0 *clobtypes.OffchainUpdates
-	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MsgCancelOrder) (*clobtypes.OffchainUpdates, error)); ok {
-		return rf(ctx, msgCancelOrder)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MsgCancelOrder) *clobtypes.OffchainUpdates); ok {
 		r0 = rf(ctx, msgCancelOrder)
 	} else {
@@ -37,6 +33,7 @@ func (_m *MemClob) CancelOrder(ctx types.Context, msgCancelOrder *clobtypes.MsgC
 		}
 	}
 
+	var r1 error
 	if rf, ok := ret.Get(1).(func(types.Context, *clobtypes.MsgCancelOrder) error); ok {
 		r1 = rf(ctx, msgCancelOrder)
 	} else {
@@ -70,10 +67,6 @@ func (_m *MemClob) DeleverageSubaccount(ctx types.Context, subaccountId subaccou
 	ret := _m.Called(ctx, subaccountId, perpetualId, deltaQuantums, isFinalSettlement)
 
 	var r0 *big.Int
-	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Context, subaccountstypes.SubaccountId, uint32, *big.Int, bool) (*big.Int, error)); ok {
-		return rf(ctx, subaccountId, perpetualId, deltaQuantums, isFinalSettlement)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, subaccountstypes.SubaccountId, uint32, *big.Int, bool) *big.Int); ok {
 		r0 = rf(ctx, subaccountId, perpetualId, deltaQuantums, isFinalSettlement)
 	} else {
@@ -82,6 +75,7 @@ func (_m *MemClob) DeleverageSubaccount(ctx types.Context, subaccountId subaccou
 		}
 	}
 
+	var r1 error
 	if rf, ok := ret.Get(1).(func(types.Context, subaccountstypes.SubaccountId, uint32, *big.Int, bool) error); ok {
 		r1 = rf(ctx, subaccountId, perpetualId, deltaQuantums, isFinalSettlement)
 	} else {
@@ -96,16 +90,13 @@ func (_m *MemClob) GetCancelOrder(ctx types.Context, orderId clobtypes.OrderId) 
 	ret := _m.Called(ctx, orderId)
 
 	var r0 uint32
-	var r1 bool
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.OrderId) (uint32, bool)); ok {
-		return rf(ctx, orderId)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.OrderId) uint32); ok {
 		r0 = rf(ctx, orderId)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
+	var r1 bool
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.OrderId) bool); ok {
 		r1 = rf(ctx, orderId)
 	} else {
@@ -120,30 +111,27 @@ func (_m *MemClob) GetMidPrice(ctx types.Context, clobPairId clobtypes.ClobPairI
 	ret := _m.Called(ctx, clobPairId)
 
 	var r0 clobtypes.Subticks
-	var r1 clobtypes.Order
-	var r2 clobtypes.Order
-	var r3 bool
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPairId) (clobtypes.Subticks, clobtypes.Order, clobtypes.Order, bool)); ok {
-		return rf(ctx, clobPairId)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPairId) clobtypes.Subticks); ok {
 		r0 = rf(ctx, clobPairId)
 	} else {
 		r0 = ret.Get(0).(clobtypes.Subticks)
 	}
 
+	var r1 clobtypes.Order
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.ClobPairId) clobtypes.Order); ok {
 		r1 = rf(ctx, clobPairId)
 	} else {
 		r1 = ret.Get(1).(clobtypes.Order)
 	}
 
+	var r2 clobtypes.Order
 	if rf, ok := ret.Get(2).(func(types.Context, clobtypes.ClobPairId) clobtypes.Order); ok {
 		r2 = rf(ctx, clobPairId)
 	} else {
 		r2 = ret.Get(2).(clobtypes.Order)
 	}
 
+	var r3 bool
 	if rf, ok := ret.Get(3).(func(types.Context, clobtypes.ClobPairId) bool); ok {
 		r3 = rf(ctx, clobPairId)
 	} else {
@@ -174,10 +162,6 @@ func (_m *MemClob) GetOperationsToReplay(ctx types.Context) ([]clobtypes.Interna
 	ret := _m.Called(ctx)
 
 	var r0 []clobtypes.InternalOperation
-	var r1 map[clobtypes.OrderHash][]byte
-	if rf, ok := ret.Get(0).(func(types.Context) ([]clobtypes.InternalOperation, map[clobtypes.OrderHash][]byte)); ok {
-		return rf(ctx)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context) []clobtypes.InternalOperation); ok {
 		r0 = rf(ctx)
 	} else {
@@ -186,6 +170,7 @@ func (_m *MemClob) GetOperationsToReplay(ctx types.Context) ([]clobtypes.Interna
 		}
 	}
 
+	var r1 map[clobtypes.OrderHash][]byte
 	if rf, ok := ret.Get(1).(func(types.Context) map[clobtypes.OrderHash][]byte); ok {
 		r1 = rf(ctx)
 	} else {
@@ -202,16 +187,13 @@ func (_m *MemClob) GetOrder(ctx types.Context, orderId clobtypes.OrderId) (clobt
 	ret := _m.Called(ctx, orderId)
 
 	var r0 clobtypes.Order
-	var r1 bool
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.OrderId) (clobtypes.Order, bool)); ok {
-		return rf(ctx, orderId)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.OrderId) clobtypes.Order); ok {
 		r0 = rf(ctx, orderId)
 	} else {
 		r0 = ret.Get(0).(clobtypes.Order)
 	}
 
+	var r1 bool
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.OrderId) bool); ok {
 		r1 = rf(ctx, orderId)
 	} else {
@@ -240,16 +222,13 @@ func (_m *MemClob) GetOrderRemainingAmount(ctx types.Context, order clobtypes.Or
 	ret := _m.Called(ctx, order)
 
 	var r0 subaccountstypes.BaseQuantums
-	var r1 bool
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.Order) (subaccountstypes.BaseQuantums, bool)); ok {
-		return rf(ctx, order)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.Order) subaccountstypes.BaseQuantums); ok {
 		r0 = rf(ctx, order)
 	} else {
 		r0 = ret.Get(0).(subaccountstypes.BaseQuantums)
 	}
 
+	var r1 bool
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.Order) bool); ok {
 		r1 = rf(ctx, order)
 	} else {
@@ -264,16 +243,13 @@ func (_m *MemClob) GetPricePremium(ctx types.Context, clobPair clobtypes.ClobPai
 	ret := _m.Called(ctx, clobPair, params)
 
 	var r0 int32
-	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPair, perpetualstypes.GetPricePremiumParams) (int32, error)); ok {
-		return rf(ctx, clobPair, params)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPair, perpetualstypes.GetPricePremiumParams) int32); ok {
 		r0 = rf(ctx, clobPair, params)
 	} else {
 		r0 = ret.Get(0).(int32)
 	}
 
+	var r1 error
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.ClobPair, perpetualstypes.GetPricePremiumParams) error); ok {
 		r1 = rf(ctx, clobPair, params)
 	} else {
@@ -288,10 +264,6 @@ func (_m *MemClob) GetSubaccountOrders(ctx types.Context, clobPairId clobtypes.C
 	ret := _m.Called(ctx, clobPairId, subaccountId, side)
 
 	var r0 []clobtypes.Order
-	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPairId, subaccountstypes.SubaccountId, clobtypes.Order_Side) ([]clobtypes.Order, error)); ok {
-		return rf(ctx, clobPairId, subaccountId, side)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPairId, subaccountstypes.SubaccountId, clobtypes.Order_Side) []clobtypes.Order); ok {
 		r0 = rf(ctx, clobPairId, subaccountId, side)
 	} else {
@@ -300,6 +272,7 @@ func (_m *MemClob) GetSubaccountOrders(ctx types.Context, clobPairId clobtypes.C
 		}
 	}
 
+	var r1 error
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.ClobPairId, subaccountstypes.SubaccountId, clobtypes.Order_Side) error); ok {
 		r1 = rf(ctx, clobPairId, subaccountId, side)
 	} else {
@@ -309,29 +282,30 @@ func (_m *MemClob) GetSubaccountOrders(ctx types.Context, clobPairId clobtypes.C
 	return r0, r1
 }
 
+// InsertZeroFillDeleveragingIntoOperationsQueue provides a mock function with given fields: ctx, subaccountId, perpetualId
+func (_m *MemClob) InsertZeroFillDeleveragingIntoOperationsQueue(ctx types.Context, subaccountId subaccountstypes.SubaccountId, perpetualId uint32) {
+	_m.Called(ctx, subaccountId, perpetualId)
+}
+
 // PlaceOrder provides a mock function with given fields: ctx, order
 func (_m *MemClob) PlaceOrder(ctx types.Context, order clobtypes.Order) (subaccountstypes.BaseQuantums, clobtypes.OrderStatus, *clobtypes.OffchainUpdates, error) {
 	ret := _m.Called(ctx, order)
 
 	var r0 subaccountstypes.BaseQuantums
-	var r1 clobtypes.OrderStatus
-	var r2 *clobtypes.OffchainUpdates
-	var r3 error
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.Order) (subaccountstypes.BaseQuantums, clobtypes.OrderStatus, *clobtypes.OffchainUpdates, error)); ok {
-		return rf(ctx, order)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.Order) subaccountstypes.BaseQuantums); ok {
 		r0 = rf(ctx, order)
 	} else {
 		r0 = ret.Get(0).(subaccountstypes.BaseQuantums)
 	}
 
+	var r1 clobtypes.OrderStatus
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.Order) clobtypes.OrderStatus); ok {
 		r1 = rf(ctx, order)
 	} else {
 		r1 = ret.Get(1).(clobtypes.OrderStatus)
 	}
 
+	var r2 *clobtypes.OffchainUpdates
 	if rf, ok := ret.Get(2).(func(types.Context, clobtypes.Order) *clobtypes.OffchainUpdates); ok {
 		r2 = rf(ctx, order)
 	} else {
@@ -340,6 +314,7 @@ func (_m *MemClob) PlaceOrder(ctx types.Context, order clobtypes.Order) (subacco
 		}
 	}
 
+	var r3 error
 	if rf, ok := ret.Get(3).(func(types.Context, clobtypes.Order) error); ok {
 		r3 = rf(ctx, order)
 	} else {
@@ -354,24 +329,20 @@ func (_m *MemClob) PlacePerpetualLiquidation(ctx types.Context, liquidationOrder
 	ret := _m.Called(ctx, liquidationOrder)
 
 	var r0 subaccountstypes.BaseQuantums
-	var r1 clobtypes.OrderStatus
-	var r2 *clobtypes.OffchainUpdates
-	var r3 error
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.LiquidationOrder) (subaccountstypes.BaseQuantums, clobtypes.OrderStatus, *clobtypes.OffchainUpdates, error)); ok {
-		return rf(ctx, liquidationOrder)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.LiquidationOrder) subaccountstypes.BaseQuantums); ok {
 		r0 = rf(ctx, liquidationOrder)
 	} else {
 		r0 = ret.Get(0).(subaccountstypes.BaseQuantums)
 	}
 
+	var r1 clobtypes.OrderStatus
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.LiquidationOrder) clobtypes.OrderStatus); ok {
 		r1 = rf(ctx, liquidationOrder)
 	} else {
 		r1 = ret.Get(1).(clobtypes.OrderStatus)
 	}
 
+	var r2 *clobtypes.OffchainUpdates
 	if rf, ok := ret.Get(2).(func(types.Context, clobtypes.LiquidationOrder) *clobtypes.OffchainUpdates); ok {
 		r2 = rf(ctx, liquidationOrder)
 	} else {
@@ -380,6 +351,7 @@ func (_m *MemClob) PlacePerpetualLiquidation(ctx types.Context, liquidationOrder
 		}
 	}
 
+	var r3 error
 	if rf, ok := ret.Get(3).(func(types.Context, clobtypes.LiquidationOrder) error); ok {
 		r3 = rf(ctx, liquidationOrder)
 	} else {

--- a/protocol/mocks/MemClobKeeper.go
+++ b/protocol/mocks/MemClobKeeper.go
@@ -29,16 +29,13 @@ func (_m *MemClobKeeper) AddOrderToOrderbookCollatCheck(ctx types.Context, clobP
 	ret := _m.Called(ctx, clobPairId, subaccountOpenOrders)
 
 	var r0 bool
-	var r1 map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPairId, map[subaccountstypes.SubaccountId][]clobtypes.PendingOpenOrder) (bool, map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult)); ok {
-		return rf(ctx, clobPairId, subaccountOpenOrders)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPairId, map[subaccountstypes.SubaccountId][]clobtypes.PendingOpenOrder) bool); ok {
 		r0 = rf(ctx, clobPairId, subaccountOpenOrders)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
+	var r1 map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.ClobPairId, map[subaccountstypes.SubaccountId][]clobtypes.PendingOpenOrder) map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult); ok {
 		r1 = rf(ctx, clobPairId, subaccountOpenOrders)
 	} else {
@@ -55,24 +52,20 @@ func (_m *MemClobKeeper) AddPreexistingStatefulOrder(ctx types.Context, order *c
 	ret := _m.Called(ctx, order, memclob)
 
 	var r0 subaccountstypes.BaseQuantums
-	var r1 clobtypes.OrderStatus
-	var r2 *clobtypes.OffchainUpdates
-	var r3 error
-	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.Order, clobtypes.MemClob) (subaccountstypes.BaseQuantums, clobtypes.OrderStatus, *clobtypes.OffchainUpdates, error)); ok {
-		return rf(ctx, order, memclob)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.Order, clobtypes.MemClob) subaccountstypes.BaseQuantums); ok {
 		r0 = rf(ctx, order, memclob)
 	} else {
 		r0 = ret.Get(0).(subaccountstypes.BaseQuantums)
 	}
 
+	var r1 clobtypes.OrderStatus
 	if rf, ok := ret.Get(1).(func(types.Context, *clobtypes.Order, clobtypes.MemClob) clobtypes.OrderStatus); ok {
 		r1 = rf(ctx, order, memclob)
 	} else {
 		r1 = ret.Get(1).(clobtypes.OrderStatus)
 	}
 
+	var r2 *clobtypes.OffchainUpdates
 	if rf, ok := ret.Get(2).(func(types.Context, *clobtypes.Order, clobtypes.MemClob) *clobtypes.OffchainUpdates); ok {
 		r2 = rf(ctx, order, memclob)
 	} else {
@@ -81,6 +74,7 @@ func (_m *MemClobKeeper) AddPreexistingStatefulOrder(ctx types.Context, order *c
 		}
 	}
 
+	var r3 error
 	if rf, ok := ret.Get(3).(func(types.Context, *clobtypes.Order, clobtypes.MemClob) error); ok {
 		r3 = rf(ctx, order, memclob)
 	} else {
@@ -95,23 +89,20 @@ func (_m *MemClobKeeper) CanDeleverageSubaccount(ctx types.Context, subaccountId
 	ret := _m.Called(ctx, subaccountId, perpetualId)
 
 	var r0 bool
-	var r1 bool
-	var r2 error
-	if rf, ok := ret.Get(0).(func(types.Context, subaccountstypes.SubaccountId, uint32) (bool, bool, error)); ok {
-		return rf(ctx, subaccountId, perpetualId)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, subaccountstypes.SubaccountId, uint32) bool); ok {
 		r0 = rf(ctx, subaccountId, perpetualId)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
+	var r1 bool
 	if rf, ok := ret.Get(1).(func(types.Context, subaccountstypes.SubaccountId, uint32) bool); ok {
 		r1 = rf(ctx, subaccountId, perpetualId)
 	} else {
 		r1 = ret.Get(1).(bool)
 	}
 
+	var r2 error
 	if rf, ok := ret.Get(2).(func(types.Context, subaccountstypes.SubaccountId, uint32) error); ok {
 		r2 = rf(ctx, subaccountId, perpetualId)
 	} else {
@@ -156,16 +147,13 @@ func (_m *MemClobKeeper) GetLongTermOrderPlacement(ctx types.Context, orderId cl
 	ret := _m.Called(ctx, orderId)
 
 	var r0 clobtypes.LongTermOrderPlacement
-	var r1 bool
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.OrderId) (clobtypes.LongTermOrderPlacement, bool)); ok {
-		return rf(ctx, orderId)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.OrderId) clobtypes.LongTermOrderPlacement); ok {
 		r0 = rf(ctx, orderId)
 	} else {
 		r0 = ret.Get(0).(clobtypes.LongTermOrderPlacement)
 	}
 
+	var r1 bool
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.OrderId) bool); ok {
 		r1 = rf(ctx, orderId)
 	} else {
@@ -180,23 +168,20 @@ func (_m *MemClobKeeper) GetOrderFillAmount(ctx types.Context, orderId clobtypes
 	ret := _m.Called(ctx, orderId)
 
 	var r0 bool
-	var r1 subaccountstypes.BaseQuantums
-	var r2 uint32
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.OrderId) (bool, subaccountstypes.BaseQuantums, uint32)); ok {
-		return rf(ctx, orderId)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.OrderId) bool); ok {
 		r0 = rf(ctx, orderId)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
+	var r1 subaccountstypes.BaseQuantums
 	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.OrderId) subaccountstypes.BaseQuantums); ok {
 		r1 = rf(ctx, orderId)
 	} else {
 		r1 = ret.Get(1).(subaccountstypes.BaseQuantums)
 	}
 
+	var r2 uint32
 	if rf, ok := ret.Get(2).(func(types.Context, clobtypes.OrderId) uint32); ok {
 		r2 = rf(ctx, orderId)
 	} else {
@@ -227,16 +212,13 @@ func (_m *MemClobKeeper) IsLiquidatable(ctx types.Context, subaccountId subaccou
 	ret := _m.Called(ctx, subaccountId)
 
 	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Context, subaccountstypes.SubaccountId) (bool, error)); ok {
-		return rf(ctx, subaccountId)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, subaccountstypes.SubaccountId) bool); ok {
 		r0 = rf(ctx, subaccountId)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
+	var r1 error
 	if rf, ok := ret.Get(1).(func(types.Context, subaccountstypes.SubaccountId) error); ok {
 		r1 = rf(ctx, subaccountId)
 	} else {
@@ -272,10 +254,6 @@ func (_m *MemClobKeeper) OffsetSubaccountPerpetualPosition(ctx types.Context, li
 	ret := _m.Called(ctx, liquidatedSubaccountId, perpetualId, deltaQuantumsTotal, isFinalSettlement)
 
 	var r0 []clobtypes.MatchPerpetualDeleveraging_Fill
-	var r1 *big.Int
-	if rf, ok := ret.Get(0).(func(types.Context, subaccountstypes.SubaccountId, uint32, *big.Int, bool) ([]clobtypes.MatchPerpetualDeleveraging_Fill, *big.Int)); ok {
-		return rf(ctx, liquidatedSubaccountId, perpetualId, deltaQuantumsTotal, isFinalSettlement)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, subaccountstypes.SubaccountId, uint32, *big.Int, bool) []clobtypes.MatchPerpetualDeleveraging_Fill); ok {
 		r0 = rf(ctx, liquidatedSubaccountId, perpetualId, deltaQuantumsTotal, isFinalSettlement)
 	} else {
@@ -284,6 +262,7 @@ func (_m *MemClobKeeper) OffsetSubaccountPerpetualPosition(ctx types.Context, li
 		}
 	}
 
+	var r1 *big.Int
 	if rf, ok := ret.Get(1).(func(types.Context, subaccountstypes.SubaccountId, uint32, *big.Int, bool) *big.Int); ok {
 		r1 = rf(ctx, liquidatedSubaccountId, perpetualId, deltaQuantumsTotal, isFinalSettlement)
 	} else {
@@ -300,31 +279,27 @@ func (_m *MemClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *
 	ret := _m.Called(ctx, matchWithOrders)
 
 	var r0 bool
-	var r1 subaccountstypes.UpdateResult
-	var r2 subaccountstypes.UpdateResult
-	var r3 *clobtypes.OffchainUpdates
-	var r4 error
-	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, *clobtypes.OffchainUpdates, error)); ok {
-		return rf(ctx, matchWithOrders)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MatchWithOrders) bool); ok {
 		r0 = rf(ctx, matchWithOrders)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
+	var r1 subaccountstypes.UpdateResult
 	if rf, ok := ret.Get(1).(func(types.Context, *clobtypes.MatchWithOrders) subaccountstypes.UpdateResult); ok {
 		r1 = rf(ctx, matchWithOrders)
 	} else {
 		r1 = ret.Get(1).(subaccountstypes.UpdateResult)
 	}
 
+	var r2 subaccountstypes.UpdateResult
 	if rf, ok := ret.Get(2).(func(types.Context, *clobtypes.MatchWithOrders) subaccountstypes.UpdateResult); ok {
 		r2 = rf(ctx, matchWithOrders)
 	} else {
 		r2 = ret.Get(2).(subaccountstypes.UpdateResult)
 	}
 
+	var r3 *clobtypes.OffchainUpdates
 	if rf, ok := ret.Get(3).(func(types.Context, *clobtypes.MatchWithOrders) *clobtypes.OffchainUpdates); ok {
 		r3 = rf(ctx, matchWithOrders)
 	} else {
@@ -333,6 +308,7 @@ func (_m *MemClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *
 		}
 	}
 
+	var r4 error
 	if rf, ok := ret.Get(4).(func(types.Context, *clobtypes.MatchWithOrders) error); ok {
 		r4 = rf(ctx, matchWithOrders)
 	} else {
@@ -347,24 +323,20 @@ func (_m *MemClobKeeper) ReplayPlaceOrder(ctx types.Context, msg *clobtypes.MsgP
 	ret := _m.Called(ctx, msg)
 
 	var r0 subaccountstypes.BaseQuantums
-	var r1 clobtypes.OrderStatus
-	var r2 *clobtypes.OffchainUpdates
-	var r3 error
-	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MsgPlaceOrder) (subaccountstypes.BaseQuantums, clobtypes.OrderStatus, *clobtypes.OffchainUpdates, error)); ok {
-		return rf(ctx, msg)
-	}
 	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MsgPlaceOrder) subaccountstypes.BaseQuantums); ok {
 		r0 = rf(ctx, msg)
 	} else {
 		r0 = ret.Get(0).(subaccountstypes.BaseQuantums)
 	}
 
+	var r1 clobtypes.OrderStatus
 	if rf, ok := ret.Get(1).(func(types.Context, *clobtypes.MsgPlaceOrder) clobtypes.OrderStatus); ok {
 		r1 = rf(ctx, msg)
 	} else {
 		r1 = ret.Get(1).(clobtypes.OrderStatus)
 	}
 
+	var r2 *clobtypes.OffchainUpdates
 	if rf, ok := ret.Get(2).(func(types.Context, *clobtypes.MsgPlaceOrder) *clobtypes.OffchainUpdates); ok {
 		r2 = rf(ctx, msg)
 	} else {
@@ -373,6 +345,7 @@ func (_m *MemClobKeeper) ReplayPlaceOrder(ctx types.Context, msg *clobtypes.MsgP
 		}
 	}
 
+	var r3 error
 	if rf, ok := ret.Get(3).(func(types.Context, *clobtypes.MsgPlaceOrder) error); ok {
 		r3 = rf(ctx, msg)
 	} else {

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -232,9 +232,10 @@ func PrepareCheckState(
 		panic(err)
 	}
 
-	// 8. Gate withdrawals by inserting a zero-fill deleveraging operation into the operations queue
-	// if any of the liquidatable subaccounts still have negative TNC.
-	if err := keeper.GateWithdrawalsIfNegativeTncSubaccountSeen(ctx, liquidatableSubaccountIds); err != nil {
+	// 8. Gate withdrawals by inserting a zero-fill deleveraging operation into the operations queue if any
+	// of the negative TNC subaccounts still have negative TNC after liquidations and deleveraging steps.
+	negativeTncSubaccountIds := keeper.DaemonLiquidationInfo.GetNegativeTncSubaccountIds()
+	if err := keeper.GateWithdrawalsIfNegativeTncSubaccountSeen(ctx, negativeTncSubaccountIds); err != nil {
 		panic(err)
 	}
 

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -232,6 +232,12 @@ func PrepareCheckState(
 		panic(err)
 	}
 
+	// 8. Insert a zero-fill deleveraging operation into the operations queue if any of the liquidatable
+	// subaccounts still have negative TNC.
+	for _, subaccountId := range liquidatableSubaccountIds {
+		keeper.CanDeleverageSubaccount(ctx, subaccountId)
+	}
+
 	// Send all off-chain Indexer events
 	keeper.SendOffchainMessages(offchainUpdates, nil, metrics.SendPrepareCheckStateOffchainUpdates)
 

--- a/protocol/x/clob/e2e/withdrawal_gating_test.go
+++ b/protocol/x/clob/e2e/withdrawal_gating_test.go
@@ -1,0 +1,224 @@
+package clob_test
+
+import (
+	"testing"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/api"
+
+	"github.com/cometbft/cometbft/types"
+
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	feetiertypes "github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	prices "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithdrawalGating(t *testing.T) {
+	tests := map[string]struct {
+		// State.
+		subaccounts                   []satypes.Subaccount
+		marketIdToOraclePriceOverride map[uint32]uint64
+
+		// Parameters.
+		placedMatchableOrders     []clobtypes.MatchableOrder
+		liquidatableSubaccountIds []satypes.SubaccountId
+		negativeTncSubaccountIds  []satypes.SubaccountId
+
+		// Configuration.
+		liquidationConfig clobtypes.LiquidationsConfig
+		liquidityTiers    []perptypes.LiquidityTier
+		perpetuals        []perptypes.Perpetual
+		clobPairs         []clobtypes.ClobPair
+
+		// Expectations.
+		expectedSubaccounts                      []satypes.Subaccount
+		expectedWithdrawalsGated                 bool
+		expectedNegativeTncSubaccountSeenAtBlock uint32
+		expectedErr                              string
+	}{
+		`Can place a liquidation order that is unfilled and cannot be deleveraged due to
+		non-overlapping bankruptcy prices, withdrawals are gated`: {
+			subaccounts: []satypes.Subaccount{
+				constants.Carl_Num0_1BTC_Short_49999USD,
+				constants.Dave_Num0_1BTC_Long_50000USD_Short,
+			},
+
+			placedMatchableOrders: []clobtypes.MatchableOrder{
+				// Carl's bankruptcy price to close 1 BTC short is $49,999, and closing at $50,000
+				// would require $1 from the insurance fund. Since the insurance fund is empty,
+				// deleveraging is required to close this position.
+				&constants.Order_Dave_Num0_Id1_Clob0_Sell025BTC_Price50000_GTB11,
+			},
+			liquidationConfig:         constants.LiquidationsConfig_FillablePrice_Max_Smmr,
+			liquidatableSubaccountIds: []satypes.SubaccountId{constants.Carl_Num0},
+			negativeTncSubaccountIds:  []satypes.SubaccountId{constants.Carl_Num0},
+
+			liquidityTiers: constants.LiquidityTiers,
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+			},
+			clobPairs: []clobtypes.ClobPair{constants.ClobPair_Btc},
+
+			expectedSubaccounts: []satypes.Subaccount{
+				// Deleveraging fails.
+				// Dave's bankruptcy price to close 1 BTC long is $50,000, and deleveraging can not be
+				// performed due to non overlapping bankruptcy prices.
+				constants.Carl_Num0_1BTC_Short_49999USD,
+				constants.Dave_Num0_1BTC_Long_50000USD_Short,
+			},
+			expectedWithdrawalsGated:                 true,
+			expectedNegativeTncSubaccountSeenAtBlock: 4,
+			expectedErr:                              "WithdrawalsAndTransfersBlocked: failed to apply subaccount updates",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+				genesis = testapp.DefaultGenesis()
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *assettypes.GenesisState) {
+						genesisState.Assets = []assettypes.Asset{
+							*constants.Usdc,
+						}
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *prices.GenesisState) {
+						// Set oracle prices in the genesis.
+						pricesGenesis := constants.TestPricesGenesisState
+
+						// Make a copy of the MarketPrices slice to avoid modifying by reference.
+						marketPricesCopy := make([]prices.MarketPrice, len(pricesGenesis.MarketPrices))
+						copy(marketPricesCopy, pricesGenesis.MarketPrices)
+
+						for marketId, oraclePrice := range tc.marketIdToOraclePriceOverride {
+							exponent, exists := constants.TestMarketIdsToExponents[marketId]
+							require.True(t, exists)
+
+							marketPricesCopy[marketId] = prices.MarketPrice{
+								Id:       marketId,
+								Price:    oraclePrice,
+								Exponent: exponent,
+							}
+						}
+
+						pricesGenesis.MarketPrices = marketPricesCopy
+						*genesisState = pricesGenesis
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *perptypes.GenesisState) {
+						genesisState.Params = constants.PerpetualsGenesisParams
+						genesisState.LiquidityTiers = tc.liquidityTiers
+						genesisState.Perpetuals = tc.perpetuals
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *satypes.GenesisState) {
+						genesisState.Subaccounts = tc.subaccounts
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *clobtypes.GenesisState) {
+						genesisState.ClobPairs = tc.clobPairs
+						genesisState.LiquidationsConfig = tc.liquidationConfig
+						genesisState.EquityTierLimitConfig = clobtypes.EquityTierLimitConfiguration{}
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *feetiertypes.GenesisState) {
+						genesisState.Params = constants.PerpetualFeeParamsNoFee
+					},
+				)
+				return genesis
+			}).Build()
+
+			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+
+			// Create all existing orders.
+			existingOrderMsgs := make([]clobtypes.MsgPlaceOrder, len(tc.placedMatchableOrders))
+			for i, matchableOrder := range tc.placedMatchableOrders {
+				existingOrderMsgs[i] = clobtypes.MsgPlaceOrder{Order: matchableOrder.MustGetOrder()}
+			}
+			for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, existingOrderMsgs...) {
+				resp := tApp.CheckTx(checkTx)
+				require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
+			}
+
+			_, err := tApp.App.Server.LiquidateSubaccounts(ctx, &api.LiquidateSubaccountsRequest{
+				LiquidatableSubaccountIds:  tc.liquidatableSubaccountIds,
+				NegativeTncSubaccountIds:   tc.negativeTncSubaccountIds,
+				SubaccountOpenPositionInfo: clobtest.GetOpenPositionsFromSubaccounts(tc.subaccounts),
+			})
+			require.NoError(t, err)
+
+			// Verify test expectations.
+			ctx = tApp.AdvanceToBlock(4, testapp.AdvanceToBlockOptions{})
+			for _, expectedSubaccount := range tc.expectedSubaccounts {
+				require.Equal(
+					t,
+					expectedSubaccount,
+					tApp.App.SubaccountsKeeper.GetSubaccount(ctx, *expectedSubaccount.Id),
+				)
+			}
+			negativeTncSubaccountSeenAtBlock, exists := tApp.App.SubaccountsKeeper.GetNegativeTncSubaccountSeenAtBlock(ctx)
+			require.Equal(t, tc.expectedWithdrawalsGated, exists)
+			require.Equal(t, tc.expectedNegativeTncSubaccountSeenAtBlock, negativeTncSubaccountSeenAtBlock)
+
+			// Verify withdrawals are blocked by trying to create a transfer message that withdraws funds.
+			withdrawMsg := sendingtypes.MsgWithdrawFromSubaccount{
+				Sender:    constants.Carl_Num0,
+				Recipient: constants.Carl_Num0.Owner,
+				AssetId:   constants.Usdc.Id,
+				Quantums:  1,
+			}
+			for _, checkTx := range testapp.MustMakeCheckTxsWithSdkMsg(
+				ctx,
+				tApp.App,
+				testapp.MustMakeCheckTxOptions{
+					AccAddressForSigning: constants.Carl_Num0.Owner,
+					Gas:                  1000000,
+					FeeAmt:               constants.TestFeeCoins_5Cents,
+				},
+				&withdrawMsg,
+			) {
+				resp := tApp.CheckTx(checkTx)
+				require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
+			}
+			ctx = tApp.AdvanceToBlock(
+				5,
+				testapp.AdvanceToBlockOptions{
+					ValidateFinalizeBlock: func(
+						ctx sdktypes.Context,
+						request abcitypes.RequestFinalizeBlock,
+						response abcitypes.ResponseFinalizeBlock,
+					) (haltchain bool) {
+						// Note the first TX is MsgProposeOperations, the second is all other TXs.
+						execResult := response.TxResults[1]
+						require.True(t, execResult.IsErr())
+						require.Equal(t, satypes.ErrFailedToUpdateSubaccounts.ABCICode(), execResult.Code)
+						require.Contains(t, execResult.Log, tc.expectedErr)
+						return false
+					},
+				},
+			)
+		})
+	}
+}

--- a/protocol/x/clob/e2e/withdrawal_gating_test.go
+++ b/protocol/x/clob/e2e/withdrawal_gating_test.go
@@ -219,6 +219,13 @@ func TestWithdrawalGating(t *testing.T) {
 					},
 				},
 			)
+			for _, expectedSubaccount := range tc.expectedSubaccounts {
+				require.Equal(
+					t,
+					expectedSubaccount,
+					tApp.App.SubaccountsKeeper.GetSubaccount(ctx, *expectedSubaccount.Id),
+				)
+			}
 		})
 	}
 }

--- a/protocol/x/clob/e2e/withdrawal_gating_test.go
+++ b/protocol/x/clob/e2e/withdrawal_gating_test.go
@@ -5,8 +5,10 @@ import (
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/liquidation/api"
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 
 	"github.com/cometbft/cometbft/types"
 
@@ -23,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithdrawalGating(t *testing.T) {
+func TestWithdrawalGating_BlocksThenUnblocks(t *testing.T) {
 	tests := map[string]struct {
 		// State.
 		subaccounts                   []satypes.Subaccount
@@ -35,10 +37,12 @@ func TestWithdrawalGating(t *testing.T) {
 		negativeTncSubaccountIds  []satypes.SubaccountId
 
 		// Configuration.
-		liquidationConfig clobtypes.LiquidationsConfig
-		liquidityTiers    []perptypes.LiquidityTier
-		perpetuals        []perptypes.Perpetual
-		clobPairs         []clobtypes.ClobPair
+		liquidationConfig            clobtypes.LiquidationsConfig
+		liquidityTiers               []perptypes.LiquidityTier
+		perpetuals                   []perptypes.Perpetual
+		clobPairs                    []clobtypes.ClobPair
+		transferOrWithdrawSubaccount satypes.SubaccountId
+		isWithdrawal                 bool
 
 		// Expectations.
 		expectedSubaccounts                      []satypes.Subaccount
@@ -51,6 +55,10 @@ func TestWithdrawalGating(t *testing.T) {
 			subaccounts: []satypes.Subaccount{
 				constants.Carl_Num0_1BTC_Short_49999USD,
 				constants.Dave_Num0_1BTC_Long_50000USD_Short,
+				constants.Dave_Num1_10_000USD,
+			},
+			marketIdToOraclePriceOverride: map[uint32]uint64{
+				constants.BtcUsd.MarketId: 5_050_000_000, // $50,500 / BTC
 			},
 
 			placedMatchableOrders: []clobtypes.MatchableOrder{
@@ -67,7 +75,9 @@ func TestWithdrawalGating(t *testing.T) {
 			perpetuals: []perptypes.Perpetual{
 				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
 			},
-			clobPairs: []clobtypes.ClobPair{constants.ClobPair_Btc},
+			clobPairs:                    []clobtypes.ClobPair{constants.ClobPair_Btc},
+			transferOrWithdrawSubaccount: constants.Dave_Num1,
+			isWithdrawal:                 true,
 
 			expectedSubaccounts: []satypes.Subaccount{
 				// Deleveraging fails.
@@ -75,6 +85,70 @@ func TestWithdrawalGating(t *testing.T) {
 				// performed due to non overlapping bankruptcy prices.
 				constants.Carl_Num0_1BTC_Short_49999USD,
 				constants.Dave_Num0_1BTC_Long_50000USD_Short,
+			},
+			expectedWithdrawalsGated:                 true,
+			expectedNegativeTncSubaccountSeenAtBlock: 4,
+			expectedErr:                              "WithdrawalsAndTransfersBlocked: failed to apply subaccount updates",
+		},
+		`Can place a liquidation order that is partially-filled filled, deleveraging is skipped but
+		its still negative TNC, withdrawals are gated`: {
+			subaccounts: []satypes.Subaccount{
+				constants.Carl_Num0_1BTC_Short_49999USD,
+				constants.Dave_Num0_1BTC_Long_50000USD_Short,
+				constants.Dave_Num1_025BTC_Long_50000USD,
+			},
+
+			placedMatchableOrders: []clobtypes.MatchableOrder{
+				&constants.Order_Dave_Num1_Id0_Clob0_Sell025BTC_Price49999_GTB10,
+				// Carl's bankruptcy price to close 1 BTC short is $49,999, and closing 0.75 BTC at $50,000
+				// would require $0.75 from the insurance fund. Since the insurance fund is empty,
+				// deleveraging is required to close this position.
+				&constants.Order_Dave_Num0_Id1_Clob0_Sell025BTC_Price50000_GTB11,
+			},
+
+			liquidationConfig:         constants.LiquidationsConfig_FillablePrice_Max_Smmr,
+			liquidatableSubaccountIds: []satypes.SubaccountId{constants.Carl_Num0},
+			negativeTncSubaccountIds:  []satypes.SubaccountId{constants.Carl_Num0},
+
+			liquidityTiers: constants.LiquidityTiers,
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+			},
+			clobPairs:                    []clobtypes.ClobPair{constants.ClobPair_Btc},
+			transferOrWithdrawSubaccount: constants.Dave_Num1,
+			isWithdrawal:                 false,
+
+			expectedSubaccounts: []satypes.Subaccount{
+				// Deleveraging fails for remaining amount.
+				{
+					Id: &constants.Carl_Num0,
+					AssetPositions: []*satypes.AssetPosition{
+						{
+							AssetId:  0,
+							Quantums: dtypes.NewInt(49_999_000_000 - 12_499_750_000),
+						},
+					},
+					PerpetualPositions: []*satypes.PerpetualPosition{
+						{
+							PerpetualId:  0,
+							Quantums:     dtypes.NewInt(-75_000_000), // -0.75 BTC
+							FundingIndex: dtypes.NewInt(0),
+						},
+					},
+				},
+				// Dave's bankruptcy price to close 1 BTC long is $50,000, and deleveraging can not be
+				// performed due to non overlapping bankruptcy prices.
+				// Dave_Num0 does not change since deleveraging against this subaccount failed.
+				constants.Dave_Num0_1BTC_Long_50000USD_Short,
+				{
+					Id: &constants.Dave_Num1,
+					AssetPositions: []*satypes.AssetPosition{
+						{
+							AssetId:  0,
+							Quantums: dtypes.NewInt(50_000_000_000 + 12_499_750_000),
+						},
+					},
+				},
 			},
 			expectedWithdrawalsGated:                 true,
 			expectedNegativeTncSubaccountSeenAtBlock: 4,
@@ -183,21 +257,35 @@ func TestWithdrawalGating(t *testing.T) {
 			require.Equal(t, tc.expectedNegativeTncSubaccountSeenAtBlock, negativeTncSubaccountSeenAtBlock)
 
 			// Verify withdrawals are blocked by trying to create a transfer message that withdraws funds.
-			withdrawMsg := sendingtypes.MsgWithdrawFromSubaccount{
-				Sender:    constants.Carl_Num0,
-				Recipient: constants.Carl_Num0.Owner,
-				AssetId:   constants.Usdc.Id,
-				Quantums:  1,
+			var msg proto.Message
+			if tc.isWithdrawal {
+				withdrawMsg := sendingtypes.MsgWithdrawFromSubaccount{
+					Sender:    tc.transferOrWithdrawSubaccount,
+					Recipient: tc.transferOrWithdrawSubaccount.Owner,
+					AssetId:   constants.Usdc.Id,
+					Quantums:  1,
+				}
+				msg = &withdrawMsg
+			} else {
+				transferMsg := sendingtypes.MsgCreateTransfer{
+					Transfer: &sendingtypes.Transfer{
+						Sender:    tc.transferOrWithdrawSubaccount,
+						Recipient: constants.Bob_Num0,
+						AssetId:   constants.Usdc.Id,
+						Amount:    1,
+					},
+				}
+				msg = &transferMsg
 			}
 			for _, checkTx := range testapp.MustMakeCheckTxsWithSdkMsg(
 				ctx,
 				tApp.App,
 				testapp.MustMakeCheckTxOptions{
-					AccAddressForSigning: constants.Carl_Num0.Owner,
+					AccAddressForSigning: tc.transferOrWithdrawSubaccount.Owner,
 					Gas:                  1000000,
 					FeeAmt:               constants.TestFeeCoins_5Cents,
 				},
-				&withdrawMsg,
+				msg,
 			) {
 				resp := tApp.CheckTx(checkTx)
 				require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
@@ -226,6 +314,35 @@ func TestWithdrawalGating(t *testing.T) {
 					tApp.App.SubaccountsKeeper.GetSubaccount(ctx, *expectedSubaccount.Id),
 				)
 			}
+
+			// Verify that transfers and withdrawals are unblocked after the withdrawal gating period passes.
+			_, err = tApp.App.Server.LiquidateSubaccounts(ctx, &api.LiquidateSubaccountsRequest{
+				LiquidatableSubaccountIds:  tc.liquidatableSubaccountIds,
+				NegativeTncSubaccountIds:   []satypes.SubaccountId{},
+				SubaccountOpenPositionInfo: clobtest.GetOpenPositionsFromSubaccounts(tc.subaccounts),
+			})
+			require.NoError(t, err)
+			tApp.AdvanceToBlock(
+				tc.expectedNegativeTncSubaccountSeenAtBlock+satypes.WITHDRAWAL_AND_TRANSFERS_BLOCKED_AFTER_NEGATIVE_TNC_SUBACCOUNT_SEEN_BLOCKS+1,
+				testapp.AdvanceToBlockOptions{},
+			)
+			for _, checkTx := range testapp.MustMakeCheckTxsWithSdkMsg(
+				ctx,
+				tApp.App,
+				testapp.MustMakeCheckTxOptions{
+					AccAddressForSigning: tc.transferOrWithdrawSubaccount.Owner,
+					Gas:                  1000000,
+					FeeAmt:               constants.TestFeeCoins_5Cents,
+				},
+				msg,
+			) {
+				resp := tApp.CheckTx(checkTx)
+				require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
+			}
+			tApp.AdvanceToBlock(
+				tc.expectedNegativeTncSubaccountSeenAtBlock+satypes.WITHDRAWAL_AND_TRANSFERS_BLOCKED_AFTER_NEGATIVE_TNC_SUBACCOUNT_SEEN_BLOCKS+2,
+				testapp.AdvanceToBlockOptions{},
+			)
 		})
 	}
 }

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -195,6 +195,16 @@ func (k Keeper) GateWithdrawalsIfNegativeTncSubaccountSeen(
 	ctx sdk.Context,
 	negativeTncSubaccountIds []satypes.SubaccountId,
 ) (err error) {
+	defer metrics.ModuleMeasureSince(
+		types.ModuleName,
+		metrics.GateWithdrawalsIfNegativeTncSubaccountSeen,
+		time.Now(),
+	)
+	metrics.IncrCounter(
+		metrics.GateWithdrawalsIfNegativeTncSubaccountSeen,
+		1,
+	)
+
 	foundNegativeTncSubaccount := false
 	var negativeTncSubaccountId satypes.SubaccountId
 	for _, subaccountId := range negativeTncSubaccountIds {
@@ -234,6 +244,13 @@ func (k Keeper) GateWithdrawalsIfNegativeTncSubaccountSeen(
 	}
 	perpetualId := subaccount.PerpetualPositions[0].PerpetualId
 	k.MemClob.InsertZeroFillDeleveragingIntoOperationsQueue(ctx, negativeTncSubaccountId, perpetualId)
+	metrics.IncrCountMetricWithLabels(
+		types.ModuleName,
+		metrics.SubaccountsNegativeTncSubaccountSeen,
+		metrics.GetLabelForIntValue(metrics.PerpetualId, int(perpetualId)),
+		metrics.GetLabelForBoolValue(metrics.IsLong, subaccount.PerpetualPositions[0].GetIsLong()),
+		metrics.GetLabelForBoolValue(metrics.DeliverTx, false),
+	)
 
 	return nil
 }

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -188,6 +188,42 @@ func (k Keeper) CanDeleverageSubaccount(
 	return false, clobPair.Status == types.ClobPair_STATUS_FINAL_SETTLEMENT, nil
 }
 
+// GateWithdrawalsIfNegativeTncSubaccountSeen gates withdrawals if a negative TNC subaccount exists.
+// It does this by inserting a zero-fill deleveraging operation into the operations queue iff any of
+// the provided liquidatable subaccounts are negative TNC.
+func (k Keeper) CanDeleverageSubaccount(
+	ctx sdk.Context,
+	subaccountId satypes.SubaccountId,
+	perpetualId uint32,
+) (shouldDeleverageAtBankruptcyPrice bool, shouldDeleverageAtOraclePrice bool, err error) {
+	bigNetCollateral,
+		_,
+		_,
+		err := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
+		ctx,
+		satypes.Update{SubaccountId: subaccountId},
+	)
+	if err != nil {
+		return false, false, err
+	}
+
+	// Negative TNC, deleverage at bankruptcy price.
+	if bigNetCollateral.Sign() == -1 {
+		return true, false, nil
+	}
+
+	clobPairId, err := k.GetClobPairIdForPerpetual(ctx, perpetualId)
+	if err != nil {
+		return false, false, err
+	}
+	clobPair := k.mustGetClobPair(ctx, clobPairId)
+
+	// Non-negative TNC, deleverage at oracle price if market is in final settlement. Deleveraging at oracle price
+	// is always a valid state transition when TNC is non-negative. This is because the TNC/TMMR ratio is improving;
+	// TNC is staying constant while TMMR is decreasing.
+	return false, clobPair.Status == types.ClobPair_STATUS_FINAL_SETTLEMENT, nil
+}
+
 // IsValidInsuranceFundDelta returns true if the insurance fund has enough funds to cover the insurance
 // fund delta. Specifically, this function returns true if either of the following are true:
 // - The `insuranceFundDelta` is non-negative.

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -190,14 +190,14 @@ func (k Keeper) CanDeleverageSubaccount(
 
 // GateWithdrawalsIfNegativeTncSubaccountSeen gates withdrawals if a negative TNC subaccount exists.
 // It does this by inserting a zero-fill deleveraging operation into the operations queue iff any of
-// the provided liquidatable subaccounts are negative TNC.
+// the provided negative TNC subaccounts are still negative TNC.
 func (k Keeper) GateWithdrawalsIfNegativeTncSubaccountSeen(
 	ctx sdk.Context,
-	liquidatableSubaccountIds []satypes.SubaccountId,
+	negativeTncSubaccountIds []satypes.SubaccountId,
 ) (err error) {
 	foundNegativeTncSubaccount := false
 	var negativeTncSubaccountId satypes.SubaccountId
-	for _, subaccountId := range liquidatableSubaccountIds {
+	for _, subaccountId := range negativeTncSubaccountIds {
 		bigNetCollateral,
 			_,
 			_,

--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -692,6 +692,7 @@ func (k Keeper) PersistMatchDeleveragingToState(
 			metrics.SubaccountsNegativeTncSubaccountSeen,
 			metrics.GetLabelForIntValue(metrics.PerpetualId, int(perpetualId)),
 			metrics.GetLabelForBoolValue(metrics.IsLong, position.GetIsLong()),
+			metrics.GetLabelForBoolValue(metrics.DeliverTx, true),
 		)
 		k.subaccountsKeeper.SetNegativeTncSubaccountSeenAtBlock(ctx, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
 		return nil

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -3,10 +3,11 @@ package memclob
 import (
 	"errors"
 	"fmt"
-	cmtlog "github.com/cometbft/cometbft/libs/log"
 	"math/big"
 	"runtime/debug"
 	"time"
+
+	cmtlog "github.com/cometbft/cometbft/libs/log"
 
 	errorsmod "cosmossdk.io/errors"
 

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -215,6 +215,20 @@ func (m *MemClobPriceTimePriority) GetSubaccountOrders(
 	)
 }
 
+// InsertZeroFillDeleveragingIntoOperationsQueue inserts a zero-fill deleveraging operation
+// into the operations queue. This is used to signify that a subaccount has negative TNC and
+// withdrawals should be disabled.
+func (m *MemClobPriceTimePriority) InsertZeroFillDeleveragingIntoOperationsQueue(
+	ctx sdk.Context,
+	subaccountId satypes.SubaccountId,
+	perpetualId uint32,
+) {
+	m.operationsToPropose.AddZeroFillDeleveragingToOperationsQueue(
+		subaccountId,
+		perpetualId,
+	)
+}
+
 // mustUpdateMemclobStateWithMatches updates the memclob state by applying matches to all bookkeeping data structures.
 // Namely, it will perform the following operations:
 //   - Append all newly-matched orders to the operations queue, along with all new matches.

--- a/protocol/x/clob/types/internal_operation.go
+++ b/protocol/x/clob/types/internal_operation.go
@@ -107,24 +107,12 @@ func NewMatchPerpetualLiquidationInternalOperation(
 
 // NewMatchPerpetualDeleveragingInternalOperation returns a new operation for deleveraging liquidated subaccount's
 // position against one or more offsetting subaccounts.
-// This function panics if there are zero maker fills.
 func NewMatchPerpetualDeleveragingInternalOperation(
 	liquidatedSubaccountId satypes.SubaccountId,
 	perpetualId uint32,
 	fills []MatchPerpetualDeleveraging_Fill,
 	isFinalSettlement bool,
 ) InternalOperation {
-	if len(fills) == 0 {
-		panic(
-			fmt.Sprintf(
-				"NewMatchPerpetualDeleveragingInternalOperation: cannot create a match perpetual "+
-					"deleveraging internal operation with no fills: subaccount (%+v), perpetual (%+v)",
-				liquidatedSubaccountId,
-				perpetualId,
-			),
-		)
-	}
-
 	return InternalOperation{
 		Operation: &InternalOperation_Match{
 			Match: &ClobMatch{

--- a/protocol/x/clob/types/memclob.go
+++ b/protocol/x/clob/types/memclob.go
@@ -137,4 +137,9 @@ type MemClob interface {
 		bestAsk Order,
 		exists bool,
 	)
+	InsertZeroFillDeleveragingIntoOperationsQueue(
+		ctx sdk.Context,
+		subaccountId satypes.SubaccountId,
+		perpetualId uint32,
+	)
 }

--- a/protocol/x/clob/types/operations_to_propose.go
+++ b/protocol/x/clob/types/operations_to_propose.go
@@ -236,6 +236,23 @@ func (o *OperationsToPropose) MustAddMatchToOperationsQueue(
 	)
 }
 
+// AddZeroFillDeleveragingToOperationsQueue adds a zero-fill deleveraging match operation to the
+// operations queue.
+func (o *OperationsToPropose) AddZeroFillDeleveragingToOperationsQueue(
+	liquidatedSubaccountId satypes.SubaccountId,
+	perpetualId uint32,
+) {
+	o.OperationsQueue = append(
+		o.OperationsQueue,
+		NewMatchPerpetualDeleveragingInternalOperation(
+			liquidatedSubaccountId,
+			perpetualId,
+			[]MatchPerpetualDeleveraging_Fill{},
+			false,
+		),
+	)
+}
+
 // MustAddDeleveragingToOperationsQueue adds a deleveraging match operation to the
 // operations queue.
 // This function will panic if:


### PR DESCRIPTION
### Changelist
Gate withdrawals if a negative TNC subaccount is encountered after the liquidation and deleveraging steps in `PrepareCheckState`.

Note that all potentially liquidatable subaccounts specified by the daemon will be checked for simplicity.

### Test Plan
Wrote E2E tests verifying that when there's negative TNC subaccounts found in state, that withdrawals are blocked.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
