### PR TITLE
[CORE-538] Fix CLI tests to correctly generate module address

### DIFF
--- a/protocol/testutil/bank/bank_helpers.go
+++ b/protocol/testutil/bank/bank_helpers.go
@@ -1,12 +1,14 @@
 package bank
 
 import (
-	sdkmath "cosmossdk.io/math"
 	"fmt"
+
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
@@ -23,12 +25,7 @@ func GetModuleAccUsdcBalance(
 	balance int64,
 	err error,
 ) {
-	moduleAddress, err := codec.InterfaceRegistry().SigningContext().AddressCodec().BytesToString(
-		[]byte(moduleName),
-	)
-	if err != nil {
-		return 0, err
-	}
+	moduleAddress := authtypes.NewModuleAddress(moduleName)
 	resp, err := testutil.GetRequest(fmt.Sprintf(
 		"%s/cosmos/bank/v1beta1/balances/%s",
 		val.APIAddress,

--- a/protocol/x/clob/client/cli/cancel_order_cli_test.go
+++ b/protocol/x/clob/client/cli/cancel_order_cli_test.go
@@ -176,7 +176,6 @@ func (s *CancelOrderIntegrationTestSuite) SetupTest() {
 // The subaccounts are then queried and assertions are performed on their QuoteBalance and PerpetualPositions.
 // The account which places the orders is also the validator's AccAddress.
 func (s *CancelOrderIntegrationTestSuite) TestCLICancelPendingOrder() {
-	s.T().Skip("TODO(CORE-538): Resolve why bank balance for subaccounts module is not found.")
 	val := s.network.Validators[0]
 	ctx := val.ClientCtx
 
@@ -294,7 +293,6 @@ func (s *CancelOrderIntegrationTestSuite) TestCLICancelPendingOrder() {
 // The subaccounts are then queried and assertions are performed on their QuoteBalance and PerpetualPositions.
 // The account which places the orders is also the validator's AccAddress.
 func (s *CancelOrderIntegrationTestSuite) TestCLICancelMatchingOrders() {
-	s.T().Skip("TODO(CORE-538): Resolve why bank balance for subaccounts module is not found.")
 	val := s.network.Validators[0]
 	ctx := val.ClientCtx
 

--- a/protocol/x/clob/client/cli/liquidations_cli_test.go
+++ b/protocol/x/clob/client/cli/liquidations_cli_test.go
@@ -54,7 +54,6 @@ type LiquidationsIntegrationTestSuite struct {
 }
 
 func TestLiquidationOrderIntegrationTestSuite(t *testing.T) {
-	t.Skip("TODO(CORE-538): Resolve why bank balance for subaccounts module is not found.")
 	// Deterministic Mnemonic.
 	validatorMnemonic := constants.AliceMnenomic
 

--- a/protocol/x/clob/client/cli/place_order_cli_test.go
+++ b/protocol/x/clob/client/cli/place_order_cli_test.go
@@ -48,7 +48,6 @@ type PlaceOrderIntegrationTestSuite struct {
 }
 
 func TestPlaceOrderIntegrationTestSuite(t *testing.T) {
-	t.Skip("TODO(CORE-538): Resolve why bank balance for subaccounts module is not found.")
 	// Deterministic Mnemonic.
 	validatorMnemonic := constants.AliceMnenomic
 


### PR DESCRIPTION
### Changelist
[CORE-538] Fix CLI tests to correctly generate module address. 

Incorrectly converted how we generate module address during Cosmos 0.50 upgrade. This was the only case of where I swapped module address generation with using the signing context erroneously.

### Test Plan
Re-enabled existing tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
