### PR TITLE
Add Indexes to candles and orders to optimize queries

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240208153050_add_candles_ticket_resolution_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240208153050_add_candles_ticket_resolution_index.ts
@@ -1,0 +1,18 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/quotes
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS candles_ticker_resolution_index ON candles("ticker", "resolution");
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "candles_ticker_resolution_index";
+  `);
+}
+
+export const config = {
+  transaction: false,
+};

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240208161948_add_orders_clobpairid_subaccountid_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240208161948_add_orders_clobpairid_subaccountid_index.ts
@@ -3,13 +3,13 @@ import * as Knex from 'knex';
 export async function up(knex: Knex): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/quotes
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS orders_clobpairid_subaccountid_index ON orders("clobPairId", "subaccountId");
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS orders_clobPairId_subaccountId_index ON orders("clobPairId", "subaccountId");
   `);
 }
 
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
-    DROP INDEX CONCURRENTLY IF EXISTS "orders_clobpairid_subaccountid_index";
+    DROP INDEX CONCURRENTLY IF EXISTS "orders_clobPairId_subaccountId_index";
   `);
 }
 

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240208161948_add_orders_clobpairid_subaccountid_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240208161948_add_orders_clobpairid_subaccountid_index.ts
@@ -1,0 +1,18 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/quotes
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS orders_clobpairid_subaccountid_index ON orders("clobPairId", "subaccountId");
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "orders_clobpairid_subaccountid_index";
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
Add Indexes to candles and orders to optimize queries:
- 150ms -> 3ms for candles
  - `select "candles".* from "candles" where "ticker" in ($1) and "resolution" = $2 order by "ticker" DESC, "resolution" DESC, "startedAt" DESC limit $3`
- 2500ms -> 180ms for orders
  - `select distinct on ("perpetualId") "funding_index_updates".* from "funding_index_updates" where "effectiveAtHeight" <= $1 order by "perpetualId" asc, "effectiveAtHeight" DESC`

### Test Plan
Tested in database directly that this reduced latency

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
