### PR TITLE
Introduce flag to ignore invalid FundingEvent where the perpetualId doesn't exist

### DIFF
--- a/indexer/services/ender/__tests__/handlers/funding-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/funding-handler.test.ts
@@ -199,7 +199,7 @@ describe('fundingHandler', () => {
       undefined,
     );
     const fundingIndices: FundingIndexUpdatesFromDatabase[] = await
-      FundingIndexUpdatesTable.findAll({}, [], {});
+    FundingIndexUpdatesTable.findAll({}, [], {});
 
     expect(fundingIndices.length).toEqual(1);
     expect(fundingIndices[0]).toEqual(expect.objectContaining({

--- a/indexer/services/ender/__tests__/handlers/funding-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/funding-handler.test.ts
@@ -26,6 +26,7 @@ import { FundingHandler } from '../../src/handlers/funding-handler';
 import {
   defaultFundingRateEvent,
   defaultFundingUpdateSampleEvent,
+  defaultFundingUpdateSampleEventWithAdditionalMarket,
   defaultHeight,
   defaultPreviousHeight,
   defaultTime,
@@ -41,6 +42,7 @@ import Big from 'big.js';
 import { redisClient } from '../../src/helpers/redis/redis-controller';
 import { bigIntToBytes } from '@dydxprotocol-indexer/v4-proto-parser';
 import { createPostgresFunctions } from '../../src/helpers/postgres/postgres-functions';
+import config from '../../src/config';
 
 describe('fundingHandler', () => {
   beforeAll(async () => {
@@ -66,6 +68,7 @@ describe('fundingHandler', () => {
     await dbHelpers.clearData();
     jest.clearAllMocks();
     await redis.deleteAllAsync(redisClient);
+    config.IGNORE_NONEXISTENT_PERPETUAL_MARKET = false;
   });
 
   afterAll(async () => {
@@ -165,6 +168,48 @@ describe('fundingHandler', () => {
         fundingUpdateSampleEvent2.updates[1].fundingValuePpm,
       )),
     );
+  });
+
+  it('successfully processes and clears cache for a new funding rate with non-existent market', async () => {
+    config.IGNORE_NONEXISTENT_PERPETUAL_MARKET = true;
+    const kafkaMessage: KafkaMessage = createKafkaMessageFromFundingEvents({
+      fundingEvents: [defaultFundingUpdateSampleEventWithAdditionalMarket],
+      height: defaultHeight,
+      time: defaultTime,
+    });
+
+    await onMessage(kafkaMessage);
+
+    await expectNextFundingRate(
+      'BTC-USD',
+      new Big(protocolTranslations.funding8HourValuePpmTo1HourRate(
+        defaultFundingUpdateSampleEvent.updates[0].fundingValuePpm,
+      )),
+    );
+
+    const kafkaMessage2: KafkaMessage = createKafkaMessageFromFundingEvents({
+      fundingEvents: [defaultFundingRateEvent],
+      height: 4,
+      time: defaultTime,
+    });
+
+    await onMessage(kafkaMessage2);
+    await expectNextFundingRate(
+      'BTC-USD',
+      undefined,
+    );
+    const fundingIndices: FundingIndexUpdatesFromDatabase[] = await
+      FundingIndexUpdatesTable.findAll({}, [], {});
+
+    expect(fundingIndices.length).toEqual(1);
+    expect(fundingIndices[0]).toEqual(expect.objectContaining({
+      perpetualId: '0',
+      rate: '0.00000125',
+      oraclePrice: '10000',
+      fundingIndex: '0.1',
+    }));
+    expect(stats.gauge).toHaveBeenCalledWith('ender.funding_index_update_event', 0.1, { ticker: 'BTC-USD' });
+    expect(stats.gauge).toHaveBeenCalledWith('ender.funding_index_update', 0.1, { ticker: 'BTC-USD' });
   });
 
   it('successfully processes and clears cache for a new funding rate', async () => {

--- a/indexer/services/ender/__tests__/helpers/constants.ts
+++ b/indexer/services/ender/__tests__/helpers/constants.ts
@@ -72,6 +72,22 @@ export const defaultFundingUpdateSampleEvent: FundingEventMessage = {
   ],
 };
 
+export const defaultFundingUpdateSampleEventWithAdditionalMarket: FundingEventMessage = {
+  type: FundingEventV1_Type.TYPE_PREMIUM_SAMPLE,
+  updates: [
+    {
+      perpetualId: 0,
+      fundingValuePpm: 10,
+      fundingIndex: bigIntToBytes(BigInt(0)),
+    },
+    {
+      perpetualId: 50,
+      fundingValuePpm: 10,
+      fundingIndex: bigIntToBytes(BigInt(0)),
+    },
+  ],
+};
+
 export const defaultFundingRateEvent: FundingEventMessage = {
   type: FundingEventV1_Type.TYPE_FUNDING_RATE_AND_INDEX,
   updates: [

--- a/indexer/services/ender/__tests__/helpers/constants.ts
+++ b/indexer/services/ender/__tests__/helpers/constants.ts
@@ -81,7 +81,7 @@ export const defaultFundingUpdateSampleEventWithAdditionalMarket: FundingEventMe
       fundingIndex: bigIntToBytes(BigInt(0)),
     },
     {
-      perpetualId: 50,
+      perpetualId: 99999,
       fundingValuePpm: 10,
       fundingIndex: bigIntToBytes(BigInt(0)),
     },

--- a/indexer/services/ender/src/config.ts
+++ b/indexer/services/ender/src/config.ts
@@ -23,6 +23,9 @@ export const configSchema = {
   SEND_WEBSOCKET_MESSAGES: parseBoolean({
     default: true,
   }),
+  IGNORE_NONEXISTENT_PERPETUAL_MARKET: parseBoolean({
+    default: false,
+  }),
 };
 
 export default parseSchema(configSchema);

--- a/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
@@ -38,7 +38,8 @@ BEGIN
         perpetual_market_id = (funding_update->'perpetualId')::bigint;
         SELECT * INTO perpetual_market_record FROM perpetual_markets WHERE "id" = perpetual_market_id;
         IF NOT FOUND THEN
-            errors_response = array_append(errors_response, to_jsonb('Received FundingUpdate with unknown perpetualId.'));
+            errors_response = array_append(errors_response, to_jsonb('Received FundingUpdate with unknown perpetualId.'::text));
+            CONTINUE;
         END IF;
 
         perpetual_markets_response = jsonb_set(perpetual_markets_response, ARRAY[(perpetual_market_record."id")::text], dydx_to_jsonb(perpetual_market_record));
@@ -81,7 +82,7 @@ BEGIN
                 funding_update_response = jsonb_set(funding_update_response, ARRAY[(funding_index_updates_record."perpetualId")::text], dydx_to_jsonb(funding_index_updates_record));
 
             ELSE
-                errors_response = array_append(errors_response, to_jsonb('Received unknown FundingEvent type.'));
+                errors_response = array_append(errors_response, to_jsonb('Received unknown FundingEvent type.'::text));
                 CONTINUE;
         END CASE;
 

--- a/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
@@ -38,7 +38,7 @@ BEGIN
         perpetual_market_id = (funding_update->'perpetualId')::bigint;
         SELECT * INTO perpetual_market_record FROM perpetual_markets WHERE "id" = perpetual_market_id;
         IF NOT FOUND THEN
-            errors_response = array_append(errors_response, 'Received FundingUpdate with unknown perpetualId.'::jsonb);
+            errors_response = array_append(errors_response, '"Received FundingUpdate with unknown perpetualId."'::jsonb);
             CONTINUE;
         END IF;
 
@@ -82,7 +82,7 @@ BEGIN
                 funding_update_response = jsonb_set(funding_update_response, ARRAY[(funding_index_updates_record."perpetualId")::text], dydx_to_jsonb(funding_index_updates_record));
 
             ELSE
-                errors_response = array_append(errors_response, 'Received unknown FundingEvent type.'::jsonb);
+                errors_response = array_append(errors_response, '"Received unknown FundingEvent type."'::jsonb);
                 CONTINUE;
         END CASE;
 

--- a/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
@@ -38,7 +38,7 @@ BEGIN
         perpetual_market_id = (funding_update->'perpetualId')::bigint;
         SELECT * INTO perpetual_market_record FROM perpetual_markets WHERE "id" = perpetual_market_id;
         IF NOT FOUND THEN
-            errors_response = array_append(errors_response, to_jsonb('Received FundingUpdate with unknown perpetualId.'::text));
+            errors_response = array_append(errors_response, 'Received FundingUpdate with unknown perpetualId.'::jsonb);
             CONTINUE;
         END IF;
 
@@ -82,7 +82,7 @@ BEGIN
                 funding_update_response = jsonb_set(funding_update_response, ARRAY[(funding_index_updates_record."perpetualId")::text], dydx_to_jsonb(funding_index_updates_record));
 
             ELSE
-                errors_response = array_append(errors_response, to_jsonb('Received unknown FundingEvent type.'::text));
+                errors_response = array_append(errors_response, 'Received unknown FundingEvent type.'::jsonb);
                 CONTINUE;
         END CASE;
 

--- a/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
@@ -38,7 +38,7 @@ BEGIN
         perpetual_market_id = (funding_update->'perpetualId')::bigint;
         SELECT * INTO perpetual_market_record FROM perpetual_markets WHERE "id" = perpetual_market_id;
         IF NOT FOUND THEN
-            errors_response = array_append(errors_response, 'Received FundingUpdate with unknown perpetualId.');
+            errors_response = array_append(errors_response, to_jsonb('Received FundingUpdate with unknown perpetualId.'));
         END IF;
 
         perpetual_markets_response = jsonb_set(perpetual_markets_response, ARRAY[(perpetual_market_record."id")::text], dydx_to_jsonb(perpetual_market_record));
@@ -81,7 +81,7 @@ BEGIN
                 funding_update_response = jsonb_set(funding_update_response, ARRAY[(funding_index_updates_record."perpetualId")::text], dydx_to_jsonb(funding_index_updates_record));
 
             ELSE
-                errors_response = array_append(errors_response, 'Received unknown FundingEvent type.');
+                errors_response = array_append(errors_response, to_jsonb('Received unknown FundingEvent type.'));
                 CONTINUE;
         END CASE;
 

--- a/indexer/services/ender/src/validators/funding-validator.ts
+++ b/indexer/services/ender/src/validators/funding-validator.ts
@@ -33,7 +33,8 @@ export class FundingValidator extends Validator<FundingEventV1> {
         if (config.IGNORE_NONEXISTENT_PERPETUAL_MARKET) {
           logger.error({
             at: `${this.constructor.name}#validate`,
-            message: 'Ignoring invalid FundingEvent, perpetualId does not exist',
+            message: 'Invalid FundingEvent, perpetualId does not exist',
+            blockHeight: this.block.height,
             event: this.event,
           });
         } else {


### PR DESCRIPTION
### Changelist
Introduce flag to ignore invalid FundingEvent where the perpetualId doesn't exist
Fix error handling in funding handler SQL script

### Test Plan
unit tested

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
