### PR TITLE
Fix `x/ratelimit` `ProcessWithdrawal` logic; improve info logs

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -404,7 +404,6 @@ const (
 
 	// x/ratelimit
 	Capacity           = "capacity"
-	PendingSendPackets = "pending_send_packets"
 	RateLimitDenom     = "rate_limit_denom"
 	LimiterIndex       = "limiter_index"
 	UndoWithdrawAmount = "undo_withdraw_amount"

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -404,6 +404,7 @@ const (
 
 	// x/ratelimit
 	Capacity           = "capacity"
+	PendingSendPackets = "pending_send_packets"
 	RateLimitDenom     = "rate_limit_denom"
 	LimiterIndex       = "limiter_index"
 	UndoWithdrawAmount = "undo_withdraw_amount"

--- a/protocol/x/ratelimit/keeper/keeper.go
+++ b/protocol/x/ratelimit/keeper/keeper.go
@@ -62,11 +62,7 @@ func (k Keeper) ProcessWithdrawal(
 	amount *big.Int,
 ) error {
 	denomCapacity := k.GetDenomCapacity(ctx, denom)
-
-	newCapacityList := make([]dtypes.SerializableInt,
-		0,
-		len(denomCapacity.CapacityList),
-	)
+	newCapacityList := make([]dtypes.SerializableInt, len(denomCapacity.CapacityList))
 
 	for i, capacity := range denomCapacity.CapacityList {
 		// Check that the withdrawal amount does not exceed each capacity.
@@ -125,10 +121,7 @@ func (k Keeper) IncrementCapacitiesForDenom(
 ) {
 	denomCapacity := k.GetDenomCapacity(ctx, denom)
 
-	newCapacityList := make([]dtypes.SerializableInt,
-		0,
-		len(denomCapacity.CapacityList),
-	)
+	newCapacityList := make([]dtypes.SerializableInt, len(denomCapacity.CapacityList))
 
 	// Credit each capacity in the list by the amount of deposit.
 	for i, capacity := range denomCapacity.CapacityList {

--- a/protocol/x/ratelimit/keeper/packet.go
+++ b/protocol/x/ratelimit/keeper/packet.go
@@ -39,7 +39,6 @@ func (k Keeper) SetPendingSendPacket(ctx sdk.Context, channelId string, sequence
 func (k Keeper) HasPendingSendPacket(ctx sdk.Context, channelId string, sequence uint64) bool {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.PendingSendPacketPrefix))
 	key := types.GetPendingSendPacketKey(channelId, sequence)
-
 	return store.Has(key)
 }
 
@@ -103,6 +102,12 @@ func (k Keeper) UndoSendPacket(
 	// Undo'ing capacity change from the withdrawal.
 	k.UndoWithdrawal(ctx, denom, amount)
 	k.RemovePendingSendPacket(ctx, channelId, sequence)
+
+	k.Logger(ctx).Info(
+		"SendPacket timeout'ed or failed acknowledgement on the receiver chain. Reverted capacity change.",
+		"denom",
+		denom,
+	)
 }
 
 // SendPacket wraps IBC ChannelKeeper's SendPacket function
@@ -139,7 +144,11 @@ func (k Keeper) SendPacket(
 		Data:             data,
 	})
 	if err != nil {
-		k.Logger(ctx).Error(fmt.Sprintf("ICS20 packet send was denied: %s", err.Error()))
+		k.Logger(ctx).Info(
+			fmt.Sprintf("ICS20 packet send was denied: %s", err.Error()),
+			"exec_mode",
+			ctx.ExecMode(),
+		)
 		return 0, err
 	}
 	return sequence, err

--- a/protocol/x/ratelimit/keeper/packet.go
+++ b/protocol/x/ratelimit/keeper/packet.go
@@ -5,7 +5,6 @@ package keeper
 // See v4-chain/protocol/x/ratelimit/LICENSE and v4-chain/protocol/x/ratelimit/README.md for licensing information.
 
 import (
-	"fmt"
 	"math/big"
 
 	"cosmossdk.io/store/prefix"
@@ -105,8 +104,14 @@ func (k Keeper) UndoSendPacket(
 
 	k.Logger(ctx).Info(
 		"SendPacket timeout'ed or failed acknowledgement on the receiver chain. Reverted capacity change.",
+		"channel_id",
+		channelId,
+		"sequence",
+		sequence,
 		"denom",
 		denom,
+		"amount",
+		amount.String(),
 	)
 }
 
@@ -145,9 +150,11 @@ func (k Keeper) SendPacket(
 	})
 	if err != nil {
 		k.Logger(ctx).Info(
-			fmt.Sprintf("ICS20 packet send was denied: %s", err.Error()),
+			"ICS20 packet send was denied",
 			"exec_mode",
 			ctx.ExecMode(),
+			"error",
+			err.Error(),
 		)
 		return 0, err
 	}

--- a/protocol/x/ratelimit/util/ibc.go
+++ b/protocol/x/ratelimit/util/ibc.go
@@ -6,11 +6,11 @@ package util
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/big"
 
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
+	"github.com/Workiva/go-datastructures/threadsafe/err"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
@@ -94,11 +94,19 @@ func UnpackAcknowledgementResponseForTransfer(
 				"acknowledgement result cannot be empty",
 			)
 		}
-		logger.Info(fmt.Sprintf("IBC transfer acknowledgement success: %+v\n", response))
+		logger.Info(
+			"IBC transfer acknowledgement success",
+			"response",
+			response,
+		)
 		return &types.AcknowledgementResponse{Status: types.AckResponseStatus_SUCCESS}, nil
 
 	case *channeltypes.Acknowledgement_Error:
-		logger.Error(fmt.Sprintf("acknowledgement error: %s", response.Error))
+		logger.Error(
+			"received acknowledgement error",
+			"error",
+			err.Error(),
+		)
 		return &types.AcknowledgementResponse{Status: types.AckResponseStatus_FAILURE, Error: response.Error}, nil
 
 	default:

--- a/protocol/x/ratelimit/util/ibc.go
+++ b/protocol/x/ratelimit/util/ibc.go
@@ -10,7 +10,6 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
-	"github.com/Workiva/go-datastructures/threadsafe/err"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
@@ -105,7 +104,7 @@ func UnpackAcknowledgementResponseForTransfer(
 		logger.Error(
 			"received acknowledgement error",
 			"error",
-			err.Error(),
+			response.Error,
 		)
 		return &types.AcknowledgementResponse{Status: types.AckResponseStatus_FAILURE, Error: response.Error}, nil
 

--- a/protocol/x/ratelimit/util/ibc.go
+++ b/protocol/x/ratelimit/util/ibc.go
@@ -94,7 +94,7 @@ func UnpackAcknowledgementResponseForTransfer(
 				"acknowledgement result cannot be empty",
 			)
 		}
-		logger.Info(fmt.Sprintf("IBC transfer acknowledgement success: %+v", response))
+		logger.Info(fmt.Sprintf("IBC transfer acknowledgement success: %+v\n", response))
 		return &types.AcknowledgementResponse{Status: types.AckResponseStatus_SUCCESS}, nil
 
 	case *channeltypes.Acknowledgement_Error:


### PR DESCRIPTION
### Changelist
- Fixed an issue where un-ratelimited denom cannot be IBC transferred
- Improved info logs in various places

### Test Plan
- Unit test (newly added)
- Local IBC testnet (documented [here](https://www.notion.so/dydx/Rate-Limiting-Local-IBC-Testnet-Notes-c9b2913c13b14f76b81c17b19e1f2421?pvs=4))

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
