### PR TITLE
[OTE-154] Update CLOB IsSingleClobMsgTx to not take ctx

### DIFF
--- a/protocol/app/ante/gas.go
+++ b/protocol/app/ante/gas.go
@@ -27,7 +27,7 @@ func (dec FreeInfiniteGasDecorator) AnteHandle(
 	simulate bool,
 	next sdk.AnteHandler,
 ) (newCtx sdk.Context, err error) {
-	isSingleClobMsgTx, err := clobante.IsSingleClobMsgTx(ctx, tx)
+	isSingleClobMsgTx, err := clobante.IsSingleClobMsgTx(tx)
 	if err != nil {
 		return ctx, err
 	}

--- a/protocol/x/clob/ante/ante_wrapper.go
+++ b/protocol/x/clob/ante/ante_wrapper.go
@@ -27,7 +27,7 @@ func (anteWrapper SingleMsgClobTxAnteWrapper) AnteHandle(
 	simulate bool,
 	next sdk.AnteHandler,
 ) (sdk.Context, error) {
-	isSingleClobMsgTx, err := IsSingleClobMsgTx(ctx, tx)
+	isSingleClobMsgTx, err := IsSingleClobMsgTx(tx)
 	if err != nil {
 		return ctx, err
 	}

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -51,7 +51,7 @@ func (cd ClobDecorator) AnteHandle(
 
 	// Ensure that if this is a clob message then that there is only one.
 	// If it isn't a clob message then pass to the next AnteHandler.
-	isSingleClobMsgTx, err := IsSingleClobMsgTx(ctx, tx)
+	isSingleClobMsgTx, err := IsSingleClobMsgTx(tx)
 	if err != nil {
 		return ctx, err
 	}
@@ -141,7 +141,7 @@ func (cd ClobDecorator) AnteHandle(
 // IsSingleClobMsgTx returns `true` if the supplied `tx` consist of a single clob message
 // (`MsgPlaceOrder` or `MsgCancelOrder`). If `msgs` consist of multiple clob messages,
 // or a mix of on-chain and clob messages, an error is returned.
-func IsSingleClobMsgTx(ctx sdk.Context, tx sdk.Tx) (bool, error) {
+func IsSingleClobMsgTx(tx sdk.Tx) (bool, error) {
 	msgs := tx.GetMsgs()
 	var hasMessage = false
 

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -283,10 +283,9 @@ func TestIsClobTransaction(t *testing.T) {
 			err := builder.SetMsgs(tc.msgs...)
 			require.NoError(t, err)
 			tx := builder.GetTx()
-			ctx, _, _ := sdktest.NewSdkContextWithMultistore()
 
 			// Invoke the function under test.
-			result, err := ante.IsSingleClobMsgTx(ctx, tx)
+			result, err := ante.IsSingleClobMsgTx(tx)
 
 			// Assert the results.
 			require.Equal(t, tc.expectedResult, result)


### PR DESCRIPTION
### Changelist
- Title

### Test Plan
- N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
