### PR TITLE
[CORE-538] Fix bogus account numbers being generated in tests and re-enable tests.

### DIFF
--- a/protocol/testutil/auth/auth_helpers.go
+++ b/protocol/testutil/auth/auth_helpers.go
@@ -12,7 +12,12 @@ func CreateTestModuleAccount(
 	moduleName string,
 	permissions []string,
 ) {
-	modBaseAcc := authtypes.NewBaseAccount(authtypes.NewModuleAddress(moduleName), nil, 0, 0)
+	modBaseAcc := authtypes.NewBaseAccount(
+		authtypes.NewModuleAddress(moduleName),
+		nil,
+		accountKeeper.NextAccountNumber(ctx),
+		0,
+	)
 	modAcc := authtypes.NewModuleAccount(modBaseAcc, moduleName, permissions...)
 	accountKeeper.SetModuleAccount(ctx, modAcc)
 }

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -24,9 +24,6 @@ import (
 )
 
 func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccount_Success(t *testing.T) {
-	t.Skip("TODO(CORE-538): The issue is that the dependent modules are not initialized " +
-		"appropriately and we error out with 'collections: conflict: index uniqueness constrain " +
-		"violation: 0'. Swap to use testapp to initialize.")
 	tests := map[string]struct {
 		testTransferFundToAccount bool
 		asset                     asstypes.Asset
@@ -148,7 +145,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 			testAccAddress, err := sdk.AccAddressFromBech32(addressStr)
 			require.NoError(t, err)
 
-			testAcc := authtypes.NewBaseAccount(testAccAddress, nil, 999, 0)
+			testAcc := authtypes.NewBaseAccount(testAccAddress, nil, accountKeeper.NextAccountNumber(ctx), 0)
 			accountKeeper.SetAccount(ctx, testAcc)
 
 			if tc.accAddressBalance.Sign() > 0 {
@@ -248,9 +245,6 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 }
 
 func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccount_Failure(t *testing.T) {
-	t.Skip("TODO(CORE-538): The issue is that the dependent modules are not initialized " +
-		"appropriately and we error out with 'collections: conflict: index uniqueness constrain " +
-		"violation: 0'. Swap to use testapp to initialize.")
 	tests := map[string]struct {
 		skipSetUpUsdc             bool
 		testTransferFundToAccount bool
@@ -378,7 +372,7 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 			testAccAddress, err := sdk.AccAddressFromBech32(addressStr)
 			require.NoError(t, err)
 
-			testAcc := authtypes.NewBaseAccount(testAccAddress, nil, 0, 0)
+			testAcc := authtypes.NewBaseAccount(testAccAddress, nil, accountKeeper.NextAccountNumber(ctx), 0)
 			accountKeeper.SetAccount(ctx, testAcc)
 
 			if tc.accAddressBalance.Sign() > 0 {
@@ -484,9 +478,6 @@ func TestWithdrawFundsFromSubaccountToAccount_DepositFundsFromAccountToSubaccoun
 }
 
 func TestTransferFeesToFeeCollectorModule(t *testing.T) {
-	t.Skip("TODO(CORE-538): The issue is that the dependent modules are not initialized " +
-		"appropriately and we error out with 'collections: conflict: index uniqueness constrain " +
-		"violation: 0'. Swap to use testapp to initialize.")
 	tests := map[string]struct {
 		skipSetUpUsdc bool
 
@@ -664,9 +655,6 @@ func TestTransferFeesToFeeCollectorModule(t *testing.T) {
 }
 
 func TestTransferInsuranceFundPayments(t *testing.T) {
-	t.Skip("TODO(CORE-538): The issue is that the dependent modules are not initialized " +
-		"appropriately and we error out with 'collections: conflict: index uniqueness constrain " +
-		"violation: 0'. Swap to use testapp to initialize.")
 	tests := map[string]struct {
 		skipSetUpUsdc bool
 


### PR DESCRIPTION
### Changelist
[CORE-538] Fix bogus account numbers being generated in tests and re-enable tests.

### Test Plan
Tests re-enabled.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
