### PR TITLE
[DEC-2202] Update datadog agent image to use ECR hosted image.

### DIFF
--- a/indexer/datadog/Dockerfile
+++ b/indexer/datadog/Dockerfile
@@ -1,5 +1,5 @@
 # Use a specific version here to control when an update to a new major version of the datadog agent is performed
 # since major releases happen about once a year and contain breaking changes.
-FROM datadog/agent:7
+FROM public.ecr.aws/datadog/agent:7
 
 ADD conf.d/redisdb.yaml /etc/datadog-agent/conf.d/redisdb.yaml

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
 
   datadog-agent:
-    image: datadog/agent:7
+    image: public.ecr.aws/datadog/agent:7
     environment:
       # See https://docs.datadoghq.com/containers/docker/?tab=standard#environment-variables for agent configuration
       - DD_API_KEY=${DD_API_KEY}


### PR DESCRIPTION
### Changelist
Update usages of `datadog/agent` to `public.ecr.aws/datadog/agent` due to more aggressive rate-limiting from Dockerhub. 

### Test Plan
Built images.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
