### PR TITLE
Start processing aggregate trading rewards from first reward

### DIFF
--- a/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
+++ b/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
@@ -173,10 +173,10 @@ export class AggregateTradingReward {
 
   /**
    * Returns the start time of the next interval to process if the
-   * AggregateTradingRewardProcessedCache is empty. 
+   * AggregateTradingRewardProcessedCache is empty.
    * - If there is a most recent complete aggregation for this period,
    * returns the end time of the most recent aggregation.
-   * - If there is a trading reward in the database, 
+   * - If there is a trading reward in the database,
    * returns the block time of the trading reward.
    * - Otherwise returns the start time of the first block in the database.
    */

--- a/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
+++ b/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
@@ -10,6 +10,7 @@ import {
   BlockTable,
   IsoString,
   IsolationLevel,
+  Ordering,
   TradingRewardAggregationColumns,
   TradingRewardAggregationCreateObject,
   TradingRewardAggregationFromDatabase,
@@ -156,7 +157,7 @@ export class AggregateTradingReward {
     if (processedTime === null) {
       logger.info({
         at: 'aggregate-trading-rewards#getTradingRewardDataToProcessInterval',
-        message: 'Resetting AggregateTradingRewardsProcessedCache',
+        message: 'AggregateTradingRewardsProcessedCache is empty',
       });
       const nextStartTime: DateTime = await this.getNextIntervalStartWhenCacheEmpty();
       await this.setProcessedTime(
@@ -172,9 +173,12 @@ export class AggregateTradingReward {
 
   /**
    * Returns the start time of the next interval to process if the
-   * AggregateTradingRewardProcessedCache is empty. If there is a most recent complete aggregation
-   * for this period, returns the end time of the most recent aggregation, otherwise returns the
-   * start time of the first block in the database.
+   * AggregateTradingRewardProcessedCache is empty. 
+   * - If there is a most recent complete aggregation for this period,
+   * returns the end time of the most recent aggregation.
+   * - If there is a trading reward in the database, 
+   * returns the block time of the trading reward.
+   * - Otherwise returns the start time of the first block in the database.
    */
   private async getNextIntervalStartWhenCacheEmpty(): Promise<DateTime> {
     const latestAggregation:
@@ -186,12 +190,23 @@ export class AggregateTradingReward {
       return DateTime.fromISO(latestAggregation.endedAt!, UTC_OPTIONS);
     }
 
-    // Since we were able to find the latest block, we assume we can find the first block
-    const firstBlock: BlockFromDatabase[] = await BlockTable.findAll({
-      blockHeight: ['1'],
+    const firstTradingReward: TradingRewardFromDatabase[] = await TradingRewardTable.findAll({
       limit: 1,
-    }, []);
-    return DateTime.fromISO(firstBlock[0].time, UTC_OPTIONS);
+    }, [], { orderBy: [[TradingRewardColumns.blockTime, Ordering.ASC]] });
+    if (firstTradingReward.length === 0) {
+      logger.info({
+        at: 'aggregate-trading-rewards#getNextIntervalStartWhenCacheEmpty',
+        message: 'No trading rewards in database, relying on first block time to pick first start time',
+      });
+      // Since we were able to find the latest block, we assume we can find the first block
+      const firstBlock: BlockFromDatabase[] = await BlockTable.findAll({
+        blockHeight: ['1'],
+        limit: 1,
+      }, []);
+      return DateTime.fromISO(firstBlock[0].time, UTC_OPTIONS);
+    }
+
+    return DateTime.fromISO(firstTradingReward[0].blockTime, UTC_OPTIONS);
   }
 
   /**


### PR DESCRIPTION
### Changelist
Fix bug that in a long running chain with only `trading_rewards` recently introduced, we should process aggregate trading rewards from the first trading reward instead of the first block, other we'll be processing no data

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
