### PR TITLE
market make

### DIFF
--- a/protocol/contracts/dydx-messages-example/src/contract.rs
+++ b/protocol/contracts/dydx-messages-example/src/contract.rs
@@ -132,10 +132,10 @@ fn execute_market_make(
 
     // Hard-code some values for BTC.
     let exponent = market_price.exponent - (-9) + (-10) - (-6);
-    let subticks = market_price.price * 10i64.pow(exponent as u32);
+    let subticks = market_price.price as f64 * (10i64 as f64).powi(exponent);
     // Round to the nearest multiple.
-    let buy_price = subticks as f64 * 0.99;
-    let sell_price = subticks as f64 * 1.01;
+    let buy_price = subticks * 0.99;
+    let sell_price = subticks * 1.01;
     let rounded_buy_subticks = (buy_price.round() as u64) / 100000 * 100000;
     let rounded_sell_subticks = (sell_price.round() as u64) / 100000 * 100000;
 

--- a/protocol/contracts/dydx-messages-example/src/contract.rs
+++ b/protocol/contracts/dydx-messages-example/src/contract.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     to_binary,
 };
 use cw2::set_contract_version;
-use dydx_cosmwasm::{DydxQuerier, DydxQueryWrapper, MarketPrice, Order, OrderId, DydxMsg, SubaccountId};
+use dydx_cosmwasm::{DydxQuerier, DydxQueryWrapper, MarketPrice, Order, OrderId, DydxMsg, SubaccountId, OrderSide};
 
 use crate::error::ContractError;
 use crate::msg::{ArbiterResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -42,7 +42,7 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<DydxQueryWrapper>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -65,7 +65,7 @@ pub fn execute(
             client_metadata,
             condition_type,
             conditional_order_trigger_subticks,
-        } => execute_place_order(
+        } => execute_market_make(
             deps,
             Order {
                 order_id: OrderId {
@@ -90,7 +90,7 @@ pub fn execute(
 }
 
 fn execute_approve(
-    deps: DepsMut,
+    deps: DepsMut<DydxQueryWrapper>,
     env: Env,
     info: MessageInfo,
     quantity: Option<u64>,
@@ -122,18 +122,42 @@ fn execute_approve(
     Ok(send_tokens(env.contract.address, config.recipient, amount, "approve"))
 }
 
-fn execute_place_order(
-    deps: DepsMut,
+fn execute_market_make(
+    deps: DepsMut<DydxQueryWrapper>,
     order: Order,
 ) -> Result<Response<DydxMsg>, ContractError> {
-    let place_order_msg = DydxMsg::PlaceOrder { order };
+    let querier = DydxQuerier::new(&deps.querier);
+    let res = querier.query_market_price(order.order_id.clob_pair_id);
+    let market_price = res.unwrap();
 
+    // Hard-code some values for BTC.
+    let exponent = market_price.exponent - (-9) + (-10) - (-6);
+    let subticks = market_price.price * 10i64.pow(exponent as u32);
+    // Round to the nearest multiple.
+    let buy_price = subticks as f64 * 0.99;
+    let sell_price = subticks as f64 * 1.01;
+    let rounded_buy_subticks = (buy_price.round() as u64) / 100000 * 100000;
+    let rounded_sell_subticks = (sell_price.round() as u64) / 100000 * 100000;
+
+    // Construct the buy order.
+    let mut buy_order = order.clone();
+    buy_order.subticks = rounded_buy_subticks;
+    buy_order.side = OrderSide::Buy;
+    let buy_order_msg = DydxMsg::PlaceOrder { order: buy_order };
+
+    // Construct the sell order.
+    let mut sell_order = order.clone();
+    sell_order.subticks = rounded_sell_subticks;
+    sell_order.side = OrderSide::Sell;
+    let sell_order_msg = DydxMsg::PlaceOrder { order: sell_order };
+
+    // Market make!
     Ok(Response::new()
-        .add_message(place_order_msg)
+        .add_messages(vec![buy_order_msg, sell_order_msg])
         .add_attribute("action", "place_order"))
 }
 
-fn execute_refund(deps: DepsMut, env: Env, _info: MessageInfo) -> Result<Response<DydxMsg>, ContractError> {
+fn execute_refund(deps: DepsMut<DydxQueryWrapper>, env: Env, _info: MessageInfo) -> Result<Response<DydxMsg>, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     // anyone can try to refund, as long as the contract is expired
     if let Some(expiration) = config.expiration {

--- a/protocol/wasmbinding/msg_plugin.go
+++ b/protocol/wasmbinding/msg_plugin.go
@@ -213,7 +213,7 @@ func (m *CustomMessenger) placeOrder(
 		// Only process short term orders in CheckTx because short term order placements
 		// are never on chain.
 		if ctx.IsCheckTx() {
-			fmt.Println("Placing short term order")
+			fmt.Printf("Placing short term order: %+v\n", order)
 			_, _, err = m.clob.PlaceShortTermOrder(ctx, &clobtypes.MsgPlaceOrder{Order: order})
 		}
 	} else {
@@ -226,7 +226,7 @@ func (m *CustomMessenger) placeOrder(
 			return nil, nil, nil
 		}
 
-		fmt.Println("Placing stateful order")
+		fmt.Printf("Placing stateful order: %+v\n", order)
 		processProposerMatchesEvents := m.clob.GetProcessProposerMatchesEvents(ctx)
 
 		if err := m.clob.PlaceStatefulOrder(ctx, &clobtypes.MsgPlaceOrder{Order: order}); err != nil {


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
- Build, deploy, instantiate contract as usual.
- Construct a json payload 
```
PLACE_ORDER='{ 
    "place_order": {
        "subaccount_id": {
            "owner": "dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4",
            "number": 0
        },
        "client_id": 0,
        "order_flags": 64,
        "clob_pair_id": 0,
        "side": 1,
        "quantums": 10000000,
        "subticks": 5000000000,
        "good_til_block_time": 1705616300,
        "time_in_force": 0,
        "reduce_only": false,
        "client_metadata": 0,
        "condition_type": 0,
        "conditional_order_trigger_subticks": 0
    }
}'
```
- Send a transaction to contract 
```
dydxprotocold tx wasm execute dydx14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s2de90j "$PLACE_ORDER" --from alice --gas auto --fees 1256394675000000000adv4tnt --chain-id localdydxprotocol --node $NODE
```
- Verify that transaction went through and both buy and sell orders were placed. 
```
code: 0
...
```
```
protocol-dydxprotocold0-1  | Placing stateful order: {OrderId:{SubaccountId:{Owner:dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4 Number:0} ClientId:0 OrderFlags:64 ClobPairId:0} Side:SIDE_BUY Quantums:10000000 Subticks:4091100000 GoodTilOneof:0x400a0b3b18 TimeInForce:TIME_IN_FORCE_UNSPECIFIED ReduceOnly:false ClientMetadata:0 ConditionType:CONDITION_TYPE_UNSPECIFIED ConditionalOrderTriggerSubticks:0}
protocol-dydxprotocold0-1  | Placing stateful order: {OrderId:{SubaccountId:{Owner:dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4 Number:0} ClientId:0 OrderFlags:64 ClobPairId:0} Side:SIDE_SELL Quantums:10000000 Subticks:4173800000 GoodTilOneof:0x400a156278 TimeInForce:TIME_IN_FORCE_UNSPECIFIED ReduceOnly:false ClientMetadata:0 ConditionType:CONDITION_TYPE_UNSPECIFIED ConditionalOrderTriggerSubticks:0}
```

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
