### PR TITLE
[CORE-824] Add upgrade handler for ratelimit keeper

### DIFF
--- a/protocol/app/upgrades.go
+++ b/protocol/app/upgrades.go
@@ -29,6 +29,7 @@ func (app *App) setupUpgradeHandlers() {
 		v4_0_0.CreateUpgradeHandler(
 			app.ModuleManager,
 			app.configurator,
+			app.RatelimitKeeper,
 		),
 	)
 }

--- a/protocol/app/upgrades/v4.0.0/upgrade.go
+++ b/protocol/app/upgrades/v4.0.0/upgrade.go
@@ -7,17 +7,21 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+
+	ratelimitkeeper "github.com/dydxprotocol/v4-chain/protocol/x/ratelimit/keeper"
+	ratelimittypes "github.com/dydxprotocol/v4-chain/protocol/x/ratelimit/types"
 )
 
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
+	rateLimitKeepr ratelimitkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
 		sdkCtx.Logger().Info(fmt.Sprintf("Running %s Upgrade...", UpgradeName))
 
-		// TODO(CORE-824): Initialize ratelimit module params to desired state.
+		rateLimitKeepr.SetLimitParams(sdkCtx, ratelimittypes.DefaultUsdcRateLimitParams())
 
 		return mm.RunMigrations(ctx, configurator, vm)
 	}

--- a/protocol/app/upgrades/v4.0.0/upgrade.go
+++ b/protocol/app/upgrades/v4.0.0/upgrade.go
@@ -21,7 +21,12 @@ func CreateUpgradeHandler(
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
 		sdkCtx.Logger().Info(fmt.Sprintf("Running %s Upgrade...", UpgradeName))
 
-		rateLimitKeepr.SetLimitParams(sdkCtx, ratelimittypes.DefaultUsdcRateLimitParams())
+		if err := rateLimitKeepr.SetLimitParams(
+			sdkCtx,
+			ratelimittypes.DefaultUsdcRateLimitParams(),
+		); err != nil {
+			panic(fmt.Sprintf("failed to set default x/ratelimit params: %s", err))
+		}
 
 		return mm.RunMigrations(ctx, configurator, vm)
 	}


### PR DESCRIPTION
### Changelist
Set default rate limit params for x/ratelimit in upgrade handler. 

### Test Plan
No easy way to test this right now except for an upgrade container test discussed [here](https://dydx-team.slack.com/archives/C0586UVB6J1/p1706303069661969?thread_ts=1703004791.136919&cid=C0586UVB6J1)

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
