### PR TITLE
Disable fast nodes and update iavl to address bugs

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -387,6 +387,7 @@ func newApp(
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
 		baseapp.SetSnapshot(snapshotStore, snapshotOptions),
 		baseapp.SetIAVLCacheSize(int(cast.ToUint64(appOpts.Get(flagIAVLCacheSize)))),
+		baseapp.SetIAVLDisableFastNode(true),
 		baseapp.SetChainID(chainID),
 	)
 }

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -54,7 +54,7 @@ require (
 	cosmossdk.io/x/upgrade v0.1.1
 	github.com/burdiyan/kafkautil v0.0.0-20190131162249-eaf83ed22d5b
 	github.com/cosmos/cosmos-db v1.0.0
-	github.com/cosmos/iavl v1.0.1
+	github.com/cosmos/iavl v1.1.1-0.20240313174921-bfaf5fcda7b3
 	github.com/cosmos/ibc-go/modules/capability v1.0.0
 	github.com/cosmos/ibc-go/v8 v8.0.0
 	github.com/cosmos/rosetta v0.50.3

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -456,8 +456,8 @@ github.com/cosmos/gogogateway v1.2.0/go.mod h1:iQpLkGWxYcnCdz5iAdLcRBSw3h7NXeOkZ
 github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETRBrkzItWU=
 github.com/cosmos/gogoproto v1.4.11 h1:LZcMHrx4FjUgrqQSWeaGC1v/TeuVFqSLa43CC6aWR2g=
 github.com/cosmos/gogoproto v1.4.11/go.mod h1:/g39Mh8m17X8Q/GDEs5zYTSNaNnInBSohtaxzQnYq1Y=
-github.com/cosmos/iavl v1.0.1 h1:D+mYbcRO2wptYzOM1Hxl9cpmmHU1ZEt9T2Wv5nZTeUw=
-github.com/cosmos/iavl v1.0.1/go.mod h1:8xIUkgVvwvVrBu81scdPty+/Dx9GqwHnAvXz4cwF7RY=
+github.com/cosmos/iavl v1.1.1-0.20240313174921-bfaf5fcda7b3 h1:1b7Bd9y4YC0SFFB9PQ4A9TVdc1vdlSLdSv2m+3mjS1Y=
+github.com/cosmos/iavl v1.1.1-0.20240313174921-bfaf5fcda7b3/go.mod h1:8xIUkgVvwvVrBu81scdPty+/Dx9GqwHnAvXz4cwF7RY=
 github.com/cosmos/ibc-go/modules/capability v1.0.0 h1:r/l++byFtn7jHYa09zlAdSeevo8ci1mVZNO9+V0xsLE=
 github.com/cosmos/ibc-go/modules/capability v1.0.0/go.mod h1:D81ZxzjZAe0ZO5ambnvn1qedsFQ8lOwtqicG6liLBco=
 github.com/cosmos/ibc-go/v8 v8.0.0 h1:QKipnr/NGwc+9L7NZipURvmSIu+nw9jOIWTJuDBqOhg=


### PR DESCRIPTION
### Changelist
- iavl upgrade fixes bugs
  - Legacy nodes being pruned when they are still being referenced
  - Hash incorrectly generated for some nodes that maintained child references to legacy nodes (but actually reference non-legacy nodes during tree modifications
  - `SaveVersion` incorrectly thinks that tree is unmodified if a previous leaf becomes the new root
- turning fast nodes off because they are not supposed to be useful in iavl v1


### Test Plan
- Successfully synced on testnet and none of the bugs occur

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [x] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
