### PR TITLE
Ensure that all matching status are returned in list orders endpoint

### DIFF
--- a/indexer/packages/postgres/src/stores/order-table.ts
+++ b/indexer/packages/postgres/src/stores/order-table.ts
@@ -135,7 +135,7 @@ export async function findAll(
   }
 
   if (status !== undefined) {
-    baseQuery = baseQuery.where(OrderColumns.status, status);
+    baseQuery = baseQuery.whereIn(OrderColumns.status, status);
   }
 
   if (reduceOnly !== undefined) {

--- a/indexer/packages/postgres/src/stores/order-table.ts
+++ b/indexer/packages/postgres/src/stores/order-table.ts
@@ -60,7 +60,7 @@ export async function findAll(
     totalFilled,
     price,
     type,
-    status,
+    statuses,
     reduceOnly,
     orderFlags,
     goodTilBlockBeforeOrAt,
@@ -83,7 +83,7 @@ export async function findAll(
       totalFilled,
       price,
       type,
-      status,
+      statuses,
       reduceOnly,
       orderFlags,
       goodTilBlockBeforeOrAt,
@@ -134,8 +134,8 @@ export async function findAll(
     baseQuery = baseQuery.where(OrderColumns.type, type);
   }
 
-  if (status !== undefined) {
-    baseQuery = baseQuery.whereIn(OrderColumns.status, status);
+  if (statuses !== undefined) {
+    baseQuery = baseQuery.whereIn(OrderColumns.status, statuses);
   }
 
   if (reduceOnly !== undefined) {

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -121,7 +121,7 @@ export interface OrderQueryConfig extends QueryConfig {
   [QueryableField.TOTAL_FILLED]?: string;
   [QueryableField.PRICE]?: string;
   [QueryableField.TYPE]?: OrderType;
-  [QueryableField.STATUS]?: OrderStatus;
+  [QueryableField.STATUS]?: OrderStatus[];
   [QueryableField.POST_ONLY]?: boolean;
   [QueryableField.REDUCE_ONLY]?: boolean;
   [QueryableField.GOOD_TIL_BLOCK_BEFORE_OR_AT]?: string;

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -26,6 +26,7 @@ export enum QueryableField {
   PRICE = 'price',
   TYPE = 'type',
   STATUS = 'status',
+  STATUSES = 'statuses',
   POST_ONLY = 'postOnly',
   REDUCE_ONLY = 'reduceOnly',
   PERPETUAL_ID = 'perpetualId',
@@ -121,7 +122,7 @@ export interface OrderQueryConfig extends QueryConfig {
   [QueryableField.TOTAL_FILLED]?: string;
   [QueryableField.PRICE]?: string;
   [QueryableField.TYPE]?: OrderType;
-  [QueryableField.STATUS]?: OrderStatus[];
+  [QueryableField.STATUSES]?: OrderStatus[];
   [QueryableField.POST_ONLY]?: boolean;
   [QueryableField.REDUCE_ONLY]?: boolean;
   [QueryableField.GOOD_TIL_BLOCK_BEFORE_OR_AT]?: string;

--- a/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
@@ -86,13 +86,9 @@ class OrdersController extends Controller {
       goodTilBlockTimeBeforeOrAt,
     };
     if (!_.isEmpty(status)) {
-      // BEST_EFFORT_OPENED status not included in the filter, orders in postgres cannot be
-      // BEST_EFFORT_OPENED. An order is only BEST_EFFORT_OPENED if it exists in redis and not
-      // in postgres.
-      orderQueryConfig.statuses = _.filter(
-        status,
-        (s: APIOrderStatus) => s !== APIOrderStatusEnum.BEST_EFFORT_OPENED,
-      ) as OrderStatus[];
+      // BEST_EFFORT_OPENED status is not filtered out, because it's a minor optimization,
+      // is more confusing, and is not going to affect the result of the query.
+      orderQueryConfig.statuses = status as OrderStatus[];
     }
     const ordering: Ordering = returnLatestOrders !== undefined
       ? returnLatestOrdersToOrdering(returnLatestOrders)

--- a/indexer/services/roundtable/src/tasks/cancel-stale-orders.ts
+++ b/indexer/services/roundtable/src/tasks/cancel-stale-orders.ts
@@ -24,7 +24,7 @@ export default async function runTask(): Promise<void> {
 
   const staleOpenOrders: OrderFromDatabase[] = await OrderTable.findAll(
     {
-      status: [OrderStatus.OPEN],
+      statuses: [OrderStatus.OPEN],
       orderFlags: ORDER_FLAG_SHORT_TERM.toString(),
       // goodTilBlock needs to be < latest block height to be guaranteed to be CANCELED
       goodTilBlockBeforeOrAt: (latestBlockHeight - 1).toString(),

--- a/indexer/services/roundtable/src/tasks/cancel-stale-orders.ts
+++ b/indexer/services/roundtable/src/tasks/cancel-stale-orders.ts
@@ -24,7 +24,7 @@ export default async function runTask(): Promise<void> {
 
   const staleOpenOrders: OrderFromDatabase[] = await OrderTable.findAll(
     {
-      status: OrderStatus.OPEN,
+      status: [OrderStatus.OPEN],
       orderFlags: ORDER_FLAG_SHORT_TERM.toString(),
       // goodTilBlock needs to be < latest block height to be guaranteed to be CANCELED
       goodTilBlockBeforeOrAt: (latestBlockHeight - 1).toString(),


### PR DESCRIPTION
### Changelist
When listing orders, we were previously only querying the latest ${limit} orders, and not matching by status. So if the latest 100 orders were all filled, and a user was attempting to untriggered orders, they would not receive any orders.

### Test Plan
add a test to ensure that status is properly filtered for

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
