### PR TITLE
Try-catch update functions in cache-update loops.

### DIFF
--- a/indexer/packages/postgres/src/loops/asset-refresher.ts
+++ b/indexer/packages/postgres/src/loops/asset-refresher.ts
@@ -1,10 +1,13 @@
 import {
-  stats, delay, logger, NodeEnv,
+  stats,
+  logger,
+  NodeEnv,
 } from '@dydxprotocol-indexer/base';
 
 import config from '../config';
 import * as AssetTable from '../stores/asset-table';
 import { AssetFromDatabase, AssetsMap, Options } from '../types';
+import { startUpdateLoop } from './loopHelper';
 
 let idToAsset: AssetsMap = {};
 
@@ -12,10 +15,11 @@ let idToAsset: AssetsMap = {};
  * Refresh loop to cache the list of all assets from the database in-memory.
  */
 export async function start(): Promise<void> {
-  for (;;) {
-    await updateAssets();
-    await delay(config.ASSET_REFRESHER_INTERVAL_MS);
-  }
+  await startUpdateLoop(
+    updateAssets,
+    config.ASSET_REFRESHER_INTERVAL_MS,
+    'updateAssets',
+  );
 }
 
 /**

--- a/indexer/packages/postgres/src/loops/liquidity-tier-refresher.ts
+++ b/indexer/packages/postgres/src/loops/liquidity-tier-refresher.ts
@@ -1,10 +1,13 @@
 import {
-  NodeEnv, delay, logger, stats,
+  NodeEnv,
+  logger,
+  stats,
 } from '@dydxprotocol-indexer/base';
 
 import config from '../config';
 import * as LiquidityTiersTable from '../stores/liquidity-tiers-table';
 import { LiquidityTiersFromDatabase, LiquidityTiersMap, Options } from '../types';
+import { startUpdateLoop } from './loopHelper';
 
 let idToLiquidityTier: LiquidityTiersMap = {};
 
@@ -12,10 +15,11 @@ let idToLiquidityTier: LiquidityTiersMap = {};
  * Refresh loop to cache the list of all liquidity tiers from the database in-memory.
  */
 export async function start(): Promise<void> {
-  for (; ;) {
-    await updateLiquidityTiers();
-    await delay(config.LIQUIDITY_TIER_REFRESHER_INTERVAL_MS);
-  }
+  await startUpdateLoop(
+    updateLiquidityTiers,
+    config.LIQUIDITY_TIER_REFRESHER_INTERVAL_MS,
+    'updateLiquidityTiers',
+  );
 }
 
 /**

--- a/indexer/packages/postgres/src/loops/loopHelper.ts
+++ b/indexer/packages/postgres/src/loops/loopHelper.ts
@@ -1,0 +1,20 @@
+import { delay, logger } from '@dydxprotocol-indexer/base';
+
+export async function startUpdateLoop(
+  updateFunction: () => Promise<void>,
+  delayMs: number,
+  name: string,
+): Promise<void> {
+  for (;;) {
+    try {
+      await updateFunction();
+    } catch (error) {
+      logger.error({
+        at: name,
+        message: 'Failed to run update',
+        error,
+      });
+    }
+    await delay(delayMs);
+  }
+}

--- a/indexer/packages/postgres/src/loops/perpetual-market-refresher.ts
+++ b/indexer/packages/postgres/src/loops/perpetual-market-refresher.ts
@@ -1,4 +1,7 @@
-import { stats, delay, NodeEnv } from '@dydxprotocol-indexer/base';
+import {
+  stats,
+  NodeEnv,
+} from '@dydxprotocol-indexer/base';
 import _ from 'lodash';
 
 import config from '../config';
@@ -6,6 +9,7 @@ import * as PerpetualMarketTable from '../stores/perpetual-market-table';
 import {
   Options, PerpetualMarketColumns, PerpetualMarketFromDatabase, PerpetualMarketsMap,
 } from '../types';
+import { startUpdateLoop } from './loopHelper';
 
 let idToPerpetualMarket: Record<string, PerpetualMarketFromDatabase> = {};
 
@@ -16,10 +20,11 @@ let idToPerpetualMarket: Record<string, PerpetualMarketFromDatabase> = {};
  * Refresh loop to cache the list of all perpetual markets from the database in-memory.
  */
 export async function start(): Promise<void> {
-  for (;;) {
-    await updatePerpetualMarkets();
-    await delay(config.PERPETUAL_MARKETS_REFRESHER_INTERVAL_MS);
-  }
+  await startUpdateLoop(
+    updatePerpetualMarkets,
+    config.PERPETUAL_MARKETS_REFRESHER_INTERVAL_MS,
+    'updatePerpetualMarkets',
+  );
 }
 
 /**


### PR DESCRIPTION
### Changelist
The cache update loops don't handle errors thrown during their execution, and can crash a service that is running the loop. This occurred when the RDS instance the services connected to was momentarily restarted to apply a security patch.

Instead, wrap the update function in a `try ... catch` to ensure services running the refresher loops don't crash.

### Test Plan
N/A.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
