### PR TITLE
[TRA-98] Update upper limit of subaccount number constraint

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/subaccounts/subaccount.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/subaccounts/subaccount.ts
@@ -8,8 +8,8 @@ export interface SubaccountId {
   /** The address of the wallet that owns this subaccount. */
   owner: string;
   /**
-   * < 128 Since 128 should be enough to start and it fits within
-   * 1 Byte (1 Bit needed to indicate that the first byte is the last).
+   * The unique number of this subaccount for the owner.
+   * Currently limited to 128*1000 subaccounts per owner.
    */
 
   number: number;
@@ -20,8 +20,8 @@ export interface SubaccountIdSDKType {
   /** The address of the wallet that owns this subaccount. */
   owner: string;
   /**
-   * < 128 Since 128 should be enough to start and it fits within
-   * 1 Byte (1 Bit needed to indicate that the first byte is the last).
+   * The unique number of this subaccount for the owner.
+   * Currently limited to 128*1000 subaccounts per owner.
    */
 
   number: number;

--- a/proto/dydxprotocol/subaccounts/subaccount.proto
+++ b/proto/dydxprotocol/subaccounts/subaccount.proto
@@ -11,8 +11,8 @@ option go_package = "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/typ
 message SubaccountId {
   // The address of the wallet that owns this subaccount.
   string owner = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
-  // < 128 Since 128 should be enough to start and it fits within
-  // 1 Byte (1 Bit needed to indicate that the first byte is the last).
+  // The unique number of this subaccount for the owner.
+  // Currently limited to 128*1000 subaccounts per owner.
   uint32 number = 2;
 }
 

--- a/protocol/x/clob/types/message_cancel_order_test.go
+++ b/protocol/x/clob/types/message_cancel_order_test.go
@@ -29,7 +29,7 @@ func TestMsgCancelOrder_ValidateBasic(t *testing.T) {
 				OrderId: OrderId{
 					SubaccountId: satypes.SubaccountId{
 						Owner:  sample.AccAddress(),
-						Number: uint32(9999),
+						Number: uint32(999_999),
 					},
 				},
 			},

--- a/protocol/x/clob/types/message_place_order_test.go
+++ b/protocol/x/clob/types/message_place_order_test.go
@@ -32,7 +32,7 @@ func TestMsgPlaceOrder_ValidateBasic(t *testing.T) {
 					OrderId: OrderId{
 						SubaccountId: satypes.SubaccountId{
 							Owner:  sample.AccAddress(),
-							Number: uint32(9999),
+							Number: uint32(999_999),
 						},
 					},
 				},

--- a/protocol/x/sending/types/message_create_transfer_test.go
+++ b/protocol/x/sending/types/message_create_transfer_test.go
@@ -49,7 +49,7 @@ func TestMsgCreateTransfer_ValidateBasic(t *testing.T) {
 				Transfer: &types.Transfer{
 					Sender: satypes.SubaccountId{
 						Owner:  sample.AccAddress(),
-						Number: uint32(9999),
+						Number: uint32(999_999),
 					},
 					Recipient: constants.Carl_Num0,
 				},
@@ -63,7 +63,7 @@ func TestMsgCreateTransfer_ValidateBasic(t *testing.T) {
 					Sender: constants.Carl_Num0,
 					Recipient: satypes.SubaccountId{
 						Owner:  sample.AccAddress(),
-						Number: uint32(9999),
+						Number: uint32(999_999),
 					},
 				},
 			},

--- a/protocol/x/subaccounts/module_test.go
+++ b/protocol/x/subaccounts/module_test.go
@@ -9,6 +9,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+
 	"github.com/dydxprotocol/v4-chain/protocol/app/module"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -132,11 +135,11 @@ func TestAppModuleBasic_ValidateGenesisErrBadState_Number(t *testing.T) {
 
 	cdc := codec.NewProtoCodec(module.InterfaceRegistry)
 
-	msg := fmt.Sprintf(`{"subaccounts": [{ "id": {"owner": "%s", "number": 128 } }]}`, sample.AccAddress())
+	msg := fmt.Sprintf(`{"subaccounts": [{ "id": {"owner": "%s", "number": 128001 } }]}`, sample.AccAddress())
 	h := json.RawMessage(msg)
 
 	err := am.ValidateGenesis(cdc, nil, h)
-	require.EqualError(t, err, "subaccount id number cannot exceed 127")
+	require.EqualError(t, err, "subaccount id number cannot exceed "+lib.IntToString(types.MaxSubaccountIdNumber))
 }
 
 func TestAppModuleBasic_ValidateGenesis(t *testing.T) {

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -2,7 +2,10 @@ package types
 
 // DONTCOVER
 
-import errorsmod "cosmossdk.io/errors"
+import (
+	errorsmod "cosmossdk.io/errors"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+)
 
 // x/subaccounts module sentinel errors
 var (
@@ -18,9 +21,13 @@ var (
 	ErrProductPositionNotUpdatable = errorsmod.Register(ModuleName, 103, "product position is not updatable")
 
 	// 200 - 299: subaccount id related.
-	ErrInvalidSubaccountIdNumber = errorsmod.Register(ModuleName, 200, "subaccount id number cannot exceed 127")
-	ErrInvalidSubaccountIdOwner  = errorsmod.Register(ModuleName, 201, "subaccount id owner is an invalid address")
-	ErrDuplicateSubaccountIds    = errorsmod.Register(ModuleName, 202, "duplicate subaccount id found in genesis")
+	ErrInvalidSubaccountIdNumber = errorsmod.Register(
+		ModuleName,
+		200,
+		"subaccount id number cannot exceed "+lib.IntToString(MaxSubaccountIdNumber),
+	)
+	ErrInvalidSubaccountIdOwner = errorsmod.Register(ModuleName, 201, "subaccount id owner is an invalid address")
+	ErrDuplicateSubaccountIds   = errorsmod.Register(ModuleName, 202, "duplicate subaccount id found in genesis")
 
 	// 300 - 399: asset position related.
 	ErrAssetPositionsOutOfOrder       = errorsmod.Register(ModuleName, 300, "asset positions are out of order")

--- a/protocol/x/subaccounts/types/genesis_test.go
+++ b/protocol/x/subaccounts/types/genesis_test.go
@@ -1,8 +1,9 @@
 package types_test
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"testing"
+
+	errorsmod "cosmossdk.io/errors"
 
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sample"
@@ -85,13 +86,13 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 			expectedError: types.ErrInvalidSubaccountIdOwner,
 		},
-		"invalid: id number is greater than 127": {
+		"invalid: id number is greater than 128_000": {
 			genState: &types.GenesisState{
 				Subaccounts: []types.Subaccount{
 					{
 						Id: &types.SubaccountId{
 							Owner:  sample.AccAddress(),
-							Number: uint32(128),
+							Number: uint32(128_001),
 						},
 					},
 				},

--- a/protocol/x/subaccounts/types/subaccount.go
+++ b/protocol/x/subaccounts/types/subaccount.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	MaxSubaccountIdNumber = 127 // 0 ... 127 are valid numbers.
+	MaxSubaccountIdNumber = 128_000 // 0 ... 128,000 are valid numbers.
 )
 
 // BaseQuantums is used to represent an amount in base quantums.

--- a/protocol/x/subaccounts/types/subaccount.pb.go
+++ b/protocol/x/subaccounts/types/subaccount.pb.go
@@ -27,8 +27,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type SubaccountId struct {
 	// The address of the wallet that owns this subaccount.
 	Owner string `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
-	// < 128 Since 128 should be enough to start and it fits within
-	// 1 Byte (1 Bit needed to indicate that the first byte is the last).
+	// The unique number of this subaccount for the owner.
+	// Currently limited to 128*1000 subaccounts per owner.
 	Number uint32 `protobuf:"varint,2,opt,name=number,proto3" json:"number,omitempty"`
 }
 

--- a/protocol/x/subaccounts/types/subaccount_test.go
+++ b/protocol/x/subaccounts/types/subaccount_test.go
@@ -53,7 +53,7 @@ func TestSubaccountIdValidate(t *testing.T) {
 		},
 		"invalid number": {
 			owner:         sample.AccAddress(),
-			number:        128,
+			number:        128_001,
 			expectedError: types.ErrInvalidSubaccountIdNumber,
 		},
 	}


### PR DESCRIPTION
### Changelist
Increase upper limit of subaccount number to 128,000 to allow for isolated margin subaccounts

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
