### PR TITLE
Cherry-pick basePositionNotional deprecation in Indexer APIs

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -483,7 +483,6 @@ export const defaultLiquidityTier: LiquidityTiersCreateObject = {
   name: 'Large-Cap',
   initialMarginPpm: '50000',  // 5%
   maintenanceFractionPpm: '600000',  // 60%
-  basePositionNotional: '1000000',
 };
 
 export const defaultLiquidityTier2: LiquidityTiersCreateObject = {
@@ -491,7 +490,6 @@ export const defaultLiquidityTier2: LiquidityTiersCreateObject = {
   name: 'Mid-Cap',
   initialMarginPpm: '100000',  // 10%
   maintenanceFractionPpm: '500000',  // 50%
-  basePositionNotional: '1000',
 };
 
 // ============== OraclePrices ==============

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240117120410_remove_unused_liquidity_tiers_columns.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240117120410_remove_unused_liquidity_tiers_columns.ts
@@ -1,0 +1,17 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex
+    .schema
+    .alterTable('liquidity_tiers', (table) => {
+      table.dropColumn('basePositionNotional');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex
+    .schema
+    .alterTable('liquidity_tiers', (table) => {
+      table.decimal('basePositionNotional', null).notNullable().defaultTo('0');
+    });
+}

--- a/indexer/packages/postgres/src/models/liquidity-tiers-model.ts
+++ b/indexer/packages/postgres/src/models/liquidity-tiers-model.ts
@@ -1,4 +1,4 @@
-import { IntegerPattern, NonNegativeNumericPattern } from '../lib/validators';
+import { IntegerPattern } from '../lib/validators';
 import UpsertQueryBuilder from '../query-builders/upsert';
 import BaseModel from './base-model';
 
@@ -21,14 +21,12 @@ export default class LiquidityTiersModel extends BaseModel {
         'name',
         'initialMarginPpm',
         'maintenanceFractionPpm',
-        'basePositionNotional',
       ],
       properties: {
         id: { type: 'integer' },
         name: { type: 'string' },
         initialMarginPpm: { type: 'string', pattern: IntegerPattern },
         maintenanceFractionPpm: { type: 'string', pattern: IntegerPattern },
-        basePositionNotional: { type: 'string', pattern: NonNegativeNumericPattern },
       },
     };
   }
@@ -45,7 +43,6 @@ export default class LiquidityTiersModel extends BaseModel {
       name: 'string',
       initialMarginPpm: 'string',
       maintenanceFractionPpm: 'string',
-      basePositionNotional: 'string',
     };
   }
 
@@ -58,6 +55,4 @@ export default class LiquidityTiersModel extends BaseModel {
   initialMarginPpm!: string;
 
   maintenanceFractionPpm!: string;
-
-  basePositionNotional!: string;
 }

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -179,7 +179,6 @@ export interface LiquidityTiersFromDatabase {
   name: string;
   initialMarginPpm: string;
   maintenanceFractionPpm: string;
-  basePositionNotional: string;
 }
 
 export interface CandleFromDatabase extends IdBasedModelFromDatabase {

--- a/indexer/packages/postgres/src/types/liquidity-tiers-types.ts
+++ b/indexer/packages/postgres/src/types/liquidity-tiers-types.ts
@@ -5,7 +5,6 @@ export interface LiquidityTiersCreateObject {
   name: string,
   initialMarginPpm: string,
   maintenanceFractionPpm: string,
-  basePositionNotional: string,
 }
 
 export interface LiquidityTiersUpdateObject {
@@ -13,7 +12,6 @@ export interface LiquidityTiersUpdateObject {
   name?: string,
   initialMarginPpm?: string,
   maintenanceFractionPpm?: string,
-  basePositionNotional?: string,
 }
 
 export enum LiquidityTiersColumns {
@@ -21,5 +19,4 @@ export enum LiquidityTiersColumns {
   name = 'name',
   initialMarginPpm = 'initialMarginPpm',
   maintenanceFractionPpm = 'maintenanceFractionPpm',
-  basePositionNotional = 'basePositionNotional',
 }

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -207,7 +207,6 @@ export interface TradingPerpetualMarketMessage {
   status?: PerpetualMarketStatus;
   initialMarginFraction?: string;
   maintenanceMarginFraction?: string;
-  basePositionNotional?: string;
   openInterest?: string;
   quantumConversionExponent?: number;
   atomicResolution?: number;

--- a/indexer/services/comlink/__tests__/lib/request-helpers/request-transformer.test.ts
+++ b/indexer/services/comlink/__tests__/lib/request-helpers/request-transformer.test.ts
@@ -70,7 +70,6 @@ describe('request-transformer', () => {
               Number(liquidityTier.maintenanceFractionPpm),
             ),
           ),
-          basePositionNotional: liquidityTier.basePositionNotional,
           openInterest: perpetualMarket.openInterest,
           atomicResolution: perpetualMarket.atomicResolution,
           quantumConversionExponent: perpetualMarket.quantumConversionExponent,

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1289,7 +1289,6 @@ fetch('https://dydx-testnet.imperator.co/v4/perpetualMarkets?limit=0',
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
-      "basePositionNotional": "string",
       "openInterest": "string",
       "atomicResolution": 0,
       "quantumConversionExponent": 0,
@@ -1309,7 +1308,6 @@ fetch('https://dydx-testnet.imperator.co/v4/perpetualMarkets?limit=0',
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
-      "basePositionNotional": "string",
       "openInterest": "string",
       "atomicResolution": 0,
       "quantumConversionExponent": 0,
@@ -2837,7 +2835,6 @@ or
   "nextFundingRate": "string",
   "initialMarginFraction": "string",
   "maintenanceMarginFraction": "string",
-  "basePositionNotional": "string",
   "openInterest": "string",
   "atomicResolution": 0,
   "quantumConversionExponent": 0,
@@ -2863,7 +2860,6 @@ or
 |nextFundingRate|string|true|none|none|
 |initialMarginFraction|string|true|none|none|
 |maintenanceMarginFraction|string|true|none|none|
-|basePositionNotional|string|true|none|none|
 |openInterest|string|true|none|none|
 |atomicResolution|number(double)|true|none|none|
 |quantumConversionExponent|number(double)|true|none|none|
@@ -2893,7 +2889,6 @@ or
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
-      "basePositionNotional": "string",
       "openInterest": "string",
       "atomicResolution": 0,
       "quantumConversionExponent": 0,
@@ -2913,7 +2908,6 @@ or
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
-      "basePositionNotional": "string",
       "openInterest": "string",
       "atomicResolution": 0,
       "quantumConversionExponent": 0,

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -724,9 +724,6 @@
           "maintenanceMarginFraction": {
             "type": "string"
           },
-          "basePositionNotional": {
-            "type": "string"
-          },
           "openInterest": {
             "type": "string"
           },
@@ -764,7 +761,6 @@
           "nextFundingRate",
           "initialMarginFraction",
           "maintenanceMarginFraction",
-          "basePositionNotional",
           "openInterest",
           "atomicResolution",
           "quantumConversionExponent",

--- a/indexer/services/comlink/public/websocket-documentation.md
+++ b/indexer/services/comlink/public/websocket-documentation.md
@@ -811,7 +811,6 @@ Returns everything from `v4/perpetualMarkets` endpoint.
         "nextFundingRate": "0",
         "initialMarginFraction": "0.050000",
         "maintenanceMarginFraction": "0.030000",
-        "basePositionNotional": "1000",
         "basePositionSize": "0",
         "incrementalPositionSize": "0",
         "maxPositionSize": "0",
@@ -836,7 +835,6 @@ Returns everything from `v4/perpetualMarkets` endpoint.
         "nextFundingRate": "0",
         "initialMarginFraction": "0.050000",
         "maintenanceMarginFraction": "0.030000",
-        "basePositionNotional": "1000",
         "basePositionSize": "0",
         "incrementalPositionSize": "0",
         "maxPositionSize": "0",
@@ -883,7 +881,6 @@ interface TradingPerpetualMarketMessage {
   quoteAsset?: string;
   initialMarginFraction?: string;
   maintenanceMarginFraction?: string;
-  basePositionNotional?: string;
   basePositionSize?: string;
   incrementalPositionSize?: string;
   maxPositionSize?: string;

--- a/indexer/services/comlink/src/request-helpers/request-transformer.ts
+++ b/indexer/services/comlink/src/request-helpers/request-transformer.ts
@@ -284,7 +284,6 @@ export function perpetualMarketToResponseObject(
         Number(liquidityTier.maintenanceFractionPpm),
       ),
     ),
-    basePositionNotional: liquidityTier.basePositionNotional,
     openInterest: perpetualMarket.openInterest,
     atomicResolution: perpetualMarket.atomicResolution,
     quantumConversionExponent: perpetualMarket.quantumConversionExponent,

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -220,7 +220,6 @@ export interface PerpetualMarketResponseObject {
   nextFundingRate: string;
   initialMarginFraction: string;
   maintenanceMarginFraction: string;
-  basePositionNotional: string;
   openInterest: string;
   atomicResolution: number;
   quantumConversionExponent: number;

--- a/indexer/services/ender/__tests__/handlers/liquidity-tier-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/liquidity-tier-handler.test.ts
@@ -11,10 +11,8 @@ import {
   LiquidityTiersFromDatabase,
   LiquidityTiersTable,
   Ordering,
-  QUOTE_CURRENCY_ATOMIC_RESOLUTION,
   TendermintEventTable,
   testConstants,
-  protocolTranslations,
   liquidityTierRefresher,
   PerpetualMarketFromDatabase,
   perpetualMarketRefresher,
@@ -176,10 +174,6 @@ export function expectLiquidityTier(
     name: event.name,
     initialMarginPpm: event.initialMarginPpm.toString(),
     maintenanceFractionPpm: event.maintenanceFractionPpm.toString(),
-    basePositionNotional: protocolTranslations.quantumsToHuman(
-      event.basePositionNotional.toString(),
-      QUOTE_CURRENCY_ATOMIC_RESOLUTION,
-    ).toFixed(),
   }));
 }
 
@@ -241,10 +235,6 @@ function validateLiquidityTierRefresher(
     name: liquidityTierEvent.name,
     initialMarginPpm: liquidityTierEvent.initialMarginPpm.toString(),
     maintenanceFractionPpm: liquidityTierEvent.maintenanceFractionPpm.toString(),
-    basePositionNotional: protocolTranslations.quantumsToHuman(
-      liquidityTierEvent.basePositionNotional.toString(),
-      QUOTE_CURRENCY_ATOMIC_RESOLUTION,
-    ).toFixed(),
   });
 }
 

--- a/indexer/services/ender/__tests__/validators/liquidity-tier-validator.test.ts
+++ b/indexer/services/ender/__tests__/validators/liquidity-tier-validator.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../helpers/indexer-proto-helpers';
 import { expectDidntLogError } from '../helpers/validator-helpers';
 import { LiquidityTierValidator } from '../../src/validators/liquidity-tier-validator';
-import Long from 'long';
 
 describe('liquidity-tier-validator', () => {
   beforeEach(async () => {
@@ -75,15 +74,6 @@ describe('liquidity-tier-validator', () => {
         } as LiquidityTierUpsertEventV1,
         'LiquidityTierUpsertEventV1 name is not populated',
       ],
-      [
-        'logs error on liquidity tier upsert event with basePositionNotional equal to 0',
-        {
-          ...defaultLiquidityTierUpsertEvent,
-          basePositionNotional: Long.fromValue(0, true),
-        } as LiquidityTierUpsertEventV1,
-        'LiquidityTierUpsertEventV1 basePositionNotional is not populated',
-      ],
-
       // ... other test cases here ...
     ])('%s', (_description: string, event: LiquidityTierUpsertEventV1, expectedMessage: string) => {
       const loggerError = jest.spyOn(logger, 'error');

--- a/indexer/services/ender/src/helpers/kafka-helper.ts
+++ b/indexer/services/ender/src/helpers/kafka-helper.ts
@@ -326,7 +326,6 @@ export function generatePerpetualMarketMessage(
             Number(liquidityTier.maintenanceFractionPpm),
           ),
         ),
-        basePositionNotional: liquidityTier.basePositionNotional,
       };
     })
     .value();

--- a/indexer/services/ender/src/scripts/handlers/dydx_liquidity_tier_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_liquidity_tier_handler.sql
@@ -15,7 +15,6 @@ BEGIN
     liquidity_tier_record."name" = event_data->>'name';
     liquidity_tier_record."initialMarginPpm" = (event_data->'initialMarginPpm')::bigint;
     liquidity_tier_record."maintenanceFractionPpm" = (event_data->'maintenanceFractionPpm')::bigint;
-    liquidity_tier_record."basePositionNotional" = dydx_trim_scale(power(10, -6)::numeric * dydx_from_jsonlib_long(event_data->'basePositionNotional'));
 
     INSERT INTO liquidity_tiers
     VALUES (liquidity_tier_record.*)
@@ -24,8 +23,7 @@ BEGIN
         SET
             "name" = liquidity_tier_record."name",
             "initialMarginPpm" = liquidity_tier_record."initialMarginPpm",
-            "maintenanceFractionPpm" = liquidity_tier_record."maintenanceFractionPpm",
-            "basePositionNotional" = liquidity_tier_record."basePositionNotional"
+            "maintenanceFractionPpm" = liquidity_tier_record."maintenanceFractionPpm"
     RETURNING * INTO liquidity_tier_record;
 
     RETURN jsonb_build_object(

--- a/indexer/services/ender/src/validators/liquidity-tier-validator.ts
+++ b/indexer/services/ender/src/validators/liquidity-tier-validator.ts
@@ -1,6 +1,5 @@
 import { logger } from '@dydxprotocol-indexer/base';
 import { IndexerTendermintEvent, LiquidityTierUpsertEventV1 } from '@dydxprotocol-indexer/v4-protos';
-import Long from 'long';
 
 import { Handler } from '../handlers/handler';
 import { LiquidityTierHandler } from '../handlers/liquidity-tier-handler';
@@ -12,15 +11,6 @@ export class LiquidityTierValidator extends Validator<LiquidityTierUpsertEventV1
       logger.error({
         at: `${this.constructor.name}#validate`,
         message: 'LiquidityTierUpsertEventV1 name is not populated',
-        blockHeight: this.block.height,
-        event: this.event,
-      });
-    }
-
-    if (this.event.basePositionNotional.eq(Long.fromValue(0))) {
-      logger.error({
-        at: `${this.constructor.name}#validate`,
-        message: 'LiquidityTierUpsertEventV1 basePositionNotional is not populated',
         blockHeight: this.block.height,
         event: this.event,
       });

--- a/indexer/services/roundtable/src/helpers/websocket.ts
+++ b/indexer/services/roundtable/src/helpers/websocket.ts
@@ -30,7 +30,6 @@ export function getMarginFields(
 ): {
   initialMarginFraction: string,
   maintenanceMarginFraction: string,
-  basePositionNotional: string,
 } {
 
   if (liquidityTiers[perpetualMarket.liquidityTierId] === undefined) {
@@ -45,7 +44,6 @@ export function getMarginFields(
         Number(liquidityTier.maintenanceFractionPpm),
       ),
     ),
-    basePositionNotional: liquidityTier.basePositionNotional,
   };
 }
 

--- a/indexer/services/roundtable/src/lib/athena-ddl-tables/liquidity_tiers.ts
+++ b/indexer/services/roundtable/src/lib/athena-ddl-tables/liquidity_tiers.ts
@@ -1,7 +1,6 @@
 import {
   getAthenaTableCreationStatement,
   getExternalAthenaTableCreationStatement,
-  castToDouble,
 } from '../../helpers/sql';
 
 const TABLE_NAME: string = 'liquidity_tiers';
@@ -9,15 +8,13 @@ const RAW_TABLE_COLUMNS: string = `
   \`id\` int,
   \`name\` string,
   \`initialMarginPpm\` bigint,
-  \`maintenanceFractionPpm\` bigint,
-  \`basePositionNotional\` decimal
+  \`maintenanceFractionPpm\` bigint
 `;
 const TABLE_COLUMNS: string = `
   "id",
   "name",
   "initialMarginPpm",
-  "maintenanceFractionPpm",
-  ${castToDouble('basePositionNotional')}
+  "maintenanceFractionPpm"
 `;
 
 export function generateRawTable(tablePrefix: string, rdsExportIdentifier: string): string {


### PR DESCRIPTION
### Changelist
Cherry-pick basePositionNotional deprecation in Indexer APIs

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
