### PR TITLE
[CORE-854] Add licensing info in `x/ratelimit` and attributions to Stride

### DIFF
--- a/protocol/x/ratelimit/LICENSE
+++ b/protocol/x/ratelimit/LICENSE
@@ -1,0 +1,178 @@
+This module incorporates code from the x/ratelimit module from Stride Labs, which is subject to the following license.
+
+   Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/protocol/x/ratelimit/README.md
+++ b/protocol/x/ratelimit/README.md
@@ -1,8 +1,8 @@
-Attribution; Modification.
+<ins>**Attribution; Modification**.</ins>
 
-This module incorporates code from the Stride Labs /ratelimit module, which is subject to this License and has been modified by us.
- 
-The code from Stride Labs incorporated into this module includes code from Osmosis provided under this License.  
+This module incorporates code from the [Stride](https://github.com/Stride-Labs/stride)'s `x/ratelimit` [module](https://github.com/Stride-Labs/stride/tree/main/x/ratelimit), which is subject to [this License](https://github.com/Stride-Labs/stride?tab=Apache-2.0-1-ov-file#readme) and has been modified by us.
+
+The code from Stride Labs incorporated into this module includes code from [Osmosis](https://github.com/osmosis-labs/osmosis) provided under [this License](https://github.com/osmosis-labs/osmosis/blob/main/LICENSE).  
 
 Copyright for ratelimit public infrastructure attributed to 2022 Stride Labs, Inc. and 2021 Osmosis Foundation Ltd.
 

--- a/protocol/x/ratelimit/README.md
+++ b/protocol/x/ratelimit/README.md
@@ -1,6 +1,6 @@
 <ins>**Attribution; Modification**.</ins>
 
-This module incorporates code from the [Stride](https://github.com/Stride-Labs/stride)'s `x/ratelimit` [module](https://github.com/Stride-Labs/stride/tree/main/x/ratelimit), which is subject to [this License](https://github.com/Stride-Labs/stride?tab=Apache-2.0-1-ov-file#readme) and has been modified by us.
+This module incorporates code from [Stride](https://github.com/Stride-Labs/stride)'s `x/ratelimit` [module](https://github.com/Stride-Labs/stride/tree/main/x/ratelimit), which is subject to [this License](https://github.com/Stride-Labs/stride?tab=Apache-2.0-1-ov-file#readme) and has been modified by us.
 
 The code from Stride Labs incorporated into this module includes code from [Osmosis](https://github.com/osmosis-labs/osmosis) provided under [this License](https://github.com/osmosis-labs/osmosis/blob/main/LICENSE).  
 

--- a/protocol/x/ratelimit/README.md
+++ b/protocol/x/ratelimit/README.md
@@ -1,0 +1,15 @@
+Attribution; Modification.
+
+This module incorporates code from the Stride Labs /ratelimit module, which is subject to this License and has been modified by us.
+ 
+The code from Stride Labs incorporated into this module includes code from Osmosis provided under this License.  
+
+Copyright for ratelimit public infrastructure attributed to 2022 Stride Labs, Inc. and 2021 Osmosis Foundation Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/protocol/x/ratelimit/ibc_middleware.go
+++ b/protocol/x/ratelimit/ibc_middleware.go
@@ -1,9 +1,5 @@
 package ratelimit
 
-// TODO(CORE-854): Improve attribution message.
-// This file was written with reference to Stride's IBC Rate Limit implementation:
-// https://github.com/Stride-Labs/stride/blob/121f2ac5d2e5f8e406f89999410a49ea4277a552/x/ratelimit
-
 import (
 	"fmt"
 

--- a/protocol/x/ratelimit/keeper/packet.go
+++ b/protocol/x/ratelimit/keeper/packet.go
@@ -1,8 +1,8 @@
 package keeper
 
-// TODO(CORE-854): Improve attribution message.
-// This file was written with reference to Stride's IBC Rate Limit implementation:
-// https://github.com/Stride-Labs/stride/blob/121f2ac5d2e5f8e406f89999410a49ea4277a552/x/ratelimit
+// This file includes keeper methods used by the IBC middleware for processing IBC packets.
+// Re-uses/adapts Stride x/ratelimit implementation: https://github.com/Stride-Labs/stride/tree/4913e1dd1a/x/ratelimit
+// See v4-chain/protocol/x/ratelimit/LICENSE and v4-chain/protocol/x/ratelimit/README.md for licensing information.
 
 import (
 	"fmt"

--- a/protocol/x/ratelimit/util/ibc.go
+++ b/protocol/x/ratelimit/util/ibc.go
@@ -1,8 +1,8 @@
 package util
 
-// TODO(CORE-854): Improve attribution message.
-// This file re-uses similar utilities (with minor tweaking) Stride's IBC Rate Limit implementation:
-// https://github.com/Stride-Labs/stride/blob/121f2ac5d2e5f8e406f89999410a49ea4277a552/x/ratelimit
+// This file includes IBC utility methods used by the IBC middleware.
+// Re-uses/adapts Stride x/ratelimit implementation: https://github.com/Stride-Labs/stride/tree/4913e1dd1a/x/ratelimit
+// See v4-chain/protocol/x/ratelimit/LICENSE and v4-chain/protocol/x/ratelimit/README.md for licensing information.
 
 import (
 	"encoding/json"

--- a/protocol/x/ratelimit/util/ibc_test.go
+++ b/protocol/x/ratelimit/util/ibc_test.go
@@ -1,9 +1,5 @@
 package util_test
 
-// TODO(CORE-854): Improve attribution message.
-// This file re-uses similar utilities (with minor tweaking) Stride's IBC Rate Limit implementation:
-// https://github.com/Stride-Labs/stride/blob/121f2ac5d2e5f8e406f89999410a49ea4277a552/x/ratelimit
-
 import (
 	"bytes"
 	"crypto/sha256"

--- a/protocol/x/ratelimit/util/parse_denom.go
+++ b/protocol/x/ratelimit/util/parse_denom.go
@@ -1,9 +1,8 @@
 package util
 
-// TODO(CORE-854): Improve attribution message.
-// Denom-parsing utility functions are copied over from Stride's implementation:
-// https://github.com/Stride-Labs/stride/blob/eb3564c/x/ratelimit/keeper/packet.go#L40
-
+// This file includes utility methods used by the IBC middleware for parsing IBC denoms.
+// Re-uses Stride x/ratelimit implementation: https://github.com/Stride-Labs/stride/tree/4913e1dd1a/x/ratelimit
+// See v4-chain/protocol/x/ratelimit/LICENSE and v4-chain/protocol/x/ratelimit/README.md for licensing information.
 import (
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"


### PR DESCRIPTION
### Changelist
Add licensing info in `x/ratelimit` and attributions to Stride. Changes will be backported to `v4.x`

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
