### PR TITLE
Indexer account for reduce only resize errors

### DIFF
--- a/protocol/indexer/shared/order_removal_reason.go
+++ b/protocol/indexer/shared/order_removal_reason.go
@@ -40,6 +40,8 @@ func GetOrderRemovalReason(
 	orderError error,
 ) (OrderRemovalReason, error) {
 	switch {
+	case errors.Is(orderError, clobtypes.ErrReduceOnlyWouldIncreasePositionSize):
+		return OrderRemovalReason_ORDER_REMOVAL_REASON_REDUCE_ONLY_RESIZE, nil
 	case errors.Is(orderError, clobtypes.ErrPostOnlyWouldCrossMakerOrder):
 		return OrderRemovalReason_ORDER_REMOVAL_REASON_POST_ONLY_WOULD_CROSS_MAKER_ORDER, nil
 	case errors.Is(orderError, clobtypes.ErrFokOrderCouldNotBeFullyFilled):

--- a/protocol/indexer/shared/order_removal_reason_test.go
+++ b/protocol/indexer/shared/order_removal_reason_test.go
@@ -44,6 +44,11 @@ func TestGetOrderRemovalReason_Success(t *testing.T) {
 			expectedReason: shared.OrderRemovalReason_ORDER_REMOVAL_REASON_POST_ONLY_WOULD_CROSS_MAKER_ORDER,
 			expectedErr:    nil,
 		},
+		"Gets order removal reason for order error ErrReduceOnlyWouldIncreasePositionSize": {
+			orderError:     clobtypes.ErrReduceOnlyWouldIncreasePositionSize,
+			expectedReason: shared.OrderRemovalReason_ORDER_REMOVAL_REASON_REDUCE_ONLY_RESIZE,
+			expectedErr:    nil,
+		},
 		"Returns error for order status Success": {
 			orderStatus:    clobtypes.Success,
 			orderError:     clobtypes.ErrNotImplemented,


### PR DESCRIPTION
Datadog error [here](https://app.datadoghq.com/logs?query=env%3Adev%20status%3Aerror&agg_q=status%2Cservice&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_t=%2C&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=pattern&x_missing=true%2Ctrue&from_ts=1704995802250&to_ts=1705082202250&live=true) after running load tester

Account for the specific error type