### PR TITLE
[DEC-2201] Ensure that we use the client context with AutoCLI

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -61,9 +61,11 @@ const (
 // NewRootCmd creates a new root command for `dydxprotocold`. It is called once in the main function.
 func NewRootCmd(
 	option *RootCmdOption,
+	homeDir string,
 ) *cobra.Command {
 	return NewRootCmdWithInterceptors(
 		option,
+		homeDir,
 		func(serverCtxPtr *server.Context) {
 
 		},
@@ -78,6 +80,7 @@ func NewRootCmd(
 
 func NewRootCmdWithInterceptors(
 	option *RootCmdOption,
+	homeDir string,
 	serverCtxInterceptor func(serverCtxPtr *server.Context),
 	appConfigInterceptor func(string, *DydxAppConfig) (string, *DydxAppConfig),
 	appInterceptor func(app *dydxapp.App) *dydxapp.App,
@@ -91,7 +94,7 @@ func NewRootCmdWithInterceptors(
 		WithInput(os.Stdin).
 		WithAccountRetriever(types.AccountRetriever{}).
 		WithBroadcastMode(flags.BroadcastSync).
-		WithHomeDir(dydxapp.DefaultNodeHome).
+		WithHomeDir(homeDir).
 		WithViper(EnvPrefix)
 
 	rootCmd := &cobra.Command{

--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -145,7 +145,10 @@ func NewRootCmdWithInterceptors(
 	}
 
 	initRootCmd(rootCmd, option, encodingConfig, appInterceptor)
-
+	initClientCtx, err := config.ReadFromClientConfig(initClientCtx)
+	if err != nil {
+		panic(err)
+	}
 	if err := autoCliOpts(encodingConfig, initClientCtx).EnhanceRootCommand(rootCmd); err != nil {
 		panic(err)
 	}

--- a/protocol/cmd/dydxprotocold/cmd/root_test.go
+++ b/protocol/cmd/dydxprotocold/cmd/root_test.go
@@ -14,10 +14,21 @@ func TestNewRootCmd_UsesClientConfig(t *testing.T) {
 
 	config.SetupConfig()
 
+	// Set the client config to point to a fake chain id since this is a required option
+	{
+		option := cmd.GetOptionWithCustomStartCmd()
+		rootCmd := cmd.NewRootCmd(option, tempDir)
+
+		cmd.AddTendermintSubcommands(rootCmd)
+		cmd.AddInitCmdPostRunE(rootCmd)
+		rootCmd.SetArgs([]string{"config", "set", "client", "chain-id", "fakeChainId"})
+		require.NoError(t, svrcmd.Execute(rootCmd, app.AppDaemonName, tempDir))
+	}
+
 	// Set the client config to point to a fake address
 	{
 		option := cmd.GetOptionWithCustomStartCmd()
-		rootCmd := cmd.NewRootCmd(option)
+		rootCmd := cmd.NewRootCmd(option, tempDir)
 
 		cmd.AddTendermintSubcommands(rootCmd)
 		cmd.AddInitCmdPostRunE(rootCmd)
@@ -27,7 +38,7 @@ func TestNewRootCmd_UsesClientConfig(t *testing.T) {
 
 	// Run a query command (that will fail) to ensure that we are reading the client config
 	option := cmd.GetOptionWithCustomStartCmd()
-	rootCmd := cmd.NewRootCmd(option)
+	rootCmd := cmd.NewRootCmd(option, tempDir)
 
 	cmd.AddTendermintSubcommands(rootCmd)
 	cmd.AddInitCmdPostRunE(rootCmd)

--- a/protocol/cmd/dydxprotocold/main.go
+++ b/protocol/cmd/dydxprotocold/main.go
@@ -13,7 +13,7 @@ func main() {
 	config.SetupConfig()
 
 	option := cmd.GetOptionWithCustomStartCmd()
-	rootCmd := cmd.NewRootCmd(option)
+	rootCmd := cmd.NewRootCmd(option, app.DefaultNodeHome)
 
 	cmd.AddTendermintSubcommands(rootCmd)
 	cmd.AddInitCmdPostRunE(rootCmd)

--- a/protocol/testing/containertest/node.go
+++ b/protocol/testing/containertest/node.go
@@ -3,6 +3,7 @@ package containertest
 import (
 	"context"
 	"fmt"
+	"github.com/dydxprotocol/v4-chain/protocol/app"
 	"time"
 
 	comethttp "github.com/cometbft/cometbft/rpc/client/http"
@@ -104,7 +105,7 @@ func (n *Node) getContextForBroadcastTx(signer string) (*client.Context, *pflag.
 		WithViper(cmd.EnvPrefix)
 
 	option := cmd.GetOptionWithCustomStartCmd()
-	rootCmd := cmd.NewRootCmd(option)
+	rootCmd := cmd.NewRootCmd(option, app.DefaultNodeHome)
 	flags.AddTxFlagsToCmd(rootCmd)
 	flags := rootCmd.Flags()
 

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -1197,6 +1197,7 @@ func launchValidatorInDir(
 	option := cmd.GetOptionWithCustomStartCmd()
 	rootCmd := cmd.NewRootCmdWithInterceptors(
 		option,
+		validatorHomeDir,
 		// Inject the app options and logger
 		func(serverCtxPtr *server.Context) {
 			for key, value := range appOptions {


### PR DESCRIPTION
### Changelist
[DEC-2201] Ensure that we use the client context with AutoCLI

Note that the basis of this code is from https://github.com/dydxprotocol/cosmos-sdk/blob/b48250d4e0efacbd40f3e0b980c1e1004d29e351/simapp/simd/cmd/root.go#L103 which is linked from the Cosmos 0.50 upgrade guide.

### Test Plan
Added unit test.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
