### PR TITLE
[TRA-116] add x/vault total shares store

### DIFF
--- a/protocol/testutil/constants/vault.go
+++ b/protocol/testutil/constants/vault.go
@@ -1,0 +1,16 @@
+package constants
+
+import (
+	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+)
+
+var (
+	Vault_Clob_0 = vaulttypes.VaultId{
+		Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
+		Number: 0,
+	}
+	Vault_Clob_1 = vaulttypes.VaultId{
+		Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
+		Number: 1,
+	}
+)

--- a/protocol/x/vault/keeper/shares.go
+++ b/protocol/x/vault/keeper/shares.go
@@ -1,0 +1,34 @@
+package keeper
+
+import (
+	"cosmossdk.io/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+)
+
+// GetTotalShares gets TotalShares for a vault.
+func (k Keeper) GetTotalShares(
+	ctx sdk.Context,
+	vaultId types.VaultId,
+) (val types.NumShares, exists bool) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.TotalSharesKeyPrefix))
+
+	b := store.Get(vaultId.ToStateKey())
+	if b == nil {
+		return val, false
+	}
+
+	k.cdc.MustUnmarshal(b, &val)
+	return val, true
+}
+
+// SetTotalShares sets TotalShares for a vault.
+func (k Keeper) SetTotalShares(
+	ctx sdk.Context,
+	vaultId types.VaultId,
+	totalShares types.NumShares,
+) {
+	b := k.cdc.MustMarshal(&totalShares)
+	totalSharesStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.TotalSharesKeyPrefix))
+	totalSharesStore.Set(vaultId.ToStateKey(), b)
+}

--- a/protocol/x/vault/keeper/shares.go
+++ b/protocol/x/vault/keeper/shares.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
@@ -22,13 +23,19 @@ func (k Keeper) GetTotalShares(
 	return val, true
 }
 
-// SetTotalShares sets TotalShares for a vault.
+// SetTotalShares sets TotalShares for a vault. Returns error if `totalShares` is negative.
 func (k Keeper) SetTotalShares(
 	ctx sdk.Context,
 	vaultId types.VaultId,
 	totalShares types.NumShares,
-) {
+) error {
+	if totalShares.NumShares.Cmp(dtypes.NewInt(0)) == -1 {
+		return types.ErrNegativeShares
+	}
+
 	b := k.cdc.MustMarshal(&totalShares)
 	totalSharesStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.TotalSharesKeyPrefix))
 	totalSharesStore.Set(vaultId.ToStateKey(), b)
+
+	return nil
 }

--- a/protocol/x/vault/keeper/shares_test.go
+++ b/protocol/x/vault/keeper/shares_test.go
@@ -47,7 +47,7 @@ func TestGetSetTotalShares(t *testing.T) {
 	require.Equal(t, dtypes.NewInt(0), numShares.NumShares)
 
 	// Set total shares for the first vault again and then get.
-	k.SetTotalShares(ctx, constants.Vault_Clob_0, types.NumShares{
+	err = k.SetTotalShares(ctx, constants.Vault_Clob_0, types.NumShares{
 		NumShares: dtypes.NewInt(123),
 	})
 	require.NoError(t, err)

--- a/protocol/x/vault/keeper/shares_test.go
+++ b/protocol/x/vault/keeper/shares_test.go
@@ -20,25 +20,47 @@ func TestGetSetTotalShares(t *testing.T) {
 	require.Equal(t, false, exists)
 
 	// Set total shares for a vault and then get.
-	k.SetTotalShares(ctx, constants.Vault_Clob_0, types.NumShares{
+	err := k.SetTotalShares(ctx, constants.Vault_Clob_0, types.NumShares{
 		NumShares: dtypes.NewInt(7),
 	})
+	require.NoError(t, err)
 	numShares, exists := k.GetTotalShares(ctx, constants.Vault_Clob_0)
 	require.Equal(t, true, exists)
 	require.Equal(t, dtypes.NewInt(7), numShares.NumShares)
 
 	// Set total shares for another vault and then get.
-	k.SetTotalShares(ctx, constants.Vault_Clob_1, types.NumShares{
+	err = k.SetTotalShares(ctx, constants.Vault_Clob_1, types.NumShares{
 		NumShares: dtypes.NewInt(456),
 	})
+	require.NoError(t, err)
 	numShares, exists = k.GetTotalShares(ctx, constants.Vault_Clob_1)
 	require.Equal(t, true, exists)
 	require.Equal(t, dtypes.NewInt(456), numShares.NumShares)
+
+	// Set total shares for second vault to 0.
+	err = k.SetTotalShares(ctx, constants.Vault_Clob_1, types.NumShares{
+		NumShares: dtypes.NewInt(0),
+	})
+	require.NoError(t, err)
+	numShares, exists = k.GetTotalShares(ctx, constants.Vault_Clob_1)
+	require.Equal(t, true, exists)
+	require.Equal(t, dtypes.NewInt(0), numShares.NumShares)
 
 	// Set total shares for the first vault again and then get.
 	k.SetTotalShares(ctx, constants.Vault_Clob_0, types.NumShares{
 		NumShares: dtypes.NewInt(123),
 	})
+	require.NoError(t, err)
+	numShares, exists = k.GetTotalShares(ctx, constants.Vault_Clob_0)
+	require.Equal(t, true, exists)
+	require.Equal(t, dtypes.NewInt(123), numShares.NumShares)
+
+	// Set total shares for the first vault to a negative value.
+	// Should get error and total shares should remain unchanged.
+	err = k.SetTotalShares(ctx, constants.Vault_Clob_0, types.NumShares{
+		NumShares: dtypes.NewInt(-1),
+	})
+	require.Equal(t, types.ErrNegativeShares, err)
 	numShares, exists = k.GetTotalShares(ctx, constants.Vault_Clob_0)
 	require.Equal(t, true, exists)
 	require.Equal(t, dtypes.NewInt(123), numShares.NumShares)

--- a/protocol/x/vault/keeper/shares_test.go
+++ b/protocol/x/vault/keeper/shares_test.go
@@ -1,0 +1,45 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSetTotalShares(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+	k := tApp.App.VaultKeeper
+
+	// Get total shares for a non-existing vault.
+	_, exists := k.GetTotalShares(ctx, constants.Vault_Clob_0)
+	require.Equal(t, false, exists)
+
+	// Set total shares for a vault and then get.
+	k.SetTotalShares(ctx, constants.Vault_Clob_0, types.NumShares{
+		NumShares: dtypes.NewInt(7),
+	})
+	numShares, exists := k.GetTotalShares(ctx, constants.Vault_Clob_0)
+	require.Equal(t, true, exists)
+	require.Equal(t, dtypes.NewInt(7), numShares.NumShares)
+
+	// Set total shares for another vault and then get.
+	k.SetTotalShares(ctx, constants.Vault_Clob_1, types.NumShares{
+		NumShares: dtypes.NewInt(456),
+	})
+	numShares, exists = k.GetTotalShares(ctx, constants.Vault_Clob_1)
+	require.Equal(t, true, exists)
+	require.Equal(t, dtypes.NewInt(456), numShares.NumShares)
+
+	// Set total shares for the first vault again and then get.
+	k.SetTotalShares(ctx, constants.Vault_Clob_0, types.NumShares{
+		NumShares: dtypes.NewInt(123),
+	})
+	numShares, exists = k.GetTotalShares(ctx, constants.Vault_Clob_0)
+	require.Equal(t, true, exists)
+	require.Equal(t, dtypes.NewInt(123), numShares.NumShares)
+}

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -1,0 +1,13 @@
+package types
+
+// DONTCOVER
+
+import errorsmod "cosmossdk.io/errors"
+
+var (
+	ErrNegativeShares = errorsmod.Register(
+		ModuleName,
+		1,
+		"Shares are negative",
+	)
+)

--- a/protocol/x/vault/types/keys.go
+++ b/protocol/x/vault/types/keys.go
@@ -1,10 +1,16 @@
 package types
 
-// Module name and store keys
+// Module name and store keys.
 const (
-	// ModuleName defines the module name
+	// ModuleName defines the module name.
 	ModuleName = "vault"
 
-	// StoreKey defines the primary module store key
+	// StoreKey defines the primary module store key.
 	StoreKey = ModuleName
+)
+
+// State.
+const (
+	// TotalSharesKeyPrefix is the prefix to retrieve all TotalShares.
+	TotalSharesKeyPrefix = "TotalShares:"
 )

--- a/protocol/x/vault/types/keys_test.go
+++ b/protocol/x/vault/types/keys_test.go
@@ -1,0 +1,17 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleKeys(t *testing.T) {
+	require.Equal(t, "vault", types.ModuleName)
+	require.Equal(t, "vault", types.StoreKey)
+}
+
+func TestStateKeys(t *testing.T) {
+	require.Equal(t, "TotalShares:", types.TotalSharesKeyPrefix)
+}

--- a/protocol/x/vault/types/vault_id.go
+++ b/protocol/x/vault/types/vault_id.go
@@ -1,0 +1,9 @@
+package types
+
+func (id *VaultId) ToStateKey() []byte {
+	b, err := id.Marshal()
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/protocol/x/vault/types/vault_id_test.go
+++ b/protocol/x/vault/types/vault_id_test.go
@@ -1,0 +1,16 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToStateKey(t *testing.T) {
+	b, _ := constants.Vault_Clob_0.Marshal()
+	require.Equal(t, b, constants.Vault_Clob_0.ToStateKey())
+
+	b, _ = constants.Vault_Clob_1.Marshal()
+	require.Equal(t, b, constants.Vault_Clob_1.ToStateKey())
+}


### PR DESCRIPTION
### Changelist
Add `TotalShares` store (and getter and setter methods)

### Test Plan
added unit tests in this PR

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
