### PR TITLE
Upgrade client/v2 to fix autocli signing issues

### DIFF
--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -411,8 +411,8 @@ require (
 )
 
 replace (
-	// Ideally we rely on a released version (we don't make any changes in our cosmos-sdk fork). In this case the
-	// latest signing mode fixes aren't tagged as a release yet.
+	// TODO(DEC-2209): Ideally we rely on a released version (we don't make any changes in our cosmos-sdk fork).
+	// In this case the latest signing mode fixes aren't tagged as a release yet.
 	cosmossdk.io/client/v2 => github.com/cosmos/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240219091002-18ea4c520045
 	// TODO(https://github.com/cosmos/rosetta/issues/76): Rosetta requires cosmossdk.io/core v0.12.0 erroneously but
 	// should use v0.11.0. The Cosmos build fails with types/context.go:65:29: undefined: comet.BlockInfo otherwise.

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -411,7 +411,9 @@ require (
 )
 
 replace (
-	cosmossdk.io/client/v2 => github.com/dydxprotocol/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240214225126-ba76b79cd4cf
+	// Ideally we rely on a released version (we don't make any changes in our cosmos-sdk fork). In this case the
+	// latest signing mode fixes aren't tagged as a release yet.
+	cosmossdk.io/client/v2 => github.com/cosmos/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240219091002-18ea4c520045
 	// TODO(https://github.com/cosmos/rosetta/issues/76): Rosetta requires cosmossdk.io/core v0.12.0 erroneously but
 	// should use v0.11.0. The Cosmos build fails with types/context.go:65:29: undefined: comet.BlockInfo otherwise.
 	cosmossdk.io/core => cosmossdk.io/core v0.11.0

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -450,6 +450,8 @@ github.com/cosmos/cosmos-db v1.0.0 h1:EVcQZ+qYag7W6uorBKFPvX6gRjw6Uq2hIh4hCWjuQ0
 github.com/cosmos/cosmos-db v1.0.0/go.mod h1:iBvi1TtqaedwLdcrZVYRSSCb6eSy61NLj4UNmdIgs0U=
 github.com/cosmos/cosmos-proto v1.0.0-beta.4 h1:aEL7tU/rLOmxZQ9z4i7mzxcLbSCY48OdY7lIWTLG7oU=
 github.com/cosmos/cosmos-proto v1.0.0-beta.4/go.mod h1:oeB+FyVzG3XrQJbJng0EnV8Vljfk9XvTIpGILNU/9Co=
+github.com/cosmos/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240219091002-18ea4c520045 h1:UQEFOXQGeEmtQxj7P69x0pagoGtAtRCXB1Jh2A1c4oM=
+github.com/cosmos/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240219091002-18ea4c520045/go.mod h1:T0ZAvOrgyB36TANZcTcLyzmY+ov2mWgvJEGSGBHd+iE=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=
@@ -534,8 +536,6 @@ github.com/dydxprotocol/cometbft v0.38.6-0.20240220185844-e704122c8540 h1:pkYQbA
 github.com/dydxprotocol/cometbft v0.38.6-0.20240220185844-e704122c8540/go.mod h1:REQN+ObgfYxi39TcYR/Hv95C9bPxY3sYJCvghryj7vY=
 github.com/dydxprotocol/cosmos-sdk v0.50.5-0.20240222221247-6eacec603896 h1:tD6NwPhiMGzM3tKmowrjLnQPDU03ezPWPCEk7D/Dnx0=
 github.com/dydxprotocol/cosmos-sdk v0.50.5-0.20240222221247-6eacec603896/go.mod h1:AgkOyykpqwdRuf8cLqoA6PxNZC6ODwNmPrEGYuRzBFY=
-github.com/dydxprotocol/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240214225126-ba76b79cd4cf h1:1S0YnPWIM1uacL73Jx9mZYK0T3uj1qoL2TqwlRtyDpw=
-github.com/dydxprotocol/cosmos-sdk/client/v2 v2.0.0-beta.1.0.20240214225126-ba76b79cd4cf/go.mod h1:Fi+Bqmvo+7wImB5+31CsBheyjBkvQxx8QRQY1acPVDU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=


### PR DESCRIPTION
### Changelist
Use client/v2 commit from cosmos-sdk v0.50.4. This package released separately, but the latest fixes aren't released yet.

Specifically, we need the deleted block in msg.go to fix the bug: https://github.com/cosmos/cosmos-sdk/pull/19219/files#diff-5560b4d40a3e412c5265a379f1e495c01249be7b08bdb6931555088832fa34d6

Without this change, sign mode handlers are overwritten and we can't sign for pure autocli messages (e.g. `slashing unjail`) (with direct mode).

Note: We don't actually support or intend to support sign mode textual.

### Test Plan
Tested `slashing unjail`. Without this change we get the error `unsuppored sign mode SIGN_MODE_TEXTUAL` when trying to run that command.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
