### PR TITLE
[CT-423] Add missing index (#1039)

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240202084811_add_perpetual_positions_open_event_id_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240202084811_add_perpetual_positions_open_event_id_index.ts
@@ -1,0 +1,18 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/quotes
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "perpetual_positions_subaccountId_perpetualId_openEventId_index" ON "perpetual_positions" ("subaccountId", "perpetualId", "openEventId" DESC);
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "perpetual_positions_subaccountId_perpetualId_openEventId_index";
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
[CT-423] Add missing index

Fetching SELECT * FROM perpetual_positions WHERE "subaccountId" = subaccount_uuid AND "perpetualId" = perpetual_id ORDER BY "openEventId" DESC LIMIT 1 was very slow on mainnet.

### Test Plan
Tested and verified manually.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
