### PR TITLE
Optimize funding index update query

### DIFF
--- a/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
+++ b/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
@@ -193,9 +193,17 @@ export async function findFundingIndexMap(
       options,
     );
 
+  // Assuming block time of 1 second, this should be 4 hours of blocks
+  const FOUR_HOUR_OF_BLOCKS = Big(3600).times(4);
   const fundingIndexUpdates: FundingIndexUpdatesFromDatabase[] = await baseQuery
     .distinctOn(FundingIndexUpdatesColumns.perpetualId)
     .where(FundingIndexUpdatesColumns.effectiveAtHeight, '<=', effectiveBeforeOrAtHeight)
+    // Optimization to reduce number of rows needed to scan
+    .where(
+      FundingIndexUpdatesColumns.effectiveAtHeight,
+      '>',
+      Big(effectiveBeforeOrAtHeight).minus(FOUR_HOUR_OF_BLOCKS).toFixed(),
+    )
     .orderBy(FundingIndexUpdatesColumns.perpetualId)
     .orderBy(FundingIndexUpdatesColumns.effectiveAtHeight, Ordering.DESC)
     .returning('*');


### PR DESCRIPTION
### Changelist
Optimize funding index update query
- 175ms -> 0.2ms for funding_index_updates
  - `select distinct on ("perpetualId") "funding_index_updates".* from "funding_index_updates" where "effectiveAtHeight" <= $1 order by "perpetualId" asc, "effectiveAtHeight" DESC`

### Test Plan
Tested in internal mainnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
