### PR TITLE
[CLOB-1063] optimize conditional order trigger runtime

### DIFF
--- a/protocol/testutil/constants/stateful_orders.go
+++ b/protocol/testutil/constants/stateful_orders.go
@@ -1052,10 +1052,12 @@ var (
 			OrderFlags:   clobtypes.OrderIdFlags_Conditional,
 			ClobPairId:   0,
 		},
-		Side:         clobtypes.Order_SIDE_SELL,
-		Quantums:     100_000_000,
-		Subticks:     50_000_000_000,
-		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+		Side:                            clobtypes.Order_SIDE_SELL,
+		Quantums:                        100_000_000,
+		Subticks:                        50_000_000_000,
+		GoodTilOneof:                    &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+		ConditionType:                   clobtypes.Order_CONDITION_TYPE_STOP_LOSS,
+		ConditionalOrderTriggerSubticks: 50_000_000_000,
 	}
 	ConditionalOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10 = clobtypes.Order{
 		OrderId: clobtypes.OrderId{
@@ -1076,10 +1078,12 @@ var (
 			OrderFlags:   clobtypes.OrderIdFlags_Conditional,
 			ClobPairId:   0,
 		},
-		Side:         clobtypes.Order_SIDE_SELL,
-		Quantums:     100_000_000,
-		Subticks:     50_000_000_000,
-		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+		Side:                            clobtypes.Order_SIDE_SELL,
+		Quantums:                        100_000_000,
+		Subticks:                        50_000_000_000,
+		GoodTilOneof:                    &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+		ConditionType:                   clobtypes.Order_CONDITION_TYPE_STOP_LOSS,
+		ConditionalOrderTriggerSubticks: 50_000_000_000,
 	}
 
 	ConditionalOrder_Bob_Num0_Id0_Clob0_Sell10_Price10_GTBT10_PO_SL_15 = clobtypes.Order{

--- a/protocol/x/clob/keeper/untriggered_conditional_orders_test.go
+++ b/protocol/x/clob/keeper/untriggered_conditional_orders_test.go
@@ -2,9 +2,10 @@ package keeper_test
 
 import (
 	"fmt"
-	testApp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"math/big"
 	"testing"
+
+	testApp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper"
@@ -97,12 +98,12 @@ func TestAddUntriggeredConditionalOrder(t *testing.T) {
 				untriggeredConditionalOrders.AddUntriggeredConditionalOrder(order)
 			}
 
-			require.Equal(
+			require.ElementsMatch(
 				t,
 				tc.expectedOrdersToTriggerWhenOraclePriceGTETriggerPrice,
 				untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceGTETriggerPrice,
 			)
-			require.Equal(
+			require.ElementsMatch(
 				t,
 				tc.expectedOrdersToTriggerWhenOraclePriceLTETriggerPrice,
 				untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceLTETriggerPrice,
@@ -205,12 +206,12 @@ func TestRemoveUntriggeredConditionalOrders(t *testing.T) {
 
 			untriggeredConditionalOrders.RemoveUntriggeredConditionalOrders(tc.conditionalOrderIdsToExpire)
 
-			require.Equal(
+			require.ElementsMatch(
 				t,
 				tc.expectedOrdersToTriggerWhenOraclePriceGTETriggerPrice,
 				untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceGTETriggerPrice,
 			)
-			require.Equal(
+			require.ElementsMatch(
 				t,
 				tc.expectedOrdersToTriggerWhenOraclePriceLTETriggerPrice,
 				untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceLTETriggerPrice,
@@ -418,18 +419,18 @@ func TestPollTriggeredConditionalOrders(t *testing.T) {
 				tc.currentSubticks,
 			)
 
-			require.Equal(
+			require.ElementsMatch(
 				t,
 				tc.expectedTriggeredOrderIds,
 				triggeredOrderIds,
 			)
 
-			require.Equal(
+			require.ElementsMatch(
 				t,
 				tc.expectedOrdersToTriggerWhenOraclePriceGTETriggerPrice,
 				untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceGTETriggerPrice,
 			)
-			require.Equal(
+			require.ElementsMatch(
 				t,
 				tc.expectedOrdersToTriggerWhenOraclePriceLTETriggerPrice,
 				untriggeredConditionalOrders.OrdersToTriggerWhenOraclePriceLTETriggerPrice,

--- a/protocol/x/clob/types/untriggered_conditional_orders.go
+++ b/protocol/x/clob/types/untriggered_conditional_orders.go
@@ -2,6 +2,11 @@ package types
 
 import "bytes"
 
+// MinConditionalOrderHeap is type alias for `[]Order` which implements "container/heap"
+// interface.
+//
+// This is a _MIN_ heap. Orders are compared by their `ConditionalOrderTriggerSubticks` field, and then by
+// their `OrderHash` if the trigger subticks are equal.
 type MinConditionalOrderHeap []Order
 
 func (h MinConditionalOrderHeap) Len() int {
@@ -10,6 +15,9 @@ func (h MinConditionalOrderHeap) Len() int {
 
 func (h MinConditionalOrderHeap) Less(i, j int) bool {
 	x, y := h[i], h[j]
+
+	// If the trigger subticks are the same, sort by order hash.
+	// This is required for determinism in the case of multiple orders with the same trigger subticks.
 	if x.ConditionalOrderTriggerSubticks == y.ConditionalOrderTriggerSubticks {
 		xHash := x.GetOrderHash()
 		yHash := y.GetOrderHash()
@@ -34,6 +42,11 @@ func (h *MinConditionalOrderHeap) Pop() interface{} {
 	return x
 }
 
+// MaxConditionalOrderHeap is type alias for `[]Order` which implements "container/heap"
+// interface.
+//
+// This is a _MAX_ heap. Orders are compared by their `ConditionalOrderTriggerSubticks` field, and then by
+// their `OrderHash` if the trigger subticks are equal.
 type MaxConditionalOrderHeap []Order
 
 func (h MaxConditionalOrderHeap) Len() int {
@@ -42,6 +55,9 @@ func (h MaxConditionalOrderHeap) Len() int {
 
 func (h MaxConditionalOrderHeap) Less(i, j int) bool {
 	x, y := h[i], h[j]
+
+	// If the trigger subticks are the same, sort by order hash.
+	// This is required for determinism in the case of multiple orders with the same trigger subticks.
 	if x.ConditionalOrderTriggerSubticks == y.ConditionalOrderTriggerSubticks {
 		xHash := x.GetOrderHash()
 		yHash := y.GetOrderHash()

--- a/protocol/x/clob/types/untriggered_conditional_orders.go
+++ b/protocol/x/clob/types/untriggered_conditional_orders.go
@@ -1,0 +1,67 @@
+package types
+
+import "bytes"
+
+type MinConditionalOrderHeap []Order
+
+func (h MinConditionalOrderHeap) Len() int {
+	return len(h)
+}
+
+func (h MinConditionalOrderHeap) Less(i, j int) bool {
+	x, y := h[i], h[j]
+	if x.ConditionalOrderTriggerSubticks == y.ConditionalOrderTriggerSubticks {
+		xHash := x.GetOrderHash()
+		yHash := y.GetOrderHash()
+		return bytes.Compare(xHash[:], yHash[:]) == -1
+	}
+	return x.ConditionalOrderTriggerSubticks < y.ConditionalOrderTriggerSubticks
+}
+
+func (h MinConditionalOrderHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *MinConditionalOrderHeap) Push(x interface{}) {
+	*h = append(*h, x.(Order))
+}
+
+func (h *MinConditionalOrderHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+type MaxConditionalOrderHeap []Order
+
+func (h MaxConditionalOrderHeap) Len() int {
+	return len(h)
+}
+
+func (h MaxConditionalOrderHeap) Less(i, j int) bool {
+	x, y := h[i], h[j]
+	if x.ConditionalOrderTriggerSubticks == y.ConditionalOrderTriggerSubticks {
+		xHash := x.GetOrderHash()
+		yHash := y.GetOrderHash()
+		return bytes.Compare(xHash[:], yHash[:]) == -1
+	}
+	return x.ConditionalOrderTriggerSubticks > y.ConditionalOrderTriggerSubticks
+}
+
+func (h MaxConditionalOrderHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *MaxConditionalOrderHeap) Push(x interface{}) {
+	*h = append(*h, x.(Order))
+}
+
+func (h *MaxConditionalOrderHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/protocol/x/clob/types/untriggered_conditional_orders_test.go
+++ b/protocol/x/clob/types/untriggered_conditional_orders_test.go
@@ -1,0 +1,99 @@
+package types_test
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/typ.v4/slices"
+)
+
+func TestMinHeap(t *testing.T) {
+	for i := 0; i < 100_000; i++ {
+		orders := []types.Order{
+			constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50001,
+			constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49995,
+			constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49999,
+			constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50005,
+			constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Buy05BTC_Price50000_GTBT10_SL_50003_FOK,
+
+			// conditional orders with the same trigger subticks.
+			constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
+			constants.ConditionalOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
+		}
+		slices.Shuffle(orders)
+
+		h := types.MinConditionalOrderHeap(orders)
+		heap.Init(&h)
+
+		heap.Push(&h, constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50300)
+		heap.Push(&h, constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49700)
+
+		actual := make([]types.Order, 0)
+		for h.Len() > 0 {
+			actual = append(actual, heap.Pop(&h).(types.Order))
+		}
+
+		require.Equal(
+			t,
+			[]types.Order{
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49700,
+				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49995,
+				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49999,
+				constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
+				constants.ConditionalOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50001,
+				constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Buy05BTC_Price50000_GTBT10_SL_50003_FOK,
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50005,
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50300,
+			},
+			actual,
+		)
+	}
+}
+
+func TestMaxHeap(t *testing.T) {
+	for i := 0; i < 100_000; i++ {
+		orders := []types.Order{
+			constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50001,
+			constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49995,
+			constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49999,
+			constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50005,
+			constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Buy05BTC_Price50000_GTBT10_SL_50003_FOK,
+
+			// conditional orders with the same trigger subticks.
+			constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
+			constants.ConditionalOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
+		}
+		slices.Shuffle(orders)
+
+		h := types.MaxConditionalOrderHeap(orders)
+		heap.Init(&h)
+
+		heap.Push(&h, constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50300)
+		heap.Push(&h, constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49700)
+
+		actual := make([]types.Order, 0)
+		for h.Len() > 0 {
+			actual = append(actual, heap.Pop(&h).(types.Order))
+		}
+
+		require.Equal(
+			t,
+			[]types.Order{
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50300,
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50005,
+				constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Buy05BTC_Price50000_GTBT10_SL_50003_FOK,
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50001,
+				constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
+				constants.ConditionalOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
+				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49999,
+				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49995,
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49700,
+			},
+			actual,
+		)
+	}
+}


### PR DESCRIPTION
### Changelist
- implement max and min heap for untriggered conditional orders

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
