### PR TITLE
Nit fix to comments in validate_market_price_updates

### DIFF
--- a/protocol/x/prices/keeper/validate_market_price_updates.go
+++ b/protocol/x/prices/keeper/validate_market_price_updates.go
@@ -87,7 +87,7 @@ func (k Keeper) PerformStatefulPriceUpdateValidation(
 
 // performNonDeterministicStatefulValidation performs stateful validations that are non-deterministic.
 //
-// Specificically, for each price update, validate the following:
+// Specifically, for each price update, validate the following:
 //   - The index price exists.
 //   - The price is "accurate". See `validatePriceAccuracy` for how "accuracy" is determined.
 //
@@ -163,7 +163,7 @@ func (k Keeper) performNonDeterministicStatefulValidation(
 
 // performDeterministicStatefulValidation performs stateful validations that are deterministic.
 //
-// Specificically, for each price update, validate the following:
+// Specifically, for each price update, validate the following:
 //   - The market exists.
 //   - The price update is greater than the min price change.
 func (k Keeper) performDeterministicStatefulValidation(


### PR DESCRIPTION
### Changelist
Updates typos in the comments describing stateful changes in validate_market_price_updates

### Test Plan
No additional tests needed, no functionality was changed

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
