### PR TITLE
[TRA-112] Add util to convert between parent and child subaccount numbers

### DIFF
--- a/indexer/packages/postgres/__tests__/lib/api-translations.test.ts
+++ b/indexer/packages/postgres/__tests__/lib/api-translations.test.ts
@@ -3,7 +3,7 @@ import {
   getChildSubaccountNums,
   getParentSubaccountNum,
   isOrderTIFPostOnly,
-  orderTIFToAPITIF
+  orderTIFToAPITIF,
 } from '../../src/lib/api-translations';
 
 describe('apiTranslations', () => {

--- a/indexer/packages/postgres/__tests__/lib/api-translations.test.ts
+++ b/indexer/packages/postgres/__tests__/lib/api-translations.test.ts
@@ -42,6 +42,7 @@ describe('apiTranslations', () => {
       const childSubaccounts = getChildSubaccountNums(0);
       expect(childSubaccounts.length).toEqual(1000);
       expect(childSubaccounts[0]).toEqual(0);
+      expect(childSubaccounts[127]).toEqual(127);
       expect(childSubaccounts[1]).toEqual(128);
       expect(childSubaccounts[999]).toEqual(128 * 999);
     });

--- a/indexer/packages/postgres/__tests__/lib/api-translations.test.ts
+++ b/indexer/packages/postgres/__tests__/lib/api-translations.test.ts
@@ -1,5 +1,10 @@
 import { APITimeInForce, TimeInForce } from '../../src/types';
-import { isOrderTIFPostOnly, orderTIFToAPITIF } from '../../src/lib/api-translations';
+import {
+  getChildSubaccountNums,
+  getParentSubaccountNum,
+  isOrderTIFPostOnly,
+  orderTIFToAPITIF
+} from '../../src/lib/api-translations';
 
 describe('apiTranslations', () => {
   describe('orderTIFToAPITIF', () => {
@@ -29,6 +34,36 @@ describe('apiTranslations', () => {
       expectedPostOnly: boolean,
     ) => {
       expect(isOrderTIFPostOnly(orderTimeInForce)).toEqual(expectedPostOnly);
+    });
+  });
+
+  describe('getChildSubaccountNums', () => {
+    it('Gets a list of all possible child subaccount numbers for a parent subaccount number', () => {
+      const childSubaccounts = getChildSubaccountNums(0);
+      expect(childSubaccounts.length).toEqual(1000);
+      expect(childSubaccounts[0]).toEqual(0);
+      expect(childSubaccounts[1]).toEqual(128);
+      expect(childSubaccounts[999]).toEqual(128 * 999);
+    });
+  });
+
+  describe('getChildSubaccountNums', () => {
+    it('Throws an error if the parent subaccount number is greater than or equal to the maximum parent subaccount number', () => {
+      expect(() => getChildSubaccountNums(128)).toThrowError('Parent subaccount number must be less than 128');
+    });
+  });
+
+  describe('getParentSubaccountNum', () => {
+    it('Gets the parent subaccount number from a child subaccount number', () => {
+      expect(getParentSubaccountNum(0)).toEqual(0);
+      expect(getParentSubaccountNum(128)).toEqual(0);
+      expect(getParentSubaccountNum(128 * 999 - 1)).toEqual(127);
+    });
+  });
+
+  describe('getParentSubaccountNum', () => {
+    it('Throws an error if the child subaccount number is greater than the max child subaccount number', () => {
+      expect(() => getParentSubaccountNum(128001)).toThrowError('Child subaccount number must be less than 128000');
     });
   });
 });

--- a/indexer/packages/postgres/__tests__/lib/api-translations.test.ts
+++ b/indexer/packages/postgres/__tests__/lib/api-translations.test.ts
@@ -38,13 +38,19 @@ describe('apiTranslations', () => {
   });
 
   describe('getChildSubaccountNums', () => {
-    it('Gets a list of all possible child subaccount numbers for a parent subaccount number', () => {
+    it('Gets a list of all possible child subaccount numbers for a parent subaccount 0', () => {
       const childSubaccounts = getChildSubaccountNums(0);
       expect(childSubaccounts.length).toEqual(1000);
       expect(childSubaccounts[0]).toEqual(0);
-      expect(childSubaccounts[127]).toEqual(127);
       expect(childSubaccounts[1]).toEqual(128);
       expect(childSubaccounts[999]).toEqual(128 * 999);
+    });
+    it('Gets a list of all possible child subaccount numbers for a parent subaccount 127', () => {
+      const childSubaccounts = getChildSubaccountNums(127);
+      expect(childSubaccounts.length).toEqual(1000);
+      expect(childSubaccounts[0]).toEqual(127);
+      expect(childSubaccounts[1]).toEqual(128 + 127);
+      expect(childSubaccounts[999]).toEqual(128 * 999 + 127);
     });
   });
 

--- a/indexer/packages/postgres/src/constants.ts
+++ b/indexer/packages/postgres/src/constants.ts
@@ -121,3 +121,7 @@ export const DEFAULT_POSTGRES_OPTIONS : Options = config.USE_READ_REPLICA
   ? {
     readReplica: true,
   } : {};
+
+export const MAX_PARENT_SUBACCOUNTS: number = 128;
+
+export const CHILD_SUBACCOUNT_MULTIPLIER: number = 1000;

--- a/indexer/packages/postgres/src/lib/api-translations.ts
+++ b/indexer/packages/postgres/src/lib/api-translations.ts
@@ -1,4 +1,4 @@
-import { TIME_IN_FORCE_TO_API_TIME_IN_FORCE } from '../constants';
+import { TIME_IN_FORCE_TO_API_TIME_IN_FORCE, CHILD_SUBACCOUNT_MULTIPLIER, MAX_PARENT_SUBACCOUNTS } from '../constants';
 import { APITimeInForce, TimeInForce } from '../types';
 
 /**
@@ -19,4 +19,31 @@ export function isOrderTIFPostOnly(timeInForce: TimeInForce): boolean {
  */
 export function orderTIFToAPITIF(timeInForce: TimeInForce): APITimeInForce {
   return TIME_IN_FORCE_TO_API_TIME_IN_FORCE[timeInForce];
+}
+
+/**
+ * Gets a list of all possible child subaccount numbers for a parent subaccount number
+ * Child subaccounts = [128*0+parentSubaccount, 128*1+parentSubaccount ... 128*999+parentSubaccount]
+ * @param parentSubaccount
+ * @returns
+ */
+export function getChildSubaccountNums(parentSubaccountNum: number): number[] {
+  if (parentSubaccountNum >= MAX_PARENT_SUBACCOUNTS) {
+    throw new Error(`Parent subaccount number must be less than ${MAX_PARENT_SUBACCOUNTS}`);
+  }
+  return Array.from({ length: CHILD_SUBACCOUNT_MULTIPLIER },
+    (_, i) => MAX_PARENT_SUBACCOUNTS * i + parentSubaccountNum);
+}
+
+/**
+ * Gets the parent subaccount number from a child subaccount number
+ * Parent subaccount = childSubaccount / 128
+ * @param childSubaccountNum
+ * @returns
+ */
+export function getParentSubaccountNum(childSubaccountNum: number): number {
+  if (childSubaccountNum > MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER) {
+    throw new Error(`Child subaccount number must be less than ${MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER}`);
+  }
+  return Math.floor(childSubaccountNum % MAX_PARENT_SUBACCOUNTS);
 }

--- a/indexer/packages/postgres/src/lib/api-translations.ts
+++ b/indexer/packages/postgres/src/lib/api-translations.ts
@@ -37,7 +37,7 @@ export function getChildSubaccountNums(parentSubaccountNum: number): number[] {
 
 /**
  * Gets the parent subaccount number from a child subaccount number
- * Parent subaccount = childSubaccount / 128
+ * Parent subaccount = childSubaccount % 128
  * @param childSubaccountNum
  * @returns
  */

--- a/indexer/packages/postgres/src/lib/api-translations.ts
+++ b/indexer/packages/postgres/src/lib/api-translations.ts
@@ -45,5 +45,5 @@ export function getParentSubaccountNum(childSubaccountNum: number): number {
   if (childSubaccountNum > MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER) {
     throw new Error(`Child subaccount number must be less than ${MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER}`);
   }
-  return Math.floor(childSubaccountNum % MAX_PARENT_SUBACCOUNTS);
+  return childSubaccountNum % MAX_PARENT_SUBACCOUNTS;
 }


### PR DESCRIPTION
### Changelist
Add utils to provide conversions between parent (user-level) subaccount numbers and child (protocol-level) subaccount numbers

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
