### PR TITLE
test: Move slinky daemon tests into single suite

### DIFF
--- a/protocol/daemons/slinky/client/price_fetcher_test.go
+++ b/protocol/daemons/slinky/client/price_fetcher_test.go
@@ -3,83 +3,20 @@ package client_test
 import (
 	"context"
 	"fmt"
-	"net"
-	"sync"
-	"testing"
 	"time"
 
 	"cosmossdk.io/log"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
-	"google.golang.org/grpc"
 
 	"github.com/skip-mev/slinky/service/servers/oracle/types"
 
-	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
-	daemonflags "github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	pricefeed_types "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/types"
-	daemonserver "github.com/dydxprotocol/v4-chain/protocol/daemons/server"
 	pricefeedserver_types "github.com/dydxprotocol/v4-chain/protocol/daemons/server/types/pricefeed"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/slinky/client"
-	daemontypes "github.com/dydxprotocol/v4-chain/protocol/daemons/types"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/appoptions"
 )
 
-func TestPriceFetcherTestSuite(t *testing.T) {
-	suite.Run(t, &PriceFetcherTestSuite{})
-}
-
-type PriceFetcherTestSuite struct {
-	suite.Suite
-	daemonFlags      daemonflags.DaemonFlags
-	appFlags         appflags.Flags
-	daemonServer     *daemonserver.Server
-	pricesGrpcServer *grpc.Server
-	wg               sync.WaitGroup
-}
-
-func (p *PriceFetcherTestSuite) SetupTest() {
-	// Setup daemon and grpc servers.
-	p.daemonFlags = daemonflags.GetDefaultDaemonFlags()
-	p.appFlags = appflags.GetFlagValuesFromOptions(appoptions.GetDefaultTestAppOptions("", nil))
-
-	// Configure and run daemon server.
-	p.daemonServer = daemonserver.NewServer(
-		log.NewNopLogger(),
-		grpc.NewServer(),
-		&daemontypes.FileHandlerImpl{},
-		p.daemonFlags.Shared.SocketAddress,
-	)
-	p.daemonServer.WithPriceFeedMarketToExchangePrices(
-		pricefeedserver_types.NewMarketToExchangePrices(5 * time.Second),
-	)
-
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		p.daemonServer.Start()
-	}()
-
-	// Create a gRPC server running on the default port and attach the mock prices query response.
-	p.pricesGrpcServer = grpc.NewServer()
-
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		ls, err := net.Listen("tcp", p.appFlags.GrpcAddress)
-		p.Require().NoError(err)
-		_ = p.pricesGrpcServer.Serve(ls)
-	}()
-}
-
-func (p *PriceFetcherTestSuite) TearDownTest() {
-	p.daemonServer.Stop()
-	p.pricesGrpcServer.Stop()
-	p.wg.Wait()
-}
-
-func (p *PriceFetcherTestSuite) TestPriceFetcher() {
+func (p *ClientTestSuite) TestPriceFetcher() {
 	logger := log.NewTestLogger(p.T())
 	mpf := mocks.NewMarketPairFetcher(p.T())
 	slinky := mocks.NewOracleClient(p.T())


### PR DESCRIPTION
### Changelist
Moved all slinky daemon tests dependent on grpc server setup to a single Suite.

### Test Plan
I was able to replicate the existing flakiness locally without this change by running all `protocol/daemons` tests with `test.count=100`. After making this change, I reran the same 100 repetition test set and was no longer able to produce the flaky result.

It's hard to be definitive in this, but it appears resolving the contention over the same socket across tests will resolve the flaky failures.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
