### PR TITLE
Disable `MsgCancelProposal` 

### DIFF
--- a/protocol/app/msgs/normal_msgs.go
+++ b/protocol/app/msgs/normal_msgs.go
@@ -91,8 +91,6 @@ var (
 		"/cosmos.feegrant.v1beta1.PeriodicAllowance":          nil,
 
 		// gov
-		"/cosmos.gov.v1.MsgCancelProposal":            &gov.MsgCancelProposal{},
-		"/cosmos.gov.v1.MsgCancelProposalResponse":    nil,
 		"/cosmos.gov.v1.MsgDeposit":                   &gov.MsgDeposit{},
 		"/cosmos.gov.v1.MsgDepositResponse":           nil,
 		"/cosmos.gov.v1.MsgVote":                      &gov.MsgVote{},

--- a/protocol/app/msgs/normal_msgs_test.go
+++ b/protocol/app/msgs/normal_msgs_test.go
@@ -75,8 +75,6 @@ func TestNormalMsgs_Key(t *testing.T) {
 		"/cosmos.feegrant.v1beta1.PeriodicAllowance",
 
 		// gov
-		"/cosmos.gov.v1.MsgCancelProposal",
-		"/cosmos.gov.v1.MsgCancelProposalResponse",
 		"/cosmos.gov.v1.MsgDeposit",
 		"/cosmos.gov.v1.MsgDepositResponse",
 		"/cosmos.gov.v1.MsgVote",

--- a/protocol/app/msgs/unsupported_msgs.go
+++ b/protocol/app/msgs/unsupported_msgs.go
@@ -2,6 +2,7 @@ package msgs
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govbeta "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
 )
@@ -10,6 +11,10 @@ var (
 	// UnsupportedMsgSamples are msgs that are registered with the app, but are not supported.
 	UnsupportedMsgSamples = map[string]sdk.Msg{
 		// gov
+		// MsgCancelProposal is not allowed by protocol, due to it's potential for abuse.
+		"/cosmos.gov.v1.MsgCancelProposal":         &gov.MsgCancelProposal{},
+		"/cosmos.gov.v1.MsgCancelProposalResponse": nil,
+		// These are deprecated/legacy msgs that we should not support.
 		"/cosmos.gov.v1beta1.MsgSubmitProposal":         &govbeta.MsgSubmitProposal{},
 		"/cosmos.gov.v1beta1.MsgSubmitProposalResponse": nil,
 

--- a/protocol/app/msgs/unsupported_msgs_test.go
+++ b/protocol/app/msgs/unsupported_msgs_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestUnsupportedMsgSamples_Key(t *testing.T) {
 	expectedMsgs := []string{
+		"/cosmos.gov.v1.MsgCancelProposal",
+		"/cosmos.gov.v1.MsgCancelProposalResponse",
 		"/cosmos.gov.v1beta1.MsgSubmitProposal",
 		"/cosmos.gov.v1beta1.MsgSubmitProposalResponse",
 

--- a/protocol/lib/ante/unsupported_msgs.go
+++ b/protocol/lib/ante/unsupported_msgs.go
@@ -2,6 +2,7 @@ package ante
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govbeta "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
 )
@@ -16,7 +17,8 @@ func IsUnsupportedMsg(msg sdk.Msg) bool {
 		*icacontrollertypes.MsgRegisterInterchainAccount,
 		// ------- CosmosSDK default modules
 		// gov
-		*govbeta.MsgSubmitProposal:
+		*govbeta.MsgSubmitProposal,
+		*gov.MsgCancelProposal:
 		return true
 	}
 	return false


### PR DESCRIPTION
### Changelist
- Disable `MsgCancelProposal` which was a new message introduced in Cosmos SDK 0.50 (Context [here](https://www.notion.so/dydx/AC-Priv-Genesis-Parameters-d2321636dd494ee49cc95b7825cbbc98?pvs=4#2490f3813f944d3e9baac8633e240e8a))

### Test Plan


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
