### PR TITLE
feat: Enforce MarketParam.Pair uniqueness constraint

### DIFF
--- a/protocol/testutil/keeper/prices.go
+++ b/protocol/testutil/keeper/prices.go
@@ -171,6 +171,17 @@ func AssertMarketEventsNotInIndexerBlock(
 	require.Equal(t, 0, len(indexerMarketEvents))
 }
 
+// AssertNMarketEventsNotInIndexerBlock verifies that N market events were included in the Indexer block message.
+func AssertNMarketEventsNotInIndexerBlock(
+	t *testing.T,
+	k *keeper.Keeper,
+	ctx sdk.Context,
+	n int,
+) {
+	indexerMarketEvents := getMarketEventsFromIndexerBlock(ctx, k)
+	require.Equal(t, n, len(indexerMarketEvents))
+}
+
 // getMarketEventsFromIndexerBlock returns the market events from the Indexer Block event Kafka message.
 func getMarketEventsFromIndexerBlock(
 	ctx sdk.Context,

--- a/protocol/x/prices/keeper/market.go
+++ b/protocol/x/prices/keeper/market.go
@@ -36,6 +36,15 @@ func (k Keeper) CreateMarket(
 	if err := marketPrice.ValidateFromParam(marketParam); err != nil {
 		return types.MarketParam{}, err
 	}
+	// Stateful Validation
+	for _, market := range k.GetAllMarketParams(ctx) {
+		if market.Pair == marketParam.Pair {
+			return types.MarketParam{}, errorsmod.Wrapf(
+				types.ErrMarketParamPairAlreadyExists,
+				marketParam.Pair,
+			)
+		}
+	}
 
 	paramBytes := k.cdc.MustMarshal(&marketParam)
 	priceBytes := k.cdc.MustMarshal(&marketPrice)

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -44,6 +44,13 @@ func (k Keeper) ModifyMarketParam(
 			errorsmod.Wrapf(types.ErrMarketExponentCannotBeUpdated, lib.UintToString(updatedMarketParam.Id))
 	}
 
+	// Validate base/quote uniqueness
+	for _, market := range k.GetAllMarketParams(ctx) {
+		if market.Pair == updatedMarketParam.Pair && market.Id != updatedMarketParam.Id {
+			return types.MarketParam{}, errorsmod.Wrapf(types.ErrMarketParamPairAlreadyExists, updatedMarketParam.Pair)
+		}
+	}
+
 	// Store the modified market param.
 	marketParamStore := k.getMarketParamStore(ctx)
 	b := k.cdc.MustMarshal(&updatedMarketParam)

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -109,13 +109,24 @@ func TestModifyMarketParam_Errors(t *testing.T) {
 				"",
 			).Error(),
 		},
+		"Duplicate pair fails": {
+			targetId:           0,
+			pair:               "1-1",
+			minExchanges:       uint32(1),
+			minPriceChangePpm:  uint32(50),
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr: errorsmod.Wrapf(
+				types.ErrMarketParamPairAlreadyExists,
+				"1-1",
+			).Error(),
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx, keeper, _, _, _, mockTimeKeeper := keepertest.PricesKeepers(t)
 			mockTimeKeeper.On("Now").Return(constants.TimeT)
 			ctx = ctx.WithTxBytes(constants.TestTxBytes)
-			keepertest.CreateNMarkets(t, ctx, keeper, 1)
+			keepertest.CreateNMarkets(t, ctx, keeper, 2)
 			_, err := keeper.ModifyMarketParam(
 				ctx,
 				types.MarketParam{

--- a/protocol/x/prices/keeper/market_price_test.go
+++ b/protocol/x/prices/keeper/market_price_test.go
@@ -135,19 +135,23 @@ func TestGetMarketIdToValidIndexPrice(t *testing.T) {
 		keeper,
 		[]types.MarketParamPrice{
 			*pricestest.GenerateMarketParamPrice(
+				pricestest.WithPair("0-0"),
 				pricestest.WithId(6),
 				pricestest.WithMinExchanges(2),
 			),
 			*pricestest.GenerateMarketParamPrice(
+				pricestest.WithPair("1-1"),
 				pricestest.WithId(7),
 				pricestest.WithMinExchanges(2),
 			),
 			*pricestest.GenerateMarketParamPrice(
+				pricestest.WithPair("2-2"),
 				pricestest.WithId(8),
 				pricestest.WithMinExchanges(2),
 				pricestest.WithExponent(-8),
 			),
 			*pricestest.GenerateMarketParamPrice(
+				pricestest.WithPair("3-3"),
 				pricestest.WithId(9),
 				pricestest.WithMinExchanges(2),
 				pricestest.WithExponent(-9),

--- a/protocol/x/prices/keeper/market_test.go
+++ b/protocol/x/prices/keeper/market_test.go
@@ -158,7 +158,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 			exchangeConfigJson:                    validExchangeConfigJson,
 			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidInput,
-				"market param id 0 does not match market price id 1",
+				"market param id 1 does not match market price id 2",
 			).Error(),
 		},
 		"Market param and price exponents don't match": {
@@ -170,14 +170,28 @@ func TestCreateMarket_Errors(t *testing.T) {
 			exchangeConfigJson: validExchangeConfigJson,
 			expectedErr: errorsmod.Wrap(
 				types.ErrInvalidInput,
-				"market param 0 exponent -6 does not match market price 0 exponent -5",
+				"market param 1 exponent -6 does not match market price 1 exponent -5",
+			).Error(),
+		},
+		"Pair already exists": {
+			pair:               "0-0",
+			minExchanges:       uint32(2),
+			minPriceChangePpm:  uint32(50),
+			price:              constants.FiveBillion,
+			exchangeConfigJson: validExchangeConfigJson,
+			expectedErr: errorsmod.Wrap(
+				types.ErrMarketParamPairAlreadyExists,
+				"0-0",
 			).Error(),
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, keeper, _, _, _, _ := keepertest.PricesKeepers(t)
+			ctx, keeper, _, _, _, mockTimeKeeper := keepertest.PricesKeepers(t)
 			ctx = ctx.WithTxBytes(constants.TestTxBytes)
+
+			mockTimeKeeper.On("Now").Return(constants.TimeT)
+			keepertest.CreateNMarkets(t, ctx, keeper, 1)
 
 			marketPriceIdOffset := uint32(0)
 			if tc.marketPriceIdDoesntMatchMarketParamId {
@@ -192,7 +206,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 			_, err := keeper.CreateMarket(
 				ctx,
 				types.MarketParam{
-					Id:                 0,
+					Id:                 1,
 					Pair:               tc.pair,
 					Exponent:           int32(-6),
 					MinExchanges:       tc.minExchanges,
@@ -200,7 +214,7 @@ func TestCreateMarket_Errors(t *testing.T) {
 					ExchangeConfigJson: tc.exchangeConfigJson,
 				},
 				types.MarketPrice{
-					Id:       0 + marketPriceIdOffset,
+					Id:       1 + marketPriceIdOffset,
 					Exponent: int32(-6) + marketPriceExponentOffset,
 					Price:    tc.price,
 				},
@@ -208,15 +222,15 @@ func TestCreateMarket_Errors(t *testing.T) {
 			require.EqualError(t, err, tc.expectedErr)
 
 			// Verify no new MarketPrice created.
-			_, err = keeper.GetMarketPrice(ctx, 0)
+			_, err = keeper.GetMarketPrice(ctx, 1)
 			require.EqualError(
 				t,
 				err,
-				errorsmod.Wrap(types.ErrMarketPriceDoesNotExist, lib.UintToString(uint32(0))).Error(),
+				errorsmod.Wrap(types.ErrMarketPriceDoesNotExist, lib.UintToString(uint32(1))).Error(),
 			)
 
 			// Verify no new market event.
-			keepertest.AssertMarketEventsNotInIndexerBlock(t, keeper, ctx)
+			keepertest.AssertNMarketEventsNotInIndexerBlock(t, keeper, ctx, 1)
 		})
 	}
 }

--- a/protocol/x/prices/types/errors.go
+++ b/protocol/x/prices/types/errors.go
@@ -24,6 +24,7 @@ var (
 	ErrMarketExponentCannotBeUpdated  = errorsmod.Register(ModuleName, 202, "Market exponent cannot be updated")
 	ErrMarketPricesAndParamsDontMatch = errorsmod.Register(ModuleName, 203, "Market prices and params don't match")
 	ErrMarketParamAlreadyExists       = errorsmod.Register(ModuleName, 204, "Market params already exists")
+	ErrMarketParamPairAlreadyExists   = errorsmod.Register(ModuleName, 205, "Market params pair already exists")
 
 	// 300 - 399: Price related errors.
 	ErrIndexPriceNotAvailable = errorsmod.Register(ModuleName, 300, "Index price is not available")


### PR DESCRIPTION
### Changelist
Enforces a uniqueness constraint on Create/Update operations for MarketParams.
This is required for Slinky since it uses Base/Quote as a compound primary key to reason about pairs being posted to chain as well as prices retrieved from the sidecar.

### Test Plan
Unit tests included. 

Mainnet data also shows no existing pairs with duplicates, so this should just prevent things in addition to avoiding this in governance votes in the interim.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
