### PR TITLE
[bugfix][protocol] fix settled funding event emission

### DIFF
--- a/protocol/x/subaccounts/types/events.go
+++ b/protocol/x/subaccounts/types/events.go
@@ -27,7 +27,7 @@ func NewCreateSettledFundingEvent(
 	return sdk.NewEvent(
 		EventTypeSettledFunding,
 		sdk.NewAttribute(AttributeKeySubaccount, subaccount.Owner),
-		sdk.NewAttribute(AttributeKeySubaccount, fmt.Sprint(subaccount.Number)),
+		sdk.NewAttribute(AttributeKeySubaccountNumber, fmt.Sprint(subaccount.Number)),
 		sdk.NewAttribute(AttributeKeyPerpetualId, fmt.Sprint(perpetualId)),
 		sdk.NewAttribute(AttributeKeyFundingPaid, fundingPaid.String()),
 	)

--- a/protocol/x/subaccounts/types/events.go
+++ b/protocol/x/subaccounts/types/events.go
@@ -19,6 +19,7 @@ const (
 
 // NewCreateSettledFundingEvent constructs a new funding sdk.Event. Note that `fundingPaid` is positive
 // if the subaccount paid funding, negative if the subaccount received funding.
+// TODO(CT-245): Add tests that this event is emitted.
 func NewCreateSettledFundingEvent(
 	subaccount SubaccountId,
 	perpetualId uint32,


### PR DESCRIPTION
### Changelist
Update the event key for subaccount number. Bug was found since downstream event indexers broke.

Note this shouldn't be consensus-breaking since this only changes event emissions.
### Test Plan
N/A since trying to get this in next release.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
