### PR TITLE
Fix Dockerfile, add bintuils-gold.

### DIFF
--- a/protocol/Dockerfile
+++ b/protocol/Dockerfile
@@ -13,7 +13,7 @@ FROM golang@sha256:${GOLANG_1_21_ALPINE_DIGEST} as builder
 ARG VERSION
 ARG COMMIT
 
-RUN set -eux; apk add --no-cache ca-certificates build-base; apk add git linux-headers bash
+RUN set -eux; apk add --no-cache ca-certificates build-base; apk add git linux-headers bash binutils-gold
 
 # Download go dependencies
 WORKDIR /dydxprotocol


### PR DESCRIPTION
### Changelist
Add `bintutils-gold` to the builder image as indicated by this [open issue](https://github.com/golang/go/issues/22040) on golang to fix issues when building the image locally on arm64.

### Test Plan
Built docker image locally (on arm64).

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
