### PR TITLE
[CORE-538] Remove genesis check that isn't needed since the issue was with how testapp was simulating block processing.

### DIFF
--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -1059,12 +1059,10 @@ func newTestingLogger() cmtlog.Logger {
 //
 // This method is thread-safe.
 func (tApp *TestApp) CheckTx(req abcitypes.RequestCheckTx) abcitypes.ResponseCheckTx {
-	// TODO(CORE-538): Expose the updated CheckTx API that uses pointers and returns errors to tests.
-
 	tApp.panicIfChainIsHalted()
 	res, err := tApp.App.CheckTx(&req)
 	// Note that the dYdX fork of CometBFT explicitly excludes place and cancel order messages. See
-	// https://github.com/dydxprotocol/cometbft/blob/4d4d3b0/mempool/v0/clist_mempool.go#L416
+	// https://github.com/dydxprotocol/cometbft/blob/5e6c4b6/mempool/clist_mempool.go#L441
 	if err == nil && res.IsOK() && !mempool.IsShortTermClobOrderTransaction(req.Tx, newTestingLogger()) {
 		// We want to ensure that we hold the lock only for updating passingCheckTxs so that App.CheckTx can execute
 		// concurrently.

--- a/protocol/testutil/keeper/delaymsg.go
+++ b/protocol/testutil/keeper/delaymsg.go
@@ -19,7 +19,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 )
 
-// TODO(CORE-538): Migrate to testapp
 func DelayMsgKeepers(
 	t testing.TB,
 ) (

--- a/protocol/testutil/logger/logger.go
+++ b/protocol/testutil/logger/logger.go
@@ -12,8 +12,6 @@ const (
 )
 
 // TestLogger returns a logger instance and a buffer where all logs are written to.
-// TODO(CORE-538): See if we can get rid of this method in favor of the Cosmos Logger now
-// (which uses zerolog under the hood).
 func TestLogger() (log.Logger, *bytes.Buffer) {
 	var logBuffer bytes.Buffer
 	return log.NewLogger(kitlog.NewSyncWriter(&logBuffer)), &logBuffer

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -136,10 +136,6 @@ func PrepareCheckState(
 		log.BlockHeight, ctx.BlockHeight()+1,
 	)
 
-	// TODO(CORE-538): Is there a cleaner way to check to see if this is genesis?
-	if ctx.BlockHeight() == 0 || ctx.BlockHeight() == 1 {
-		return
-	}
 	// Get the events generated from processing the matches in the latest block.
 	processProposerMatchesEvents := keeper.GetProcessProposerMatchesEvents(ctx)
 	if ctx.BlockHeight() != int64(processProposerMatchesEvents.BlockHeight) {


### PR DESCRIPTION
### Changelist
[CORE-538] Remove genesis check that isn't needed since the issue was with how testapp was simulating block processing.

Also clean-up TODO comments that aren't important and are low value.

### Test Plan
No changes to tests, existing tests pass.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
