### PR TITLE
[TRA-126] Add E2E test for isolated subaccount transfers.

### DIFF
--- a/protocol/testutil/constants/subaccounts.go
+++ b/protocol/testutil/constants/subaccounts.go
@@ -12,7 +12,7 @@ var (
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_10_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Alice_Num0_100_000USD = satypes.Subaccount{
 		Id: &Alice_Num0,
@@ -20,6 +20,19 @@ var (
 			&Usdc_Asset_100_000,
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{},
+	}
+	Alice_Num0_1ISO_LONG_10_000USD = satypes.Subaccount{
+		Id: &Alice_Num0,
+		AssetPositions: []*satypes.AssetPosition{
+			&Usdc_Asset_10_000,
+		},
+		PerpetualPositions: []*satypes.PerpetualPosition{
+			{
+				PerpetualId:  3,
+				Quantums:     dtypes.NewInt(1_000_000_000), // 1 ISO
+				FundingIndex: dtypes.NewInt(0),
+			},
+		},
 	}
 	Alice_Num1_10_000USD = satypes.Subaccount{
 		Id: &Alice_Num1,
@@ -64,7 +77,7 @@ var (
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_10_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Bob_Num0_100_000USD = satypes.Subaccount{
 		Id: &Bob_Num0,
@@ -72,6 +85,19 @@ var (
 			&Usdc_Asset_100_000,
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{},
+	}
+	Bob_Num0_1ISO2_LONG_10_000USD = satypes.Subaccount{
+		Id: &Bob_Num0,
+		AssetPositions: []*satypes.AssetPosition{
+			&Usdc_Asset_10_000,
+		},
+		PerpetualPositions: []*satypes.PerpetualPosition{
+			{
+				PerpetualId:  4,
+				Quantums:     dtypes.NewInt(10_000_000), // 1 ISO2
+				FundingIndex: dtypes.NewInt(0),
+			},
+		},
 	}
 	Carl_Num0_100BTC_Short_10100USD = satypes.Subaccount{
 		Id: &Carl_Num0,

--- a/protocol/testutil/constants/subaccounts.go
+++ b/protocol/testutil/constants/subaccounts.go
@@ -88,6 +88,19 @@ var (
 		},
 		PerpetualPositions: nil,
 	}
+	Bob_Num0_1ISO_LONG_10_000USD = satypes.Subaccount{
+		Id: &Bob_Num0,
+		AssetPositions: []*satypes.AssetPosition{
+			&Usdc_Asset_10_000,
+		},
+		PerpetualPositions: []*satypes.PerpetualPosition{
+			{
+				PerpetualId:  3,
+				Quantums:     dtypes.NewInt(10_000_000), // 1 ISO2
+				FundingIndex: dtypes.NewInt(0),
+			},
+		},
+	}
 	Bob_Num0_1ISO2_LONG_10_000USD = satypes.Subaccount{
 		Id: &Bob_Num0,
 		AssetPositions: []*satypes.AssetPosition{

--- a/protocol/testutil/constants/subaccounts.go
+++ b/protocol/testutil/constants/subaccounts.go
@@ -19,7 +19,7 @@ var (
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_100_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Alice_Num0_1ISO_LONG_10_000USD = satypes.Subaccount{
 		Id: &Alice_Num0,
@@ -39,14 +39,14 @@ var (
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_10_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Alice_Num1_100_000USD = satypes.Subaccount{
 		Id: &Alice_Num1,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_100_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Alice_Num1_1BTC_Short_100_000USD = satypes.Subaccount{
 		Id: &Alice_Num1,
@@ -55,8 +55,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -67,8 +68,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(100_000_000), // +1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(100_000_000), // +1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -84,7 +86,7 @@ var (
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_100_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Bob_Num0_1ISO2_LONG_10_000USD = satypes.Subaccount{
 		Id: &Bob_Num0,
@@ -106,8 +108,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-10_000_000_000), // -100 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-10_000_000_000), // -100 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -118,8 +121,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -130,8 +134,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -161,8 +166,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -176,8 +182,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -207,8 +214,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(100_000_000), // 1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -238,8 +246,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -253,12 +262,14 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 			{
-				PerpetualId: 1,
-				Quantums:    dtypes.NewInt(1_000_000_000), // 1 ETH
+				PerpetualId:  1,
+				Quantums:     dtypes.NewInt(1_000_000_000), // 1 ETH
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -267,68 +278,68 @@ var (
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_599,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num0_660USD = satypes.Subaccount{
 		Id: &Carl_Num0,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_660,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num0_10000USD = satypes.Subaccount{
 		Id: &Carl_Num0,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_10_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num0_50000USD = satypes.Subaccount{
 		Id: &Carl_Num0,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_50_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num0_100000USD = satypes.Subaccount{
 		Id: &Carl_Num0,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_100_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num0_500000USD = satypes.Subaccount{
 		Id: &Carl_Num0,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_500_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num0_0USD = satypes.Subaccount{
 		Id:                 &Carl_Num0,
 		AssetPositions:     []*satypes.AssetPosition{},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num1_500USD = satypes.Subaccount{
 		Id: &Carl_Num1,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_500,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num1_100000USD = satypes.Subaccount{
 		Id: &Carl_Num1,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_100_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num1_Short_500USD = satypes.Subaccount{
 		Id: &Carl_Num1,
 		AssetPositions: []*satypes.AssetPosition{
 			&Short_Usdc_Asset_500,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Carl_Num1_01BTC_Long_4600USD_Short = satypes.Subaccount{
 		Id: &Carl_Num1,
@@ -337,8 +348,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(10_000_000), // 0.1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(10_000_000), // 0.1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -352,8 +364,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -364,8 +377,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(10_000_000), // 0.1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(10_000_000), // 0.1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -405,8 +419,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-100_000_000), // -1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-100_000_000), // -1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -452,8 +467,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(100_000_000), // 1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -494,21 +510,21 @@ var (
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_599,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Dave_Num0_10000USD = satypes.Subaccount{
 		Id: &Dave_Num0,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_10_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Dave_Num0_500000USD = satypes.Subaccount{
 		Id: &Dave_Num0,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_500_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Dave_Num0_100BTC_Short_10200USD = satypes.Subaccount{
 		Id: &Dave_Num0,
@@ -517,8 +533,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-10_000_000_000), // -100 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-10_000_000_000), // -100 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -529,8 +546,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(10_000_000_000), // 100 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(10_000_000_000), // 100 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -541,8 +559,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(100_000_000), // 1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -553,12 +572,14 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(100_000_000), // 1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 			{
-				PerpetualId: 1,
-				Quantums:    dtypes.NewInt(1_000_000_000), // 1 ETH
+				PerpetualId:  1,
+				Quantums:     dtypes.NewInt(1_000_000_000), // 1 ETH
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -567,14 +588,14 @@ var (
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_10_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Dave_Num1_500000USD = satypes.Subaccount{
 		Id: &Dave_Num1,
 		AssetPositions: []*satypes.AssetPosition{
 			&Usdc_Asset_500_000,
 		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
+		PerpetualPositions: nil,
 	}
 	Dave_Num1_025BTC_Long_50000USD = satypes.Subaccount{
 		Id: &Dave_Num1,
@@ -583,8 +604,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(25_000_000), // 0.25 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(25_000_000), // 0.25 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -595,8 +617,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(50_000_000), // 0.5 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(50_000_000), // 0.5 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -607,8 +630,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(100_000_000), // 1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -619,8 +643,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(-10_000_000_000), // -100 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(-10_000_000_000), // -100 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -634,8 +659,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 0,
-				Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				PerpetualId:  0,
+				Quantums:     dtypes.NewInt(100_000_000), // 1 BTC
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}
@@ -646,8 +672,9 @@ var (
 		},
 		PerpetualPositions: []*satypes.PerpetualPosition{
 			{
-				PerpetualId: 1,
-				Quantums:    dtypes.NewInt(1_000_000_000), // 1 ETH
+				PerpetualId:  1,
+				Quantums:     dtypes.NewInt(1_000_000_000), // 1 ETH
+				FundingIndex: dtypes.NewInt(0),
 			},
 		},
 	}

--- a/protocol/x/sending/e2e/isolated_subaccount_transfers_test.go
+++ b/protocol/x/sending/e2e/isolated_subaccount_transfers_test.go
@@ -213,6 +213,37 @@ func TestTransfer_Isolated_Non_Isolated_Subaccounts(t *testing.T) {
 			},
 			expectedErr: "insufficient funds",
 		},
+		`Can transfer from isolated subaccount to isolated subaccount in the same isolated markets, no
+		coins are sent`: {
+			subaccounts: []satypes.Subaccount{
+				constants.Alice_Num0_1ISO_LONG_10_000USD,
+				constants.Bob_Num0_1ISO_LONG_10_000USD,
+			},
+			collateralPoolBalances: map[string]int64{
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.Params.Id),
+				).String(): 10_000_000_000, // $10,000 USDC
+			},
+			senderSubaccountId:   constants.Alice_Num0,
+			receiverSubaccountId: constants.Bob_Num0,
+			quantums:             100_000_000, // $100
+			liquidityTiers:       constants.LiquidityTiers,
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+				constants.EthUsd_20PercentInitial_10PercentMaintenance,
+				constants.IsoUsd_IsolatedMarket,
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				changeUsdcBalance(constants.Alice_Num0_1ISO_LONG_10_000USD, -100_000_000),
+				changeUsdcBalance(constants.Bob_Num0_1ISO_LONG_10_000USD, 100_000_000),
+			},
+			expectedCollateralPoolBalances: map[string]int64{
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.Params.Id),
+				).String(): 10_000_000_000, // No change
+			},
+			expectedErr: "",
+		},
 	}
 
 	for name, tc := range tests {

--- a/protocol/x/sending/e2e/isolated_subaccount_transfers_test.go
+++ b/protocol/x/sending/e2e/isolated_subaccount_transfers_test.go
@@ -1,0 +1,394 @@
+package sending_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/cosmos/gogoproto/proto"
+
+	sdkmath "cosmossdk.io/math"
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	feetiertypes "github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransfer_Isolated_Non_Isolated_Subaccounts(t *testing.T) {
+	tests := map[string]struct {
+		// State.
+		subaccounts            []satypes.Subaccount
+		collateralPoolBalances map[string]int64
+
+		// Parameters.
+		senderSubaccountId   satypes.SubaccountId
+		receiverSubaccountId satypes.SubaccountId
+		quantums             uint64
+
+		// Configuration.
+		liquidityTiers []perptypes.LiquidityTier
+		perpetuals     []perptypes.Perpetual
+		clobPairs      []clobtypes.ClobPair
+
+		// Expectations.
+		expectedSubaccounts            []satypes.Subaccount
+		expectedCollateralPoolBalances map[string]int64
+		expectedErr                    string
+	}{
+		`Can transfer from isolated subaccount to non-isolated subaccount, and coins are sent from
+		isolated subaccount collateral pool to cross collateral pool`: {
+			subaccounts: []satypes.Subaccount{
+				constants.Alice_Num0_1ISO_LONG_10_000USD,
+				constants.Bob_Num0_10_000USD,
+			},
+			collateralPoolBalances: map[string]int64{
+				satypes.ModuleAddress.String(): 10_000_000_000, // $10,000 USDC
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.Params.Id),
+				).String(): 10_000_000_000, // $10,000 USDC
+			},
+			senderSubaccountId:   constants.Alice_Num0,
+			receiverSubaccountId: constants.Bob_Num0,
+			quantums:             100_000_000, // $100
+			liquidityTiers:       constants.LiquidityTiers,
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+				constants.EthUsd_20PercentInitial_10PercentMaintenance,
+				constants.IsoUsd_IsolatedMarket,
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				changeUsdcBalance(constants.Alice_Num0_1ISO_LONG_10_000USD, -100_000_000),
+				changeUsdcBalance(constants.Bob_Num0_10_000USD, 100_000_000),
+			},
+			expectedCollateralPoolBalances: map[string]int64{
+				satypes.ModuleAddress.String(): 10_100_000_000, // $10,100 USDC
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.Params.Id),
+				).String(): 9_900_000_000, // $9,900 USDC
+			},
+			expectedErr: "",
+		},
+		`Can transfer from non-isolated subaccount to isolated subaccount, and coins are sent from
+		cross collateral pool to isolated subaccount collateral pool`: {
+			subaccounts: []satypes.Subaccount{
+				constants.Alice_Num0_1ISO_LONG_10_000USD,
+				constants.Bob_Num0_10_000USD,
+			},
+			collateralPoolBalances: map[string]int64{
+				satypes.ModuleAddress.String(): 10_000_000_000, // $10,000 USDC
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.Params.Id),
+				).String(): 10_000_000_000, // $10,000 USDC
+			},
+			senderSubaccountId:   constants.Bob_Num0,
+			receiverSubaccountId: constants.Alice_Num0,
+			quantums:             100_000_000, // $100
+			liquidityTiers:       constants.LiquidityTiers,
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+				constants.EthUsd_20PercentInitial_10PercentMaintenance,
+				constants.IsoUsd_IsolatedMarket,
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				changeUsdcBalance(constants.Alice_Num0_1ISO_LONG_10_000USD, 100_000_000),
+				changeUsdcBalance(constants.Bob_Num0_10_000USD, -100_000_000),
+			},
+			expectedCollateralPoolBalances: map[string]int64{
+				satypes.ModuleAddress.String(): 9_900_000_000, // $9,900 USDC
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.Params.Id),
+				).String(): 10_100_000_000, // $10,100 USDC
+			},
+			expectedErr: "",
+		},
+		`Can transfer from isolated subaccount to isolated subaccount in different isolated markets, and
+		coins are sent from one isolated collateral pool to the other isolated collateral pool`: {
+			subaccounts: []satypes.Subaccount{
+				constants.Alice_Num0_1ISO_LONG_10_000USD,
+				constants.Bob_Num0_1ISO2_LONG_10_000USD,
+			},
+			collateralPoolBalances: map[string]int64{
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.Iso2Usd_IsolatedMarket.Params.Id),
+				).String(): 10_000_000_000, // $10,000 USDC
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.Params.Id),
+				).String(): 10_000_000_000, // $10,000 USDC
+			},
+			senderSubaccountId:   constants.Alice_Num0,
+			receiverSubaccountId: constants.Bob_Num0,
+			quantums:             100_000_000, // $100
+			liquidityTiers:       constants.LiquidityTiers,
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+				constants.EthUsd_20PercentInitial_10PercentMaintenance,
+				constants.IsoUsd_IsolatedMarket,
+				constants.Iso2Usd_IsolatedMarket,
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				changeUsdcBalance(constants.Alice_Num0_1ISO_LONG_10_000USD, -100_000_000),
+				changeUsdcBalance(constants.Bob_Num0_1ISO2_LONG_10_000USD, 100_000_000),
+			},
+			expectedCollateralPoolBalances: map[string]int64{
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.IsoUsd_IsolatedMarket.Params.Id),
+				).String(): 9_900_000_000, // $9,900 USDC
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.Iso2Usd_IsolatedMarket.Params.Id),
+				).String(): 10_100_000_000, // $10,100 USDC
+			},
+			expectedErr: "",
+		},
+		`Can't transfer from isolated subaccount to non-isolated subaccount if collateral pool has 
+		insufficient funds`: {
+			subaccounts: []satypes.Subaccount{
+				constants.Alice_Num0_1ISO_LONG_10_000USD,
+				constants.Bob_Num0_10_000USD,
+			},
+			collateralPoolBalances: map[string]int64{
+				satypes.ModuleAddress.String(): 10_000_000_000, // $10,000 USDC
+				// Isolated perpetual collateral pool has no entry and is therefore empty ($0).
+			},
+			senderSubaccountId:   constants.Alice_Num0,
+			receiverSubaccountId: constants.Bob_Num0,
+			quantums:             100_000_000, // $100
+			liquidityTiers:       constants.LiquidityTiers,
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+				constants.EthUsd_20PercentInitial_10PercentMaintenance,
+				constants.IsoUsd_IsolatedMarket,
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				constants.Alice_Num0_1ISO_LONG_10_000USD, // No changes as transfer should fail.
+				constants.Bob_Num0_10_000USD,
+			},
+			expectedCollateralPoolBalances: map[string]int64{
+				satypes.ModuleAddress.String(): 10_000_000_000, // No changes to collateral pools as transfer fails.
+			},
+			expectedErr: "insufficient funds",
+		},
+		`Can't transfer from isolated subaccount to isolated subaccount with different isolated 
+		perpetuals if collateral pool has insufficient funds`: {
+			subaccounts: []satypes.Subaccount{
+				constants.Alice_Num0_1ISO_LONG_10_000USD,
+				constants.Bob_Num0_1ISO2_LONG_10_000USD,
+			},
+			collateralPoolBalances: map[string]int64{
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.Iso2Usd_IsolatedMarket.Params.Id),
+				).String(): 10_000_000_000, // $10,000 USDC
+				// Isolated perpetual collateral pool has no entry and is therefore empty ($0).
+			},
+			senderSubaccountId:   constants.Alice_Num0,
+			receiverSubaccountId: constants.Bob_Num0,
+			quantums:             100_000_000, // $100
+			liquidityTiers:       constants.LiquidityTiers,
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+				constants.EthUsd_20PercentInitial_10PercentMaintenance,
+				constants.IsoUsd_IsolatedMarket,
+				constants.Iso2Usd_IsolatedMarket,
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				constants.Alice_Num0_1ISO_LONG_10_000USD, // No changes as transfer should fail.
+				constants.Bob_Num0_1ISO2_LONG_10_000USD,
+			},
+			expectedCollateralPoolBalances: map[string]int64{
+				authtypes.NewModuleAddress(
+					satypes.ModuleName + ":" + lib.UintToString(constants.Iso2Usd_IsolatedMarket.Params.Id),
+				).String(): 10_000_000_000, // No changes to collateral pools as transfer fails.
+			},
+			expectedErr: "insufficient funds",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Configure the test application.
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+				genesis = testapp.DefaultGenesis()
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *assettypes.GenesisState) {
+						genesisState.Assets = []assettypes.Asset{
+							*constants.Usdc,
+						}
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *banktypes.GenesisState) {
+						// If the collateral pool address is already in bank genesis state, update it.
+						foundPools := make(map[string]struct{})
+						for i, bal := range genesisState.Balances {
+							usdcBal, exists := tc.collateralPoolBalances[bal.Address]
+							if exists {
+								foundPools[bal.Address] = struct{}{}
+								genesisState.Balances[i] = banktypes.Balance{
+									Address: bal.Address,
+									Coins: sdktypes.Coins{
+										sdktypes.NewCoin(constants.Usdc.Denom, sdkmath.NewInt(usdcBal)),
+									},
+								}
+							}
+						}
+						// If the collateral pool address is not in the bank genesis state, add it.
+						for addr, bal := range tc.collateralPoolBalances {
+							_, exists := foundPools[addr]
+							if exists {
+								continue
+							}
+							genesisState.Balances = append(genesisState.Balances, banktypes.Balance{
+								Address: addr,
+								Coins: sdktypes.Coins{
+									sdktypes.NewCoin(constants.Usdc.Denom, sdkmath.NewInt(bal)),
+								},
+							})
+						}
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *perptypes.GenesisState) {
+						genesisState.Params = constants.PerpetualsGenesisParams
+						genesisState.LiquidityTiers = tc.liquidityTiers
+						genesisState.Perpetuals = tc.perpetuals
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *satypes.GenesisState) {
+						genesisState.Subaccounts = tc.subaccounts
+					},
+				)
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *feetiertypes.GenesisState) {
+						genesisState.Params = constants.PerpetualFeeParamsNoFee
+					},
+				)
+				return genesis
+			}).Build()
+
+			ctx := tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+
+			// Send transfer message.
+			var msg proto.Message
+			transferMsg := sendingtypes.MsgCreateTransfer{
+				Transfer: &sendingtypes.Transfer{
+					Sender:    tc.senderSubaccountId,
+					Recipient: tc.receiverSubaccountId,
+					AssetId:   constants.Usdc.Id,
+					Amount:    tc.quantums,
+				},
+			}
+			msg = &transferMsg
+			for _, checkTx := range testapp.MustMakeCheckTxsWithSdkMsg(
+				ctx,
+				tApp.App,
+				testapp.MustMakeCheckTxOptions{
+					AccAddressForSigning: tc.senderSubaccountId.Owner,
+					Gas:                  1000000,
+					FeeAmt:               constants.TestFeeCoins_5Cents,
+				},
+				msg,
+			) {
+				resp := tApp.CheckTx(checkTx)
+				require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
+			}
+
+			// Verify test expectations, subaccount and collateral pools should be updated.
+			ctx = tApp.AdvanceToBlock(
+				3,
+				testapp.AdvanceToBlockOptions{
+					ValidateFinalizeBlock: func(
+						ctx sdktypes.Context,
+						request abcitypes.RequestFinalizeBlock,
+						response abcitypes.ResponseFinalizeBlock,
+					) (haltchain bool) {
+						execResult := response.TxResults[1]
+						if tc.expectedErr != "" {
+							// Note the first TX is MsgProposedOperations, the second is all other TXs.
+							execResult := response.TxResults[1]
+							require.True(t, execResult.IsErr())
+							require.Equal(t, sdkerrors.ErrInsufficientFunds.ABCICode(), execResult.Code)
+							require.Contains(t, execResult.Log, tc.expectedErr)
+						} else {
+							require.False(t, execResult.IsErr())
+						}
+						return false
+					},
+				},
+			)
+			for _, expectedSubaccount := range tc.expectedSubaccounts {
+				require.Equal(
+					t,
+					expectedSubaccount,
+					tApp.App.SubaccountsKeeper.GetSubaccount(ctx, *expectedSubaccount.Id),
+				)
+			}
+			for addr, expectedBalance := range tc.expectedCollateralPoolBalances {
+				require.Equal(
+					t,
+					sdkmath.NewIntFromBigInt(big.NewInt(expectedBalance)),
+					tApp.App.BankKeeper.GetBalance(ctx, sdktypes.MustAccAddressFromBech32(addr), constants.Usdc.Denom).Amount,
+				)
+			}
+		})
+	}
+}
+
+// Creates a copy of a subaccount and changes the USDC asset position size of the subaccount by the passed in delta.
+func changeUsdcBalance(subaccount satypes.Subaccount, deltaQuantums int64) satypes.Subaccount {
+	subaccountId := satypes.SubaccountId{
+		Owner:  subaccount.Id.Owner,
+		Number: subaccount.Id.Number,
+	}
+	assetPositions := make([]*satypes.AssetPosition, 0)
+	for _, ap := range subaccount.AssetPositions {
+		if ap.AssetId != constants.Usdc.Id {
+			assetPositions = append(assetPositions, &satypes.AssetPosition{
+				AssetId:  ap.AssetId,
+				Quantums: dtypes.NewInt(ap.Quantums.BigInt().Int64()),
+			})
+		} else {
+			assetPositions = append(assetPositions, &satypes.AssetPosition{
+				AssetId:  ap.AssetId,
+				Quantums: dtypes.NewInt(ap.Quantums.BigInt().Int64() + deltaQuantums),
+			})
+		}
+	}
+	if len(assetPositions) == 0 {
+		assetPositions = nil
+	}
+	perpetualPositions := make([]*satypes.PerpetualPosition, 0)
+	for _, pp := range subaccount.PerpetualPositions {
+		perpetualPositions = append(perpetualPositions, &satypes.PerpetualPosition{
+			PerpetualId:  pp.PerpetualId,
+			Quantums:     dtypes.NewInt(pp.Quantums.BigInt().Int64()),
+			FundingIndex: dtypes.NewInt(pp.FundingIndex.BigInt().Int64()),
+		})
+	}
+	if len(perpetualPositions) == 0 {
+		perpetualPositions = nil
+	}
+	return satypes.Subaccount{
+		Id:                 &subaccountId,
+		AssetPositions:     assetPositions,
+		PerpetualPositions: perpetualPositions,
+		MarginEnabled:      subaccount.MarginEnabled,
+	}
+}


### PR DESCRIPTION
### Changelist
Add E2E test for transfers from / to isolated subaccounts.

Additional changes:
- cleaned up some tech debt I found where subaccounts with no perpetual positions should have `nil` and not an empty slice for test constants
- cleaned up some tech debt I found where perpetual positions should be initialized with a 0 funding index rather than the default value for the byte array for test constants

### Test Plan
Ran test.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
