### PR TITLE
[CORE-538] Update iaviewer comment.

### DIFF
--- a/protocol/scripts/iaviewer/iaviewer.go
+++ b/protocol/scripts/iaviewer/iaviewer.go
@@ -1,5 +1,4 @@
-// Originally forked from https://github.com/cosmos/iavl/blob/v0.20.0/cmd/iaviewer/main.go
-// TODO(CORE-538): Update this fork for Cosmos 0.50 upgrade.
+// Originally forked from https://github.com/cosmos/iavl/blob/v1.0.0/cmd/iaviewer/main.go
 package main
 
 import (


### PR DESCRIPTION
### Changelist
[CORE-538] Update iaviewer comment.

Turns out that during the 0.47 -> 0.50 upgrade I made all same changes the 0.20.0 -> 1.0.0 conversion did so there is nothing left to do here.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
