### PR TITLE
Optimize string building loop to write to a single buffer instead of to multiple buffers that are concatenated.

### DIFF
--- a/protocol/x/clob/types/operation.go
+++ b/protocol/x/clob/types/operation.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	"bytes"
 	fmt "fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
 )
@@ -51,10 +51,11 @@ func (o *InternalOperation) GetInternalOperationTextString() string {
 
 // GetOperationsQueueString returns a string representation of the provided operations.
 func GetInternalOperationsQueueTextString(operations []InternalOperation) string {
-	var result string
-	for _, operation := range operations {
-		result += operation.GetInternalOperationTextString() + "\n"
+	var buf bytes.Buffer
+	for _, op := range operations {
+		// Note that MarshalText only throws errors if the writer throws errors which it never does
+		proto.MarshalText(&buf, &op) //nolint:errcheck
+		buf.Write([]byte("\n"))
 	}
-
-	return result
+	return buf.String()
 }


### PR DESCRIPTION
### Changelist
Optimize string building loop to write to a single buffer instead of to multiple buffers that are concatenated.

This reduced the cost of the method from 1.86s to 600ms when executing on the dev5 testnet when the nodes were at full load. This is a method that is performed when a block is applied so it reduces how long we hold an exclusive lock preventing CheckTx from occurring.

### Test Plan
Existing tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
