### PR TITLE
[IND-556] wait until bazooka image finishes upgrading before running bazooka in auxo lambda

### DIFF
--- a/indexer/scripts/deploy-commit-to-env.sh
+++ b/indexer/scripts/deploy-commit-to-env.sh
@@ -32,7 +32,6 @@ printf "account: %s\n" $account
 
 dockerfile=Dockerfile.service.remote
 case $service in
-    "auxo") dockerfile=Dockerfile.auxo.remote;;
     "bazooka") dockerfile=Dockerfile.bazooka.remote;;
     "auxo") dockerfile=Dockerfile.auxo.remote;;
 esac

--- a/indexer/scripts/deploy-commit-to-env.sh
+++ b/indexer/scripts/deploy-commit-to-env.sh
@@ -32,6 +32,7 @@ printf "account: %s\n" $account
 
 dockerfile=Dockerfile.service.remote
 case $service in
+    "auxo") dockerfile=Dockerfile.auxo.remote;;
     "bazooka") dockerfile=Dockerfile.bazooka.remote;;
     "auxo") dockerfile=Dockerfile.auxo.remote;;
 esac

--- a/indexer/services/auxo/src/index.ts
+++ b/indexer/services/auxo/src/index.ts
@@ -158,7 +158,7 @@ async function getImageDetail(
   event: APIGatewayEvent & AuxoEventJson,
 ): Promise<ImageDetail> {
   logger.info({
-    at: 'index#upgradeBazooka',
+    at: 'index#getImageDetail',
     message: 'Getting ecr images',
     repositoryName,
     event,
@@ -172,7 +172,7 @@ async function getImageDetail(
     ],
   }));
   logger.info({
-    at: 'index#upgradeBazooka',
+    at: 'index#getImageDetail',
     message: 'Successfully got ecr images',
     images,
     repositoryName,
@@ -181,7 +181,7 @@ async function getImageDetail(
 
   if (!images.imageDetails || images.imageDetails.length === 0) {
     logger.error({
-      at: 'index#upgradeBazooka',
+      at: 'index#getImageDetail',
       message: 'Unable to find ecr image',
       imageTag: event.upgrade_tag,
       repositoryName,

--- a/indexer/services/auxo/src/index.ts
+++ b/indexer/services/auxo/src/index.ts
@@ -24,7 +24,8 @@ import {
   InvokeCommandOutput,
   LambdaClient,
   UpdateFunctionCodeCommand,
-  UpdateFunctionCodeCommandOutput,
+  GetFunctionCommandOutput,
+  LastUpdateStatus,
 } from '@aws-sdk/client-lambda';
 import { logger, startBugsnag } from '@dydxprotocol-indexer/base';
 import {
@@ -46,8 +47,6 @@ import {
   EcsServiceNames,
   TaskDefinitionArnMap,
 } from './types';
-import {GetFunctionCommandOutput} from '@aws-sdk/client-lambda/dist-types/commands/GetFunctionCommand';
-import {LastUpdateStatus} from '@aws-sdk/client-lambda/dist-types/models/models_0';
 
 /**
  * Upgrades all services and run migrations


### PR DESCRIPTION
### Changelist
Wait until bazooka image finishes upgrading before running bazooka in auxo lambda.
When running auxo in our testnet environment, the old bazooka image was used, which led to an expected db migration not happening.

### Test Plan
ran in dev

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
