### PR TITLE
[TRA-121] move place stateful order logic from msg server to keeper

### DIFF
--- a/protocol/mocks/ClobKeeper.go
+++ b/protocol/mocks/ClobKeeper.go
@@ -625,6 +625,24 @@ func (_m *ClobKeeper) HandleMsgCancelOrder(ctx types.Context, msg *clobtypes.Msg
 	return r0
 }
 
+// HandleMsgPlaceOrder provides a mock function with given fields: ctx, msg
+func (_m *ClobKeeper) HandleMsgPlaceOrder(ctx types.Context, msg *clobtypes.MsgPlaceOrder) error {
+	ret := _m.Called(ctx, msg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HandleMsgPlaceOrder")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MsgPlaceOrder) error); ok {
+		r0 = rf(ctx, msg)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // HasAuthority provides a mock function with given fields: authority
 func (_m *ClobKeeper) HasAuthority(authority string) bool {
 	ret := _m.Called(authority)

--- a/protocol/x/clob/types/clob_keeper.go
+++ b/protocol/x/clob/types/clob_keeper.go
@@ -44,6 +44,10 @@ type ClobKeeper interface {
 		ctx sdk.Context,
 		msg *MsgCancelOrder,
 	) (err error)
+	HandleMsgPlaceOrder(
+		ctx sdk.Context,
+		msg *MsgPlaceOrder,
+	) (err error)
 	GetAllClobPairs(ctx sdk.Context) (list []ClobPair)
 	GetClobPair(ctx sdk.Context, id ClobPairId) (val ClobPair, found bool)
 	HasAuthority(authority string) bool
@@ -53,6 +57,7 @@ type ClobKeeper interface {
 		err error,
 	)
 	PlaceStatefulOrder(ctx sdk.Context, msg *MsgPlaceOrder) error
+
 	PruneStateFillAmountsForShortTermOrders(
 		ctx sdk.Context,
 	)


### PR DESCRIPTION
### Changelist
move place stateful order logic from msg server to keeper

### Test Plan
existing tests are sufficient

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
