### PR TITLE
Have /fills endpoint return a list rather than dictionary

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
@@ -60,8 +60,8 @@ describe('fills-controller#V4', () => {
         createdAtHeight: testConstants.defaultFill.createdAtHeight,
       };
 
-      expect(response.body.fills).toHaveLength(1);
-      expect(response.body.fills).toEqual(
+      expect(response.body).toHaveLength(1);
+      expect(response.body).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             ...expected,
@@ -110,8 +110,8 @@ describe('fills-controller#V4', () => {
       };
 
       // Only the ETH-USD order should be returned
-      expect(response.body.fills).toHaveLength(1);
-      expect(response.body.fills).toEqual(
+      expect(response.body).toHaveLength(1);
+      expect(response.body).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             ...expected,
@@ -175,8 +175,8 @@ describe('fills-controller#V4', () => {
       ];
 
       // Fills should be returned sorted by createdAtHeight in descending order.
-      expect(response.body.fills).toHaveLength(2);
-      expect(response.body.fills).toEqual(
+      expect(response.body).toHaveLength(2);
+      expect(response.body).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             ...expected[0],
@@ -200,7 +200,7 @@ describe('fills-controller#V4', () => {
           `&market=${testConstants.defaultPerpetualMarket2.ticker}&marketType=${MarketType.PERPETUAL}`,
       });
 
-      expect(response.body.fills).toEqual([]);
+      expect(response.body).toEqual([]);
     });
 
     it.each([

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -565,32 +565,67 @@ fetch('https://dydx-testnet.imperator.co/v4/fills?address=string&subaccountNumbe
 > 200 Response
 
 ```json
-{
-  "fills": [
-    {
-      "id": "string",
-      "side": "BUY",
-      "liquidity": "TAKER",
-      "type": "LIMIT",
-      "market": "string",
-      "marketType": "PERPETUAL",
-      "price": "string",
-      "size": "string",
-      "fee": "string",
-      "createdAt": "string",
-      "createdAtHeight": "string",
-      "orderId": "string",
-      "clientMetadata": "string"
-    }
-  ]
-}
+[
+  {
+    "id": "string",
+    "side": "BUY",
+    "liquidity": "TAKER",
+    "type": "LIMIT",
+    "market": "string",
+    "marketType": "PERPETUAL",
+    "price": "string",
+    "size": "string",
+    "fee": "string",
+    "createdAt": "string",
+    "createdAtHeight": "string",
+    "orderId": "string",
+    "clientMetadata": "string"
+  }
+]
 ```
 
 ### Responses
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Ok|[FillResponse](#schemafillresponse)|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Ok|Inline|
+
+### Response Schema
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[FillResponseObject](#schemafillresponseobject)]|false|none|none|
+|» id|string|true|none|none|
+|» side|[OrderSide](#schemaorderside)|true|none|none|
+|» liquidity|[Liquidity](#schemaliquidity)|true|none|none|
+|» type|[FillType](#schemafilltype)|true|none|none|
+|» market|string|true|none|none|
+|» marketType|[MarketType](#schemamarkettype)|true|none|none|
+|» price|string|true|none|none|
+|» size|string|true|none|none|
+|» fee|string|true|none|none|
+|» createdAt|[IsoString](#schemaisostring)|true|none|none|
+|» createdAtHeight|string|true|none|none|
+|» orderId|string|false|none|none|
+|» clientMetadata|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|side|BUY|
+|side|SELL|
+|liquidity|TAKER|
+|liquidity|MAKER|
+|type|LIMIT|
+|type|LIQUIDATED|
+|type|LIQUIDATION|
+|type|DELEVERAGED|
+|type|OFFSETTING|
+|marketType|PERPETUAL|
+|marketType|SPOT|
 
 <aside class="success">
 This operation does not require authentication
@@ -2630,42 +2665,6 @@ This operation does not require authentication
 |createdAtHeight|string|true|none|none|
 |orderId|string|false|none|none|
 |clientMetadata|string|false|none|none|
-
-## FillResponse
-
-<a id="schemafillresponse"></a>
-<a id="schema_FillResponse"></a>
-<a id="tocSfillresponse"></a>
-<a id="tocsfillresponse"></a>
-
-```json
-{
-  "fills": [
-    {
-      "id": "string",
-      "side": "BUY",
-      "liquidity": "TAKER",
-      "type": "LIMIT",
-      "market": "string",
-      "marketType": "PERPETUAL",
-      "price": "string",
-      "size": "string",
-      "fee": "string",
-      "createdAt": "string",
-      "createdAtHeight": "string",
-      "orderId": "string",
-      "clientMetadata": "string"
-    }
-  ]
-}
-
-```
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|fills|[[FillResponseObject](#schemafillresponseobject)]|true|none|none|
 
 ## HeightResponse
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -427,21 +427,6 @@
         "type": "object",
         "additionalProperties": false
       },
-      "FillResponse": {
-        "properties": {
-          "fills": {
-            "items": {
-              "$ref": "#/components/schemas/FillResponseObject"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "fills"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      },
       "HeightResponse": {
         "properties": {
           "height": {
@@ -1366,7 +1351,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FillResponse"
+                  "items": {
+                    "$ref": "#/components/schemas/FillResponseObject"
+                  },
+                  "type": "array"
                 }
               }
             }

--- a/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
@@ -32,7 +32,7 @@ import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { fillToResponseObject } from '../../../request-helpers/request-transformer';
 import {
-  FillRequest, FillResponse, FillResponseObject, MarketAndTypeByClobPairId, MarketType,
+  FillRequest, FillResponseObject, MarketAndTypeByClobPairId, MarketType,
 } from '../../../types';
 
 const router: express.Router = express.Router();
@@ -49,7 +49,7 @@ class FillsController extends Controller {
       @Query() limit: number,
       @Query() createdBeforeOrAtHeight?: number,
       @Query() createdBeforeOrAt?: IsoString,
-  ): Promise<FillResponse> {
+  ): Promise<FillResponseObject[]> {
     // TODO(DEC-656): Change to using a cache of markets in Redis similar to Librarian instead of
     // querying the DB.
     let clobPairId: string | undefined;
@@ -88,11 +88,9 @@ class FillsController extends Controller {
       },
     );
 
-    return {
-      fills: fills.map((fill: FillFromDatabase): FillResponseObject => {
-        return fillToResponseObject(fill, clobPairIdToMarket);
-      }),
-    };
+    return fills.map((fill: FillFromDatabase): FillResponseObject => {
+      return fillToResponseObject(fill, clobPairIdToMarket);
+    });
   }
 }
 
@@ -143,7 +141,7 @@ router.get(
     // querying the DB.
     try {
       const controller: FillsController = new FillsController();
-      const response: FillResponse = await controller.getFills(
+      const response: FillResponseObject[] = await controller.getFills(
         address,
         subaccountNumber,
         market,

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -111,10 +111,6 @@ export type AssetPositionsMap = { [symbol: string]: AssetPositionResponseObject 
 
 /* ------- FILL TYPES ------- */
 
-export interface FillResponse {
-  fills: FillResponseObject[],
-}
-
 export interface FillResponseObject {
   id: string,
   side: OrderSide,


### PR DESCRIPTION
### Changelist
/orders endpoint returns a list of OrderResponseObject. Have /fills endpoint do the same.

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
