### PR TITLE
Remove first block from aggregate trading rewards roundtable task interval

### DIFF
--- a/indexer/services/roundtable/__tests__/tasks/aggregate-trading-rewards.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/aggregate-trading-rewards.test.ts
@@ -121,7 +121,7 @@ describe('aggregate-trading-rewards', () => {
       TradingRewardAggregationPeriod.DAILY,
       TradingRewardAggregationPeriod.WEEKLY,
       TradingRewardAggregationPeriod.MONTHLY,
-    ])('Successfully returns interval if cache is empty no aggregations, and no trading rewards', async (
+    ])('Throws error if cache is empty no aggregations, and no trading rewards', async (
       period: TradingRewardAggregationPeriod,
     ) => {
       const firstBlockTime: DateTime = DateTime.fromISO(
@@ -130,18 +130,12 @@ describe('aggregate-trading-rewards', () => {
       ).toUTC();
       await createBlockWithTime(firstBlockTime.plus({ hours: 1 }));
       const aggregateTradingReward: AggregateTradingReward = new AggregateTradingReward(period);
-      const interval:
-      Interval = await aggregateTradingReward.getTradingRewardDataToProcessInterval();
-
-      expect(interval).not.toBeUndefined();
-      expect(interval).toEqual(Interval.fromDateTimes(
-        firstBlockTime,
-        firstBlockTime.plus({ hours: 1 })),
-      );
+      await expect(aggregateTradingReward.getTradingRewardDataToProcessInterval())
+        .rejects.toEqual(new Error('No trading rewards in database'));
     });
 
     it(
-      'Successfully returns interval when cache is empty and no aggregation for the period and trading reward',
+      'Throws error interval when cache is empty and no aggregation for the period and trading reward',
       async () => {
         await TradingRewardAggregationTable.create({
           ...defaultMonthlyTradingRewardAggregation,
@@ -150,19 +144,8 @@ describe('aggregate-trading-rewards', () => {
         const aggregateTradingReward: AggregateTradingReward = new AggregateTradingReward(
           TradingRewardAggregationPeriod.MONTHLY,
         );
-        const interval:
-        Interval = await aggregateTradingReward.getTradingRewardDataToProcessInterval();
-
-        const firstBlockTime: DateTime = DateTime.fromISO(
-          testConstants.defaultBlock.time,
-          UTC_OPTIONS,
-        ).toUTC();
-        expect(interval).toEqual(Interval.fromDateTimes(
-          firstBlockTime,
-          firstBlockTime.plus({
-            milliseconds: config.AGGREGATE_TRADING_REWARDS_MAX_INTERVAL_SIZE_MS,
-          })),
-        );
+        await expect(aggregateTradingReward.getTradingRewardDataToProcessInterval())
+          .rejects.toEqual(new Error('No trading rewards in database'));
       },
     );
 


### PR DESCRIPTION
### Changelist
Remove first block from aggregate trading rewards roundtable task interval. Turns the block time for the genesis block can be years ago. We don't need to calculate from the first block ever, we can just wait for the first trading reward to calculate aggregations.

### Test Plan
Tested in staging, and works

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
