### PR TITLE
Remove delaymsg from module_accounts list

### DIFF
--- a/protocol/app/module_accounts.go
+++ b/protocol/app/module_accounts.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/app/config"
 	bridgemoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	clobmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	rewardsmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	vestmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
@@ -50,9 +49,6 @@ var (
 		vestmoduletypes.CommunityTreasuryAccountName: nil,
 		// community vester account vests funds into the community treasury.
 		vestmoduletypes.CommunityVesterAccountName: nil,
-		// delaymsg module account doesn't hold funds. It's used as the authority of
-		// delayed messages.
-		delaymsgtypes.ModuleName: nil,
 	}
 	// Blocked module accounts which cannot receive external funds.
 	// By default, all non-custom modules (except for gov) are blocked. This prevents

--- a/protocol/app/module_accounts_test.go
+++ b/protocol/app/module_accounts_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/app"
 	bridgemoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/bridge/types"
 	clobmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	rewardsmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	vestmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
@@ -34,7 +33,6 @@ func TestModuleAccountsToAddresses(t *testing.T) {
 		rewardsmoduletypes.VesterAccountName:         "dydx1ltyc6y4skclzafvpznpt2qjwmfwgsndp458rmp",
 		vestmoduletypes.CommunityTreasuryAccountName: "dydx15ztc7xy42tn2ukkc0qjthkucw9ac63pgp70urn",
 		vestmoduletypes.CommunityVesterAccountName:   "dydx1wxje320an3karyc6mjw4zghs300dmrjkwn7xtk",
-		delaymsgtypes.ModuleName:                     "dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr",
 		icatypes.ModuleName:                          "dydx1vlthgax23ca9syk7xgaz347xmf4nunefw3cnv8",
 	}
 
@@ -74,7 +72,6 @@ func TestMaccPerms(t *testing.T) {
 		"rewards_vester":         nil,
 		"community_treasury":     nil,
 		"community_vester":       nil,
-		"delaymsg":               nil,
 	}
 	require.Equal(t, expectedMaccPerms, maccPerms, "default macc perms list does not match expected")
 }
@@ -95,7 +92,6 @@ func TestModuleAccountAddrs(t *testing.T) {
 		"dydx1ltyc6y4skclzafvpznpt2qjwmfwgsndp458rmp": true, // x/rewards.vester
 		"dydx15ztc7xy42tn2ukkc0qjthkucw9ac63pgp70urn": true, // x/vest.communityTreasury
 		"dydx1wxje320an3karyc6mjw4zghs300dmrjkwn7xtk": true, // x/vest.communityVester
-		"dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr": true, // x/delaymsg
 	}
 
 	require.Equal(t, expectedModuleAccAddresses, app.ModuleAccountAddrs())


### PR DESCRIPTION
### Changelist

`x/delaymsg` were [added](https://github.com/dydxprotocol/v4-chain/pull/661) as a module accounts shortly after V4 release, when we didn't fully understand [issue with module accounts. ](https://www.notion.so/dydx/Module-accounts-not-correctly-initialized-9cbb83d403704f8da8e14617fb499f6f?pvs=4). Since `x/delaymsg` never holds funds or need any module permissions, we should do one of the following:
- Remove it from the module accounts list
- Add it to the [BlockedModuleAccounts](https://github.com/dydxprotocol/v4-chain/blob/a1352a5a409e9e12a9772c889b45c25eac3a2920/protocol/app/module_accounts.go#L60) list so it can not receive bank transfer transfer

Preferring the former, since there's simply no reason for `x/delaymsg` to be a module account (similar to other custom modules like `x/clob`, `x/perpetual`, etc. 

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
