### PR TITLE
[CORE-850] Bump Cosmos-SDK version for updated default gov parameters

### DIFF
--- a/protocol/app/testdata/default_genesis_state.json
+++ b/protocol/app/testdata/default_genesis_state.json
@@ -264,10 +264,10 @@
       "threshold": "0.500000000000000000",
       "veto_threshold": "0.334000000000000000",
       "min_initial_deposit_ratio": "0.000000000000000000",
-      "proposal_cancel_ratio": "0.500000000000000000",
+      "proposal_cancel_ratio": "1.000000000000000000",
       "proposal_cancel_dest": "",
       "expedited_voting_period": "86400s",
-      "expedited_threshold": "0.667000000000000000",
+      "expedited_threshold": "0.750000000000000000",
       "expedited_min_deposit": [
         {
           "denom": "stake",

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -411,7 +411,7 @@ replace (
 	// Use dYdX fork of CometBFT
 	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240122193240-cddd98eb4f4d
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240126201553-f1da3a9865bb
 )
 
 replace (

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -527,8 +527,8 @@ github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQx
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8 h1:zmH6go7DRhFcQHoiN/rQ1INaAelp01VUPUTSqSDJsAU=
 github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8/go.mod h1:KQ8mOea6U2satQbGe2WjxBopa8mGgHatMKS9sQsJ6uY=
-github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240122193240-cddd98eb4f4d h1:rdsAzWhPJprx72jbl++E5gsljM76bwW7z799HtLX8ak=
-github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240122193240-cddd98eb4f4d/go.mod h1:y+5fRLbztsvx6GHBVXPlgM51ZpuNd8M7y4YEAQNnTPU=
+github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240126201553-f1da3a9865bb h1:pL998nZ1vEbER/66yiCjoFFoYDeWNyKbSoR481eHU/I=
+github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240126201553-f1da3a9865bb/go.mod h1:y+5fRLbztsvx6GHBVXPlgM51ZpuNd8M7y4YEAQNnTPU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=

--- a/protocol/testutil/constants/genesis.go
+++ b/protocol/testutil/constants/genesis.go
@@ -825,13 +825,13 @@ const GenesisState = `{
           }
         ],
         "min_initial_deposit_ratio": "0.000000000000000000",
-        "proposal_cancel_ratio": "0.500000000000000000",
+        "proposal_cancel_ratio": "1.000000000000000000",
         "quorum": "0.334000000000000000",
         "threshold": "0.500000000000000000",
         "veto_threshold": "0.334000000000000000",
 		"min_deposit_ratio": "0.010000000000000000",
         "expedited_voting_period": "86400s",
-        "expedited_threshold": "0.667000000000000000",
+        "expedited_threshold": "0.750000000000000000",
         "expedited_min_deposit": [
           {
             "amount": "50000000",


### PR DESCRIPTION
### Changelist
- Bump `cosmos-sdk` fork version which updates default gov parameters as part of state migration

### Test Plan
No easy way to test this currently, except for a container test for `v4.0.0` upgrade discussed [here](https://dydx-team.slack.com/archives/C0586UVB6J1/p1706303069661969?thread_ts=1703004791.136919&cid=C0586UVB6J1)

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
