### PR TITLE
rename block_already_parsed metric since it's now expected

### DIFF
--- a/indexer/services/ender/__tests__/lib/on-message.test.ts
+++ b/indexer/services/ender/__tests__/lib/on-message.test.ts
@@ -759,7 +759,7 @@ describe('on-message', () => {
 
     await onMessage(kafkaMessage);
 
-    expect(stats.increment).toHaveBeenCalledWith(`${config.SERVICE_NAME}.block_already_parsed.failure`, 1);
+    expect(stats.increment).toHaveBeenCalledWith(`${config.SERVICE_NAME}.block_already_parsed`, 1);
     expect(stats.increment).toHaveBeenCalledWith('ender.received_kafka_message', 1);
     expect(stats.timing).toHaveBeenCalledWith(
       'ender.message_time_in_queue', expect.any(Number), 1, { topic: KafkaTopics.TO_ENDER });

--- a/indexer/services/ender/src/caches/block-cache.ts
+++ b/indexer/services/ender/src/caches/block-cache.ts
@@ -51,7 +51,7 @@ export async function shouldSkipBlock(
   canRefreshCache: boolean = true,
 ): Promise<boolean> {
   if (blockAlreadyProcessed(blockHeight)) {
-    stats.increment(`${config.SERVICE_NAME}.block_already_parsed.failure`, 1);
+    stats.increment(`${config.SERVICE_NAME}.block_already_parsed`, 1);
     logger.info({
       at: 'onMessage#onMessage',
       message: `Already processed block with block height: ${blockHeight}, so skipping`,


### PR DESCRIPTION
### Changelist
rename block_already_parsed metric since it's now expected
see https://github.com/dydxprotocol/v4-infrastructure/pull/81 for context

### Test Plan
unit tested

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
