### PR TITLE
[CT-82] Split equity tier validation for short term and stateful orders

### DIFF
--- a/protocol/mocks/MemClobKeeper.go
+++ b/protocol/mocks/MemClobKeeper.go
@@ -387,8 +387,22 @@ func (_m *MemClobKeeper) SetLongTermOrderPlacement(ctx types.Context, order clob
 	_m.Called(ctx, order, blockHeight)
 }
 
-// ValidateSubaccountEquityTierLimitForNewOrder provides a mock function with given fields: ctx, order
-func (_m *MemClobKeeper) ValidateSubaccountEquityTierLimitForNewOrder(ctx types.Context, order clobtypes.Order) error {
+// ValidateSubaccountEquityTierLimitForShortTermOrder provides a mock function with given fields: ctx, order
+func (_m *MemClobKeeper) ValidateSubaccountEquityTierLimitForShortTermOrder(ctx types.Context, order clobtypes.Order) error {
+	ret := _m.Called(ctx, order)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.Order) error); ok {
+		r0 = rf(ctx, order)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ValidateSubaccountEquityTierLimitForStatefulOrder provides a mock function with given fields: ctx, order
+func (_m *MemClobKeeper) ValidateSubaccountEquityTierLimitForStatefulOrder(ctx types.Context, order clobtypes.Order) error {
 	ret := _m.Called(ctx, order)
 
 	var r0 error

--- a/protocol/testutil/memclob/keeper.go
+++ b/protocol/testutil/memclob/keeper.go
@@ -496,11 +496,15 @@ func (f *FakeMemClobKeeper) IsLiquidatable(
 	panic("This function should not be implemented as FakeMemClobKeeper is getting deprecated (CLOB-175)")
 }
 
-func (f *FakeMemClobKeeper) ValidateSubaccountEquityTierLimitForShortTermOrder(ctx sdk.Context, order types.Order) error {
+func (f *FakeMemClobKeeper) ValidateSubaccountEquityTierLimitForShortTermOrder(
+	ctx sdk.Context,
+	order types.Order) error {
 	return nil
 }
 
-func (f *FakeMemClobKeeper) ValidateSubaccountEquityTierLimitForStatefulOrder(ctx sdk.Context, order types.Order) error {
+func (f *FakeMemClobKeeper) ValidateSubaccountEquityTierLimitForStatefulOrder(
+	ctx sdk.Context,
+	order types.Order) error {
 	return nil
 }
 

--- a/protocol/testutil/memclob/keeper.go
+++ b/protocol/testutil/memclob/keeper.go
@@ -496,7 +496,11 @@ func (f *FakeMemClobKeeper) IsLiquidatable(
 	panic("This function should not be implemented as FakeMemClobKeeper is getting deprecated (CLOB-175)")
 }
 
-func (f *FakeMemClobKeeper) ValidateSubaccountEquityTierLimitForNewOrder(ctx sdk.Context, order types.Order) error {
+func (f *FakeMemClobKeeper) ValidateSubaccountEquityTierLimitForShortTermOrder(ctx sdk.Context, order types.Order) error {
+	return nil
+}
+
+func (f *FakeMemClobKeeper) ValidateSubaccountEquityTierLimitForStatefulOrder(ctx sdk.Context, order types.Order) error {
 	return nil
 }
 

--- a/protocol/x/clob/keeper/equity_tier_limit.go
+++ b/protocol/x/clob/keeper/equity_tier_limit.go
@@ -56,7 +56,8 @@ func (k *Keeper) InitializeEquityTierLimit(
 
 // getEquityTierLimitForSubaccount returns the equity tier limit for a subaccount based on its net collateral.
 // The equity tier limit is the maximum amount of open orders a subaccount can have based on its net collateral
-// and the equity tier limits configuration. An error is returned if calculating the net collateral returns an error or the user has zero allowed open orders based upon their net collateral.
+// and the equity tier limits configuration. An error is returned if calculating the net collateral returns an
+// error or the user has zero allowed open orders based upon their net collateral.
 // Also returns the net collateral of the subaccount for debug purposes.
 func (k Keeper) getEquityTierLimitForSubaccount(
 	ctx sdk.Context, subaccountId satypes.SubaccountId,
@@ -108,7 +109,11 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForShortTermOrder(ctx sdk.Conte
 		return nil
 	}
 
-	equityTierLimit, netCollateral, err := k.getEquityTierLimitForSubaccount(ctx, order.GetSubaccountId(), equityTierLimits)
+	equityTierLimit, netCollateral, err := k.getEquityTierLimitForSubaccount(
+		ctx,
+		order.GetSubaccountId(),
+		equityTierLimits,
+	)
 	if err != nil {
 		return err
 	}
@@ -144,7 +149,11 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForStatefulOrder(ctx sdk.Contex
 		return nil
 	}
 
-	equityTierLimit, netCollateral, err := k.getEquityTierLimitForSubaccount(ctx, order.GetSubaccountId(), equityTierLimits)
+	equityTierLimit, netCollateral, err := k.getEquityTierLimitForSubaccount(
+		ctx,
+		order.GetSubaccountId(),
+		equityTierLimits,
+	)
 	if err != nil {
 		return err
 	}

--- a/protocol/x/clob/keeper/equity_tier_limit.go
+++ b/protocol/x/clob/keeper/equity_tier_limit.go
@@ -58,7 +58,6 @@ func (k Keeper) getEquityTierLimit(
 	ctx sdk.Context, subaccountId satypes.SubaccountId,
 	equityTierLimits []types.EquityTierLimit,
 ) (types.EquityTierLimit, error) {
-
 	netCollateral, _, _, err := k.subaccountsKeeper.GetNetCollateralAndMarginRequirements(
 		ctx,
 		satypes.Update{
@@ -137,7 +136,6 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForShortTermOrder(ctx sdk.Conte
 //
 // And for `checkState`, we add to the above sum the number of uncommitted stateful orders in the mempool.
 func (k Keeper) ValidateSubaccountEquityTierLimitForStatefulOrder(ctx sdk.Context, order types.Order) error {
-
 	equityTierLimits := k.GetEquityTierLimitConfiguration(ctx).StatefulOrderEquityTiers
 	if len(equityTierLimits) == 0 {
 		return nil

--- a/protocol/x/clob/keeper/equity_tier_limit.go
+++ b/protocol/x/clob/keeper/equity_tier_limit.go
@@ -127,8 +127,8 @@ func (k Keeper) ValidateSubaccountEquityTierLimitForShortTermOrder(ctx sdk.Conte
 			types.ErrOrderWouldExceedMaxOpenOrdersEquityTierLimit,
 			"Opening order would exceed equity tier limit of %d. Order count: %d, total net collateral: %+v, order id: %+v",
 			equityTierLimit.Limit,
-			netCollateral,
 			equityTierCount,
+			netCollateral,
 			order.GetOrderId(),
 		)
 	}

--- a/protocol/x/clob/keeper/equity_tier_limit.go
+++ b/protocol/x/clob/keeper/equity_tier_limit.go
@@ -56,7 +56,7 @@ func (k *Keeper) InitializeEquityTierLimit(
 
 // getEquityTierLimitForSubaccount returns the equity tier limit for a subaccount based on its net collateral.
 // The equity tier limit is the maximum amount of open orders a subaccount can have based on its net collateral
-// and the equity tier limits configuration. If the subaccount has no net collateral, return an error.
+// and the equity tier limits configuration. An error is returned if calculating the net collateral returns an error or the user has zero allowed open orders based upon their net collateral.
 // Also returns the net collateral of the subaccount for debug purposes.
 func (k Keeper) getEquityTierLimitForSubaccount(
 	ctx sdk.Context, subaccountId satypes.SubaccountId,

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -140,7 +140,7 @@ func (k Keeper) PlaceShortTermOrder(
 	}
 
 	// Validate that adding the order wouldn't exceed subaccount equity tier limits.
-	err = k.ValidateSubaccountEquityTierLimitForNewOrder(ctx, order)
+	err = k.ValidateSubaccountEquityTierLimitForShortTermOrder(ctx, order)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -293,7 +293,7 @@ func (k Keeper) PlaceStatefulOrder(
 	}
 
 	// 3. Check that adding the order would not exceed the equity tier for the account.
-	if err := k.ValidateSubaccountEquityTierLimitForNewOrder(ctx, order); err != nil {
+	if err := k.ValidateSubaccountEquityTierLimitForStatefulOrder(ctx, order); err != nil {
 		return err
 	}
 

--- a/protocol/x/clob/types/mem_clob_keeper.go
+++ b/protocol/x/clob/types/mem_clob_keeper.go
@@ -104,7 +104,11 @@ type MemClobKeeper interface {
 		bool,
 		error,
 	)
-	ValidateSubaccountEquityTierLimitForNewOrder(
+	ValidateSubaccountEquityTierLimitForShortTermOrder(
+		ctx sdk.Context,
+		order Order,
+	) error
+	ValidateSubaccountEquityTierLimitForStatefulOrder(
 		ctx sdk.Context,
 		order Order,
 	) error


### PR DESCRIPTION
### Changelist
Split the equity tier limit validation checks into separate functions for short term orders and stateful orders

### Test Plan
Existing test suite since this is just a superficial refactor

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.
