### PR TITLE
[OTE-218] Add state validity test for perpetual market type

### DIFF
--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -238,10 +238,10 @@ benchmark:
 	@VERSION=$(VERSION) go test -mod=readonly -tags='$(build_tags)' -bench=. ./...
 
 test-container:
-	@SKIP_DISABLED=true VERSION=$(VERSION) go test -mod=readonly -tags='container_test $(build_tags)' ./testing/containertest
+	@SKIP_DISABLED=true VERSION=$(VERSION) go test -mod=readonly -tags='container_test $(build_tags)' ./...
 
 test-container-accept:
-	@SKIP_DISABLED=true VERSION=$(VERSION) go test -mod=readonly -tags='container_test $(build_tags)' ./testing/containertest -args -accept
+	@SKIP_DISABLED=true VERSION=$(VERSION) go test -mod=readonly -tags='container_test $(build_tags)' ./... -args -accept
 
 test-container-build:
 	$(MAKE) localnet-build

--- a/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
@@ -1,0 +1,144 @@
+//go:build all || container_test
+
+package v_5_0_0_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/gogoproto/proto"
+	v_5_0_0 "github.com/dydxprotocol/v4-chain/protocol/app/upgrades/v5.0.0"
+	containertest "github.com/dydxprotocol/v4-chain/protocol/testing/containertest"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	perpetuals "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	upgrade "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+)
+
+const govModuleAddress = "dydx10d07y265gmmuvt4z0w9aw880jnsr700jnmapky"
+
+var nodeAddresses = []string{
+	constants.AliceAccAddress.String(),
+	constants.BobAccAddress.String(),
+	constants.CarlAccAddress.String(),
+	constants.DaveAccAddress.String(),
+}
+
+func TestUpgrade(t *testing.T) {
+	testnet, err := containertest.NewTestnetWithPreupgradeGenesis()
+	require.NoError(t, err, "failed to create testnet - is docker daemon running?")
+	err = testnet.Start()
+	require.NoError(t, err)
+	defer testnet.MustCleanUp()
+	node := testnet.Nodes["alice"]
+	nodeAddress := constants.AliceAccAddress.String()
+	err = upgradeTestnet(nodeAddress, t, node, v_5_0_0.UpgradeName)
+	require.NoError(t, err)
+}
+
+func TestStateUpgrade(t *testing.T) {
+	testnet, err := containertest.NewTestnetWithPreupgradeGenesis()
+	require.NoError(t, err, "failed to create testnet - is docker daemon running?")
+	err = testnet.Start()
+	require.NoError(t, err)
+	defer testnet.MustCleanUp()
+	node := testnet.Nodes["alice"]
+	nodeAddress := constants.AliceAccAddress.String()
+
+	preUpgradeChecks(node, t)
+
+	err = upgradeTestnet(nodeAddress, t, node, v_5_0_0.UpgradeName)
+	require.NoError(t, err)
+
+	postUpgradeChecks(node, t)
+}
+
+func preUpgradeChecks(node *containertest.Node, t *testing.T) {
+	preUpgradeCheckPerpetualMarketType(node, t)
+	// Add test for your upgrade handler logic below
+}
+
+func postUpgradeChecks(node *containertest.Node, t *testing.T) {
+	postUpgradecheckPerpetualMarketType(node, t)
+	// Add test for your upgrade handler logic below
+}
+
+func preUpgradeCheckPerpetualMarketType(node *containertest.Node, t *testing.T) {
+	perpetualsList := &perpetuals.QueryAllPerpetualsResponse{}
+	resp, err := containertest.Query(
+		node,
+		perpetuals.NewQueryClient,
+		perpetuals.QueryClient.AllPerpetuals,
+		&perpetuals.QueryAllPerpetualsRequest{},
+	)
+	require.NoError(t, err)
+	err = proto.UnmarshalText(resp.String(), perpetualsList)
+	require.NoError(t, err)
+	for _, perpetual := range perpetualsList.Perpetual {
+		assert.Equal(t, perpetuals.PerpetualMarketType_PERPETUAL_MARKET_TYPE_UNSPECIFIED, perpetual.Params.MarketType)
+	}
+}
+
+func postUpgradecheckPerpetualMarketType(node *containertest.Node, t *testing.T) {
+	perpetualsList := &perpetuals.QueryAllPerpetualsResponse{}
+	resp, err := containertest.Query(
+		node,
+		perpetuals.NewQueryClient,
+		perpetuals.QueryClient.AllPerpetuals,
+		&perpetuals.QueryAllPerpetualsRequest{},
+	)
+	require.NoError(t, err)
+	err = proto.UnmarshalText(resp.String(), perpetualsList)
+	require.NoError(t, err)
+	for _, perpetual := range perpetualsList.Perpetual {
+		assert.Equal(t, perpetuals.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS, perpetual.Params.MarketType)
+	}
+}
+
+func upgradeTestnet(nodeAddress string, t *testing.T, node *containertest.Node, upgradeToVersion string) error {
+	proposal, err := gov.NewMsgSubmitProposal(
+		[]sdk.Msg{
+			&upgrade.MsgSoftwareUpgrade{
+				Authority: govModuleAddress,
+				Plan: upgrade.Plan{
+					Name:   upgradeToVersion,
+					Height: 10,
+				},
+			},
+		},
+		testapp.TestDeposit,
+		nodeAddress,
+		testapp.TestMetadata,
+		testapp.TestTitle,
+		testapp.TestSummary,
+		false,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, containertest.BroadcastTx(
+		node,
+		proposal,
+		nodeAddress,
+	))
+	err = node.Wait(2)
+	require.NoError(t, err)
+
+	for _, address := range nodeAddresses {
+		require.NoError(t, containertest.BroadcastTx(
+			node,
+			&gov.MsgVote{
+				ProposalId: 1,
+				Voter:      address,
+				Option:     gov.VoteOption_VOTE_OPTION_YES,
+			},
+			address,
+		))
+	}
+
+	err = node.WaitUntilBlockHeight(12)
+	return err
+}

--- a/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
@@ -28,18 +28,6 @@ var nodeAddresses = []string{
 	constants.DaveAccAddress.String(),
 }
 
-func TestUpgrade(t *testing.T) {
-	testnet, err := containertest.NewTestnetWithPreupgradeGenesis()
-	require.NoError(t, err, "failed to create testnet - is docker daemon running?")
-	err = testnet.Start()
-	require.NoError(t, err)
-	defer testnet.MustCleanUp()
-	node := testnet.Nodes["alice"]
-	nodeAddress := constants.AliceAccAddress.String()
-	err = upgradeTestnet(nodeAddress, t, node, v_5_0_0.UpgradeName)
-	require.NoError(t, err)
-}
-
 func TestStateUpgrade(t *testing.T) {
 	testnet, err := containertest.NewTestnetWithPreupgradeGenesis()
 	require.NoError(t, err, "failed to create testnet - is docker daemon running?")

--- a/protocol/testing/containertest/testnet_test.go
+++ b/protocol/testing/containertest/testnet_test.go
@@ -291,7 +291,7 @@ func TestUpgrade(t *testing.T) {
 	defer testnet.MustCleanUp()
 	node := testnet.Nodes["alice"]
 	nodeAddress := constants.AliceAccAddress.String()
-	upgradeTestnet(nodeAddress, t, node)
+	err = upgradeTestnet(nodeAddress, t, node)
 	require.NoError(t, err)
 }
 

--- a/protocol/testing/containertest/testnet_utils.go
+++ b/protocol/testing/containertest/testnet_utils.go
@@ -1,0 +1,66 @@
+package containertest
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/stretchr/testify/require"
+
+	upgrade "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+)
+
+const GovModuleAddress = "dydx10d07y265gmmuvt4z0w9aw880jnsr700jnmapky"
+
+var NodeAddresses = []string{
+	constants.AliceAccAddress.String(),
+	constants.BobAccAddress.String(),
+	constants.CarlAccAddress.String(),
+	constants.DaveAccAddress.String(),
+}
+
+func UpgradeTestnet(nodeAddress string, t *testing.T, node *Node, upgradeToVersion string) error {
+	proposal, err := gov.NewMsgSubmitProposal(
+		[]sdk.Msg{
+			&upgrade.MsgSoftwareUpgrade{
+				Authority: GovModuleAddress,
+				Plan: upgrade.Plan{
+					Name:   upgradeToVersion,
+					Height: 10,
+				},
+			},
+		},
+		testapp.TestDeposit,
+		nodeAddress,
+		testapp.TestMetadata,
+		testapp.TestTitle,
+		testapp.TestSummary,
+		false,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, BroadcastTx(
+		node,
+		proposal,
+		nodeAddress,
+	))
+	err = node.Wait(2)
+	require.NoError(t, err)
+
+	for _, address := range NodeAddresses {
+		require.NoError(t, BroadcastTx(
+			node,
+			&gov.MsgVote{
+				ProposalId: 1,
+				Voter:      address,
+				Option:     gov.VoteOption_VOTE_OPTION_YES,
+			},
+			address,
+		))
+	}
+
+	err = node.WaitUntilBlockHeight(12)
+	return err
+}


### PR DESCRIPTION
### Changelist
Adds an upgrade test which checks state validity for perpetual market type
Refactors testnet upgrade code so that it can be used across tests

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
