### PR TITLE
add FINAL_SETTLEMENT to perpetual markets status constraint

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/perpetual-market-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/perpetual-market-table.test.ts
@@ -1,16 +1,10 @@
-import {
-  MarketCreateObject,
-  PerpetualMarketFromDatabase,
-} from '../../src/types';
+import { MarketCreateObject, PerpetualMarketFromDatabase, PerpetualMarketStatus } from '../../src/types';
 import * as PerpetualMarketTable from '../../src/stores/perpetual-market-table';
 import * as LiquidityTiersTable from '../../src/stores/liquidity-tiers-table';
+import { clearData, migrate, teardown } from '../../src/helpers/db-helpers';
 import {
-  clearData,
-  migrate,
-  teardown,
-} from '../../src/helpers/db-helpers';
-import {
-  defaultLiquidityTier, defaultLiquidityTier2,
+  defaultLiquidityTier,
+  defaultLiquidityTier2,
   defaultMarket,
   defaultMarket2,
   defaultPerpetualMarket,
@@ -154,6 +148,21 @@ describe('PerpetualMarket store', () => {
     expect(perpetualMarket).toEqual(expect.objectContaining({
       ...defaultPerpetualMarket,
       trades24H: 100,
+    }));
+  });
+
+  it('Successfully winds down a perpetual market', async () => {
+    await PerpetualMarketTable.create(defaultPerpetualMarket);
+
+    const perpetualMarket: PerpetualMarketFromDatabase | undefined = await PerpetualMarketTable
+      .update({
+        id: defaultPerpetualMarket.id,
+        status: PerpetualMarketStatus.FINAL_SETTLEMENT,
+      });
+
+    expect(perpetualMarket).toEqual(expect.objectContaining({
+      ...defaultPerpetualMarket,
+      status: PerpetualMarketStatus.FINAL_SETTLEMENT,
     }));
   });
 

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240108175501_add_perpetual_markets_status_final_settlement.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240108175501_add_perpetual_markets_status_final_settlement.ts
@@ -1,0 +1,19 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.raw(`
+    ALTER TABLE "perpetual_markets"
+    DROP CONSTRAINT "perpetual_markets_status_check",
+    ADD CONSTRAINT "perpetual_markets_status_check" 
+     CHECK (status IN ('ACTIVE', 'PAUSED', 'CANCEL_ONLY', 'POST_ONLY', 'INITIALIZING', 'FINAL_SETTLEMENT'))
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.raw(`
+    ALTER TABLE "perpetual_markets"
+    DROP CONSTRAINT "perpetual_markets_status_check",
+    ADD CONSTRAINT "perpetual_markets_status_check" 
+     CHECK (status IN ('ACTIVE', 'PAUSED', 'CANCEL_ONLY', 'POST_ONLY', 'INITIALIZING'))
+  `);
+}


### PR DESCRIPTION
### Changelist
breaking staging env currently
add FINAL_SETTLEMENT to perpetual markets status constraint

### Test Plan
unit tested

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
