### PR TITLE
Fix Aggregate Historical Trading rewards and always use generated id in tables

### DIFF
--- a/indexer/packages/postgres/src/stores/candle-table.ts
+++ b/indexer/packages/postgres/src/stores/candle-table.ts
@@ -111,8 +111,8 @@ export async function create(
   return CandleModel.query(
     Transaction.get(options.txId),
   ).insert({
-    id: uuid(candle.startedAt, candle.ticker, candle.resolution),
     ...candle,
+    id: uuid(candle.startedAt, candle.ticker, candle.resolution),
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/fill-table.ts
+++ b/indexer/packages/postgres/src/stores/fill-table.ts
@@ -170,8 +170,8 @@ export async function create(
   return FillModel.query(
     Transaction.get(options.txId),
   ).insert({
-    id: uuid(fillToCreate.eventId, fillToCreate.liquidity),
     ...fillToCreate,
+    id: uuid(fillToCreate.eventId, fillToCreate.liquidity),
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
+++ b/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
@@ -122,12 +122,12 @@ export async function create(
   return FundingIndexUpdatesModel.query(
     Transaction.get(options.txId),
   ).insert({
+    ...fundingIndexUpdateToCreate,
     id: uuid(
       fundingIndexUpdateToCreate.effectiveAtHeight,
       fundingIndexUpdateToCreate.eventId,
       fundingIndexUpdateToCreate.perpetualId,
     ),
-    ...fundingIndexUpdateToCreate,
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/oracle-price-table.ts
+++ b/indexer/packages/postgres/src/stores/oracle-price-table.ts
@@ -117,8 +117,8 @@ export async function create(
   return OraclePriceModel.query(
     Transaction.get(options.txId),
   ).insert({
-    id: uuid(oraclePriceToCreate.marketId, oraclePriceToCreate.effectiveAtHeight),
     ...oraclePriceToCreate,
+    id: uuid(oraclePriceToCreate.marketId, oraclePriceToCreate.effectiveAtHeight),
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/order-table.ts
+++ b/indexer/packages/postgres/src/stores/order-table.ts
@@ -199,13 +199,13 @@ export async function create(
   return OrderModel.query(
     Transaction.get(options.txId),
   ).insert({
+    ...orderToCreate,
     id: uuid(
       orderToCreate.subaccountId,
       orderToCreate.clientId,
       orderToCreate.clobPairId,
       orderToCreate.orderFlags,
     ),
-    ...orderToCreate,
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/perpetual-position-table.ts
+++ b/indexer/packages/postgres/src/stores/perpetual-position-table.ts
@@ -148,8 +148,8 @@ export async function create(
   return PerpetualPositionModel.query(
     Transaction.get(options.txId),
   ).insert({
-    id: uuid(perpetualPositionToCreate.subaccountId, perpetualPositionToCreate.openEventId),
     ...perpetualPositionToCreate,
+    id: uuid(perpetualPositionToCreate.subaccountId, perpetualPositionToCreate.openEventId),
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
+++ b/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
@@ -142,8 +142,8 @@ export async function create(
   return PnlTicksModel.query(
     Transaction.get(options.txId),
   ).insert({
-    id: uuid(pnlTicksToCreate.subaccountId, pnlTicksToCreate.createdAt),
     ...pnlTicksToCreate,
+    id: uuid(pnlTicksToCreate.subaccountId, pnlTicksToCreate.createdAt),
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/subaccount-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-table.ts
@@ -133,8 +133,8 @@ export async function create(
   return SubaccountModel.query(
     Transaction.get(options.txId),
   ).insert({
-    id: uuid(subaccountToCreate.address, subaccountToCreate.subaccountNumber),
     ...subaccountToCreate,
+    id: uuid(subaccountToCreate.address, subaccountToCreate.subaccountNumber),
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/tendermint-event-table.ts
+++ b/indexer/packages/postgres/src/stores/tendermint-event-table.ts
@@ -108,12 +108,12 @@ export async function create(
   return TendermintEventModel.query(
     Transaction.get(options.txId),
   ).insert({
+    ...tendermintEventToCreate,
     id: createEventId(
       tendermintEventToCreate.blockHeight,
       tendermintEventToCreate.transactionIndex,
       tendermintEventToCreate.eventIndex,
     ),
-    ...tendermintEventToCreate,
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/trading-reward-aggregation-table.ts
+++ b/indexer/packages/postgres/src/stores/trading-reward-aggregation-table.ts
@@ -137,12 +137,12 @@ export async function create(
   return TradingRewardAggregationModel.query(
     Transaction.get(options.txId),
   ).insert({
+    ...aggregationToCreate,
     id: uuid(
       aggregationToCreate.address,
       aggregationToCreate.period,
       aggregationToCreate.startedAtHeight,
     ),
-    ...aggregationToCreate,
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/trading-reward-table.ts
+++ b/indexer/packages/postgres/src/stores/trading-reward-table.ts
@@ -107,8 +107,8 @@ export async function create(
   return TradingRewardModel.query(
     Transaction.get(options.txId),
   ).insert({
-    id: uuid(tradingRewardToCreate.address, tradingRewardToCreate.blockHeight),
     ...tradingRewardToCreate,
+    id: uuid(tradingRewardToCreate.address, tradingRewardToCreate.blockHeight),
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/transaction-table.ts
+++ b/indexer/packages/postgres/src/stores/transaction-table.ts
@@ -98,8 +98,8 @@ export async function create(
   return TransactionModel.query(
     Transaction.get(options.txId),
   ).insert({
-    id: uuid(transactionToCreate.blockHeight, transactionToCreate.transactionIndex),
     ...transactionToCreate,
+    id: uuid(transactionToCreate.blockHeight, transactionToCreate.transactionIndex),
   }).returning('*');
 }
 

--- a/indexer/packages/postgres/src/stores/transfer-table.ts
+++ b/indexer/packages/postgres/src/stores/transfer-table.ts
@@ -406,6 +406,7 @@ export async function create(
   return TransferModel.query(
     Transaction.get(options.txId),
   ).insert({
+    ...transferToCreate,
     id: uuid(
       transferToCreate.eventId,
       transferToCreate.assetId,
@@ -414,7 +415,6 @@ export async function create(
       transferToCreate.senderWalletAddress,
       transferToCreate.recipientWalletAddress,
     ),
-    ...transferToCreate,
   }).returning('*');
 }
 

--- a/indexer/services/roundtable/__tests__/tasks/aggregate-trading-rewards.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/aggregate-trading-rewards.test.ts
@@ -385,6 +385,11 @@ describe('aggregate-trading-rewards', () => {
           intervalToBeProcessed.start.toISO(),
           redisClient,
         ),
+        TradingRewardAggregationTable.create({
+          ...defaultCreatedTradingRewardAggregation,
+          startedAt: intervalToBeProcessed.start.minus({ days: 1 }).toISO(),
+          startedAtHeight: '1',
+        }),
       ]);
 
       const aggregateTradingReward: AggregateTradingReward = new AggregateTradingReward(
@@ -396,7 +401,7 @@ describe('aggregate-trading-rewards', () => {
         TradingRewardAggregationPeriod.DAILY,
         intervalToBeProcessed.end.toISO(),
       );
-      await validateNumberOfAggregations(1);
+      await validateNumberOfAggregations(2);
       await validateAggregationWithExpectedValue(defaultCreatedTradingRewardAggregation);
     });
 

--- a/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
+++ b/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
@@ -329,11 +329,14 @@ export class AggregateTradingReward {
   ): Promise<AggregationUpdateAndCreateObjects> {
     const tradingRewardAddresses: string[] = Object.keys(intervalTradingRewardsByAddress);
 
+    const startedAt: string = this.getStartedAt(interval);
+    const startedAtHeight: string = await this.getNextBlock(startedAt);
     const existingAggregateTradingRewards:
     TradingRewardAggregationFromDatabase[] = await runFuncWithTimingStat(
       TradingRewardAggregationTable.findAll({
         addresses: tradingRewardAddresses,
         period: this.period,
+        startedAtHeight,
       }, []),
       this.generateTimingStatsOptions('findAllExistingAggregations'),
     );
@@ -343,8 +346,6 @@ export class AggregateTradingReward {
       TradingRewardAggregationColumns.address,
     );
 
-    const startedAt: string = this.getStartedAt(interval);
-    const startedAtHeight: string = await this.getNextBlock(startedAt);
     const aggregateTradingRewardsToUpdate: TradingRewardAggregationUpdateObject[] = _.intersection(
       tradingRewardAddresses,
       Object.keys(existingAggregateTradingRewardsMap),


### PR DESCRIPTION
### Changelist
Fix Aggregate Historical Trading rewards and always use generated id in tables
- Since we did not query for existing `trading_reward_aggregations` with `startedAtHeight`, any existing trading aggregation for that address and period was found and we would attempt to update a `trading_reward_aggregations` that did not exist rather than create a new aggregation.
- Always use generated ids in tables instead of defaulting to the object that is passed in. This will prevent errors where the object contains an id that is incorrect is sent to the table. Instead of overwriting the incorrect id with the generated id, postgres would use the passed in id.

### Test Plan
Unit tests, will test in staging before merging

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
