### PR TITLE
Update default postgres options for tables

### DIFF
--- a/indexer/packages/postgres/src/stores/fill-table.ts
+++ b/indexer/packages/postgres/src/stores/fill-table.ts
@@ -498,7 +498,7 @@ export async function getOpenSizeWithFundingIndex(
 export async function getClobPairs(
   subaccountId: string,
   effectiveBeforeOrAtHeight: string,
-  options: Options = {},
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
 ): Promise<string[]> {
   const baseQuery: QueryBuilder<FillModel> = setupBaseQuery<
     FillModel>(

--- a/indexer/packages/postgres/src/stores/order-table.ts
+++ b/indexer/packages/postgres/src/stores/order-table.ts
@@ -253,7 +253,7 @@ export async function findById(
 export async function findBySubaccountIdAndClobPair(
   subaccountId: string,
   clobPairId: string,
-  options: Options = {},
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
 ): Promise<OrderFromDatabase[]> {
   const baseQuery: QueryBuilder<OrderModel> = setupBaseQuery<OrderModel>(
     OrderModel,
@@ -271,7 +271,7 @@ export async function findBySubaccountIdAndClobPairAfterHeight(
   subaccountId: string,
   clobPairId: string,
   height: number,
-  options: Options = {},
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
 ): Promise<OrderFromDatabase[]> {
   const baseQuery: QueryBuilder<OrderModel> = setupBaseQuery<OrderModel>(
     OrderModel,

--- a/indexer/packages/postgres/src/stores/perpetual-position-table.ts
+++ b/indexer/packages/postgres/src/stores/perpetual-position-table.ts
@@ -232,7 +232,7 @@ export async function findOpenPositionsForSubaccounts(
 export async function closePosition(
   existingPosition: PerpetualPositionFromDatabase,
   perpetualPositionCloseObject: PerpetualPositionCloseObject,
-  options: Options = {},
+  options: Options = { txId: undefined },
 ): Promise<PerpetualPositionFromDatabase | undefined> {
   const updateObject: PerpetualPositionUpdateObject = closePositionUpdateObject(
     existingPosition,
@@ -315,7 +315,7 @@ export async function getOpenInterestLong(perpetualMarketIds: string[]): Promise
 
 export async function bulkCreate(
   positions: PerpetualPositionCreateObject[],
-  options: Options = {},
+  options: Options = { txId: undefined },
 ): Promise<PerpetualPositionFromDatabase[]> {
   const perpetualPositionsToCreate:
   PerpetualPositionCreateObject[] = _.map(positions, (position: PerpetualPositionCreateObject) => {
@@ -349,7 +349,7 @@ export async function bulkCreate(
  */
 export async function bulkUpdateSubaccountFields(
   positions: PerpetualPositionSubaccountUpdateObject[],
-  options: Options = {},
+  options: Options = { txId: undefined },
 ): Promise<void> {
   if (positions.length === 0) {
     return;

--- a/indexer/packages/postgres/src/stores/subaccount-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-table.ts
@@ -105,7 +105,7 @@ export async function findAll(
 
 export async function getSubaccountsWithTransfers(
   createdBeforeOrAtHeight: string,
-  options: Options = {},
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
 ): Promise<SubaccountFromDatabase[]> {
   const queryString: string = `
     SELECT *


### PR DESCRIPTION
### Changelist
Update default postgres options for tables. Set to DEFAULT_POSTGRES_OPTIONS for all read operations and `{ txId: undefined }` for all write operations

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
