### PR TITLE
perf: optimize `slinky_adapter` via in-memory cache [SKI-13]

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1406,6 +1406,9 @@ func New(
 
 		// Hydrate the keeper in-memory data structures.
 		app.hydrateKeeperInMemoryDataStructures()
+
+		// load the x/prices keeper currency-pair ID cache
+		app.loadCurrencyPairIDsForMarkets()
 	}
 	app.initializeRateLimiters()
 
@@ -1608,6 +1611,17 @@ func (app *App) RegisterDaemonWithHealthMonitor(
 // DisableHealthMonitorForTesting disables the health monitor for testing.
 func (app *App) DisableHealthMonitorForTesting() {
 	app.DaemonHealthMonitor.DisableForTesting()
+}
+
+// loadCurrencyPairIDsForMarkets loads the currency pair IDs for the markets from the x/prices state.
+func (app *App) loadCurrencyPairIDsForMarkets() {
+	// Create an `uncachedCtx` where the underlying MultiStore is the `rootMultiStore`.
+	// We use this to load the `currencyPairIDs` with market-params from the
+	// x/prices state according to the underlying `rootMultiStore`.
+	uncachedCtx := app.BaseApp.NewUncachedContext(true, tmproto.Header{})
+
+	// Load the currency pair IDs for the markets from the x/prices state.
+	app.PricesKeeper.LoadCurrencyPairIDCache(uncachedCtx)
 }
 
 // hydrateMemStores hydrates the memStores used for caching state.

--- a/protocol/x/prices/keeper/currency_pair_id_cache.go
+++ b/protocol/x/prices/keeper/currency_pair_id_cache.go
@@ -1,0 +1,56 @@
+package keeper
+
+import "sync"
+
+// CurrencyPairIDCache handles the caching logic of currency-pairs to their corresponding IDs. This 
+// data-structure is thread-safe, allowing concurrent reads + synchronized writes.
+type CurrencyPairIDCache struct {
+	// ID -> CurrencyPair
+	idToCurrencyPair map[uint64]string
+	// CurrencyPair -> ID
+	currencyPairToID map[string]uint64
+	// lock
+	sync.RWMutex
+}
+
+// NewCurrencyPairIDCache creates a new CurrencyPairIDCache
+func NewCurrencyPairIDCache() *CurrencyPairIDCache {
+	return &CurrencyPairIDCache{
+		idToCurrencyPair: make(map[uint64]string),
+		currencyPairToID: make(map[string]uint64),
+	}
+}
+
+// AddCurrencyPair adds a currency pair to the cache. This method takes out a write lock on the cache
+// or blocks until one is available before updating the cache.
+func (c *CurrencyPairIDCache) AddCurrencyPair(id uint64, currencyPair string) {
+	// acquire write lock
+	c.Lock()
+	defer c.Unlock()
+
+	// update cache
+	c.idToCurrencyPair[id] = currencyPair
+	c.currencyPairToID[currencyPair] = id
+}
+
+// GetCurrencyPairFromID returns the currency pair from the cache
+func (c *CurrencyPairIDCache) GetCurrencyPairFromID(id uint64) (string, bool) {
+	// acquire read lock
+	c.RLock()
+	defer c.RUnlock() 
+
+	// get currency pair from cache
+	currencyPair, found := c.idToCurrencyPair[id]
+	return currencyPair, found
+}
+
+// GetIDForCurrencyPair returns the ID for the currency pair from the cache
+func (c *CurrencyPairIDCache) GetIDForCurrencyPair(currencyPair string) (uint64, bool) {
+	// acquire read lock
+	c.RLock()
+	defer c.RUnlock()
+
+	// get ID for currency pair from cache
+	id, found := c.currencyPairToID[currencyPair]
+	return id, found
+}

--- a/protocol/x/prices/keeper/currency_pair_id_cache.go
+++ b/protocol/x/prices/keeper/currency_pair_id_cache.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-// CurrencyPairIDCache handles the caching logic of currency-pairs to their corresponding IDs. This 
+// CurrencyPairIDCache handles the caching logic of currency-pairs to their corresponding IDs. This
 // data-structure is thread-safe, allowing concurrent reads + synchronized writes.
 type CurrencyPairIDCache struct {
 	// ID -> CurrencyPair
@@ -39,7 +39,7 @@ func (c *CurrencyPairIDCache) AddCurrencyPair(id uint64, currencyPair string) {
 func (c *CurrencyPairIDCache) GetCurrencyPairFromID(id uint64) (string, bool) {
 	// acquire read lock
 	c.RLock()
-	defer c.RUnlock() 
+	defer c.RUnlock()
 
 	// get currency pair from cache
 	currencyPair, found := c.idToCurrencyPair[id]

--- a/protocol/x/prices/keeper/currency_pair_id_cache.go
+++ b/protocol/x/prices/keeper/currency_pair_id_cache.go
@@ -54,3 +54,12 @@ func (c *CurrencyPairIDCache) GetIDForCurrencyPair(currencyPair string) (uint64,
 	id, found := c.currencyPairToID[currencyPair]
 	return id, found
 }
+
+// Remove removes the currency-pair (by ID) from the cache
+func (c *CurrencyPairIDCache) Remove(id uint64) {
+	currencyPair, found := c.idToCurrencyPair[id]
+	if found {
+		delete(c.idToCurrencyPair, id)
+		delete(c.currencyPairToID, currencyPair)
+	}
+}

--- a/protocol/x/prices/keeper/currency_pair_id_cache.go
+++ b/protocol/x/prices/keeper/currency_pair_id_cache.go
@@ -1,6 +1,8 @@
 package keeper
 
-import "sync"
+import (
+	"sync"
+)
 
 // CurrencyPairIDCache handles the caching logic of currency-pairs to their corresponding IDs. This 
 // data-structure is thread-safe, allowing concurrent reads + synchronized writes.
@@ -55,8 +57,14 @@ func (c *CurrencyPairIDCache) GetIDForCurrencyPair(currencyPair string) (uint64,
 	return id, found
 }
 
-// Remove removes the currency-pair (by ID) from the cache
+// Remove removes the currency-pair (by ID) from the cache. This method takes out a write lock on the
+// cache or blocks until one is available before updating the cache.
 func (c *CurrencyPairIDCache) Remove(id uint64) {
+	// acquire write lock
+	c.Lock()
+	defer c.Unlock()
+
+	// remove currency pair from cache
 	currencyPair, found := c.idToCurrencyPair[id]
 	if found {
 		delete(c.idToCurrencyPair, id)

--- a/protocol/x/prices/keeper/keeper.go
+++ b/protocol/x/prices/keeper/keeper.go
@@ -46,6 +46,7 @@ func NewKeeper(
 		indexerEventManager: indexerEventManager,
 		marketToCreatedAt:   map[uint32]time.Time{},
 		authorities:         lib.UniqueSliceToSet(authorities),
+		currencyPairIDCache: NewCurrencyPairIDCache(),
 	}
 }
 

--- a/protocol/x/prices/keeper/keeper.go
+++ b/protocol/x/prices/keeper/keeper.go
@@ -24,6 +24,7 @@ type (
 		indexerEventManager indexer_manager.IndexerEventManager
 		marketToCreatedAt   map[uint32]time.Time
 		authorities         map[string]struct{}
+		currencyPairIDCache *CurrencyPairIDCache
 	}
 )
 

--- a/protocol/x/prices/keeper/market.go
+++ b/protocol/x/prices/keeper/market.go
@@ -9,6 +9,7 @@ import (
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
@@ -54,6 +55,15 @@ func (k Keeper) CreateMarket(
 
 	marketPriceStore := k.getMarketPriceStore(ctx)
 	marketPriceStore.Set(lib.Uint32ToKey(marketPrice.Id), priceBytes)
+
+	// add the pair to the currency-pair-id cache
+	cp, err := slinky.MarketPairToCurrencyPair(marketParam.Pair)
+	if err != nil {
+		k.Logger(ctx).Error("failed to add currency pair to cache", "pair", marketParam.Pair, "err", err)
+	} else {
+		// add the pair to the currency-pair-id cache
+		k.currencyPairIDCache.AddCurrencyPair(uint64(marketParam.Id), cp.String())
+	}
 
 	// Generate indexer event.
 	k.GetIndexerEventManager().AddTxnEvent(

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -5,6 +5,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
 
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -53,6 +54,20 @@ func (k Keeper) ModifyMarketParam(
 	marketParamStore := k.getMarketParamStore(ctx)
 	b := k.cdc.MustMarshal(&updatedMarketParam)
 	marketParamStore.Set(lib.Uint32ToKey(updatedMarketParam.Id), b)
+	
+	// if the market pair has been changed, we need to update the in-memory market pair cache
+	if existingParam.Pair != updatedMarketParam.Pair {
+		// remove the old cache entry
+		k.currencyPairIDCache.Remove(uint64(existingParam.Id))
+
+		// add the new cache entry
+		cp, err := slinky.MarketPairToCurrencyPair(updatedMarketParam.Pair)
+		if err == nil {
+			k.currencyPairIDCache.AddCurrencyPair(uint64(updatedMarketParam.Id), cp.String())
+		} else {
+			k.Logger(ctx).Error("failed to add currency pair to cache", "pair", updatedMarketParam.Pair)
+		}
+	}
 
 	// Generate indexer event.
 	k.GetIndexerEventManager().AddTxnEvent(

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -54,7 +54,7 @@ func (k Keeper) ModifyMarketParam(
 	marketParamStore := k.getMarketParamStore(ctx)
 	b := k.cdc.MustMarshal(&updatedMarketParam)
 	marketParamStore.Set(lib.Uint32ToKey(updatedMarketParam.Id), b)
-	
+
 	// if the market pair has been changed, we need to update the in-memory market pair cache
 	if existingParam.Pair != updatedMarketParam.Pair {
 		// remove the old cache entry

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -47,7 +47,7 @@ func TestModifyMarketParam(t *testing.T) {
 }
 
 func TestModifyMarketParamUpdatesCache(t *testing.T) {
-	ctx, keeper, _, _, _, mockTimeProvider := keepertest.PricesKeepers(t)
+	ctx, keeper, _, _, mockTimeProvider := keepertest.PricesKeepers(t)
 	mockTimeProvider.On("Now").Return(constants.TimeT)
 	ctx = ctx.WithTxBytes(constants.TestTxBytes)
 

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -43,6 +44,62 @@ func TestModifyMarketParam(t *testing.T) {
 		require.Equal(t, fmt.Sprintf(`{"id":"%v"}`, i), newItem.ExchangeConfigJson)
 		keepertest.AssertMarketModifyEventInIndexerBlock(t, keeper, ctx, newItem)
 	}
+}
+
+func TestModifyMarketParamUpdatesCache(t *testing.T) {
+	ctx, keeper, _, _, _, mockTimeProvider := keepertest.PricesKeepers(t)
+	mockTimeProvider.On("Now").Return(constants.TimeT)
+	ctx = ctx.WithTxBytes(constants.TestTxBytes)
+
+	id := uint32(1)
+	oldParam := types.MarketParam{
+		Id:                 id,
+		Pair: "foo-bar",
+		MinExchanges:       uint32(2),
+		Exponent:           8,
+		MinPriceChangePpm:  uint32(50),
+		ExchangeConfigJson: `{"id":"1"}`,
+	}
+	mp, err := keeper.CreateMarket(ctx, oldParam, types.MarketPrice{
+		Id:		id,
+		Exponent: 8,
+		Price: 1,
+	})
+	require.NoError(t, err)
+
+	// check that the existing entry exists
+	cp, err := slinky.MarketPairToCurrencyPair(mp.Pair)
+	require.NoError(t, err)
+
+	// check that the existing entry exists
+	cpID, found := keeper.GetIDForCurrencyPair(ctx, cp)
+	require.True(t, found)
+	require.Equal(t, uint64(id), cpID)
+	
+	// modify the market param
+	newParam, err := keeper.ModifyMarketParam(
+		ctx,
+		types.MarketParam{
+			Id:                 id,
+			Pair:               "bar-foo",
+			MinExchanges:       uint32(2),
+			Exponent:           8,
+			MinPriceChangePpm:  uint32(50),
+			ExchangeConfigJson: `{"id":"1"}`,
+		},
+	)
+	require.NoError(t, err)
+
+	// check that the existing entry does not exist
+	_, found = keeper.GetIDForCurrencyPair(ctx, cp)
+	require.False(t, found)
+
+	// check that the new entry exists
+	cp, err = slinky.MarketPairToCurrencyPair(newParam.Pair)
+	require.NoError(t, err)
+	cpID, found = keeper.GetIDForCurrencyPair(ctx, cp)
+	require.True(t, found)
+	require.Equal(t, uint64(id), cpID)
 }
 
 func TestModifyMarketParam_Errors(t *testing.T) {

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -54,16 +54,16 @@ func TestModifyMarketParamUpdatesCache(t *testing.T) {
 	id := uint32(1)
 	oldParam := types.MarketParam{
 		Id:                 id,
-		Pair: "foo-bar",
+		Pair:               "foo-bar",
 		MinExchanges:       uint32(2),
 		Exponent:           8,
 		MinPriceChangePpm:  uint32(50),
 		ExchangeConfigJson: `{"id":"1"}`,
 	}
 	mp, err := keeper.CreateMarket(ctx, oldParam, types.MarketPrice{
-		Id:		id,
+		Id:       id,
 		Exponent: 8,
-		Price: 1,
+		Price:    1,
 	})
 	require.NoError(t, err)
 
@@ -75,7 +75,7 @@ func TestModifyMarketParamUpdatesCache(t *testing.T) {
 	cpID, found := keeper.GetIDForCurrencyPair(ctx, cp)
 	require.True(t, found)
 	require.Equal(t, uint64(id), cpID)
-	
+
 	// modify the market param
 	newParam, err := keeper.ModifyMarketParam(
 		ctx,

--- a/protocol/x/prices/keeper/slinky_adapter.go
+++ b/protocol/x/prices/keeper/slinky_adapter.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
 	"strings"
 )
 
@@ -35,7 +36,7 @@ func (k Keeper) GetCurrencyPairFromID(ctx sdk.Context, id uint64) (cp slinkytype
 	}
 	pair = mp.Pair
 
-	cp, err := MarketPairToCurrencyPair(pair)
+	cp, err := slinky.MarketPairToCurrencyPair(pair)
 	if err != nil {
 		k.Logger(ctx).Error("CurrencyPairFromString", "error", err)
 		return cp, false
@@ -54,7 +55,7 @@ func (k Keeper) GetIDForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPai
 	// if not found, iterate through all market params and find the id
 	mps := k.GetAllMarketParams(ctx)
 	for _, mp := range mps {
-		mpCp, err := MarketPairToCurrencyPair(mp.Pair)
+		mpCp, err := slinky.MarketPairToCurrencyPair(mp.Pair)
 		if err != nil {
 			k.Logger(ctx).Error("market param pair invalid format", "pair", mp.Pair)
 			continue
@@ -81,17 +82,4 @@ func (k Keeper) GetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.Currency
 	return oracletypes.QuotePrice{
 		Price: math.NewIntFromUint64(mp.Price),
 	}, nil
-}
-
-func MarketPairToCurrencyPair(marketPair string) (slinkytypes.CurrencyPair, error) {
-	split := strings.Split(marketPair, "-")
-	if len(split) != 2 {
-		return slinkytypes.CurrencyPair{}, fmt.Errorf("incorrectly formatted CurrencyPair: %s", marketPair)
-	}
-	cp := slinkytypes.CurrencyPair{
-		Base:  strings.ToUpper(split[0]),
-		Quote: strings.ToUpper(split[1]),
-	}
-
-	return cp, cp.ValidateBasic()
 }

--- a/protocol/x/prices/keeper/slinky_adapter.go
+++ b/protocol/x/prices/keeper/slinky_adapter.go
@@ -4,9 +4,9 @@ import (
 	"cosmossdk.io/math"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
-	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
 	"strings"
 )
 

--- a/protocol/x/prices/keeper/slinky_adapter.go
+++ b/protocol/x/prices/keeper/slinky_adapter.go
@@ -41,7 +41,7 @@ func (k Keeper) GetCurrencyPairFromID(ctx sdk.Context, id uint64) (cp slinkytype
 		k.Logger(ctx).Error("CurrencyPairFromString", "error", err)
 		return cp, false
 	}
-	
+
 	return cp, true
 }
 

--- a/protocol/x/prices/keeper/slinky_adapter.go
+++ b/protocol/x/prices/keeper/slinky_adapter.go
@@ -1,15 +1,12 @@
 package keeper
 
 import (
-	"fmt"
-	"strings"
-
 	"cosmossdk.io/math"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
-
-	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
+	"strings"
 )
 
 /*
@@ -21,43 +18,80 @@ import (
  */
 
 func (k Keeper) GetCurrencyPairFromID(ctx sdk.Context, id uint64) (cp slinkytypes.CurrencyPair, found bool) {
+	// check in the keeper's cache first
+	pair, found := k.currencyPairIDCache.GetCurrencyPairFromID(id)
+	if found {
+		cp, err := slinkytypes.CurrencyPairFromString(pair)
+		if err != nil {
+			k.Logger(ctx).Error("CurrencyPairFromString", "error", err)
+			return cp, false
+		}
+		return cp, true
+	}
+
 	mp, found := k.GetMarketParam(ctx, uint32(id))
 	if !found {
 		return cp, false
 	}
-	cp, err := slinky.MarketPairToCurrencyPair(mp.Pair)
+	pair = mp.Pair
+
+	cp, err := MarketPairToCurrencyPair(pair)
 	if err != nil {
 		k.Logger(ctx).Error("CurrencyPairFromString", "error", err)
 		return cp, false
 	}
+	
 	return cp, true
 }
 
 func (k Keeper) GetIDForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (uint64, bool) {
+	// check in the keeper's cache first
+	id, found := k.currencyPairIDCache.GetIDForCurrencyPair(cp.String())
+	if found {
+		return id, true
+	}
+
+	// if not found, iterate through all market params and find the id
 	mps := k.GetAllMarketParams(ctx)
 	for _, mp := range mps {
-		mpCp, err := slinky.MarketPairToCurrencyPair(mp.Pair)
+		mpCp, err := MarketPairToCurrencyPair(mp.Pair)
 		if err != nil {
 			k.Logger(ctx).Error("market param pair invalid format", "pair", mp.Pair)
 			continue
 		}
+
+		// compare the currency pairs to the one that we're looking for
 		if strings.EqualFold(mpCp.String(), cp.String()) {
 			return uint64(mp.Id), true
 		}
 	}
+
 	return 0, false
 }
 
 func (k Keeper) GetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (oracletypes.QuotePrice, error) {
 	id, found := k.GetIDForCurrencyPair(ctx, cp)
 	if !found {
-		return oracletypes.QuotePrice{}, fmt.Errorf("id for currency pair %s not found", cp.String())
+		return oracletypes.QuotePrice{}, fmt.Errorf("currency pair %s not found", cp.String())
 	}
 	mp, err := k.GetMarketPrice(ctx, uint32(id))
 	if err != nil {
-		return oracletypes.QuotePrice{}, fmt.Errorf("market price not found for currency pair %s", cp.String())
+		return oracletypes.QuotePrice{}, fmt.Errorf("currency pair %s not found", cp.String())
 	}
 	return oracletypes.QuotePrice{
 		Price: math.NewIntFromUint64(mp.Price),
 	}, nil
+}
+
+func MarketPairToCurrencyPair(marketPair string) (slinkytypes.CurrencyPair, error) {
+	split := strings.Split(marketPair, "-")
+	if len(split) != 2 {
+		return slinkytypes.CurrencyPair{}, fmt.Errorf("incorrectly formatted CurrencyPair: %s", marketPair)
+	}
+	cp := slinkytypes.CurrencyPair{
+		Base:  strings.ToUpper(split[0]),
+		Quote: strings.ToUpper(split[1]),
+	}
+
+	return cp, cp.ValidateBasic()
 }


### PR DESCRIPTION
### Changelist
- Introduces a `CurrencyPairIDCache` to the `PricesKeeper`
- Reads from the `slinky_adapter` hit the cache first
- Caching semantics
    - Stores an in-memory cache between `currency-pair-id -> currency-pair`
    - `ticker -> ID`
    - The cache is updated dynamically, as new currency-pairs are queried + placed in vote-extensions
 
### Test Plan
- unit-tests, tested via petri

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
