### PR TITLE
Upgrade cosmos fork to fix RPC queries

### DIFF
--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -376,7 +376,7 @@ replace (
 	// Use dYdX fork of CometBFT
 	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.37.3-0.20230908230338-65f7a2f25c18
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.47.5-0.20231025201005-bef8a051e94f
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.47.5-0.20240111163003-128eb0a555af
 	// Cosmos SDK 0.47.x upgrade guide (https://github.com/cosmos/cosmos-sdk/blob/main/UPGRADING.md#replaces) mentions
 	// that there are stability issues. See https://github.com/cosmos/cosmos-sdk/issues/14949 and
 	// https://github.com/ethereum/go-ethereum/pull/25413 for further context.

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -505,8 +505,8 @@ github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQx
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dydxprotocol/cometbft v0.37.3-0.20230908230338-65f7a2f25c18 h1:1RIco92QcPS24BeNCNWJC4zXza4GEHHuoviWIQEQ/NI=
 github.com/dydxprotocol/cometbft v0.37.3-0.20230908230338-65f7a2f25c18/go.mod h1:cpghf0+1GJpJvrqpTHE6UyTcD05m/xllo0xpufL3PgA=
-github.com/dydxprotocol/cosmos-sdk v0.47.5-0.20231025201005-bef8a051e94f h1:q1WhMJ0EjcF2Tj7MBPd+nacxmj3juiRwz11MZ+m6WAE=
-github.com/dydxprotocol/cosmos-sdk v0.47.5-0.20231025201005-bef8a051e94f/go.mod h1:iaAXVu5Jcd//vREctLTuxLqj5ScUP4psgqW7M6XsaQ8=
+github.com/dydxprotocol/cosmos-sdk v0.47.5-0.20240111163003-128eb0a555af h1:k2P6lzSMdE0fUPsJ4jLEBqbLVZQoqJ0zbQASoPxh+T4=
+github.com/dydxprotocol/cosmos-sdk v0.47.5-0.20240111163003-128eb0a555af/go.mod h1:iaAXVu5Jcd//vREctLTuxLqj5ScUP4psgqW7M6XsaQ8=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=


### PR DESCRIPTION
### Changelist
- Latest cosmos fork https://github.com/dydxprotocol/cosmos-sdk/pull/33 needed to fix RPC queries

### Test Plan
- Tested locally. Will test on internal node before releasing testnet validators.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
