### PR TITLE
[IND-545]: Batch Process Vulcan messages

### DIFF
--- a/indexer/packages/kafka/__tests__/consumer.test.ts
+++ b/indexer/packages/kafka/__tests__/consumer.test.ts
@@ -1,5 +1,5 @@
 import {
-  consumer, startConsumer, addOnMessageFunction, stopConsumer,
+  consumer, startConsumer, updateOnMessageFunction, stopConsumer,
 } from '../src/consumer';
 import { producer } from '../src/producer';
 import { createKafkaMessage } from './helpers/kafka';
@@ -26,7 +26,7 @@ describe.skip('consumer', () => {
 
   it('is consuming message', async () => {
     const onMessageFn: (topic: string, message: KafkaMessage) => Promise<void> = jest.fn();
-    addOnMessageFunction(onMessageFn);
+    updateOnMessageFunction(onMessageFn);
     const kafkaMessage: KafkaMessage = createKafkaMessage(null);
 
     await producer.send({

--- a/indexer/packages/kafka/src/config.ts
+++ b/indexer/packages/kafka/src/config.ts
@@ -18,10 +18,10 @@ export const kafkaConfigSchema = {
     default: 'localhost:9092',
     requireInEnv: [NodeEnv.PRODUCTION, NodeEnv.STAGING],
   }),
-  KAFKA_CONNECTION_TIMEOUT_MS: parseInteger({ default: 5000 }),
-  KAFKA_SESSION_TIMEOUT_MS: parseInteger({ default: 60000 }),
-  KAFKA_REBALANCE_TIMEOUT_MS: parseInteger({ default: 50000 }),
-  KAFKA_HEARTBEAT_INTERVAL_MS: parseInteger({ default: 5000 }),
+  KAFKA_CONNECTION_TIMEOUT_MS: parseInteger({ default: 5_000 }),
+  KAFKA_SESSION_TIMEOUT_MS: parseInteger({ default: 60_000 }),
+  KAFKA_REBALANCE_TIMEOUT_MS: parseInteger({ default: 50_000 }),
+  KAFKA_HEARTBEAT_INTERVAL_MS: parseInteger({ default: 5_000 }),
   KAFKA_CONCURRENT_PARTITIONS: parseInteger({ default: 1 }),
   // If true, consumers will have unique group ids, and SERVICE_NAME will be a common prefix for
   // the consumer group ids.

--- a/indexer/packages/kafka/src/config.ts
+++ b/indexer/packages/kafka/src/config.ts
@@ -21,7 +21,7 @@ export const kafkaConfigSchema = {
   KAFKA_CONNECTION_TIMEOUT_MS: parseInteger({ default: 5000 }),
   KAFKA_SESSION_TIMEOUT_MS: parseInteger({ default: 60000 }),
   KAFKA_REBALANCE_TIMEOUT_MS: parseInteger({ default: 50000 }),
-  KAFKA_HEARTBEAT_INTERVAL_MS: parseInteger({ default: 2000 }),
+  KAFKA_HEARTBEAT_INTERVAL_MS: parseInteger({ default: 5000 }),
   KAFKA_CONCURRENT_PARTITIONS: parseInteger({ default: 1 }),
   // If true, consumers will have unique group ids, and SERVICE_NAME will be a common prefix for
   // the consumer group ids.

--- a/indexer/services/ender/src/helpers/kafka/kafka-controller.ts
+++ b/indexer/services/ender/src/helpers/kafka/kafka-controller.ts
@@ -20,9 +20,9 @@ export async function connect(): Promise<void> {
     fromBeginning: true,
   });
 
-  updateOnMessageFunction((_topic: string, message: KafkaMessage): Promise<void> => {
-    return onMessage(message);
-  });
+  updateOnMessageFunction(
+    (_topic: string, message: KafkaMessage): Promise<void> => onMessage(message),
+  );
 
   logger.info({
     at: 'consumers#connect',

--- a/indexer/services/ender/src/helpers/kafka/kafka-controller.ts
+++ b/indexer/services/ender/src/helpers/kafka/kafka-controller.ts
@@ -1,6 +1,6 @@
 import { logger } from '@dydxprotocol-indexer/base';
 import {
-  consumer, producer, TO_ENDER_TOPIC, addOnMessageFunction,
+  consumer, producer, TO_ENDER_TOPIC, updateOnMessageFunction,
 } from '@dydxprotocol-indexer/kafka';
 import { KafkaMessage } from 'kafkajs';
 
@@ -20,7 +20,7 @@ export async function connect(): Promise<void> {
     fromBeginning: true,
   });
 
-  addOnMessageFunction((_topic: string, message: KafkaMessage): Promise<void> => {
+  updateOnMessageFunction((_topic: string, message: KafkaMessage): Promise<void> => {
     return onMessage(message);
   });
 

--- a/indexer/services/scripts/src/print-block.ts
+++ b/indexer/services/scripts/src/print-block.ts
@@ -1,6 +1,6 @@
 import { logger, wrapBackgroundTask } from '@dydxprotocol-indexer/base';
 import {
-  addOnMessageFunction,
+  updateOnMessageFunction,
   consumer,
   producer,
   startConsumer,
@@ -66,7 +66,7 @@ export async function connect(height: number): Promise<void> {
     fromBeginning: true,
   });
 
-  addOnMessageFunction((_topic: string, message: KafkaMessage): Promise<void> => {
+  updateOnMessageFunction((_topic: string, message: KafkaMessage): Promise<void> => {
     return printMessageAtHeight(message, height);
   });
 

--- a/indexer/services/socks/src/lib/message-forwarder.ts
+++ b/indexer/services/socks/src/lib/message-forwarder.ts
@@ -4,7 +4,7 @@ import {
   InfoObject,
   safeJsonStringify,
 } from '@dydxprotocol-indexer/base';
-import { addOnMessageFunction } from '@dydxprotocol-indexer/kafka';
+import { updateOnMessageFunction } from '@dydxprotocol-indexer/kafka';
 import { KafkaMessage } from 'kafkajs';
 import _ from 'lodash';
 
@@ -63,7 +63,7 @@ export class MessageForwarder {
 
     // Kafkajs requires the function passed into `eachMessage` be an async function.
     // eslint-disable-next-line @typescript-eslint/require-await
-    addOnMessageFunction(async (topic, message): Promise<void> => {
+    updateOnMessageFunction(async (topic, message): Promise<void> => {
       return this.onMessage(topic, message);
     });
 

--- a/indexer/services/vulcan/src/config.ts
+++ b/indexer/services/vulcan/src/config.ts
@@ -7,7 +7,6 @@ import {
   parseSchema,
   baseConfigSchema,
   parseBoolean,
-  ONE_SECOND_IN_MILLISECONDS,
 } from '@dydxprotocol-indexer/base';
 import {
   kafkaConfigSchema,
@@ -26,7 +25,7 @@ export const configSchema = {
     default: 20,
   }),
   KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS: parseNumber({
-    default: 3 * ONE_SECOND_IN_MILLISECONDS,
+    default: 3_000,
   }),
   FLUSH_KAFKA_MESSAGES_INTERVAL_MS: parseNumber({
     default: 10,

--- a/indexer/services/vulcan/src/config.ts
+++ b/indexer/services/vulcan/src/config.ts
@@ -7,6 +7,7 @@ import {
   parseSchema,
   baseConfigSchema,
   parseBoolean,
+  ONE_SECOND_IN_MILLISECONDS,
 } from '@dydxprotocol-indexer/base';
 import {
   kafkaConfigSchema,
@@ -20,6 +21,13 @@ export const configSchema = {
   ...kafkaConfigSchema,
   ...redisConfigSchema,
 
+  BATCH_PROCESSING_ENABLED: parseBoolean({ default: true }),
+  KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY: parseNumber({
+    default: 20,
+  }),
+  KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS: parseNumber({
+    default: 3 * ONE_SECOND_IN_MILLISECONDS,
+  }),
   FLUSH_KAFKA_MESSAGES_INTERVAL_MS: parseNumber({
     default: 10,
   }),

--- a/indexer/services/vulcan/src/config.ts
+++ b/indexer/services/vulcan/src/config.ts
@@ -21,9 +21,6 @@ export const configSchema = {
   ...redisConfigSchema,
 
   BATCH_PROCESSING_ENABLED: parseBoolean({ default: true }),
-  KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY: parseNumber({
-    default: 20,
-  }),
   KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS: parseNumber({
     default: 3_000,
   }),

--- a/indexer/services/vulcan/src/index.ts
+++ b/indexer/services/vulcan/src/index.ts
@@ -37,7 +37,7 @@ async function startService(): Promise<void> {
     connectToRedis(),
   ]);
 
-  await startConsumer();
+  await startConsumer(config.BATCH_PROCESSING_ENABLED);
 
   logger.info({
     at: 'index#start',

--- a/indexer/services/vulcan/src/lib/on-batch.ts
+++ b/indexer/services/vulcan/src/lib/on-batch.ts
@@ -1,0 +1,92 @@
+import { logger, stats } from '@dydxprotocol-indexer/base';
+import {
+  Batch,
+  EachBatchPayload,
+  KafkaMessage,
+} from 'kafkajs';
+
+import config from '../config';
+import { onMessage } from './on-message';
+
+export async function onBatch(
+  payload: EachBatchPayload,
+): Promise<void> {
+  const batch: Batch = payload.batch;
+  const topic: string = batch.topic;
+  const partition: string = batch.partition.toString();
+  const metricTags: Record<string, string> = { topic, partition };
+  if (batch.isEmpty()) {
+    logger.error({
+      at: 'on-batch#onBatch',
+      message: 'Empty batch',
+      ...metricTags,
+    });
+    return;
+  }
+
+  const startTime: number = Date.now();
+  const firstMessageTimestamp: number = Number(batch.messages[0].timestamp);
+  const batchTimeInQueue: number = startTime - firstMessageTimestamp;
+  const batchInfo = {
+    firstMessageTimestamp: new Date(firstMessageTimestamp).toISOString(),
+    batchTimeInQueue,
+    messagesInBatch: batch.messages.length,
+    firstOffset: batch.firstOffset(),
+    lastOffset: batch.lastOffset(),
+    ...metricTags,
+  };
+
+  logger.info({
+    at: 'on-batch#onBatch',
+    message: 'Received batch',
+    ...batchInfo,
+  });
+  stats.timing(
+    'vulcan.batch_time_in_queue',
+    batchTimeInQueue,
+    metricTags,
+  );
+
+  let lastCommitTime: number = startTime;
+  for (let i = 0; i < batch.messages.length; i++) {
+    const message: KafkaMessage = batch.messages[i];
+    await onMessage(message);
+
+    // Commit every KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS to reduce number of roundtrips, and
+    // also prevent disconnecting from the broker due to inactivity.
+    const now: number = Date.now();
+    if (now - lastCommitTime > config.KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS) {
+      logger.info({
+        at: 'on-batch#onBatch',
+        message: 'Committing offsets and sending heart beat',
+        ...batchInfo,
+      });
+      payload.resolveOffset(message.offset);
+      await Promise.all([
+        payload.heartbeat(),
+        // commitOffsetsIfNecessary will respect autoCommitThreshold and will not commit if
+        // fewer messages than the threshold have been processed since the last commit.
+        payload.commitOffsetsIfNecessary(),
+      ]);
+      lastCommitTime = now;
+    }
+  }
+
+  const batchProcessingTime: number = Date.now() - startTime;
+  logger.info({
+    at: 'on-batch#onBatch',
+    message: 'Finished Processing Batch',
+    batchProcessingTime,
+    ...batchInfo,
+  });
+  stats.timing(
+    'vulcan.batch_processing_time',
+    batchProcessingTime,
+    metricTags,
+  );
+  stats.gauge(
+    'vulcan.batch_size',
+    batch.messages.length,
+    metricTags,
+  );
+}

--- a/indexer/services/vulcan/src/lib/on-batch.ts
+++ b/indexer/services/vulcan/src/lib/on-batch.ts
@@ -84,7 +84,7 @@ export async function onBatch(
     batchProcessingTime,
     metricTags,
   );
-  stats.gauge(
+  stats.timing(
     'vulcan.batch_size',
     batch.messages.length,
     metricTags,


### PR DESCRIPTION
### Changelist
Batch Process Vulcan messages. It doesn't seem like this change makes much of an impact on processing, I believe it's because Vulcan is reading from multiple partitions and the benefit would be improved if there the same number of partitions as instances of vulcan.

See research [here](https://www.notion.so/dydx/Vulcan-Batch-Processing-646a032e6d2c4a939fe6016f4d8e6516?pvs=4)

### Test Plan
Tested in Staging and internal mainnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
