### PR TITLE
[OTE-129] remove geoblocking from Indexer endpoints

### DIFF
--- a/indexer/services/comlink/src/controllers/api/v4/candles-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/candles-controller.ts
@@ -12,7 +12,6 @@ import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import { CheckLimitSchema, CheckTickerParamSchema } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import { candleToResponseObject } from '../../../request-helpers/request-transformer';
@@ -50,7 +49,6 @@ class CandleController extends Controller {
 
 router.get(
   '/perpetualMarkets/:ticker',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ...CheckLimitSchema,
   ...CheckTickerParamSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -17,7 +17,6 @@ import config from '../../../config';
 import { complianceProvider } from '../../../helpers/compliance/compliance-clients';
 import { create4xxResponse, handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import { getIpAddr } from '../../../lib/utils';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
@@ -101,7 +100,6 @@ class ComplianceController extends Controller {
 
 router.get(
   '/',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ...checkSchema({
     address: {

--- a/indexer/services/comlink/src/controllers/api/v4/height-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/height-controller.ts
@@ -8,7 +8,6 @@ import config from '../../../config';
 import { NotFoundError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { HeightResponse } from '../../../types';
 
@@ -33,7 +32,6 @@ class HeightController extends Controller {
 
 router.get(
   '/',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {

--- a/indexer/services/comlink/src/controllers/api/v4/historical-funding-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-funding-controller.ts
@@ -20,7 +20,6 @@ import config from '../../../config';
 import { NotFoundError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import { CheckEffectiveBeforeOrAtSchema, CheckLimitSchema, CheckTickerParamSchema } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
@@ -80,7 +79,6 @@ class HistoricalFundingController extends Controller {
 
 router.get(
   '/:ticker',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ...CheckLimitSchema,
   ...CheckTickerParamSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/orderbook-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orderbook-controller.ts
@@ -13,7 +13,6 @@ import { redisClient } from '../../../helpers/redis/redis-controller';
 import { NotFoundError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { OrderbookLevelsToResponseObject } from '../../../request-helpers/request-transformer';
@@ -53,7 +52,6 @@ class OrderbookController extends Controller {
 
 router.get(
   '/perpetualMarket/:ticker',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ...checkSchema({
     ticker: {

--- a/indexer/services/comlink/src/controllers/api/v4/perpetual-markets-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/perpetual-markets-controller.ts
@@ -25,7 +25,6 @@ import {
   handleControllerError,
 } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import { CheckLimitSchema, CheckTickerOptionalQuerySchema } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
@@ -113,7 +112,6 @@ class PerpetualMarketsController extends Controller {
 
 router.get(
   '/',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ...CheckLimitSchema,
   ...CheckTickerOptionalQuerySchema,

--- a/indexer/services/comlink/src/controllers/api/v4/sparklines-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/sparklines-controller.ts
@@ -21,7 +21,6 @@ import config from '../../../config';
 import { SPARKLINE_TIME_PERIOD_TO_LIMIT_MAP, SPARKLINE_TIME_PERIOD_TO_RESOLUTION_MAP } from '../../../lib/constants';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import { candlesToSparklineResponseObject } from '../../../request-helpers/request-transformer';
 import { SparklineResponseObject, SparklinesRequest, SparklineTimePeriod } from '../../../types';
@@ -59,7 +58,6 @@ class FillsController extends Controller {
 
 router.get(
   '/',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ...checkSchema({
     timePeriod: {

--- a/indexer/services/comlink/src/controllers/api/v4/time-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/time-controller.ts
@@ -4,7 +4,6 @@ import { Controller, Get, Route } from 'tsoa';
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { TimeResponse } from '../../../types';
 
@@ -26,7 +25,6 @@ class TimeController extends Controller {
 
 router.get(
   '/',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ExportResponseCodeStats({ controllerName }),
   (_req: express.Request, res: express.Response) => {

--- a/indexer/services/comlink/src/controllers/api/v4/trades-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/trades-controller.ts
@@ -23,7 +23,6 @@ import {
   handleControllerError,
 } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { rejectRestrictedCountries } from '../../../lib/restrict-countries';
 import { CheckLimitAndCreatedBeforeOrAtSchema } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
@@ -77,7 +76,6 @@ class TradesController extends Controller {
 
 router.get(
   '/perpetualMarket/:ticker',
-  rejectRestrictedCountries,
   rateLimiterMiddleware(getReqRateLimiter),
   ...CheckLimitAndCreatedBeforeOrAtSchema,
   ...checkSchema({


### PR DESCRIPTION
### Changelist

Remove geoblocking from Indexer endpoints:

- Compliance endpoints
- GetCandles
- GetHeight
- GetHistoricalFunding
- GetPerpetualMarket
- ListPerpetualMarkets
- GetSparkLines
- GetTime
- GetTrades

### Test Plan

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
