### PR TITLE
[IND-557] fix occasional missing pnl ticks

### DIFF
--- a/indexer/services/roundtable/__tests__/helpers/pnl-ticks-helper.test.ts
+++ b/indexer/services/roundtable/__tests__/helpers/pnl-ticks-helper.test.ts
@@ -26,6 +26,7 @@ import {
   getPnlTicksCreateObjects,
   getUsdcTransfersSinceLastPnlTick,
   getAccountsToUpdate,
+  normalizeStartTime,
 } from '../../src/helpers/pnl-ticks-helper';
 import { defaultPnlTickForSubaccounts } from '../../src/helpers/constants';
 import Big from 'big.js';
@@ -230,6 +231,18 @@ describe('pnl-ticks-helper', () => {
     }));
   });
 
+  it('normalizeStartTime', () => {
+    const time: Date = new Date('2021-01-09T20:00:50.000Z');
+    // 1 hour
+    config.PNL_TICK_UPDATE_INTERVAL_MS = 1000 * 60 * 60;
+    const result1: Date = normalizeStartTime(time);
+    expect(result1.toISOString()).toBe('2021-01-09T20:00:00.000Z');
+    // 1 day
+    config.PNL_TICK_UPDATE_INTERVAL_MS = 1000 * 60 * 60 * 24;
+    const result2: Date = normalizeStartTime(time);
+    expect(result2.toISOString()).toBe('2021-01-09T00:00:00.000Z');
+  });
+
   it('getAccountsToUpdate', () => {
     const accountToLastUpdatedBlockTime: _.Dictionary<IsoString> = {
       account1: '2024-01-01T10:00:00Z',
@@ -237,11 +250,12 @@ describe('pnl-ticks-helper', () => {
       account3: '2024-01-01T11:01:00Z',
       account4: '2024-01-01T11:10:00Z',
       account5: '2024-01-01T12:00:00Z',
+      account6: '2024-01-01T12:00:10Z',
     };
-    const blockTime: IsoString = '2024-01-01T12:00:00Z';
+    const blockTime: IsoString = '2024-01-01T12:01:00Z';
     config.PNL_TICK_UPDATE_INTERVAL_MS = ONE_HOUR_IN_MILLISECONDS;
 
-    const expectedAccountsToUpdate: string[] = ['account1', 'account2', 'account3'];
+    const expectedAccountsToUpdate: string[] = ['account1', 'account2', 'account3', 'account4'];
     const accountsToUpdate: string[] = getAccountsToUpdate(
       accountToLastUpdatedBlockTime,
       blockTime,

--- a/indexer/services/roundtable/__tests__/helpers/pnl-ticks-helper.test.ts
+++ b/indexer/services/roundtable/__tests__/helpers/pnl-ticks-helper.test.ts
@@ -25,6 +25,7 @@ import {
   getNewPnlTick,
   getPnlTicksCreateObjects,
   getUsdcTransfersSinceLastPnlTick,
+  getAccountsToUpdate,
 } from '../../src/helpers/pnl-ticks-helper';
 import { defaultPnlTickForSubaccounts } from '../../src/helpers/constants';
 import Big from 'big.js';
@@ -35,6 +36,7 @@ import { ZERO } from '../../src/lib/constants';
 import { SubaccountUsdcTransferMap } from '../../src/helpers/types';
 import config from '../../src/config';
 import _ from 'lodash';
+import { ONE_HOUR_IN_MILLISECONDS } from '@dydxprotocol-indexer/base';
 
 describe('pnl-ticks-helper', () => {
   const positions: PerpetualPositionFromDatabase[] = [
@@ -226,6 +228,25 @@ describe('pnl-ticks-helper', () => {
       [testConstants.defaultSubaccountId]: new Big('-20.5'),
       [testConstants.defaultSubaccountId2]: new Big('20.5'),
     }));
+  });
+
+  it('getAccountsToUpdate', () => {
+    const accountToLastUpdatedBlockTime: _.Dictionary<IsoString> = {
+      account1: '2024-01-01T10:00:00Z',
+      account2: '2024-01-01T11:00:00Z',
+      account3: '2024-01-01T11:01:00Z',
+      account4: '2024-01-01T11:10:00Z',
+      account5: '2024-01-01T12:00:00Z',
+    };
+    const blockTime: IsoString = '2024-01-01T12:00:00Z';
+    config.PNL_TICK_UPDATE_INTERVAL_MS = ONE_HOUR_IN_MILLISECONDS;
+
+    const expectedAccountsToUpdate: string[] = ['account1', 'account2', 'account3'];
+    const accountsToUpdate: string[] = getAccountsToUpdate(
+      accountToLastUpdatedBlockTime,
+      blockTime,
+    );
+    expect(accountsToUpdate).toEqual(expectedAccountsToUpdate);
   });
 
   it('calculateEquity', () => {

--- a/indexer/services/roundtable/__tests__/tasks/create-pnl-ticks.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/create-pnl-ticks.test.ts
@@ -11,7 +11,7 @@ import {
   FundingIndexUpdatesTable,
 } from '@dydxprotocol-indexer/postgres';
 
-import createPnlTicksTask, { normalizeStartTime } from '../../src/tasks/create-pnl-ticks';
+import createPnlTicksTask from '../../src/tasks/create-pnl-ticks';
 import { LatestAccountPnlTicksCache, PnlTickForSubaccounts, redis } from '@dydxprotocol-indexer/redis';
 import { DateTime } from 'luxon';
 import config from '../../src/config';
@@ -121,18 +121,6 @@ describe('create-pnl-ticks', () => {
         },
       ]),
     );
-  });
-
-  it('normalizeStartTime', () => {
-    const time: Date = new Date('2021-01-09T20:00:50.000Z');
-    // 1 hour
-    config.PNL_TICK_UPDATE_INTERVAL_MS = 1000 * 60 * 60;
-    const result1: Date = normalizeStartTime(time);
-    expect(result1.toISOString()).toBe('2021-01-09T20:00:00.000Z');
-    // 1 day
-    config.PNL_TICK_UPDATE_INTERVAL_MS = 1000 * 60 * 60 * 24;
-    const result2: Date = normalizeStartTime(time);
-    expect(result2.toISOString()).toBe('2021-01-09T00:00:00.000Z');
   });
 
   it('succeeds with no prior pnl ticks and open perpetual positions', async () => {

--- a/indexer/services/roundtable/__tests__/tasks/create-pnl-ticks.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/create-pnl-ticks.test.ts
@@ -27,6 +27,13 @@ describe('create-pnl-ticks', () => {
       blockTime: DateTime.utc(2022, 6, 1, 0, 0, 0).toISO(),
     },
   };
+  const existingPnlTicksNeedsUpdate: PnlTickForSubaccounts = {
+    [testConstants.defaultSubaccountId]: {
+      ...testConstants.defaultPnlTick,
+      createdAt: DateTime.utc(2022, 5, 31, 23, 59, 0).toISO(),
+      blockTime: DateTime.utc(2022, 5, 31, 23, 59, 0).toISO(),
+    },
+  };
   const dateTime: DateTime = DateTime.utc(2022, 6, 1, 0, 30, 0);
 
   beforeAll(async () => {
@@ -168,6 +175,58 @@ describe('create-pnl-ticks', () => {
       ]),
     );
   });
+
+  it(
+    'succeeds with prior pnl ticks and open perpetual positions, updates pnl correctly',
+    async () => {
+      const date: number = new Date(2023, 4, 18, 0, 0, 0).valueOf();
+      jest.spyOn(Date, 'now').mockImplementation(() => date);
+      config.PNL_TICK_UPDATE_INTERVAL_MS = 3_600_000;
+      jest.spyOn(DateTime, 'utc').mockImplementation(() => dateTime);
+      await LatestAccountPnlTicksCache.set(
+        existingPnlTicksNeedsUpdate,
+        redisClient,
+      );
+      await Promise.all([
+        PerpetualPositionTable.create(testConstants.defaultPerpetualPosition),
+        PerpetualPositionTable.create({
+          ...testConstants.defaultPerpetualPosition,
+          perpetualId: testConstants.defaultPerpetualMarket2.id,
+          openEventId: testConstants.defaultTendermintEventId2,
+        }),
+      ]);
+      await createPnlTicksTask();
+      const pnlTicks: PnlTicksFromDatabase[] = await PnlTicksTable.findAll(
+        {},
+        [],
+        {},
+      );
+      expect(pnlTicks.length).toEqual(2);
+      expect(pnlTicks).toEqual(
+        expect.arrayContaining([
+          {
+            id: PnlTicksTable.uuid(testConstants.defaultSubaccountId2, dateTime.toISO()),
+            createdAt: dateTime.toISO(),
+            blockHeight: '5',
+            blockTime: testConstants.defaultBlock.time,
+            equity: '0.000000',
+            netTransfers: '20.500000',
+            subaccountId: testConstants.defaultSubaccountId2,
+            totalPnl: '-20.500000',
+          },
+          {
+            id: PnlTicksTable.uuid(testConstants.defaultSubaccountId, dateTime.toISO()),
+            createdAt: dateTime.toISO(),
+            blockHeight: '5',
+            blockTime: testConstants.defaultBlock.time,
+            equity: '105000.000000',
+            netTransfers: '-20.500000',
+            subaccountId: testConstants.defaultSubaccountId,
+            totalPnl: '105020.500000',
+          },
+        ]),
+      );
+    });
 
   it(
     'succeeds with prior pnl ticks and open perpetual positions, respects PNL_TICK_UPDATE_INTERVAL_MS',

--- a/indexer/services/roundtable/__tests__/tasks/create-pnl-ticks.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/create-pnl-ticks.test.ts
@@ -24,6 +24,7 @@ describe('create-pnl-ticks', () => {
     [testConstants.defaultSubaccountId]: {
       ...testConstants.defaultPnlTick,
       createdAt: DateTime.utc(2022, 6, 1, 0, 0, 0).toISO(),
+      blockTime: DateTime.utc(2022, 6, 1, 0, 0, 0).toISO(),
     },
   };
   const dateTime: DateTime = DateTime.utc(2022, 6, 1, 0, 30, 0);

--- a/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
+++ b/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
@@ -10,19 +10,8 @@ import { LatestAccountPnlTicksCache } from '@dydxprotocol-indexer/redis';
 import _ from 'lodash';
 
 import config from '../config';
-import { getPnlTicksCreateObjects } from '../helpers/pnl-ticks-helper';
+import { getPnlTicksCreateObjects, normalizeStartTime } from '../helpers/pnl-ticks-helper';
 import { redisClient } from '../helpers/redis';
-
-export function normalizeStartTime(
-  time: Date,
-): Date {
-  const epochMs: number = time.getTime();
-  const normalizedTimeMs: number = epochMs - (
-    epochMs % config.PNL_TICK_UPDATE_INTERVAL_MS
-  );
-
-  return new Date(normalizedTimeMs);
-}
 
 export default async function runTask(): Promise<void> {
   const startGetNewTicks: number = Date.now();


### PR DESCRIPTION
### Changelist
Fix occasional missing pnl ticks.

Pnl computation is skipping some hours for some subaccounts. 
For example, 106bcbc8-f80d-5d62-bf65-e88708c88ec9 subaccount id in staging missed the pnl computation at 2024-01-09 04:00:25.572+00 because the last pnl tick happened at 2024-01-09 03:00:50.58+00, which is slightly < 1 hr ago.

When checking whether or not to update a subaccount's pnl, change the time threshold from 1 hr to 0.9 hrs.

### Test Plan
unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
