### PR TITLE
add lock multiplier for pnl ticks roundtable task

### DIFF
--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -100,6 +100,7 @@ export const configSchema = {
   // Lock multipliers
   MARKET_UPDATER_LOCK_MULTIPLIER: parseInteger({ default: 10 }),
   DELETE_ZERO_PRICE_LEVELS_LOCK_MULTIPLIER: parseInteger({ default: 1 }),
+  PNL_TICK_UPDATE_LOCK_MULTIPLIER: parseInteger({ default: 20 }),
 
   // Maximum number of running tasks - set this equal to PG_POOL_MIN in .env, default is 2
   MAX_CONCURRENT_RUNNING_TASKS: parseInteger({ default: 2 }),

--- a/indexer/services/roundtable/src/index.ts
+++ b/indexer/services/roundtable/src/index.ts
@@ -68,6 +68,7 @@ async function start(): Promise<void> {
       createPnlTicksTask,
       'create_pnl_ticks',
       config.LOOPS_INTERVAL_MS_PNL_TICKS,
+      config.PNL_TICK_UPDATE_LOCK_MULTIPLIER,
     );
   }
 


### PR DESCRIPTION
### Changelist
add lock multiplier for pnl ticks roundtable task

Sometimes, we see multiple pnl ticks for the same hour. The current interval is set to 30s. If the pnl computation takes longer than 30s, it's possible another pnl task starts concurrently. Introduce a lock interval multiplier for pnl task to ensure there's only 1 pnl tick computed per hour.

### Test Plan
test in dev/staging

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
