### PR TITLE
Emit metric to track withdrawal amounts

### DIFF
--- a/protocol/lib/metrics/lib.go
+++ b/protocol/lib/metrics/lib.go
@@ -109,12 +109,12 @@ func isAllowedExecutionMode(
 func EmitTelemetryWithLabelsForExecMode(
 	ctx sdk.Context,
 	allowedModes []sdk.ExecMode,
-	telemtryFuncWithLabels TelemetryEmitWithLabelsFunc,
+	telemetryFuncWithLabels TelemetryEmitWithLabelsFunc,
 	key string,
 	val float32,
 	labels ...gometrics.Label,
 ) {
 	if isAllowedExecutionMode(ctx, allowedModes) {
-		telemtryFuncWithLabels(key, val, labels...)
+		telemetryFuncWithLabels(key, val, labels...)
 	}
 }

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -24,6 +24,7 @@ const (
 	GateWithdrawalsIfNegativeTncSubaccountSeen         = "gate_withdrawals_if_negative_tnc_subaccount_seen"
 	ChainOutageSeen                                    = "chain_outage_seen"
 	SubaccountCreatedCount                             = "subaccount_created_count"
+	RateLimitWithdrawalAmount                          = "rate_limit_withdrawal_amount"
 
 	// Gauges
 	InsuranceFundBalance                      = "insurance_fund_balance"

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -24,7 +24,6 @@ const (
 	GateWithdrawalsIfNegativeTncSubaccountSeen         = "gate_withdrawals_if_negative_tnc_subaccount_seen"
 	ChainOutageSeen                                    = "chain_outage_seen"
 	SubaccountCreatedCount                             = "subaccount_created_count"
-	RateLimitWithdrawalAmount                          = "rate_limit_withdrawal_amount"
 
 	// Gauges
 	InsuranceFundBalance                      = "insurance_fund_balance"
@@ -33,6 +32,7 @@ const (
 	ClobConditionalOrderTriggered             = "clob_conditional_order_triggered"
 	ClobSubaccountsRequiringDeleveragingCount = "clob_subaccounts_requiring_deleveraging_count"
 	SendingProcessDepositToSubaccount         = "sending_process_deposit_to_subaccount"
+	RateLimitInsufficientWithdrawalAmount     = "rate_limit_insufficient_withdrawal_amount"
 
 	// Samples
 	ClobDeleverageSubaccountTotalQuoteQuantumsDistribution         = "clob_deleverage_subaccount_total_quote_quantums_distribution"
@@ -45,6 +45,7 @@ const (
 	LiquidationsLiquidatableSubaccountIdsCount                     = "liquidations_liquidatable_subaccount_ids_count"
 	LiquidationsPercentFilledDistribution                          = "liquidations_percent_filled_distribution"
 	LiquidationsPlacePerpetualLiquidationQuoteQuantumsDistribution = "liquidations_place_perpetual_liquidation_quote_quantums_distribution"
+	RateLimitWithdrawalAmount                                      = "rate_limit_withdrawal_amount"
 
 	// Measure Since
 	ClobOffsettingSubaccountPerpetualPosition         = "clob_offsetting_subaccount_perpetual_position"

--- a/protocol/x/ratelimit/keeper/keeper.go
+++ b/protocol/x/ratelimit/keeper/keeper.go
@@ -77,6 +77,15 @@ func (k Keeper) ProcessWithdrawal(
 			)
 		}
 
+		metrics.EmitTelemetryWithLabelsForExecMode(
+			ctx,
+			[]sdk.ExecMode{sdk.ExecModeFinalize},
+			metrics.IncrCounterWithLabels,
+			metrics.RateLimitWithdrawalAmount,
+			metrics.GetMetricValueFromBigInt(amount),
+			metrics.GetLabelForStringValue(metrics.RateLimitDenom, denom),
+		)
+
 		// Debit each capacity in the list by the amount of withdrawal.
 		newCapacityList[i] = dtypes.NewIntFromBigInt(
 			new(big.Int).Sub(

--- a/protocol/x/ratelimit/keeper/keeper.go
+++ b/protocol/x/ratelimit/keeper/keeper.go
@@ -77,15 +77,6 @@ func (k Keeper) ProcessWithdrawal(
 			)
 		}
 
-		metrics.EmitTelemetryWithLabelsForExecMode(
-			ctx,
-			[]sdk.ExecMode{sdk.ExecModeFinalize},
-			metrics.IncrCounterWithLabels,
-			metrics.RateLimitWithdrawalAmount,
-			metrics.GetMetricValueFromBigInt(amount),
-			metrics.GetLabelForStringValue(metrics.RateLimitDenom, denom),
-		)
-
 		// Debit each capacity in the list by the amount of withdrawal.
 		newCapacityList[i] = dtypes.NewIntFromBigInt(
 			new(big.Int).Sub(


### PR DESCRIPTION
### Changelist
Emits metric only on finalize which keeps track of withdrawal amounts
Correct a slight typo in name

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new telemetry metrics for rate limit withdrawals, including insufficient withdrawal amount and withdrawal amount metrics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->