### PR TITLE
[OTE-178] Increase maximum number of connections

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/config.go
+++ b/protocol/cmd/dydxprotocold/cmd/config.go
@@ -81,6 +81,11 @@ func initTendermintConfig() *tmcfg.Config {
 	// Expose the Tendermint RPC.
 	cfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
 	cfg.RPC.CORSAllowedOrigins = []string{"*"}
+	// goroutine profiling showed that we were using exactly 900 threads (the default) which was throttling
+	// the maximum amount of load that the process could take. As of the last load test, at max QPS we were
+	// seeing ~1700 threads being used.
+	cfg.RPC.MaxOpenConnections = 4000
+	cfg.RPC.GRPCMaxOpenConnections = 4000
 
 	// Mempool config.
 	// We specifically are using a number greater than max QPS (currently set at 5000) * ShortBlockWindow to prevent


### PR DESCRIPTION
### Changelist
[OTE-178] Increase maximum number of connections

Allowed load tester to scale even higher removing one of the bottlenecks.
Before this change:
![image](https://github.com/dydxprotocol/v4-chain/assets/126621805/19ca9e1c-eac8-4c0e-8018-3f29284135b1)

After this change:
![image](https://github.com/dydxprotocol/v4-chain/assets/126621805/5eed350f-b0e2-4f50-86ab-205ed5488afb)

### Test Plan
Manually verified during load testing.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
