### PR TITLE
[OTE-162] Modify `GetInitialMarginQuoteQuantums` to reflect OIMF

### DIFF
--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1016,7 +1016,10 @@ func GetMarginRequirementsInQuoteQuantums(
 	)
 
 	// Initial margin requirement quote quantums = size in quote quantums * initial margin PPM.
-	bigInitialMarginQuoteQuantums = liquidityTier.GetInitialMarginQuoteQuantums(bigQuoteQuantums)
+	bigInitialMarginQuoteQuantums = liquidityTier.GetInitialMarginQuoteQuantums(
+		bigQuoteQuantums,
+		big.NewInt(0), // Temporary for open interest notional. TODO(OTE-214): replace with actual value.
+	)
 
 	// Maintenance margin requirement quote quantums = IM in quote quantums * maintenance fraction PPM.
 	bigMaintenanceMarginQuoteQuantums = lib.BigRatRound(

--- a/protocol/x/perpetuals/types/liquidity_tier.go
+++ b/protocol/x/perpetuals/types/liquidity_tier.go
@@ -172,17 +172,9 @@ func (liquidityTier LiquidityTier) GetInitialMarginQuoteQuantums(
 		true, // Round up initial margin.
 	)
 
-	if bigIMREffective.Cmp(bigQuoteQuantums) > 0 {
-		panic(
-			fmt.Sprintf(
-				"GetInitialMarginQuoteQuantums: bigIMREffective (%v) > bigQuoteQuantums (%v), "+
-					"liquidityTier: %+v, openInterestQuoteQuantums: %s",
-				bigIMREffective,
-				bigQuoteQuantums,
-				liquidityTier,
-				openInterestQuoteQuantums.String(),
-			),
-		)
+	// Return min(Effective IMR, Quote Quantums)
+	if bigIMREffective.Cmp(bigQuoteQuantums) >= 0 {
+		return bigQuoteQuantums
 	}
 	return bigIMREffective
 }

--- a/protocol/x/perpetuals/types/liquidity_tier.go
+++ b/protocol/x/perpetuals/types/liquidity_tier.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"math/big"
 
 	errorsmod "cosmossdk.io/errors"
@@ -91,42 +92,38 @@ func (liquidityTier LiquidityTier) GetMaxAbsFundingClampPpm(clampFactorPpm uint3
 //
 // note:
 // - divisions are delayed for precision purposes.
-// - input `openInterestQuoteQuantums“ is modified for memory efficiency
 func (liquidityTier LiquidityTier) GetInitialMarginQuoteQuantums(
 	bigQuoteQuantums *big.Int,
 	openInterestQuoteQuantums *big.Int,
 ) *big.Int {
 	bigOpenInterestUpperCap := new(big.Int).SetUint64(liquidityTier.OpenInterestUpperCap)
 
-	// Calculate base IMR: multiply `bigQuoteQuantums` with `initialMarginPpm` and divide by 1 million.
-	ratQuoteQuantums := new(big.Rat).SetInt(bigQuoteQuantums)
-	ratBaseIMR := lib.BigRatMulPpm(ratQuoteQuantums, liquidityTier.InitialMarginPpm)
-
-	// If `open_interest_upper_cap` is 0, OIMF is disabled (always use base IMF)
-	if liquidityTier.OpenInterestUpperCap == 0 {
-		return lib.BigRatRound(ratBaseIMR, true) // Round up initial margin.
-	}
-
-	// If `open_interest` > `open_interest_upper_cap`,
+	// If `open_interest` >= `open_interest_upper_cap` where `upper_cap` is non-zero,
 	// OIMF = 1.0 so return input quote quantums as the IMR.
 	if openInterestQuoteQuantums.Cmp(
 		bigOpenInterestUpperCap,
-	) >= 0 {
+	) >= 0 && liquidityTier.OpenInterestUpperCap != 0 {
 		return bigQuoteQuantums
 	}
 
-	// If `current_interest` < `open_interest_lower_cap`, use base IMF as OIMF.
+	ratQuoteQuantums := new(big.Rat).SetInt(bigQuoteQuantums)
+
+	// If `open_interest_upper_cap` is 0, OIMF is disabled。
+	// Or if `current_interest` <= `open_interest_lower_cap`, IMF is not scaled.
+	// In both cases, use base IMF as OIMF.
 	bigOpenInterestLowerCap := new(big.Int).SetUint64(liquidityTier.OpenInterestLowerCap)
-	if openInterestQuoteQuantums.Cmp(
+	if liquidityTier.OpenInterestUpperCap == 0 || openInterestQuoteQuantums.Cmp(
 		bigOpenInterestLowerCap,
 	) <= 0 {
+		// Calculate base IMR: multiply `bigQuoteQuantums` with `initialMarginPpm` and divide by 1 million.
+		ratBaseIMR := lib.BigRatMulPpm(ratQuoteQuantums, liquidityTier.InitialMarginPpm)
 		return lib.BigRatRound(ratBaseIMR, true) // Round up initial margin.
 	}
 
-	// If `open_interest_lower_cap` <= `open_interest` <= `open_interest_upper_cap`, calculate the scaled OIMF.
+	// If `open_interest_lower_cap` < `open_interest` <= `open_interest_upper_cap`, calculate the scaled OIMF.
 	// `Scaling Factor = (Open Notional - Lower Cap) / (Upper Cap - Lower Cap)`
 	ratScalingFactor := new(big.Rat).SetFrac(
-		openInterestQuoteQuantums.Sub(
+		new(big.Int).Sub(
 			openInterestQuoteQuantums, // reuse pointer for memory efficiency
 			bigOpenInterestLowerCap,
 		),
@@ -137,37 +134,55 @@ func (liquidityTier LiquidityTier) GetInitialMarginQuoteQuantums(
 	)
 
 	// `IMF Increase = Scaling Factor * (1 - Base IMF)`
-	ratIMFIncrease := ratScalingFactor.Mul(
-		ratScalingFactor, // reuse pointer for memory efficiency
-		new(big.Rat).SetFrac64(
-			int64(lib.OneMillion-liquidityTier.InitialMarginPpm), // >= 0, since we check in `liquidityTier.Validate()`
-			int64(lib.OneMillion),
-		),
+	ratIMFIncrease := lib.BigRatMulPpm(
+		ratScalingFactor,
+		lib.OneMillion-liquidityTier.InitialMarginPpm, // >= 0, since we check in `liquidityTier.Validate()`
 	)
 
 	// Calculate `Max(IMF Increase, 0)`.
 	if ratIMFIncrease.Sign() < 0 {
-		ratIMFIncrease.SetUint64(0)
+		panic(
+			fmt.Sprintf(
+				"GetInitialMarginQuoteQuantums: IMF Increase is negative (%s), liquidityTier: %+v, openInterestQuoteQuantums: %s",
+				ratIMFIncrease.String(),
+				liquidityTier,
+				openInterestQuoteQuantums.String(),
+			),
+		)
 	}
-	// `Effective IMF = Min(Base IMF + Max(IMF Increase, 0), 1.0)`
-	// Multiply `quoteQuantums` on both sides:
-	// `Effective IMR = Min(Base IMR + Max(IMF Increase, 0) * quoteQuantums, quoteQuantums)`
-	ratIMRIncrease := ratIMFIncrease.Mul(
-		ratIMFIncrease, // reuse pointer for memory efficiency
-		ratQuoteQuantums,
+
+	// First, calculate base IMF in big.Rat
+	ratBaseIMF := new(big.Rat).SetFrac64(
+		int64(liquidityTier.InitialMarginPpm), // safe, since `InitialMargin` is uint32
+		int64(lib.OneMillion),
 	)
 
+	// `Effective IMF = Min(Base IMF + Max(IMF Increase, 0), 1.0)`
+	ratEffectiveIMF := ratBaseIMF.Add(
+		ratBaseIMF, // reuse pointer for memory efficiency
+		ratIMFIncrease,
+	)
+
+	// `Effective IMR = Effective IMF * Quote Quantums`
 	bigIMREffective := lib.BigRatRound(
-		ratBaseIMR.Add(
-			ratBaseIMR, // reuse pointer for memory efficiency
-			ratIMRIncrease,
+		ratEffectiveIMF.Mul(
+			ratEffectiveIMF, // reuse pointer for memory efficiency
+			ratQuoteQuantums,
 		),
 		true, // Round up initial margin.
 	)
 
-	// Return `Min(Effective IMR, quoteQuantums)`.
-	if bigIMREffective.Cmp(bigQuoteQuantums) < 0 {
-		return bigIMREffective
+	if bigIMREffective.Cmp(bigQuoteQuantums) > 0 {
+		panic(
+			fmt.Sprintf(
+				"GetInitialMarginQuoteQuantums: bigIMREffective (%v) > bigQuoteQuantums (%v), "+
+					"liquidityTier: %+v, openInterestQuoteQuantums: %s",
+				bigIMREffective,
+				bigQuoteQuantums,
+				liquidityTier,
+				openInterestQuoteQuantums.String(),
+			),
+		)
 	}
-	return bigQuoteQuantums
+	return bigIMREffective
 }


### PR DESCRIPTION
### Changelist
Modify `GetInitialMarginQuoteQuantums` to reflect OIMF. Note that this PR doesn't introduce behavior change due to `zero` being passed in as open interest

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
