### PR TITLE
[TRA-139] Add logic to transfer collateral when open/close isolated perpetual position.

### DIFF
--- a/protocol/testutil/constants/positions.go
+++ b/protocol/testutil/constants/positions.go
@@ -76,7 +76,7 @@ var (
 	// Long position for arbitrary isolated market
 	PerpetualPosition_OneISOLong = satypes.PerpetualPosition{
 		PerpetualId:  3,
-		Quantums:     dtypes.NewInt(100_000_000),
+		Quantums:     dtypes.NewInt(1_000_000_000),
 		FundingIndex: dtypes.NewInt(0),
 	}
 	PerpetualPosition_OneISO2Long = satypes.PerpetualPosition{

--- a/protocol/x/subaccounts/keeper/isolated_subaccount.go
+++ b/protocol/x/subaccounts/keeper/isolated_subaccount.go
@@ -2,16 +2,35 @@ package keeper
 
 import (
 	"math"
+	"math/big"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
+type positionStateTransition uint
+
+const (
+	opened positionStateTransition = iota
+	closed
+)
+
+// Represents a state transition for an isolated perpetual.
+type isolatedPerpetualStateTranisition struct {
+	perpetualId uint32
+	// TODO(DEC-715): Support non-USDC assets.
+	// USDC position size of the subaccount that has a state change for an isolated perpetual.
+	usdcQuantumsBeforeUpdate *big.Int
+	transition               positionStateTransition
+}
+
 // checkIsolatedSubaccountConstaints will validate all `updates` to the relevant subaccounts against
-// isolated subaccount constraints.
+// isolated subaccount constraints and computes whether each update leads to a state change
+// (open / close) to an isolated perpetual occurred due to the updates if they are valid.
 // This function checks each update in isolation, so if multiple updates for the same subaccount id
 // are passed in, they are not evaluated separately.
 // The input subaccounts must be settled.
@@ -20,6 +39,10 @@ import (
 // Returns a `successPerUpdates` value, which is a slice of `UpdateResult`.
 // These map to the updates and are used to indicate which of the updates
 // caused a failure, if any.
+// Returns a `isolatedPerpetualStateTransitions` value, which is a slice of
+// `isolatedPerpetualStateTransition`.
+// These map to the updates and are used to indicate which of the updates opened or closed an
+// isolated perpetual position.
 func (k Keeper) checkIsolatedSubaccountConstraints(
 	ctx sdk.Context,
 	settledUpdates []settledUpdate,
@@ -27,10 +50,12 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 ) (
 	success bool,
 	successPerUpdate []types.UpdateResult,
+	isolatedPerpetualStateTranisitions []*isolatedPerpetualStateTranisition,
 	err error,
 ) {
 	success = true
 	successPerUpdate = make([]types.UpdateResult, len(settledUpdates))
+	isolatedPerpetualStateTranisitions = make([]*isolatedPerpetualStateTranisition, len(settledUpdates))
 	var perpIdToMarketType = make(map[uint32]perptypes.PerpetualMarketType)
 
 	for _, perpetual := range perpetuals {
@@ -38,23 +63,25 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 	}
 
 	for i, u := range settledUpdates {
-		result, err := isValidIsolatedPerpetualUpdates(u, perpIdToMarketType)
+		result, stateTransition, err := processIsolatedPerpetualUpdates(u, perpIdToMarketType)
 		if err != nil {
-			return false, nil, err
+			return false, nil, nil, err
 		}
 		if result != types.Success {
 			success = false
 		}
 
 		successPerUpdate[i] = result
+		isolatedPerpetualStateTranisitions[i] = stateTransition
 	}
 
-	return success, successPerUpdate, nil
+	return success, successPerUpdate, isolatedPerpetualStateTranisitions, nil
 }
 
-// Checks whether the perpetual updates to a settled subaccount violates constraints for isolated
-// perpetuals. This function assumes the settled subaccount is valid and does not violate the
-// the constraints.
+// processIsolatedPerpetualUpdates checks whether the perpetual updates to a settled subaccount
+// violates constraints for isolated perpetuals and computes whether the perpetual updates result in
+// a state change (open / close) for an isolated perpetual position if the updates are valid.
+// This function assumes the settled subaccount is valid and does not violate the constraints.
 // The constraint being checked is:
 //   - a subaccount with a position in an isolated perpetual cannot have updates for other
 //     perpetuals
@@ -62,23 +89,27 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 //     perpetuals
 //   - a subaccount with no positions cannot be updated to have positions in multiple isolated
 //     perpetuals or a combination of isolated and non-isolated perpetuals
-func isValidIsolatedPerpetualUpdates(
+//
+// If there is a state change (open / close) from the perpetual updates, it is returned along with
+// the perpetual id of the isolated perpetual and the size of the USDC position in the subaccount.
+func processIsolatedPerpetualUpdates(
 	settledUpdate settledUpdate,
 	perpIdToMarketType map[uint32]perptypes.PerpetualMarketType,
-) (types.UpdateResult, error) {
+) (types.UpdateResult, *isolatedPerpetualStateTranisition, error) {
 	// If there are no perpetual updates, then this update does not violate constraints for isolated
 	// markets.
 	if len(settledUpdate.PerpetualUpdates) == 0 {
-		return types.Success, nil
+		return types.Success, nil, nil
 	}
 
 	// Check if the updates contain an update to an isolated perpetual.
 	hasIsolatedUpdate := false
 	isolatedUpdatePerpetualId := uint32(math.MaxUint32)
+	isolatedUpdate := (*types.PerpetualUpdate)(nil)
 	for _, perpetualUpdate := range settledUpdate.PerpetualUpdates {
 		marketType, exists := perpIdToMarketType[perpetualUpdate.PerpetualId]
 		if !exists {
-			return types.UpdateCausedError, errorsmod.Wrap(
+			return types.UpdateCausedError, nil, errorsmod.Wrap(
 				perptypes.ErrPerpetualDoesNotExist, lib.UintToString(perpetualUpdate.PerpetualId),
 			)
 		}
@@ -86,6 +117,10 @@ func isValidIsolatedPerpetualUpdates(
 		if marketType == perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED {
 			hasIsolatedUpdate = true
 			isolatedUpdatePerpetualId = perpetualUpdate.PerpetualId
+			isolatedUpdate = &types.PerpetualUpdate{
+				PerpetualId:      perpetualUpdate.PerpetualId,
+				BigQuantumsDelta: perpetualUpdate.GetBigQuantums(),
+			}
 			break
 		}
 	}
@@ -94,11 +129,12 @@ func isValidIsolatedPerpetualUpdates(
 	// Assumes the subaccount itself does not violate the isolated perpetual constraints.
 	isIsolatedSubaccount := false
 	isolatedPositionPerpetualId := uint32(math.MaxUint32)
+	isolatedPerpetualPosition := (*types.PerpetualPosition)(nil)
 	hasPerpetualPositions := len(settledUpdate.SettledSubaccount.PerpetualPositions) > 0
 	for _, perpetualPosition := range settledUpdate.SettledSubaccount.PerpetualPositions {
 		marketType, exists := perpIdToMarketType[perpetualPosition.PerpetualId]
 		if !exists {
-			return types.UpdateCausedError, errorsmod.Wrap(
+			return types.UpdateCausedError, nil, errorsmod.Wrap(
 				perptypes.ErrPerpetualDoesNotExist, lib.UintToString(perpetualPosition.PerpetualId),
 			)
 		}
@@ -106,6 +142,7 @@ func isValidIsolatedPerpetualUpdates(
 		if marketType == perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED {
 			isIsolatedSubaccount = true
 			isolatedPositionPerpetualId = perpetualPosition.PerpetualId
+			isolatedPerpetualPosition = perpetualPosition
 			break
 		}
 	}
@@ -113,19 +150,19 @@ func isValidIsolatedPerpetualUpdates(
 	// A subaccount with a perpetual position in an isolated perpetual cannot have updates to other
 	// non-isolated perpetuals.
 	if isIsolatedSubaccount && !hasIsolatedUpdate {
-		return types.ViolatesIsolatedSubaccountConstraints, nil
+		return types.ViolatesIsolatedSubaccountConstraints, nil, nil
 	}
 
 	// A subaccount with perpetual positions in non-isolated perpetuals cannot have an update
 	// to an isolated perpetual.
 	if !isIsolatedSubaccount && hasPerpetualPositions && hasIsolatedUpdate {
-		return types.ViolatesIsolatedSubaccountConstraints, nil
+		return types.ViolatesIsolatedSubaccountConstraints, nil, nil
 	}
 
 	// There cannot be more than a single perpetual update if an update to an isolated perpetual
 	// exists in the slice of perpetual updates.
 	if hasIsolatedUpdate && len(settledUpdate.PerpetualUpdates) > 1 {
-		return types.ViolatesIsolatedSubaccountConstraints, nil
+		return types.ViolatesIsolatedSubaccountConstraints, nil, nil
 	}
 
 	// Note we can assume that if `hasIsolatedUpdate` is true, there is only a single perpetual
@@ -135,8 +172,130 @@ func isValidIsolatedPerpetualUpdates(
 	if isIsolatedSubaccount &&
 		hasIsolatedUpdate &&
 		isolatedPositionPerpetualId != isolatedUpdatePerpetualId {
-		return types.ViolatesIsolatedSubaccountConstraints, nil
+		return types.ViolatesIsolatedSubaccountConstraints, nil, nil
 	}
 
-	return types.Success, nil
+	return types.Success,
+		getIsolatedPerpetualStateTransition(
+			settledUpdate.SettledSubaccount,
+			isolatedPerpetualPosition,
+			isolatedUpdate,
+		),
+		nil
+}
+
+// getIsolatedPerpetualStateTransition computes whether an isolated perpetual position will be
+// opened or closed for a subaccount given an isolated perpetual update for the subaccount.
+// Input subaccount account must be settled.
+func getIsolatedPerpetualStateTransition(
+	settledSubaccount types.Subaccount,
+	isolatedPerpetualPosition *types.PerpetualPosition,
+	isolatedPerpetualUpdate *types.PerpetualUpdate,
+) *isolatedPerpetualStateTranisition {
+	// If there is no update to an isolated perpetual position, then no state transitions have
+	// happened for the isolated perpetual.
+	if isolatedPerpetualUpdate == nil {
+		return nil
+	}
+
+	perpetualId := isolatedPerpetualUpdate.PerpetualId
+	// TODO(DEC-715): Support non-USDC assets.
+	usdcQuantumsBeforeUpdate := new(big.Int).Set(settledSubaccount.GetUsdcPosition())
+
+	// If the subaccount has no isolated perpetual position, then this update is opening an isolated
+	// perpetual position.
+	if isolatedPerpetualPosition == nil {
+		return &isolatedPerpetualStateTranisition{
+			perpetualId:              perpetualId,
+			usdcQuantumsBeforeUpdate: usdcQuantumsBeforeUpdate,
+			transition:               opened,
+		}
+	}
+
+	// If the position size after the update is zero, then this update is closing an isolated
+	// perpetual position.
+	if finalPositionSize := new(big.Int).Add(
+		isolatedPerpetualPosition.GetBigQuantums(),
+		isolatedPerpetualUpdate.GetBigQuantums(),
+	); finalPositionSize.Cmp(lib.BigInt0()) == 0 {
+		return &isolatedPerpetualStateTranisition{
+			perpetualId:              perpetualId,
+			usdcQuantumsBeforeUpdate: usdcQuantumsBeforeUpdate,
+			transition:               closed,
+		}
+	}
+
+	// If a position was not opened or closed, no state transition happened from the perpetual
+	// update.
+	return nil
+}
+
+// transferCollateralForIsolatedPerpetual transfers collateral between an isolated collateral pool
+// and the cross-perpetual collateral pool based on whether an isolated perpetual position was
+// opened or closed in a subaccount.
+// Note: This uses the `x/bank` keeper and modifies `x/bank` state.
+func (k *Keeper) transferCollateralForIsolatedPerpetual(
+	ctx sdk.Context,
+	updatedSubaccount types.Subaccount,
+	stateTransition *isolatedPerpetualStateTranisition,
+) error {
+	// No collateral to transfer if no state transition.
+	if stateTransition == nil {
+		return nil
+	}
+
+	isolatedCollateralPoolAddr, err := k.GetCollateralPoolFromPerpetualId(ctx, stateTransition.perpetualId)
+	if err != nil {
+		return err
+	}
+
+	// If an isolated perpetual position was opened in the subaccount, then move collateral equivalent
+	// to the USDC asset position size of the subaccount before the update from the
+	// cross-perpetual collateral pool to the isolated perpetual collateral pool.
+	if stateTransition.transition == opened {
+		_, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
+			ctx,
+			// TODO(DEC-715): Support non-USDC assets.
+			assettypes.AssetUsdc.Id,
+			stateTransition.usdcQuantumsBeforeUpdate,
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := k.bankKeeper.SendCoins(
+			ctx,
+			types.ModuleAddress,
+			isolatedCollateralPoolAddr,
+			[]sdk.Coin{coinToTransfer},
+		); err != nil {
+			return err
+		}
+		return nil
+		// If the isolated perpetual position was closed, then move collateral equivalent to the USDC
+		// asset position size of the subaccount after the update from the isolated perpetual collateral
+		// pool to the cross-perpetual collateral pool.
+	} else if stateTransition.transition == closed {
+		_, coinToTransfer, err := k.assetsKeeper.ConvertAssetToCoin(
+			ctx,
+			// TODO(DEC-715): Support non-USDC assets.
+			assettypes.AssetUsdc.Id,
+			updatedSubaccount.GetUsdcPosition(),
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := k.bankKeeper.SendCoins(
+			ctx,
+			isolatedCollateralPoolAddr,
+			types.ModuleAddress,
+			[]sdk.Coin{coinToTransfer},
+		); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return nil
 }

--- a/protocol/x/subaccounts/keeper/isolated_subaccount.go
+++ b/protocol/x/subaccounts/keeper/isolated_subaccount.go
@@ -20,7 +20,7 @@ const (
 )
 
 // Represents a state transition for an isolated perpetual.
-type isolatedPerpetualStateTranisition struct {
+type isolatedPerpetualStateTransition struct {
 	perpetualId uint32
 	// TODO(DEC-715): Support non-USDC assets.
 	// USDC position size of the subaccount that has a state change for an isolated perpetual.
@@ -50,12 +50,12 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 ) (
 	success bool,
 	successPerUpdate []types.UpdateResult,
-	isolatedPerpetualStateTranisitions []*isolatedPerpetualStateTranisition,
+	isolatedPerpetualStateTransitions []*isolatedPerpetualStateTransition,
 	err error,
 ) {
 	success = true
 	successPerUpdate = make([]types.UpdateResult, len(settledUpdates))
-	isolatedPerpetualStateTranisitions = make([]*isolatedPerpetualStateTranisition, len(settledUpdates))
+	isolatedPerpetualStateTransitions = make([]*isolatedPerpetualStateTransition, len(settledUpdates))
 	var perpIdToMarketType = make(map[uint32]perptypes.PerpetualMarketType)
 
 	for _, perpetual := range perpetuals {
@@ -72,10 +72,10 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 		}
 
 		successPerUpdate[i] = result
-		isolatedPerpetualStateTranisitions[i] = stateTransition
+		isolatedPerpetualStateTransitions[i] = stateTransition
 	}
 
-	return success, successPerUpdate, isolatedPerpetualStateTranisitions, nil
+	return success, successPerUpdate, isolatedPerpetualStateTransitions, nil
 }
 
 // processIsolatedPerpetualUpdates checks whether the perpetual updates to a settled subaccount
@@ -95,7 +95,7 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 func processIsolatedPerpetualUpdates(
 	settledUpdate settledUpdate,
 	perpIdToMarketType map[uint32]perptypes.PerpetualMarketType,
-) (types.UpdateResult, *isolatedPerpetualStateTranisition, error) {
+) (types.UpdateResult, *isolatedPerpetualStateTransition, error) {
 	// If there are no perpetual updates, then this update does not violate constraints for isolated
 	// markets.
 	if len(settledUpdate.PerpetualUpdates) == 0 {
@@ -191,7 +191,7 @@ func getIsolatedPerpetualStateTransition(
 	settledSubaccount types.Subaccount,
 	isolatedPerpetualPosition *types.PerpetualPosition,
 	isolatedPerpetualUpdate *types.PerpetualUpdate,
-) *isolatedPerpetualStateTranisition {
+) *isolatedPerpetualStateTransition {
 	// If there is no update to an isolated perpetual position, then no state transitions have
 	// happened for the isolated perpetual.
 	if isolatedPerpetualUpdate == nil {
@@ -205,7 +205,7 @@ func getIsolatedPerpetualStateTransition(
 	// If the subaccount has no isolated perpetual position, then this update is opening an isolated
 	// perpetual position.
 	if isolatedPerpetualPosition == nil {
-		return &isolatedPerpetualStateTranisition{
+		return &isolatedPerpetualStateTransition{
 			perpetualId:              perpetualId,
 			usdcQuantumsBeforeUpdate: usdcQuantumsBeforeUpdate,
 			transition:               opened,
@@ -218,7 +218,7 @@ func getIsolatedPerpetualStateTransition(
 		isolatedPerpetualPosition.GetBigQuantums(),
 		isolatedPerpetualUpdate.GetBigQuantums(),
 	); finalPositionSize.Cmp(lib.BigInt0()) == 0 {
-		return &isolatedPerpetualStateTranisition{
+		return &isolatedPerpetualStateTransition{
 			perpetualId:              perpetualId,
 			usdcQuantumsBeforeUpdate: usdcQuantumsBeforeUpdate,
 			transition:               closed,
@@ -237,7 +237,7 @@ func getIsolatedPerpetualStateTransition(
 func (k *Keeper) transferCollateralForIsolatedPerpetual(
 	ctx sdk.Context,
 	updatedSubaccount types.Subaccount,
-	stateTransition *isolatedPerpetualStateTranisition,
+	stateTransition *isolatedPerpetualStateTransition,
 ) error {
 	// No collateral to transfer if no state transition.
 	if stateTransition == nil {

--- a/protocol/x/subaccounts/keeper/isolated_subaccount.go
+++ b/protocol/x/subaccounts/keeper/isolated_subaccount.go
@@ -12,9 +12,8 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
-// processIsolatedSubaccountUpdates will validate all `updates` to the relevant subaccounts against
-// isolated subaccount constraints and computes whether each update leads to a state change
-// (open / close) to an isolated perpetual occurred due to the updates if they are valid.
+// checkIsolatedSubaccountConstaints will validate all `updates` to the relevant subaccounts against
+// isolated subaccount constraints.
 // This function checks each update in isolation, so if multiple updates for the same subaccount id
 // are passed in, they are not evaluated separately.
 // The input subaccounts must be settled.
@@ -23,52 +22,37 @@ import (
 // Returns a `successPerUpdates` value, which is a slice of `UpdateResult`.
 // These map to the updates and are used to indicate which of the updates
 // caused a failure, if any.
-// Returns a `isolatedPerpetualStateTransitions` value, which is a slice of
-// `IsolatedPerpetualStateTransition`.
-// These map to the updates and are used to indicate which of the updates opened or closed an
-// isolated perpetual position.
-func (k Keeper) processIsolatedSubaccountUpdates(
+func (k Keeper) checkIsolatedSubaccountConstraints(
 	ctx sdk.Context,
-	settledUpdates []settledUpdate,
+	settledUpdates []SettledUpdate,
 	perpetuals []perptypes.Perpetual,
 ) (
 	success bool,
 	successPerUpdate []types.UpdateResult,
-	isolatedPerpetualPositionStateTransitions []*types.IsolatedPerpetualPositionStateTransition,
 	err error,
 ) {
 	success = true
 	successPerUpdate = make([]types.UpdateResult, len(settledUpdates))
-	isolatedPerpetualPositionStateTransitions = make(
-		[]*types.IsolatedPerpetualPositionStateTransition,
-		len(settledUpdates),
-	)
-	var perpIdToMarketType = make(map[uint32]perptypes.PerpetualMarketType)
-
-	for _, perpetual := range perpetuals {
-		perpIdToMarketType[perpetual.GetId()] = perpetual.Params.MarketType
-	}
+	perpIdToMarketType := getPerpIdToMarketTypeMap(perpetuals)
 
 	for i, u := range settledUpdates {
-		result, stateTransition, err := processSingleIsolatedSubaccountUpdate(u, perpIdToMarketType)
+		result, err := isValidIsolatedPerpetualUpdates(u, perpIdToMarketType)
 		if err != nil {
-			return false, nil, nil, err
+			return false, nil, err
 		}
 		if result != types.Success {
 			success = false
 		}
 
 		successPerUpdate[i] = result
-		isolatedPerpetualPositionStateTransitions[i] = stateTransition
 	}
 
-	return success, successPerUpdate, isolatedPerpetualPositionStateTransitions, nil
+	return success, successPerUpdate, nil
 }
 
-// processSingleIsolatedSubaccountUpdate checks whether the perpetual updates to a settled subaccount
-// violates constraints for isolated perpetuals and computes whether the perpetual updates result in
-// a state change (open / close) for an isolated perpetual position if the updates are valid.
-// This function assumes the settled subaccount is valid and does not violate the constraints.
+// Checks whether the perpetual updates to a settled subaccount violates constraints for isolated
+// perpetuals. This function assumes the settled subaccount is valid and does not violate the
+// the constraints.
 // The constraint being checked is:
 //   - a subaccount with a position in an isolated perpetual cannot have updates for other
 //     perpetuals
@@ -76,27 +60,23 @@ func (k Keeper) processIsolatedSubaccountUpdates(
 //     perpetuals
 //   - a subaccount with no positions cannot be updated to have positions in multiple isolated
 //     perpetuals or a combination of isolated and non-isolated perpetuals
-//
-// If there is a state change (open / close) from the perpetual updates, it is returned along with
-// the perpetual id of the isolated perpetual and the size of the USDC position in the subaccount.
-func processSingleIsolatedSubaccountUpdate(
-	settledUpdate settledUpdate,
+func isValidIsolatedPerpetualUpdates(
+	settledUpdate SettledUpdate,
 	perpIdToMarketType map[uint32]perptypes.PerpetualMarketType,
-) (types.UpdateResult, *types.IsolatedPerpetualPositionStateTransition, error) {
+) (types.UpdateResult, error) {
 	// If there are no perpetual updates, then this update does not violate constraints for isolated
 	// markets.
 	if len(settledUpdate.PerpetualUpdates) == 0 {
-		return types.Success, nil, nil
+		return types.Success, nil
 	}
 
 	// Check if the updates contain an update to an isolated perpetual.
 	hasIsolatedUpdate := false
 	isolatedUpdatePerpetualId := uint32(math.MaxUint32)
-	isolatedUpdate := (*types.PerpetualUpdate)(nil)
 	for _, perpetualUpdate := range settledUpdate.PerpetualUpdates {
 		marketType, exists := perpIdToMarketType[perpetualUpdate.PerpetualId]
 		if !exists {
-			return types.UpdateCausedError, nil, errorsmod.Wrap(
+			return types.UpdateCausedError, errorsmod.Wrap(
 				perptypes.ErrPerpetualDoesNotExist, lib.UintToString(perpetualUpdate.PerpetualId),
 			)
 		}
@@ -104,10 +84,6 @@ func processSingleIsolatedSubaccountUpdate(
 		if marketType == perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED {
 			hasIsolatedUpdate = true
 			isolatedUpdatePerpetualId = perpetualUpdate.PerpetualId
-			isolatedUpdate = &types.PerpetualUpdate{
-				PerpetualId:      perpetualUpdate.PerpetualId,
-				BigQuantumsDelta: perpetualUpdate.GetBigQuantums(),
-			}
 			break
 		}
 	}
@@ -116,12 +92,11 @@ func processSingleIsolatedSubaccountUpdate(
 	// Assumes the subaccount itself does not violate the isolated perpetual constraints.
 	isIsolatedSubaccount := false
 	isolatedPositionPerpetualId := uint32(math.MaxUint32)
-	isolatedPerpetualPosition := (*types.PerpetualPosition)(nil)
 	hasPerpetualPositions := len(settledUpdate.SettledSubaccount.PerpetualPositions) > 0
 	for _, perpetualPosition := range settledUpdate.SettledSubaccount.PerpetualPositions {
 		marketType, exists := perpIdToMarketType[perpetualPosition.PerpetualId]
 		if !exists {
-			return types.UpdateCausedError, nil, errorsmod.Wrap(
+			return types.UpdateCausedError, errorsmod.Wrap(
 				perptypes.ErrPerpetualDoesNotExist, lib.UintToString(perpetualPosition.PerpetualId),
 			)
 		}
@@ -129,7 +104,6 @@ func processSingleIsolatedSubaccountUpdate(
 		if marketType == perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED {
 			isIsolatedSubaccount = true
 			isolatedPositionPerpetualId = perpetualPosition.PerpetualId
-			isolatedPerpetualPosition = perpetualPosition
 			break
 		}
 	}
@@ -137,19 +111,19 @@ func processSingleIsolatedSubaccountUpdate(
 	// A subaccount with a perpetual position in an isolated perpetual cannot have updates to other
 	// non-isolated perpetuals.
 	if isIsolatedSubaccount && !hasIsolatedUpdate {
-		return types.ViolatesIsolatedSubaccountConstraints, nil, nil
+		return types.ViolatesIsolatedSubaccountConstraints, nil
 	}
 
 	// A subaccount with perpetual positions in non-isolated perpetuals cannot have an update
 	// to an isolated perpetual.
 	if !isIsolatedSubaccount && hasPerpetualPositions && hasIsolatedUpdate {
-		return types.ViolatesIsolatedSubaccountConstraints, nil, nil
+		return types.ViolatesIsolatedSubaccountConstraints, nil
 	}
 
 	// There cannot be more than a single perpetual update if an update to an isolated perpetual
 	// exists in the slice of perpetual updates.
 	if hasIsolatedUpdate && len(settledUpdate.PerpetualUpdates) > 1 {
-		return types.ViolatesIsolatedSubaccountConstraints, nil, nil
+		return types.ViolatesIsolatedSubaccountConstraints, nil
 	}
 
 	// Note we can assume that if `hasIsolatedUpdate` is true, there is only a single perpetual
@@ -159,60 +133,106 @@ func processSingleIsolatedSubaccountUpdate(
 	if isIsolatedSubaccount &&
 		hasIsolatedUpdate &&
 		isolatedPositionPerpetualId != isolatedUpdatePerpetualId {
-		return types.ViolatesIsolatedSubaccountConstraints, nil, nil
+		return types.ViolatesIsolatedSubaccountConstraints, nil
 	}
 
-	return types.Success,
-		GetIsolatedPerpetualStateTransition(
-			// TODO(DEC-715): Support non-USDC assets.
-			settledUpdate.SettledSubaccount.GetUsdcPosition(),
-			isolatedPerpetualPosition,
-			isolatedUpdate,
-		),
-		nil
+	return types.Success, nil
 }
 
 // GetIsolatedPerpetualStateTransition computes whether an isolated perpetual position will be
-// opened or closed for a subaccount given an isolated perpetual update for the subaccount.
+// opened or closed for a subaccount.
+// This function assumes that the subaccount is valid under isolated perpetual constraints.
+// The input `settledUpdate` must have an updated subaccount (`settledUpdate.SettledSubaccount`),
+// so all the updates must have been applied already to the subaccount.
 func GetIsolatedPerpetualStateTransition(
-	subaccountQuoteQuantums *big.Int,
-	isolatedPerpetualPosition *types.PerpetualPosition,
-	isolatedPerpetualUpdate *types.PerpetualUpdate,
-) *types.IsolatedPerpetualPositionStateTransition {
-	// If there is no update to an isolated perpetual position, then no state transitions have
-	// happened for the isolated perpetual.
-	if isolatedPerpetualUpdate == nil {
-		return nil
+	settledUpdateWithUpdatedSubaccount SettledUpdate,
+	perpetuals []perptypes.Perpetual,
+) (*types.IsolatedPerpetualPositionStateTransition, error) {
+	perpIdToMarketType := getPerpIdToMarketTypeMap(perpetuals)
+	// This subaccount needs to have had the updates in the `settledUpdate` already applied to it.
+	updatedSubaccount := settledUpdateWithUpdatedSubaccount.SettledSubaccount
+	// If there are no perpetual updates, then no perpetual position could have been opened or closed
+	// on the subaccount.
+	if len(settledUpdateWithUpdatedSubaccount.PerpetualUpdates) == 0 {
+		return nil, nil
 	}
 
-	perpetualId := isolatedPerpetualUpdate.PerpetualId
+	// If there are more than 1 valid perpetual update, or more than 1 valid perpetual position on the
+	// subaccount, it is not isolated to an isolated perpetual, and so no isolated perpetual position
+	// could have been opened or closed.
+	if len(settledUpdateWithUpdatedSubaccount.PerpetualUpdates) > 1 ||
+		len(updatedSubaccount.PerpetualPositions) > 1 {
+		return nil, nil
+	}
 
-	// If the subaccount has no isolated perpetual position, then this update is opening an isolated
-	// perpetual position.
-	if isolatedPerpetualPosition == nil {
+	// Now, from the above checks, we know there is only a single perpetual update and 0 or 1 perpetual
+	// positions.
+	perpetualUpdate := settledUpdateWithUpdatedSubaccount.PerpetualUpdates[0]
+	marketType, exists := perpIdToMarketType[perpetualUpdate.PerpetualId]
+	if !exists {
+		return nil, errorsmod.Wrap(
+			perptypes.ErrPerpetualDoesNotExist, lib.UintToString(perpetualUpdate.PerpetualId),
+		)
+	}
+	// If the perpetual update is not for an isolated perpetual, no isolated perpetual position is
+	// being opened or closed.
+	if marketType != perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED {
+		return nil, nil
+	}
+
+	// If the updated subaccount does not have any perpetual positions, then an isolated perpetual
+	// position must have been closed due to the perpetual update.
+	if len(updatedSubaccount.PerpetualPositions) == 0 {
 		return &types.IsolatedPerpetualPositionStateTransition{
-			PerpetualId:               perpetualId,
-			QuoteQuantumsBeforeUpdate: subaccountQuoteQuantums,
-			Transition:                types.Opened,
-		}
+			SubaccountId:  updatedSubaccount.Id,
+			PerpetualId:   perpetualUpdate.PerpetualId,
+			QuoteQuantums: updatedSubaccount.GetUsdcPosition(),
+			Transition:    types.Closed,
+		}, nil
 	}
 
-	// If the position size after the update is zero, then this update is closing an isolated
-	// perpetual position.
-	if finalPositionSize := new(big.Int).Add(
-		isolatedPerpetualPosition.GetBigQuantums(),
-		isolatedPerpetualUpdate.GetBigQuantums(),
-	); finalPositionSize.Cmp(lib.BigInt0()) == 0 {
+	// After the above checks, the subaccount must have only a single perpetual position, which is for
+	// the same isolated perpetual as the perpetual update.
+	perpetualPosition := updatedSubaccount.PerpetualPositions[0]
+	// If the size of the update and the position are the same, the perpetual update must have opened
+	// the position.
+	if perpetualUpdate.GetBigQuantums().Cmp(perpetualPosition.GetBigQuantums()) == 0 {
+		if len(settledUpdateWithUpdatedSubaccount.AssetUpdates) != 1 {
+			return nil, errorsmod.Wrapf(
+				types.ErrFailedToUpdateSubaccounts,
+				"Subaccount with id %v opened perpteual position with perpetual id %d with invalid number of"+
+					" changes to asset positions (%d), should only be 1 asset update",
+				updatedSubaccount.Id,
+				perpetualUpdate.PerpetualId,
+				len(settledUpdateWithUpdatedSubaccount.AssetUpdates),
+			)
+		}
+		if settledUpdateWithUpdatedSubaccount.AssetUpdates[0].AssetId != assettypes.AssetUsdc.Id {
+			return nil, errorsmod.Wrapf(
+				types.ErrFailedToUpdateSubaccounts,
+				"Subaccount with id %v opened perpteual position with perpetual id %d without a change to the"+
+					" quote currency's asset position.",
+				updatedSubaccount.Id,
+				perpetualUpdate.PerpetualId,
+			)
+		}
+		// Collateral equal to the quote currency asset position before the update was applied needs to be transferred.
+		// Subtract the delta from the updated subaccount's quote currency asset position size to get the size
+		// of the quote currency asset position.
+		quoteQuantumsBeforeUpdate := new(big.Int).Sub(
+			updatedSubaccount.GetUsdcPosition(),
+			settledUpdateWithUpdatedSubaccount.AssetUpdates[0].GetBigQuantums(),
+		)
 		return &types.IsolatedPerpetualPositionStateTransition{
-			PerpetualId:               perpetualId,
-			QuoteQuantumsBeforeUpdate: subaccountQuoteQuantums,
-			Transition:                types.Closed,
-		}
+			SubaccountId:  updatedSubaccount.Id,
+			PerpetualId:   perpetualUpdate.PerpetualId,
+			QuoteQuantums: quoteQuantumsBeforeUpdate,
+			Transition:    types.Opened,
+		}, nil
 	}
 
-	// If a position was not opened or closed, no state transition happened from the perpetual
-	// update.
-	return nil
+	// The isolated perpetual position changed size but was not opened or closed.
+	return nil, nil
 }
 
 // transferCollateralForIsolatedPerpetual transfers collateral between an isolated collateral pool
@@ -221,7 +241,6 @@ func GetIsolatedPerpetualStateTransition(
 // Note: This uses the `x/bank` keeper and modifies `x/bank` state.
 func (k *Keeper) transferCollateralForIsolatedPerpetual(
 	ctx sdk.Context,
-	updatedSubaccount types.Subaccount,
 	stateTransition *types.IsolatedPerpetualPositionStateTransition,
 ) error {
 	// No collateral to transfer if no state transition.
@@ -235,22 +254,17 @@ func (k *Keeper) transferCollateralForIsolatedPerpetual(
 	}
 	var toModuleAddr sdk.AccAddress
 	var fromModuleAddr sdk.AccAddress
-	var quoteQuantums *big.Int
 
-	// If an isolated perpetual position was opened in the subaccount, then move collateral equivalent
-	// to the USDC asset position size of the subaccount before the update from the
+	// If an isolated perpetual position was opened in the subaccount, then move collateral from the
 	// cross-perpetual collateral pool to the isolated perpetual collateral pool.
 	if stateTransition.Transition == types.Opened {
 		toModuleAddr = isolatedCollateralPoolAddr
 		fromModuleAddr = types.ModuleAddress
-		quoteQuantums = stateTransition.QuoteQuantumsBeforeUpdate
-		// If the isolated perpetual position was closed, then move collateral equivalent to the USDC
-		// asset position size of the subaccount after the update from the isolated perpetual collateral
-		// pool to the cross-perpetual collateral pool.
+		// If the isolated perpetual position was closed, then move collateral from the isolated
+		// perpetual collateral pool to the cross-perpetual collateral pool.
 	} else if stateTransition.Transition == types.Closed {
 		toModuleAddr = types.ModuleAddress
 		fromModuleAddr = isolatedCollateralPoolAddr
-		quoteQuantums = updatedSubaccount.GetUsdcPosition()
 	} else {
 		// Should never hit this.
 		return errorsmod.Wrapf(
@@ -258,25 +272,25 @@ func (k *Keeper) transferCollateralForIsolatedPerpetual(
 			"Invalid state transition %v for isolated perpetual with id %d in subaccount with id %v",
 			stateTransition,
 			stateTransition.PerpetualId,
-			updatedSubaccount.Id,
+			stateTransition.SubaccountId,
 		)
 	}
 
 	// If there are zero quantums to transfer, don't transfer collateral.
-	if quoteQuantums.Sign() == 0 {
+	if stateTransition.QuoteQuantums.Sign() == 0 {
 		return nil
 	}
 
 	// Invalid to transfer negative quantums. This should already be caught by collateralization
 	// checks as well.
-	if quoteQuantums.Sign() == -1 {
+	if stateTransition.QuoteQuantums.Sign() == -1 {
 		return errorsmod.Wrapf(
 			types.ErrFailedToUpdateSubaccounts,
 			"Subaccount with id %v %s perpteual position with perpetual id %d with negative collateral %s to transfer",
-			updatedSubaccount.Id,
+			stateTransition.SubaccountId,
 			stateTransition.Transition.String(),
 			stateTransition.PerpetualId,
-			quoteQuantums.String(),
+			stateTransition.QuoteQuantums.String(),
 		)
 	}
 
@@ -285,7 +299,7 @@ func (k *Keeper) transferCollateralForIsolatedPerpetual(
 		ctx,
 		// TODO(DEC-715): Support non-USDC assets.
 		assettypes.AssetUsdc.Id,
-		quoteQuantums,
+		stateTransition.QuoteQuantums,
 	)
 	if err != nil {
 		return err
@@ -301,4 +315,16 @@ func (k *Keeper) transferCollateralForIsolatedPerpetual(
 	}
 
 	return nil
+}
+
+func getPerpIdToMarketTypeMap(
+	perpetuals []perptypes.Perpetual,
+) map[uint32]perptypes.PerpetualMarketType {
+	var perpIdToMarketType = make(map[uint32]perptypes.PerpetualMarketType)
+
+	for _, perpetual := range perpetuals {
+		perpIdToMarketType[perpetual.GetId()] = perpetual.Params.MarketType
+	}
+
+	return perpIdToMarketType
 }

--- a/protocol/x/subaccounts/keeper/isolated_subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/isolated_subaccount_test.go
@@ -1,0 +1,107 @@
+package keeper_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
+	tests := map[string]struct {
+		// parameters
+		subaccountQuoteQuantums   *big.Int
+		isolatedPerpetualUpdate   *types.PerpetualUpdate
+		isolatedPerpetualPosition *types.PerpetualPosition
+
+		// expectation
+		expectedStateTransition *types.IsolatedPerpetualPositionStateTransition
+	}{
+		`If perpetual update is nil, nil state transition is returned`: {
+			subaccountQuoteQuantums:   big.NewInt(100_000_000), // $100
+			isolatedPerpetualUpdate:   nil,
+			isolatedPerpetualPosition: nil,
+			expectedStateTransition:   nil,
+		},
+		`If perpetual update is nil and isolated position exists, nil state transition is returned`: {
+			subaccountQuoteQuantums:   big.NewInt(100_000_000), // $100
+			isolatedPerpetualUpdate:   nil,
+			isolatedPerpetualPosition: &constants.PerpetualPosition_OneISOLong,
+			expectedStateTransition:   nil,
+		},
+		`If perpetual update exists and isolated position is nil, state transition representing an
+		isolated perpetual position being opened is returned`: {
+			subaccountQuoteQuantums: big.NewInt(100_000_000), // $100
+			isolatedPerpetualUpdate: &types.PerpetualUpdate{
+				PerpetualId:      uint32(3),
+				BigQuantumsDelta: big.NewInt(1_000_000_000), // 1 ISO
+			},
+			isolatedPerpetualPosition: nil,
+			expectedStateTransition: &types.IsolatedPerpetualPositionStateTransition{
+				PerpetualId:               uint32(3),
+				QuoteQuantumsBeforeUpdate: big.NewInt(100_000_000),
+				Transition:                types.Opened,
+			},
+		},
+		`If perpetual update exists and isolated position exists, and perpetual update would close
+		isolated position, state transition representing an isolated perpetual position being closed is returned`: {
+			subaccountQuoteQuantums: big.NewInt(100_000_000), // $100
+			isolatedPerpetualUpdate: &types.PerpetualUpdate{
+				PerpetualId:      uint32(3),
+				BigQuantumsDelta: new(big.Int).Neg(constants.PerpetualPosition_OneISOLong.GetBigQuantums()),
+			},
+			isolatedPerpetualPosition: &constants.PerpetualPosition_OneISOLong,
+			expectedStateTransition: &types.IsolatedPerpetualPositionStateTransition{
+				PerpetualId:               uint32(3),
+				QuoteQuantumsBeforeUpdate: big.NewInt(100_000_000),
+				Transition:                types.Closed,
+			},
+		},
+		`If perpetual update exists and isolated position exists, and perpetual update would increase
+		isolated position, nil state transition is returned`: {
+			subaccountQuoteQuantums: big.NewInt(100_000_000), // $100
+			isolatedPerpetualUpdate: &types.PerpetualUpdate{
+				PerpetualId:      uint32(3),
+				BigQuantumsDelta: big.NewInt(10_000_000),
+			},
+			isolatedPerpetualPosition: &constants.PerpetualPosition_OneISOLong,
+			expectedStateTransition:   nil,
+		},
+		`If perpetual update exists and isolated position exists, and perpetual update would decrease
+		isolated position, nil state transition is returned`: {
+			subaccountQuoteQuantums: big.NewInt(100_000_000), // $100
+			isolatedPerpetualUpdate: &types.PerpetualUpdate{
+				PerpetualId:      uint32(3),
+				BigQuantumsDelta: big.NewInt(-10_000_000),
+			},
+			isolatedPerpetualPosition: &constants.PerpetualPosition_OneISOLong,
+			expectedStateTransition:   nil,
+		},
+		`If perpetual update exists and isolated position exists, and perpetual update would flip
+		isolated position, nil state transition is returned`: {
+			subaccountQuoteQuantums: big.NewInt(100_000_000), // $100
+			isolatedPerpetualUpdate: &types.PerpetualUpdate{
+				PerpetualId:      uint32(3),
+				BigQuantumsDelta: big.NewInt(-10_000_000_000),
+			},
+			isolatedPerpetualPosition: &constants.PerpetualPosition_OneISOLong,
+			expectedStateTransition:   nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(
+			name, func(t *testing.T) {
+				stateTransition := keeper.GetIsolatedPerpetualStateTransition(
+					tc.subaccountQuoteQuantums,
+					tc.isolatedPerpetualPosition,
+					tc.isolatedPerpetualUpdate,
+				)
+				require.Equal(t, tc.expectedStateTransition, stateTransition)
+			},
+		)
+	}
+}

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -284,7 +284,7 @@ func (k Keeper) UpdateSubaccounts(
 	}
 
 	allPerps := k.perpetualsKeeper.GetAllPerpetuals(ctx)
-	success, successPerUpdate, isolatedPerpetualStateTranisitions, err := k.internalCanUpdateSubaccounts(
+	success, successPerUpdate, isolatedPerpetualStateTransitions, err := k.internalCanUpdateSubaccounts(
 		ctx,
 		settledUpdates,
 		updateType,
@@ -312,7 +312,7 @@ func (k Keeper) UpdateSubaccounts(
 
 	// Transfer collateral between collateral pools for any isolated perpetual positions that changed
 	// state due to an update.
-	for i, stateTransition := range isolatedPerpetualStateTranisitions {
+	for i, stateTransition := range isolatedPerpetualStateTransitions {
 		if err := k.transferCollateralForIsolatedPerpetual(
 			ctx,
 			settledUpdates[i].SettledSubaccount,
@@ -556,13 +556,13 @@ func (k Keeper) internalCanUpdateSubaccounts(
 ) (
 	success bool,
 	successPerUpdate []types.UpdateResult,
-	isolatedPerpetualStateTransitions []*isolatedPerpetualStateTranisition,
+	isolatedPerpetualStateTransitions []*isolatedPerpetualStateTransition,
 	err error,
 ) {
 	// TODO(TRA-99): Add integration / E2E tests on order placement / matching with this new
 	// constraint.
 	// Check if the updates satisfy the isolated perpetual constraints.
-	success, successPerUpdate, isolatedPerpetualStateTranisitions, err := k.checkIsolatedSubaccountConstraints(
+	success, successPerUpdate, isolatedPerpetualStateTransitions, err = k.checkIsolatedSubaccountConstraints(
 		ctx,
 		settledUpdates,
 		perpetuals,
@@ -711,7 +711,7 @@ func (k Keeper) internalCanUpdateSubaccounts(
 		successPerUpdate[i] = result
 	}
 
-	return success, successPerUpdate, isolatedPerpetualStateTranisitions, nil
+	return success, successPerUpdate, isolatedPerpetualStateTransitions, nil
 }
 
 // IsValidStateTransitionForUndercollateralizedSubaccount returns an `UpdateResult`

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -313,18 +313,12 @@ func (k Keeper) UpdateSubaccounts(
 	// Transfer collateral between collateral pools for any isolated perpetual positions that changed
 	// state due to an update.
 	for _, settledUpdateWithUpdatedSubaccount := range settledUpdates {
-		// The subaccount in `settledUpdateWithUpdatedSubaccount` already has the perpetual updates
-		// and asset updates applied to it.
-		stateTransition, err := GetIsolatedPerpetualStateTransition(
+		if err := k.computeAndExecuteCollateralTransfer(
+			ctx,
+			// The subaccount in `settledUpdateWithUpdatedSubaccount` already has the perpetual updates
+			// and asset updates applied to it.
 			settledUpdateWithUpdatedSubaccount,
 			allPerps,
-		)
-		if err != nil {
-			return false, nil, err
-		}
-		if err := k.transferCollateralForIsolatedPerpetual(
-			ctx,
-			stateTransition,
 		); err != nil {
 			return false, nil, err
 		}

--- a/protocol/x/subaccounts/keeper/subaccount_helper.go
+++ b/protocol/x/subaccounts/keeper/subaccount_helper.go
@@ -12,7 +12,7 @@ import (
 // been updated. This will include any asset postions that were closed due to an update.
 // TODO(DEC-1295): look into reducing code duplication here using Generics+Reflect.
 func getUpdatedAssetPositions(
-	update settledUpdate,
+	update SettledUpdate,
 ) []*types.AssetPosition {
 	assetIdToPositionMap := make(map[uint32]*types.AssetPosition)
 	for _, assetPosition := range update.SettledSubaccount.AssetPositions {
@@ -53,7 +53,7 @@ func getUpdatedAssetPositions(
 // been updated. This will include any perpetual postions that were closed due to an update or that
 // received / paid out funding payments..
 func getUpdatedPerpetualPositions(
-	update settledUpdate,
+	update SettledUpdate,
 	fundingPayments map[uint32]dtypes.SerializableInt,
 ) []*types.PerpetualPosition {
 	perpetualIdToPositionMap := make(map[uint32]*types.PerpetualPosition)
@@ -102,7 +102,7 @@ func getUpdatedPerpetualPositions(
 // to reflect settledUpdate.PerpetualUpdates.
 // For newly created positions, use `perpIdToFundingIndex` map to populate the `FundingIndex` field.
 func UpdatePerpetualPositions(
-	settledUpdates []settledUpdate,
+	settledUpdates []SettledUpdate,
 	perpIdToFundingIndex map[uint32]dtypes.SerializableInt,
 ) {
 	// Apply the updates.
@@ -166,7 +166,7 @@ func UpdatePerpetualPositions(
 // For each settledUpdate in settledUpdates, updates its SettledSubaccount.AssetPositions
 // to reflect settledUpdate.AssetUpdates.
 func UpdateAssetPositions(
-	settledUpdates []settledUpdate,
+	settledUpdates []SettledUpdate,
 ) {
 	// Apply the updates.
 	for i, u := range settledUpdates {

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -2323,7 +2323,7 @@ func TestUpdateSubaccounts(t *testing.T) {
 		},
 		`Isolated - subaccounts - subaccount has update to close position for isolated perpetual,
 		collateral is moved from isolated perpetual collateral pool to cross perpetual collateral pool`: {
-			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(999_900_000_000)),
+			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(999_900_000_000)), // $999,900 USDC
 			collateralPoolUsdcBalances: map[string]int64{
 				types.ModuleAddress.String(): 2_000_000_000_000, // $500,000 USDC
 				authtypes.NewModuleAddress(

--- a/protocol/x/subaccounts/keeper/update.go
+++ b/protocol/x/subaccounts/keeper/update.go
@@ -4,11 +4,11 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
-// settledUpdate is used internally in the subaccounts keeper to
+// SettledUpdate is used internally in the subaccounts keeper to
 // to specify changes to one or more `Subaccounts` (for example the
 // result of a trade, transfer, etc).
 // The subaccount is always in its settled state.
-type settledUpdate struct {
+type SettledUpdate struct {
 	// The `Subaccount` for which this update applies to, in its settled form.
 	SettledSubaccount types.Subaccount
 	// A list of changes to make to any `AssetPositions` in the `Subaccount`.

--- a/protocol/x/subaccounts/types/isolated_perpetual_position_state_transition.go
+++ b/protocol/x/subaccounts/types/isolated_perpetual_position_state_transition.go
@@ -1,0 +1,34 @@
+package types
+
+import "math/big"
+
+type PositionStateTransition uint
+
+const (
+	Opened PositionStateTransition = iota
+	Closed
+)
+
+var positionStateTransitionStringMap = map[PositionStateTransition]string{
+	Opened: "opened",
+	Closed: "closed",
+}
+
+func (t PositionStateTransition) String() string {
+	result, exists := positionStateTransitionStringMap[t]
+	if !exists {
+		return "UnexpectedStateTransitionError"
+	}
+
+	return result
+}
+
+// Represents a state transition for an isolated perpetual position.
+type IsolatedPerpetualPositionStateTransition struct {
+	PerpetualId uint32
+	// TODO(DEC-715): Support non-USDC assets.
+	// Quote quantums position size of the subaccount that has a state change for an isolated perpetual.
+	QuoteQuantumsBeforeUpdate *big.Int
+	// The state transition that occurred for the isolated perpetual positions.
+	Transition PositionStateTransition
+}

--- a/protocol/x/subaccounts/types/isolated_perpetual_position_state_transition.go
+++ b/protocol/x/subaccounts/types/isolated_perpetual_position_state_transition.go
@@ -23,12 +23,13 @@ func (t PositionStateTransition) String() string {
 	return result
 }
 
-// Represents a state transition for an isolated perpetual position.
+// Represents a state transition for an isolated perpetual position in a subaccount.
 type IsolatedPerpetualPositionStateTransition struct {
-	PerpetualId uint32
+	SubaccountId *SubaccountId
+	PerpetualId  uint32
 	// TODO(DEC-715): Support non-USDC assets.
-	// Quote quantums position size of the subaccount that has a state change for an isolated perpetual.
-	QuoteQuantumsBeforeUpdate *big.Int
+	// Quote quantums of collateral to transfer as a result of the state transition.
+	QuoteQuantums *big.Int
 	// The state transition that occurred for the isolated perpetual positions.
 	Transition PositionStateTransition
 }

--- a/protocol/x/subaccounts/types/isolated_perpetual_position_state_transition_test.go
+++ b/protocol/x/subaccounts/types/isolated_perpetual_position_state_transition_test.go
@@ -1,0 +1,36 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositionStateTransitionString(t *testing.T) {
+	tests := map[string]struct {
+		value          types.PositionStateTransition
+		expectedResult string
+	}{
+		"Opened": {
+			value:          types.Opened,
+			expectedResult: "opened",
+		},
+		"Closed": {
+			value:          types.Closed,
+			expectedResult: "closed",
+		},
+		"UnexpectedError": {
+			value:          types.PositionStateTransition(2),
+			expectedResult: "UnexpectedStateTransitionError",
+		},
+	}
+
+	// Run tests.
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := tc.value.String()
+			require.Equal(t, result, tc.expectedResult)
+		})
+	}
+}


### PR DESCRIPTION
### Changelist
Update `UpdateSubaccounts` to transfer collateral between collateral pools when a subaccount opens/closes an isolated perpetual position.
Adds multiple helper functions to calculate / track the collateral transfers.

Note: This changes the assumption that `UpdateSubaccounts` only changes state in the `x/subaccount` module as it will now change state in the `x/bank` module as well.

### Test Plan
Unit tests. E2E tests are planned under this [ticket](https://linear.app/dydx/issue/TRA-99/add-integration-e2e-tests-for-placing-orders-in-isolated-markets-cross).

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
