### PR TITLE
[CORE-538] Update usage of mocks and re-enable test.

### DIFF
--- a/protocol/x/clob/keeper/mev_test.go
+++ b/protocol/x/clob/keeper/mev_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	sdkmath "cosmossdk.io/math"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/dydxprotocol/v4-chain/protocol/app/process"
@@ -27,10 +26,6 @@ import (
 )
 
 func TestRecordMevMetrics(t *testing.T) {
-	t.Skip("TODO(CORE-538): The issue is that the mock interactions have changed and we error out with " +
-		"'mock: I don't know what to return because the method call was unexpected.'. Swap to use testapp to " +
-		"initialize or update mock interactions.")
-
 	// Set the maximum spread to 10%.
 	keeper.MAX_SPREAD_BEFORE_FALLING_BACK_TO_ORACLE = new(big.Rat).SetFrac64(1, 10)
 
@@ -967,7 +962,7 @@ func TestRecordMevMetrics(t *testing.T) {
 			require.NoError(t, err)
 			mockStakingKeeper := &mocks.ProcessStakingKeeper{}
 			mockStakingKeeper.On("GetValidatorByConsAddr", mock.Anything, constants.AliceConsAddress).
-				Return(aliceValidator, true)
+				Return(aliceValidator, nil)
 
 			mockPerpetualKeeper := &mocks.ProcessPerpetualKeeper{}
 			if tc.setupPerpetualKeeperMocks != nil {


### PR DESCRIPTION
### Changelist
[CORE-538] Update usage of mocks and re-enable test.

### Test Plan
Re-enabled existing test.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
