### PR TITLE
[CT-521] move funding handler from unordered_handlers to ordered_handlers

### DIFF
--- a/indexer/services/ender/__tests__/handlers/funding-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/funding-handler.test.ts
@@ -168,46 +168,47 @@ describe('fundingHandler', () => {
     );
   });
 
-  it('successfully processes and clears cache for a new funding rate with non-existent market', async () => {
-    const kafkaMessage: KafkaMessage = createKafkaMessageFromFundingEvents({
-      fundingEvents: [defaultFundingUpdateSampleEventWithAdditionalMarket],
-      height: defaultHeight,
-      time: defaultTime,
+  it('successfully processes and clears cache for a new funding rate with both existing/non-existent market',
+    async () => {
+      const kafkaMessage: KafkaMessage = createKafkaMessageFromFundingEvents({
+        fundingEvents: [defaultFundingUpdateSampleEventWithAdditionalMarket],
+        height: defaultHeight,
+        time: defaultTime,
+      });
+
+      await onMessage(kafkaMessage);
+
+      await expectNextFundingRate(
+        'BTC-USD',
+        new Big(protocolTranslations.funding8HourValuePpmTo1HourRate(
+          defaultFundingUpdateSampleEvent.updates[0].fundingValuePpm,
+        )),
+      );
+
+      const kafkaMessage2: KafkaMessage = createKafkaMessageFromFundingEvents({
+        fundingEvents: [defaultFundingRateEvent],
+        height: 4,
+        time: defaultTime,
+      });
+
+      await onMessage(kafkaMessage2);
+      await expectNextFundingRate(
+        'BTC-USD',
+        undefined,
+      );
+      const fundingIndices: FundingIndexUpdatesFromDatabase[] = await
+      FundingIndexUpdatesTable.findAll({}, [], {});
+
+      expect(fundingIndices.length).toEqual(1);
+      expect(fundingIndices[0]).toEqual(expect.objectContaining({
+        perpetualId: '0',
+        rate: '0.00000125',
+        oraclePrice: '10000',
+        fundingIndex: '0.1',
+      }));
+      expect(stats.gauge).toHaveBeenCalledWith('ender.funding_index_update_event', 0.1, { ticker: 'BTC-USD' });
+      expect(stats.gauge).toHaveBeenCalledWith('ender.funding_index_update', 0.1, { ticker: 'BTC-USD' });
     });
-
-    await onMessage(kafkaMessage);
-
-    await expectNextFundingRate(
-      'BTC-USD',
-      new Big(protocolTranslations.funding8HourValuePpmTo1HourRate(
-        defaultFundingUpdateSampleEvent.updates[0].fundingValuePpm,
-      )),
-    );
-
-    const kafkaMessage2: KafkaMessage = createKafkaMessageFromFundingEvents({
-      fundingEvents: [defaultFundingRateEvent],
-      height: 4,
-      time: defaultTime,
-    });
-
-    await onMessage(kafkaMessage2);
-    await expectNextFundingRate(
-      'BTC-USD',
-      undefined,
-    );
-    const fundingIndices: FundingIndexUpdatesFromDatabase[] = await
-    FundingIndexUpdatesTable.findAll({}, [], {});
-
-    expect(fundingIndices.length).toEqual(1);
-    expect(fundingIndices[0]).toEqual(expect.objectContaining({
-      perpetualId: '0',
-      rate: '0.00000125',
-      oraclePrice: '10000',
-      fundingIndex: '0.1',
-    }));
-    expect(stats.gauge).toHaveBeenCalledWith('ender.funding_index_update_event', 0.1, { ticker: 'BTC-USD' });
-    expect(stats.gauge).toHaveBeenCalledWith('ender.funding_index_update', 0.1, { ticker: 'BTC-USD' });
-  });
 
   it('successfully processes and clears cache for a new funding rate', async () => {
     const kafkaMessage: KafkaMessage = createKafkaMessageFromFundingEvents({

--- a/indexer/services/ender/__tests__/handlers/funding-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/funding-handler.test.ts
@@ -196,7 +196,7 @@ describe('fundingHandler', () => {
       undefined,
     );
     const fundingIndices: FundingIndexUpdatesFromDatabase[] = await
-      FundingIndexUpdatesTable.findAll({}, [], {});
+    FundingIndexUpdatesTable.findAll({}, [], {});
 
     expect(fundingIndices.length).toEqual(1);
     expect(fundingIndices[0]).toEqual(expect.objectContaining({

--- a/indexer/services/ender/__tests__/handlers/perpetual-market-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/perpetual-market-handler.test.ts
@@ -38,6 +38,7 @@ import {
 } from '../helpers/constants';
 import { updateBlockCache } from '../../src/caches/block-cache';
 import { createPostgresFunctions } from '../../src/helpers/postgres/postgres-functions';
+import { expectPerpetualMarketMatchesEvent } from '../helpers/postgres-helpers';
 
 describe('perpetualMarketHandler', () => {
   beforeAll(async () => {
@@ -163,23 +164,6 @@ describe('perpetualMarketHandler', () => {
     expectPerpetualMarketKafkaMessage(producerSendMock, [perpetualMarket!]);
   });
 });
-
-function expectPerpetualMarketMatchesEvent(
-  perpetual: PerpetualMarketCreateEventV1,
-  perpetualMarket: PerpetualMarketFromDatabase,
-) {
-  expect(perpetualMarket).toEqual(expect.objectContaining({
-    id: perpetual.id.toString(),
-    clobPairId: perpetual.clobPairId.toString(),
-    ticker: perpetual.ticker,
-    marketId: perpetual.marketId,
-    quantumConversionExponent: perpetual.quantumConversionExponent,
-    atomicResolution: perpetual.atomicResolution,
-    subticksPerTick: perpetual.subticksPerTick,
-    stepBaseQuantums: Number(perpetual.stepBaseQuantums),
-    liquidityTierId: perpetual.liquidityTier,
-  }));
-}
 
 function createKafkaMessageFromPerpetualMarketEvent({
   perpetualMarketEvent,

--- a/indexer/services/ender/__tests__/helpers/constants.ts
+++ b/indexer/services/ender/__tests__/helpers/constants.ts
@@ -72,6 +72,22 @@ export const defaultFundingUpdateSampleEvent: FundingEventMessage = {
   ],
 };
 
+export const defaultFundingUpdateSampleEventWithAdditionalMarket: FundingEventMessage = {
+  type: FundingEventV1_Type.TYPE_PREMIUM_SAMPLE,
+  updates: [
+    {
+      perpetualId: 0,
+      fundingValuePpm: 10,
+      fundingIndex: bigIntToBytes(BigInt(0)),
+    },
+    {
+      perpetualId: 99999,
+      fundingValuePpm: 10,
+      fundingIndex: bigIntToBytes(BigInt(0)),
+    },
+  ],
+};
+
 export const defaultFundingRateEvent: FundingEventMessage = {
   type: FundingEventV1_Type.TYPE_FUNDING_RATE_AND_INDEX,
   updates: [

--- a/indexer/services/ender/__tests__/helpers/postgres-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/postgres-helpers.ts
@@ -1,0 +1,19 @@
+import { PerpetualMarketFromDatabase } from '@dydxprotocol-indexer/postgres';
+import { PerpetualMarketCreateEventV1 } from '@dydxprotocol-indexer/v4-protos';
+
+export function expectPerpetualMarketMatchesEvent(
+  perpetual: PerpetualMarketCreateEventV1,
+  perpetualMarket: PerpetualMarketFromDatabase,
+) {
+  expect(perpetualMarket).toEqual(expect.objectContaining({
+    id: perpetual.id.toString(),
+    clobPairId: perpetual.clobPairId.toString(),
+    ticker: perpetual.ticker,
+    marketId: perpetual.marketId,
+    quantumConversionExponent: perpetual.quantumConversionExponent,
+    atomicResolution: perpetual.atomicResolution,
+    subticksPerTick: perpetual.subticksPerTick,
+    stepBaseQuantums: Number(perpetual.stepBaseQuantums),
+    liquidityTierId: perpetual.liquidityTier,
+  }));
+}

--- a/indexer/services/ender/__tests__/lib/on-message.test.ts
+++ b/indexer/services/ender/__tests__/lib/on-message.test.ts
@@ -252,7 +252,7 @@ describe('on-message', () => {
       expect.any(Number), 1, { success: 'true' });
   });
 
-  it('successfully processes block with market create and funding events', async () => {
+  it('successfully processes block with market create and its funding events', async () => {
     await Promise.all([
       MarketTable.create(testConstants.defaultMarket),
       MarketTable.create(testConstants.defaultMarket2),

--- a/indexer/services/ender/src/lib/sync-handlers.ts
+++ b/indexer/services/ender/src/lib/sync-handlers.ts
@@ -16,6 +16,7 @@ export const SYNCHRONOUS_SUBTYPES: DydxIndexerSubtypes[] = [
   DydxIndexerSubtypes.PERPETUAL_MARKET,
   DydxIndexerSubtypes.UPDATE_PERPETUAL,
   DydxIndexerSubtypes.UPDATE_CLOB_PAIR,
+  DydxIndexerSubtypes.FUNDING,
 ];
 
 /**

--- a/indexer/services/ender/src/scripts/handlers/dydx_block_processor_ordered_handlers.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_block_processor_ordered_handlers.sql
@@ -53,6 +53,8 @@ BEGIN
                 rval[i] = dydx_update_perpetual_handler(event_data);
             WHEN '"update_clob_pair"'::jsonb THEN
                 rval[i] = dydx_update_clob_pair_handler(event_data);
+            WHEN '"funding_values"'::jsonb THEN
+                rval[i] = dydx_funding_handler(block_height, block_time, event_data, event_index, transaction_index);
             ELSE
                 NULL;
             END CASE;

--- a/indexer/services/ender/src/scripts/handlers/dydx_block_processor_unordered_handlers.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_block_processor_unordered_handlers.sql
@@ -56,8 +56,6 @@ BEGIN
                 rval[i] = dydx_transfer_handler(block_height, block_time, event_data, event_index, transaction_index, jsonb_array_element_text(block->'txHashes', transaction_index));
             WHEN '"stateful_order"'::jsonb THEN
                 rval[i] = dydx_stateful_order_handler(block_height, block_time, event_data);
-            WHEN '"funding_values"'::jsonb THEN
-                rval[i] = dydx_funding_handler(block_height, block_time, event_data, event_index, transaction_index);
             WHEN '"deleveraging"'::jsonb THEN
                 rval[i] = dydx_deleveraging_handler(block_height, block_time, event_data, event_index, transaction_index, jsonb_array_element_text(block->'txHashes', transaction_index));
             WHEN '"trading_reward"'::jsonb THEN

--- a/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
@@ -38,7 +38,8 @@ BEGIN
         perpetual_market_id = (funding_update->'perpetualId')::bigint;
         SELECT * INTO perpetual_market_record FROM perpetual_markets WHERE "id" = perpetual_market_id;
         IF NOT FOUND THEN
-            errors_response = array_append(errors_response, 'Received FundingUpdate with unknown perpetualId.');
+            errors_response = array_append(errors_response, '"Received FundingUpdate with unknown perpetualId."'::jsonb);
+            CONTINUE;
         END IF;
 
         perpetual_markets_response = jsonb_set(perpetual_markets_response, ARRAY[(perpetual_market_record."id")::text], dydx_to_jsonb(perpetual_market_record));
@@ -81,7 +82,7 @@ BEGIN
                 funding_update_response = jsonb_set(funding_update_response, ARRAY[(funding_index_updates_record."perpetualId")::text], dydx_to_jsonb(funding_index_updates_record));
 
             ELSE
-                errors_response = array_append(errors_response, 'Received unknown FundingEvent type.');
+                errors_response = array_append(errors_response, '"Received unknown FundingEvent type."'::jsonb);
                 CONTINUE;
         END CASE;
 

--- a/indexer/services/ender/src/validators/funding-validator.ts
+++ b/indexer/services/ender/src/validators/funding-validator.ts
@@ -1,3 +1,4 @@
+import { logger } from '@dydxprotocol-indexer/base';
 import { perpetualMarketRefresher } from '@dydxprotocol-indexer/postgres';
 import {
   FundingEventV1,
@@ -28,10 +29,12 @@ export class FundingValidator extends Validator<FundingEventV1> {
         perpetualMarketRefresher.getPerpetualMarketFromId(
           perpetualId.toString(),
         ) === undefined) {
-        return this.logAndThrowParseMessageError(
-          'Invalid FundingEvent, perpetualId does not exist',
-          { event: this.event },
-        );
+        logger.error({
+          at: `${this.constructor.name}#validate`,
+          message: 'Invalid FundingEvent, perpetualId does not exist',
+          blockHeight: this.block.height,
+          event: this.event,
+        });
       }
     });
   }


### PR DESCRIPTION
### Changelist

- move funding handler from unordered_handlers to ordered_handlers
- fix funding sql script error handling as in https://github.com/dydxprotocol/v4-chain/pull/1093, and corresponding unit test
- the perp market can be created in the same block as the funding sample, so only log an error in funding validator if the perpetualId can't be found in the `perpetual-markets-refresher` cache
- add an e2e test in `on-message.test.ts` that tests the case where a single block both creates the event & has a funding sample for the newly created market


### Test Plan
unit tested

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
