### PR TITLE
Fix withdrawal gating double usage of metrics name for two different types of counters.

### DIFF
--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -21,6 +21,7 @@ const (
 	LiquidationsLiquidationMatchNegativeTNC            = "liquidations_liquidation_match_negative_tnc"
 	ClobMevErrorCount                                  = "clob_mev_error_count"
 	SubaccountsNegativeTncSubaccountSeen               = "negative_tnc_subaccount_seen"
+	GateWithdrawalsIfNegativeTncSubaccountSeen         = "gate_withdrawals_if_negative_tnc_subaccount_seen"
 
 	// Gauges
 	InsuranceFundBalance             = "insurance_fund_balance"
@@ -41,14 +42,14 @@ const (
 	LiquidationsPlacePerpetualLiquidationQuoteQuantumsDistribution = "liquidations_place_perpetual_liquidation_quote_quantums_distribution"
 
 	// Measure Since
-	ClobOffsettingSubaccountPerpetualPosition  = "clob_offsetting_subaccount_perpetual_position"
-	DaemonGetPreviousBlockInfoLatency          = "daemon_get_previous_block_info_latency"
-	DaemonGetAllMarketPricesLatency            = "daemon_get_all_market_prices_latency"
-	DaemonGetMarketPricesPaginatedLatency      = "daemon_get_market_prices_paginated_latency"
-	DaemonGetAllLiquidityTiersLatency          = "daemon_get_all_liquidity_tiers_latency"
-	DaemonGetLiquidityTiersPaginatedLatency    = "daemon_get_liquidity_tiers_paginated_latency"
-	DaemonGetAllPerpetualsLatency              = "daemon_get_all_perpetuals_latency"
-	DaemonGetPerpetualsPaginatedLatency        = "daemon_get_perpetuals_paginated_latency"
-	MevLatency                                 = "mev_latency"
-	GateWithdrawalsIfNegativeTncSubaccountSeen = "gate_withdrawals_if_negative_tnc_subaccount_seen"
+	ClobOffsettingSubaccountPerpetualPosition         = "clob_offsetting_subaccount_perpetual_position"
+	DaemonGetPreviousBlockInfoLatency                 = "daemon_get_previous_block_info_latency"
+	DaemonGetAllMarketPricesLatency                   = "daemon_get_all_market_prices_latency"
+	DaemonGetMarketPricesPaginatedLatency             = "daemon_get_market_prices_paginated_latency"
+	DaemonGetAllLiquidityTiersLatency                 = "daemon_get_all_liquidity_tiers_latency"
+	DaemonGetLiquidityTiersPaginatedLatency           = "daemon_get_liquidity_tiers_paginated_latency"
+	DaemonGetAllPerpetualsLatency                     = "daemon_get_all_perpetuals_latency"
+	DaemonGetPerpetualsPaginatedLatency               = "daemon_get_perpetuals_paginated_latency"
+	MevLatency                                        = "mev_latency"
+	GateWithdrawalsIfNegativeTncSubaccountSeenLatency = "gate_withdrawals_if_negative_tnc_subaccount_seen_latency"
 )

--- a/protocol/x/clob/keeper/deleveraging.go
+++ b/protocol/x/clob/keeper/deleveraging.go
@@ -195,7 +195,7 @@ func (k Keeper) GateWithdrawalsIfNegativeTncSubaccountSeen(
 ) (err error) {
 	defer metrics.ModuleMeasureSince(
 		types.ModuleName,
-		metrics.GateWithdrawalsIfNegativeTncSubaccountSeen,
+		metrics.GateWithdrawalsIfNegativeTncSubaccountSeenLatency,
 		time.Now(),
 	)
 	metrics.IncrCounter(


### PR DESCRIPTION
### Changelist
Fix withdrawal gating double usage of metrics name for two different types of counters.

### Test Plan
Manually test on persistent environment.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
