### PR TITLE
[STAB-32] Push CheckTx concurrency into protocol

### DIFF
--- a/protocol/app/ante.go
+++ b/protocol/app/ante.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -50,6 +51,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 // NewAnteDecoratorChain returns a list of AnteDecorators in the expected application chain ordering
 func NewAnteDecoratorChain(options HandlerOptions) []sdk.AnteDecorator {
 	return []sdk.AnteDecorator{
+		baseapp.NewLockAndCacheContextAnteDecorator(),
 		// Note: app-injected messages, and clob transactions don't require Gas fees.
 		libante.NewAppInjectedMsgAnteWrapper(
 			clobante.NewSingleMsgClobTxAnteWrapper(

--- a/protocol/app/ante_whitebox_test.go
+++ b/protocol/app/ante_whitebox_test.go
@@ -77,6 +77,7 @@ func TestAnteHandlerChainOrder_Valid(t *testing.T) {
 	decoratorTypes := humanReadableDecoratorTypes(decoratorChain)
 
 	expectedDecoratorTypes := []string{
+		"baseapp.lockAndCacheContextDecorator",
 		"ante.AppInjectedMsgAnteWrapper(ante.SingleMsgClobTxAnteWrapper(ante.SetUpContextDecorator))",
 		"ante.FreeInfiniteGasDecorator",
 		"ante.RejectExtensionOptionsDecorator",

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -417,7 +417,7 @@ replace (
 	// Use dYdX fork of CometBFT
 	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206213020-ef2fbbac2693
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206224621-ffeae5184c58
 )
 
 replace (

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -537,8 +537,8 @@ github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQx
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8 h1:zmH6go7DRhFcQHoiN/rQ1INaAelp01VUPUTSqSDJsAU=
 github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8/go.mod h1:KQ8mOea6U2satQbGe2WjxBopa8mGgHatMKS9sQsJ6uY=
-github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206213020-ef2fbbac2693 h1:FdOhkelNwqyXMP6JFJzi+d9A0cxGJEiieDIkDYtcCa4=
-github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206213020-ef2fbbac2693/go.mod h1:y+5fRLbztsvx6GHBVXPlgM51ZpuNd8M7y4YEAQNnTPU=
+github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206224621-ffeae5184c58 h1:3nW+id7dbHUv+RJB2pecjKtA0WWQr3oit4KrxBJ0+kw=
+github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206224621-ffeae5184c58/go.mod h1:y+5fRLbztsvx6GHBVXPlgM51ZpuNd8M7y4YEAQNnTPU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=


### PR DESCRIPTION
### Changelist
[STAB-32] Push CheckTx concurrency into protocol

This pushes locking slightly closer to the CLOB ante decorator hopefully allowing for protocol to control parallelism more finely in the future.

### Test Plan
Tests were added in the [Cosmos SDK fork PR](https://github.com/dydxprotocol/cosmos-sdk/pull/37) and there is this [existing concurrency test](https://github.com/dydxprotocol/v4-chain/blob/bc578353766af1b81ecfb93720b54d5890e4f96e/protocol/x/clob/e2e/app_test.go#L231) that is of note.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
