### PR TITLE
Fix mock-gen build

### DIFF
--- a/protocol/mocks/Makefile
+++ b/protocol/mocks/Makefile
@@ -1,17 +1,17 @@
 GOPATH=$(shell go env GOPATH)
 
-COSMOS_VERSION=$(shell go list -m all | grep "github.com/dydxprotocol/cosmos-sdk" | awk '{print $$NF}')
-COSMOS_STORE_VERSION=$(shell go list -m all | grep "cosmossdk.io/store" | awk '{print $$NF}')
-COSMOS_LOG_VERSION=$(shell go list -m all | grep "cosmossdk.io/log" | awk '{print $$NF}')
-COSMOS_GOGOPROTO_VERSION=$(shell go list -m all | grep "github.com/cosmos/gogoproto" | awk '{print $$NF}')
+COSMOS_VERSION=$(shell go list -m all | grep "github.com/dydxprotocol/cosmos-sdk[^/]" | awk '{print $$NF}')
+COSMOS_STORE_VERSION=$(shell go list -m all | grep "cosmossdk.io/store[^/]" | awk '{print $$NF}')
+COSMOS_LOG_VERSION=$(shell go list -m all | grep "cosmossdk.io/log[^/]" | awk '{print $$NF}')
+COSMOS_GOGOPROTO_VERSION=$(shell go list -m all | grep "github.com/cosmos/gogoproto[^/]" | awk '{print $$NF}')
 
 mock-clean:
 	@rm -f ./mocks/*.go
 
 mock-gen:
 	@go run github.com/vektra/mockery/v2 --name=Configurator --dir=$(GOPATH)/pkg/mod/github.com/dydxprotocol/cosmos-sdk@$(COSMOS_VERSION)/types --recursive --output=./mocks
-	@go run github.com/vektra/mockery/v2 --name=MultiStore --dir=$(GOPATH)/pkg/mod/cosmossdk.io/store@$(COSMOS_STORE_VERSION)/types --recursive --output=./mocks
-	@go run github.com/vektra/mockery/v2 --name=CacheMultiStore --dir=$(GOPATH)/pkg/mod/cosmossdk.io/store@$(COSMOS_STORE_VERSION)/types --recursive --output=./mocks
+	@go run github.com/vektra/mockery/v2 --name=MultiStore --dir=$(GOPATH)/pkg/mod/github.com/dydxprotocol/cosmos-sdk/store@$(COSMOS_STORE_VERSION)/types --recursive --output=./mocks
+	@go run github.com/vektra/mockery/v2 --name=CacheMultiStore --dir=$(GOPATH)/pkg/mod/github.com/dydxprotocol/cosmos-sdk/store@$(COSMOS_STORE_VERSION)/types --recursive --output=./mocks
 	@go run github.com/vektra/mockery/v2 --name=AnteDecorator --dir=$(GOPATH)/pkg/mod/github.com/dydxprotocol/cosmos-sdk@$(COSMOS_VERSION)/types --recursive --output=./mocks
 	@go run github.com/vektra/mockery/v2 --name=TxConfig --dir=$(GOPATH)/pkg/mod/github.com/dydxprotocol/cosmos-sdk@$(COSMOS_VERSION)/client --recursive --output=./mocks
 	@go run github.com/vektra/mockery/v2 --name=TxBuilder --dir=$(GOPATH)/pkg/mod/github.com/dydxprotocol/cosmos-sdk@$(COSMOS_VERSION)/client --recursive --output=./mocks
@@ -42,7 +42,6 @@ mock-gen:
 	@go run github.com/vektra/mockery/v2 --name=GrpcServer --dir=./daemons/types --recursive --output=./mocks
 	@go run github.com/vektra/mockery/v2 --name=GrpcClient --dir=./daemons/types --recursive --output=./mocks
 	@go run github.com/vektra/mockery/v2 --name=TimeProvider --dir=./lib/time --recursive --output=./mocks
-	@go run github.com/vektra/mockery/v2 --name=Marshaler --dir=./indexer/common --recursive --output=./mocks
 	@go run github.com/vektra/mockery/v2 --name=QueryClient --dir=./testutil/grpc --recursive --output=./mocks
 	@go run github.com/vektra/mockery/v2 --name=QueryServer --dir=./testutil/grpc --recursive --output=./mocks
 	@go run github.com/vektra/mockery/v2 --name=ExchangeQueryHandler --dir=./daemons/pricefeed/client/handler --recursive --output=./mocks


### PR DESCRIPTION
It seems that with this pr [here](https://github.com/dydxprotocol/cosmos-sdk/commit/f4e166bc10570e14ef243a00a28b5033aa5e67f6#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R203) we have changed dependencies in the go.mod file.

Now our previous approach of grepping out the version via:
```
hyperon@Hyperon protocol % go list -m all | grep "github.com/dydxprotocol/cosmos-sdk" 
cosmossdk.io/store v1.0.2 => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240227194839-f4e166bc1057
github.com/cosmos/cosmos-sdk v0.50.4 => github.com/dydxprotocol/cosmos-sdk v0.50.5-0.20240227194839-f4e166bc1057
hyperon@Hyperon protocol %
```
is incorrect because there are multiple lines and nested strings.

Fix:
1. add regex to ensure there's no nested strings
2. Remove `Marshaler` mock gen since there seems to be no more marshaler
3. Account for replaces

Testing:
ran `make mock-gen`