### PR TITLE
Fix unnecessary home directory creation issues

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -28,7 +28,6 @@ import (
 	runtimeservices "github.com/cosmos/cosmos-sdk/runtime/services"
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
@@ -46,6 +45,7 @@ import (
 
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	// Unnamed import of statik for swagger UI support.
 	// Used in cosmos-sdk when registering the route for swagger docs.
@@ -86,12 +86,14 @@ func NewRootCmdWithInterceptors(
 	appConfigInterceptor func(string, *DydxAppConfig) (string, *DydxAppConfig),
 	appInterceptor func(app *dydxapp.App) *dydxapp.App,
 ) *cobra.Command {
+	initAppOptions := viper.New()
+	initAppOptions.Set(flags.FlagHome, tempDir())
 	tempApp := dydxapp.New(
 		log.NewNopLogger(),
 		dbm.NewMemDB(),
 		nil,
 		true,
-		simtestutil.NewAppOptionsWithFlagHome(tempDir()),
+		initAppOptions,
 	)
 	defer func() {
 		if err := tempApp.Close(); err != nil {

--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -38,7 +38,6 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	rosettaCmd "github.com/cosmos/rosetta/cmd"
-	"github.com/dydxprotocol/v4-chain/protocol/app"
 	dydxapp "github.com/dydxprotocol/v4-chain/protocol/app"
 	"github.com/dydxprotocol/v4-chain/protocol/app/constants"
 	protocolflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
@@ -431,7 +430,7 @@ func appExport(
 var tempDir = func() string {
 	dir, err := os.MkdirTemp("", "dydxprotocol")
 	if err != nil {
-		dir = app.DefaultNodeHome
+		dir = dydxapp.DefaultNodeHome
 	}
 	defer os.RemoveAll(dir)
 

--- a/protocol/cmd/dydxprotocold/main.go
+++ b/protocol/cmd/dydxprotocold/main.go
@@ -14,12 +14,7 @@ func main() {
 	config.SetupConfig()
 
 	option := cmd.GetOptionWithCustomStartCmd()
-	// [ Home Dir Temp Fix ] (also see protocol/cmd/dydxprotocold/cmd/root.go)
-	// We pass in a tempdir as a temporary hack until fixed in cosmos.
-	// If not, and we pass in a custom home dir, it will try read or create the default home dir
-	// before using the custom home dir.
-	// See https://github.com/cosmos/cosmos-sdk/issues/18868.
-	rootCmd := cmd.NewRootCmd(option, tempDir())
+	rootCmd := cmd.NewRootCmd(option, app.DefaultNodeHome)
 
 	cmd.AddTendermintSubcommands(rootCmd)
 	cmd.AddInitCmdPostRunE(rootCmd)
@@ -27,14 +22,4 @@ func main() {
 	if err := svrcmd.Execute(rootCmd, constants.AppDaemonName, app.DefaultNodeHome); err != nil {
 		os.Exit(1)
 	}
-}
-
-var tempDir = func() string {
-	dir, err := os.MkdirTemp("", "dydxprotocol")
-	if err != nil {
-		dir = app.DefaultNodeHome
-	}
-	defer os.RemoveAll(dir)
-
-	return dir
 }

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -417,7 +417,7 @@ replace (
 	// Use dYdX fork of CometBFT
 	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206224621-ffeae5184c58
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240213190038-7210e1b9588e
 )
 
 replace (

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -411,13 +411,14 @@ require (
 )
 
 replace (
+	cosmossdk.io/client/v2 => github.com/dydxprotocol/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240214225126-ba76b79cd4cf
 	// TODO(https://github.com/cosmos/rosetta/issues/76): Rosetta requires cosmossdk.io/core v0.12.0 erroneously but
 	// should use v0.11.0. The Cosmos build fails with types/context.go:65:29: undefined: comet.BlockInfo otherwise.
 	cosmossdk.io/core => cosmossdk.io/core v0.11.0
 	// Use dYdX fork of CometBFT
 	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240213190038-7210e1b9588e
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240214225126-ba76b79cd4cf
 )
 
 replace (

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -537,8 +537,8 @@ github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQx
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8 h1:zmH6go7DRhFcQHoiN/rQ1INaAelp01VUPUTSqSDJsAU=
 github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8/go.mod h1:KQ8mOea6U2satQbGe2WjxBopa8mGgHatMKS9sQsJ6uY=
-github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206224621-ffeae5184c58 h1:3nW+id7dbHUv+RJB2pecjKtA0WWQr3oit4KrxBJ0+kw=
-github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240206224621-ffeae5184c58/go.mod h1:y+5fRLbztsvx6GHBVXPlgM51ZpuNd8M7y4YEAQNnTPU=
+github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240213190038-7210e1b9588e h1:AKYCYBf/EFV7zLXn3UT6oUGm3OJ1E3nyCV9g26Hdlv0=
+github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240213190038-7210e1b9588e/go.mod h1:y+5fRLbztsvx6GHBVXPlgM51ZpuNd8M7y4YEAQNnTPU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -193,8 +193,6 @@ cloud.google.com/go/workflows v1.6.0/go.mod h1:6t9F5h/unJz41YqfBmqSASJSXccBLtD1V
 cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoISEXH2bcHC3M=
 cosmossdk.io/api v0.7.2 h1:BO3i5fvKMKvfaUiMkCznxViuBEfyWA/k6w2eAF6q1C4=
 cosmossdk.io/api v0.7.2/go.mod h1:IcxpYS5fMemZGqyYtErK7OqvdM0C8kdW3dq8Q/XIG38=
-cosmossdk.io/client/v2 v2.0.0-beta.1 h1:XkHh1lhrLYIT9zKl7cIOXUXg2hdhtjTPBUfqERNA1/Q=
-cosmossdk.io/client/v2 v2.0.0-beta.1/go.mod h1:JEUSu9moNZQ4kU3ir1DKD5eU4bllmAexrGWjmb9k8qU=
 cosmossdk.io/collections v0.4.0 h1:PFmwj2W8szgpD5nOd8GWH6AbYNi1f2J6akWXJ7P5t9s=
 cosmossdk.io/collections v0.4.0/go.mod h1:oa5lUING2dP+gdDquow+QjlF45eL1t4TJDypgGd+tv0=
 cosmossdk.io/core v0.11.0 h1:vtIafqUi+1ZNAE/oxLOQQ7Oek2n4S48SWLG8h/+wdbo=
@@ -537,8 +535,10 @@ github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQx
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8 h1:zmH6go7DRhFcQHoiN/rQ1INaAelp01VUPUTSqSDJsAU=
 github.com/dydxprotocol/cometbft v0.38.3-0.20231204185009-5e6c4b6d67b8/go.mod h1:KQ8mOea6U2satQbGe2WjxBopa8mGgHatMKS9sQsJ6uY=
-github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240213190038-7210e1b9588e h1:AKYCYBf/EFV7zLXn3UT6oUGm3OJ1E3nyCV9g26Hdlv0=
-github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240213190038-7210e1b9588e/go.mod h1:y+5fRLbztsvx6GHBVXPlgM51ZpuNd8M7y4YEAQNnTPU=
+github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240214225126-ba76b79cd4cf h1:buHamAV21CWNE8IVKe/v6RPzQaLM9t3ZkTijGFaS4c4=
+github.com/dydxprotocol/cosmos-sdk v0.50.4-0.20240214225126-ba76b79cd4cf/go.mod h1:y+5fRLbztsvx6GHBVXPlgM51ZpuNd8M7y4YEAQNnTPU=
+github.com/dydxprotocol/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240214225126-ba76b79cd4cf h1:1S0YnPWIM1uacL73Jx9mZYK0T3uj1qoL2TqwlRtyDpw=
+github.com/dydxprotocol/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240214225126-ba76b79cd4cf/go.mod h1:Fi+Bqmvo+7wImB5+31CsBheyjBkvQxx8QRQY1acPVDU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=


### PR DESCRIPTION
### Changelist
- Revert https://github.com/dydxprotocol/v4-chain/pull/1062 temporary fix and bring in official cosmos fix for it
- Pass in a temp dir in client tempApp to prevent creation of `data` directory in the cwd

### Test Plan
- Tested query commands to ensure correct home directory was being used in default and non-default cases. Checked to make sure default one wasn't created when not intended.
- Ran local net and inspected containers to make sure data directory isn't created in `/dydxprotocol/`.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
