### PR TITLE
[CT-631] add index that includes createdAt to fills to address read replica lag

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240304115004_create_fills_clob_pair_id_created_at_height_created_at_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240304115004_create_fills_clob_pair_id_created_at_height_created_at_index.ts
@@ -1,0 +1,21 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // Partial index only when `liquidity` is 'TAKER' as this index is meant to speed up the query to
+  // fetch all trades from the database, and we arbitrarily only use 'TAKER' fills for trades to
+  // avoid double counting.
+  // eslint-disable-next-line @typescript-eslint/quotes
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "fills_clobPairId_createdAtHeight_createdAt_partial" ON "fills" ("clobPairId", "createdAtHeight", "createdAt") WHERE "liquidity" = 'TAKER';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "fills_clobPairId_createdAtHeight_createdAt_partial";
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
add index that includes createdAt to fills to address read replica lag

### Test Plan
pushed to mainnet over weekend. See https://dydx-team.slack.com/archives/C05SD03C1A7/p1709414088044459 for details. Metrics [here](https://ap1.datadoghq.com/dashboard/wvp-x3m-ghh/v4-indexer-comlink?fromUser=false&fullscreen_end_ts=1709435097529&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1709403169928&fullscreen_widget=7176307515184638&refresh_mode=sliding&view=spans&from_ts=1709485068252&to_ts=1709571468252&live=true)


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
