### PR TITLE
Use read replica rather than main instance for aggregate-trading-rewards query

### DIFF
--- a/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
+++ b/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
@@ -384,7 +384,7 @@ export class AggregateTradingReward {
     const blocks: BlockFromDatabase[] = await BlockTable.findAll({
       createdOnOrAfter: time,
       limit: 1,
-    }, []);
+    }, [], { readReplica: true });
 
     if (blocks.length === 0) {
       logger.error({


### PR DESCRIPTION
### Changelist
Use read replica rather than main instance for aggregate-trading-rewards query.

Over the past week, this is the 2nd top query by db wait time on the primary db instance.

<img width="1627" alt="Screenshot 2024-03-18 at 1 14 12 PM" src="https://github.com/dydxprotocol/v4-chain/assets/119354122/5df7cbcb-43cd-432c-922b-f4ad877c02de">


### Test Plan


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
