### PR TITLE
Revert "Revert "[CLOB-1014] [CLOB-1004] Unify metrics library, un-mod…

### DIFF
--- a/.github/workflows/protocol-build-and-push-snapshot.yml
+++ b/.github/workflows/protocol-build-and-push-snapshot.yml
@@ -3,7 +3,6 @@ name: Protocol Build & Push Image to AWS ECR
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - jonfung/**
       - main
       - 'release/[a-z]+/v0.[0-9]+.x'  # e.g. release/protocol/v0.1.x
       - 'release/[a-z]+/v[0-9]+.x'  # e.g. release/protocol/v1.x

--- a/protocol/lib/metrics/lib.go
+++ b/protocol/lib/metrics/lib.go
@@ -69,3 +69,24 @@ func ModuleMeasureSince(module string, key string, start time.Time) {
 		key,
 	)
 }
+
+// ModuleMeasureSinceWithLabels provides a short hand method for emitting a time measure
+// metric for a module with labels. Global labels are not included in this metric.
+// Please try to use `AddSampleWithLabels` instead.
+// TODO(CLOB-1022) Roll our own calculations for timing on top of AddSample instead
+// of using MeasureSince.
+func ModuleMeasureSinceWithLabels(
+	module string,
+	keys []string,
+	start time.Time,
+	labels []gometrics.Label,
+) {
+	gometrics.MeasureSinceWithLabels(
+		keys,
+		start.UTC(),
+		append(
+			[]gometrics.Label{telemetry.NewLabel(telemetry.MetricLabelNameModule, module)},
+			labels...,
+		),
+	)
+}

--- a/protocol/lib/metrics/util.go
+++ b/protocol/lib/metrics/util.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"math/big"
 	"strconv"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -66,25 +65,6 @@ func GetLabelForStringValue(labelName string, labelValue string) gometrics.Label
 func GetMetricValueFromBigInt(i *big.Int) float32 {
 	r, _ := new(big.Float).SetInt(i).Float32()
 	return r
-}
-
-// ModuleMeasureSinceWithLabels provides a short hand method for emitting a time measure
-// metric for a module with a given set of keys and labels.
-// NOTE: global labels are not included in this metric.
-func ModuleMeasureSinceWithLabels(
-	module string,
-	keys []string,
-	start time.Time,
-	labels []gometrics.Label,
-) {
-	gometrics.MeasureSinceWithLabels(
-		keys,
-		start.UTC(),
-		append(
-			[]gometrics.Label{telemetry.NewLabel(telemetry.MetricLabelNameModule, module)},
-			labels...,
-		),
-	)
 }
 
 // GetCallbackMetricFromCtx determines the callback metric based on the context. Note that DeliverTx is implied

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -14,7 +14,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	gometrics "github.com/hashicorp/go-metrics"
 )
 
 // BeginBlocker executes all ABCI BeginBlock logic respective to the clob module.
@@ -73,10 +72,10 @@ func EndBlocker(
 				),
 			),
 		)
-		telemetry.IncrCounterWithLabels(
-			[]string{types.ModuleName, metrics.Expired, metrics.StatefulOrderRemoved, metrics.Count},
+		metrics.IncrCounterWithLabels(
+			metrics.ClobExpiredStatefulOrders,
 			1,
-			orderId.GetOrderIdLabels(),
+			orderId.GetOrderIdLabels()...,
 		)
 	}
 
@@ -118,10 +117,9 @@ func EndBlocker(
 	keeper.PruneRateLimits(ctx)
 
 	// Emit relevant metrics at the end of every block.
-	telemetry.SetGaugeWithLabels(
-		[]string{metrics.InsuranceFundBalance},
+	metrics.SetGauge(
+		metrics.InsuranceFundBalance,
 		metrics.GetMetricValueFromBigInt(keeper.GetInsuranceFundBalance(ctx)),
-		[]gometrics.Label{},
 	)
 }
 

--- a/protocol/x/clob/types/order_id.go
+++ b/protocol/x/clob/types/order_id.go
@@ -7,7 +7,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
-	gometrics "github.com/hashicorp/go-metrics"
 )
 
 const (
@@ -174,8 +173,8 @@ func MustSortAndHaveNoDuplicates(orderIds []OrderId) {
 }
 
 // GetOrderIdLabels returns the telemetry labels of this order ID.
-func (o *OrderId) GetOrderIdLabels() []gometrics.Label {
-	return []gometrics.Label{
+func (o *OrderId) GetOrderIdLabels() []metrics.Label {
+	return []metrics.Label{
 		metrics.GetLabelForIntValue(metrics.OrderFlag, int(o.GetOrderFlags())),
 		metrics.GetLabelForIntValue(metrics.ClobPairId, int(o.GetClobPairId())),
 	}


### PR DESCRIPTION
…ularize … (#967)"

#967 was reverted erroneously to debug missing metrics. Migrate all callsites back to the new `	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"` library.