### PR TITLE
Make app runnable without creating default home dir

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -165,6 +165,9 @@ func NewRootCmdWithInterceptors(
 	if err != nil {
 		panic(err)
 	}
+	// [ Home Dir Temp Fix ] (also see protocol/cmd/dydxprotocold/main.go)
+	// Unset the temp home dir. This must be done after `ReadFromClientConfig`, otherwise it will
+	// create a temp dir in cwd.
 	initClientCtx.HomeDir = ""
 	if err := autoCliOpts(tempApp, initClientCtx).EnhanceRootCommand(rootCmd); err != nil {
 		panic(err)

--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -165,6 +165,7 @@ func NewRootCmdWithInterceptors(
 	if err != nil {
 		panic(err)
 	}
+	initClientCtx.HomeDir = ""
 	if err := autoCliOpts(tempApp, initClientCtx).EnhanceRootCommand(rootCmd); err != nil {
 		panic(err)
 	}

--- a/protocol/cmd/dydxprotocold/main.go
+++ b/protocol/cmd/dydxprotocold/main.go
@@ -14,7 +14,7 @@ func main() {
 	config.SetupConfig()
 
 	option := cmd.GetOptionWithCustomStartCmd()
-	rootCmd := cmd.NewRootCmd(option, app.DefaultNodeHome)
+	rootCmd := cmd.NewRootCmd(option, tempDir())
 
 	cmd.AddTendermintSubcommands(rootCmd)
 	cmd.AddInitCmdPostRunE(rootCmd)
@@ -22,4 +22,14 @@ func main() {
 	if err := svrcmd.Execute(rootCmd, constants.AppDaemonName, app.DefaultNodeHome); err != nil {
 		os.Exit(1)
 	}
+}
+
+var tempDir = func() string {
+	dir, err := os.MkdirTemp("", "dydxprotocol")
+	if err != nil {
+		dir = app.DefaultNodeHome
+	}
+	defer os.RemoveAll(dir)
+
+	return dir
 }

--- a/protocol/cmd/dydxprotocold/main.go
+++ b/protocol/cmd/dydxprotocold/main.go
@@ -14,6 +14,11 @@ func main() {
 	config.SetupConfig()
 
 	option := cmd.GetOptionWithCustomStartCmd()
+	// [ Home Dir Temp Fix ] (also see protocol/cmd/dydxprotocold/cmd/root.go)
+	// We pass in a tempdir as a temporary hack until fixed in cosmos.
+	// If not, and we pass in a custom home dir, it will try read or create the default home dir
+	// before using the custom home dir.
+	// See https://github.com/cosmos/cosmos-sdk/issues/18868.
 	rootCmd := cmd.NewRootCmd(option, tempDir())
 
 	cmd.AddTendermintSubcommands(rootCmd)

--- a/protocol/testing/containertest/node.go
+++ b/protocol/testing/containertest/node.go
@@ -3,8 +3,9 @@ package containertest
 import (
 	"context"
 	"fmt"
-	"github.com/dydxprotocol/v4-chain/protocol/app"
 	"time"
+
+	"github.com/dydxprotocol/v4-chain/protocol/app"
 
 	comethttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/client"


### PR DESCRIPTION
### Changelist
- Create a temp dir instead as a quick hack.

### Test Plan
- Run localnet, inspect the containers and see that no default home dir was created during any step.
- Run a command `./build/dydxprotocold  query subaccounts show-subaccount dydx1q628jg3e8vzy6xcns6fxls7k7kplqgxr0gy87t 0 --home ~/.dydxprotocol2`, with existing custom home dir, ensure it works properly and doesn't create default home dir.
  - Now run it without custom home dir, ensure it creates default home dir and uses it
  - Now run it with custom home dir again, ensure it's still using the custom home dir

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
