### PR TITLE
[TRA-78] Add function to retrieve collateral pool addr for a subaccount

### DIFF
--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -66,7 +66,6 @@ func (k Keeper) GetCollateralPoolForSubaccount(ctx sdk.Context, subaccountId typ
 	if err != nil {
 		return nil, err
 	}
-
 	return authtypes.NewModuleAddress(poolName), nil
 }
 
@@ -91,18 +90,11 @@ func (k Keeper) GetCollateralPoolNameForSubaccount(ctx sdk.Context, subaccountId
 
 // IsIsolatedMarketSubaccount returns whether a subaccount is isolated to a specific market.
 func (k Keeper) IsIsolatedMarketSubaccount(ctx sdk.Context, subaccountId types.SubaccountId) (bool, error) {
-	subaccount := k.GetSubaccount(ctx, subaccountId)
-	if len(subaccount.PerpetualPositions) == 0 {
-		return false, nil
-	}
-
-	// Get the first perpetual position and return whether it is an isolated market.
-	perpetual, err := k.perpetualsKeeper.GetPerpetual(ctx, subaccount.PerpetualPositions[0].PerpetualId)
+	poolName, err := k.GetCollateralPoolNameForSubaccount(ctx, subaccountId)
 	if err != nil {
-		return false, err
+		panic(fmt.Sprintf("IsIsolatedMarketSubaccount: %v", err))
 	}
-
-	return perpetual.Params.MarketType == perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED, nil
+	return poolName != types.ModuleName, nil
 }
 
 // GetSubaccount returns a subaccount from its index.

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -7,6 +7,8 @@ import (
 	"math/rand"
 	"time"
 
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
 	"github.com/cosmos/gogoproto/proto"
 
 	storetypes "cosmossdk.io/store/types"
@@ -50,6 +52,57 @@ func (k Keeper) SetSubaccount(ctx sdk.Context, subaccount types.Subaccount) {
 		b := k.cdc.MustMarshal(&subaccount)
 		store.Set(key, b)
 	}
+}
+
+// GetCollateralPoolForSubaccount returns the collateral pool address for a subaccount
+// based on the subaccount's perpetual positions. If the subaccount holds a position in an isolated
+// market, the collateral pool address will be the isolated market's pool address. Otherwise, the
+// collateral pool address will be the module's pool address.
+func (k Keeper) GetCollateralPoolForSubaccount(ctx sdk.Context, subaccountId types.SubaccountId) (
+	sdk.AccAddress,
+	error,
+) {
+	poolName, err := k.GetCollateralPoolNameForSubaccount(ctx, subaccountId)
+	if err != nil {
+		return nil, err
+	}
+
+	return authtypes.NewModuleAddress(poolName), nil
+}
+
+func (k Keeper) GetCollateralPoolNameForSubaccount(ctx sdk.Context, subaccountId types.SubaccountId) (string, error) {
+	subaccount := k.GetSubaccount(ctx, subaccountId)
+	if len(subaccount.PerpetualPositions) == 0 {
+		return types.ModuleName, nil
+	}
+
+	// Get the first perpetual position and return the collateral pool name.
+	perpetual, err := k.perpetualsKeeper.GetPerpetual(ctx, subaccount.PerpetualPositions[0].PerpetualId)
+	if err != nil {
+		panic(fmt.Sprintf("GetCollateralPoolNameForSubaccount: %v", err))
+	}
+
+	if perpetual.Params.MarketType == perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED {
+		return types.ModuleName + ":" + lib.UintToString(perpetual.GetId()), nil
+	}
+
+	return types.ModuleName, nil
+}
+
+// IsIsolatedMarketSubaccount returns whether a subaccount is isolated to a specific market.
+func (k Keeper) IsIsolatedMarketSubaccount(ctx sdk.Context, subaccountId types.SubaccountId) (bool, error) {
+	subaccount := k.GetSubaccount(ctx, subaccountId)
+	if len(subaccount.PerpetualPositions) == 0 {
+		return false, nil
+	}
+
+	// Get the first perpetual position and return whether it is an isolated market.
+	perpetual, err := k.perpetualsKeeper.GetPerpetual(ctx, subaccount.PerpetualPositions[0].PerpetualId)
+	if err != nil {
+		return false, err
+	}
+
+	return perpetual.Params.MarketType == perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED, nil
 }
 
 // GetSubaccount returns a subaccount from its index.

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -129,7 +129,9 @@ func TestGetCollateralPool(t *testing.T) {
 					Quantums:    dtypes.NewInt(100_000_000),
 				},
 			},
-			expectedAddress: authtypes.NewModuleAddress(types.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.GetId())),
+			expectedAddress: authtypes.NewModuleAddress(
+				types.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.GetId()),
+			),
 		},
 		"collateral pool with no positions": {
 			perpetualPositions: make([]*types.PerpetualPosition, 0),
@@ -171,7 +173,6 @@ func TestGetCollateralPool(t *testing.T) {
 			},
 		)
 	}
-
 }
 
 func TestSubaccountGet(t *testing.T) {

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -6,6 +6,9 @@ import (
 	"strconv"
 	"testing"
 
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
@@ -97,6 +100,78 @@ func assertSubaccountUpdateEventsInIndexerBlock(
 		)
 		require.Contains(t, subaccountUpdates, expecetedSubaccountUpdateEvent)
 	}
+}
+
+func TestGetCollateralPool(t *testing.T) {
+	tests := map[string]struct {
+		// state
+		perpetuals         []perptypes.Perpetual
+		perpetualPositions []*types.PerpetualPosition
+
+		expectedAddress sdk.AccAddress
+	}{
+		"collateral pool with cross margin markets": {
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_SmallMarginRequirement,
+			},
+			perpetualPositions: []*types.PerpetualPosition{
+				&constants.PerpetualPosition_OneBTCLong,
+			},
+			expectedAddress: authtypes.NewModuleAddress(types.ModuleName),
+		},
+		"collateral pool with isolated margin markets": {
+			perpetuals: []perptypes.Perpetual{
+				constants.IsoUsd_IsolatedMarket,
+			},
+			perpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId: constants.IsoUsd_IsolatedMarket.GetId(),
+					Quantums:    dtypes.NewInt(100_000_000),
+				},
+			},
+			expectedAddress: authtypes.NewModuleAddress(types.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.GetId())),
+		},
+		"collateral pool with no positions": {
+			perpetualPositions: make([]*types.PerpetualPosition, 0),
+			expectedAddress:    authtypes.NewModuleAddress(types.ModuleName),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(
+			name, func(t *testing.T) {
+				ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _ := testutil.SubaccountsKeepers(
+					t,
+					true,
+				)
+
+				testutil.CreateTestMarkets(t, ctx, pricesKeeper)
+				testutil.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
+
+				require.NoError(t, testutil.CreateUsdcAsset(ctx, assetsKeeper))
+				for _, p := range tc.perpetuals {
+					_, err := perpetualsKeeper.CreatePerpetual(
+						ctx,
+						p.Params.Id,
+						p.Params.Ticker,
+						p.Params.MarketId,
+						p.Params.AtomicResolution,
+						p.Params.DefaultFundingPpm,
+						p.Params.LiquidityTier,
+						p.Params.MarketType,
+					)
+					require.NoError(t, err)
+				}
+
+				subaccount := createNSubaccount(keeper, ctx, 1, big.NewInt(1_000))[0]
+				subaccount.PerpetualPositions = tc.perpetualPositions
+				keeper.SetSubaccount(ctx, subaccount)
+				collateralPoolAddr, err := keeper.GetCollateralPoolForSubaccount(ctx, *subaccount.Id)
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedAddress, collateralPoolAddr)
+			},
+		)
+	}
+
 }
 
 func TestSubaccountGet(t *testing.T) {


### PR DESCRIPTION
### Changelist
Add functions to get collateral pool address for cross or isolated markets based on the subaccount being used

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [x] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [x] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [x] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
