### PR TITLE
[CT-509] Batch Cancel CLI + additional validation

### DIFF
--- a/protocol/x/clob/client/cli/batch_cancel.go
+++ b/protocol/x/clob/client/cli/batch_cancel.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+)
+
+func CmdBatchCancel() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "batch-cancel owner subaccount_number clobPairId goodTilBlock --clientIds=\"<list of ids>\"",
+		Short: "Broadcast message batch cancel for a specific clobPairId",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			argOwner := args[0]
+			clientIds, err := cmd.Flags().GetString("clientIds")
+			if err != nil {
+				return err
+			}
+			argClientIds := make([]uint32, len(clientIds))
+			for _, idString := range strings.Fields(clientIds) {
+				idUint64, err := strconv.ParseUint(idString, 10, 32)
+				if err != nil {
+					return err
+				}
+				argClientIds = append(argClientIds, uint32(idUint64))
+			}
+
+			argNumber, err := cast.ToUint32E(args[1])
+			if err != nil {
+				return err
+			}
+
+			argClobPairId, err := cast.ToUint32E(args[2])
+			if err != nil {
+				return err
+			}
+
+			argGoodTilBlock, err := cast.ToUint32E(args[3])
+			if err != nil {
+				return err
+			}
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgBatchCancel(
+				satypes.SubaccountId{
+					Owner:  argOwner,
+					Number: argNumber,
+				},
+				[]types.OrderBatch{
+					{
+						ClobPairId: argClobPairId,
+						ClientIds:  argClientIds,
+					},
+				},
+				argGoodTilBlock,
+			)
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/protocol/x/clob/client/cli/cancel_order_cli_test.go
+++ b/protocol/x/clob/client/cli/cancel_order_cli_test.go
@@ -207,6 +207,7 @@ func (s *CancelOrderIntegrationTestSuite) TestCLICancelPendingOrder() {
 		s.validatorAddress,
 		cancelsSubaccountNumberZero,
 		clientId,
+		constants.ClobPair_Btc.Id,
 		goodTilBlock,
 	)
 	s.Require().NoError(err)
@@ -232,6 +233,7 @@ func (s *CancelOrderIntegrationTestSuite) TestCLICancelPendingOrder() {
 		s.validatorAddress,
 		cancelsSubaccountNumberZero,
 		unknownClientId,
+		constants.ClobPair_Btc.Id,
 		goodTilBlock,
 	)
 	s.Require().NoError(err)
@@ -345,6 +347,7 @@ func (s *CancelOrderIntegrationTestSuite) TestCLICancelMatchingOrders() {
 		s.validatorAddress,
 		cancelsSubaccountNumberZero,
 		clientId,
+		constants.ClobPair_Btc.Id,
 		goodTilBlock,
 	)
 	s.Require().NoError(err)

--- a/protocol/x/clob/client/cli/tx.go
+++ b/protocol/x/clob/client/cli/tx.go
@@ -27,7 +27,9 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(CmdPlaceOrder())
 	cmd.AddCommand(CmdCancelOrder())
-	cmd.AddCommand(CmdBatchCancel())
+	batchCancelCmd := CmdBatchCancel()
+	batchCancelCmd.PersistentFlags().String("clientIds", "", "A list of client ids to to batch cancel")
+	cmd.AddCommand(batchCancelCmd)
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/protocol/x/clob/client/cli/tx.go
+++ b/protocol/x/clob/client/cli/tx.go
@@ -27,6 +27,7 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(CmdPlaceOrder())
 	cmd.AddCommand(CmdCancelOrder())
+	cmd.AddCommand(CmdBatchCancel())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/protocol/x/clob/client/cli/tx_batch_cancel.go
+++ b/protocol/x/clob/client/cli/tx_batch_cancel.go
@@ -24,7 +24,7 @@ func CmdBatchCancel() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			argClientIds := make([]uint32, len(clientIds))
+			argClientIds := []uint32{}
 			for _, idString := range strings.Fields(clientIds) {
 				idUint64, err := strconv.ParseUint(idString, 10, 32)
 				if err != nil {

--- a/protocol/x/clob/client/cli/tx_cancel_order.go
+++ b/protocol/x/clob/client/cli/tx_cancel_order.go
@@ -13,7 +13,7 @@ import (
 func CmdCancelOrder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cancel-order owner number clientId clobPairId goodTilBlock",
-		Short: "Broadcast message cancel_order",
+		Short: "Broadcasts message cancel_order. Assumes short term order cancellation.",
 		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argOwner := args[0]

--- a/protocol/x/clob/client/cli/tx_cancel_order.go
+++ b/protocol/x/clob/client/cli/tx_cancel_order.go
@@ -12,9 +12,9 @@ import (
 
 func CmdCancelOrder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cancel-order owner number clientId goodTilBlock",
+		Use:   "cancel-order owner number clientId clobPairId goodTilBlock",
 		Short: "Broadcast message cancel_order",
-		Args:  cobra.ExactArgs(4),
+		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argOwner := args[0]
 
@@ -28,7 +28,12 @@ func CmdCancelOrder() *cobra.Command {
 				return err
 			}
 
-			argGoodTilBlock, err := cast.ToUint32E(args[3])
+			argClobPairId, err := cast.ToUint32E(args[3])
+			if err != nil {
+				return err
+			}
+
+			argGoodTilBlock, err := cast.ToUint32E(args[4])
 			if err != nil {
 				return err
 			}
@@ -40,7 +45,8 @@ func CmdCancelOrder() *cobra.Command {
 
 			msg := types.NewMsgCancelOrderShortTerm(
 				types.OrderId{
-					ClientId: argClientId,
+					ClobPairId: argClobPairId,
+					ClientId:   argClientId,
 					SubaccountId: satypes.SubaccountId{
 						Owner:  argOwner,
 						Number: argNumber,

--- a/protocol/x/clob/client/cli/tx_cancel_order.go
+++ b/protocol/x/clob/client/cli/tx_cancel_order.go
@@ -12,13 +12,13 @@ import (
 
 func CmdCancelOrder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cancel-order owner number clientId clobPairId goodTilBlock",
+		Use:   "cancel-order owner subaccount_number clientId clobPairId goodTilBlock",
 		Short: "Broadcasts message cancel_order. Assumes short term order cancellation.",
 		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argOwner := args[0]
 
-			argNumber, err := cast.ToUint32E(args[1])
+			argSubaccountNumber, err := cast.ToUint32E(args[1])
 			if err != nil {
 				return err
 			}
@@ -49,7 +49,7 @@ func CmdCancelOrder() *cobra.Command {
 					ClientId:   argClientId,
 					SubaccountId: satypes.SubaccountId{
 						Owner:  argOwner,
-						Number: argNumber,
+						Number: argSubaccountNumber,
 					},
 				},
 				argGoodTilBlock,

--- a/protocol/x/clob/client/cli/tx_place_order.go
+++ b/protocol/x/clob/client/cli/tx_place_order.go
@@ -13,7 +13,7 @@ import (
 func CmdPlaceOrder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "place-order owner number clientId clobPairId side quantums subticks goodTilBlock",
-		Short: "Broadcast message place_order",
+		Short: "Broadcast message place_order. Assumes short term order placement.",
 		Args:  cobra.ExactArgs(8),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argOwner := args[0]

--- a/protocol/x/clob/client/cli/tx_place_order.go
+++ b/protocol/x/clob/client/cli/tx_place_order.go
@@ -12,13 +12,13 @@ import (
 
 func CmdPlaceOrder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "place-order owner number clientId clobPairId side quantums subticks goodTilBlock",
+		Use:   "place-order owner subaccount_number clientId clobPairId side quantums subticks goodTilBlock",
 		Short: "Broadcast message place_order. Assumes short term order placement.",
 		Args:  cobra.ExactArgs(8),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argOwner := args[0]
 
-			argNumber, err := cast.ToUint32E(args[1])
+			argSubaccountNumber, err := cast.ToUint32E(args[1])
 			if err != nil {
 				return err
 			}
@@ -64,7 +64,7 @@ func CmdPlaceOrder() *cobra.Command {
 						ClientId: argClientId,
 						SubaccountId: satypes.SubaccountId{
 							Owner:  argOwner,
-							Number: argNumber,
+							Number: argSubaccountNumber,
 						},
 						ClobPairId: argClobPairId,
 					},

--- a/protocol/x/clob/client/testutil/cli_helpers.go
+++ b/protocol/x/clob/client/testutil/cli_helpers.go
@@ -55,12 +55,14 @@ func MsgCancelOrderExec(
 	owner sdk.AccAddress,
 	number uint32,
 	clientId uint64,
+	clobPairId uint32,
 	goodTilBlock uint32,
 ) (testutil.BufferWriter, error) {
 	args := []string{
 		owner.String(),
 		fmt.Sprint(number),
 		fmt.Sprint(clientId),
+		fmt.Sprint(clobPairId),
 		fmt.Sprint(goodTilBlock),
 	}
 

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -105,7 +105,7 @@ func (k Keeper) BatchCancelShortTermOrder(
 				failure = append(failure, clientId)
 				log.InfoLog(
 					ctx,
-					"Failed to cancel short term order.",
+					"Batch Cancel: Failed to cancel a short term order.",
 					log.Error, err,
 				)
 			} else {

--- a/protocol/x/clob/module_test.go
+++ b/protocol/x/clob/module_test.go
@@ -240,9 +240,10 @@ func TestAppModuleBasic_GetTxCmd(t *testing.T) {
 
 	cmd := am.GetTxCmd()
 	require.Equal(t, "clob", cmd.Use)
-	require.Equal(t, 2, len(cmd.Commands()))
-	require.Equal(t, "cancel-order", cmd.Commands()[0].Name())
-	require.Equal(t, "place-order", cmd.Commands()[1].Name())
+	require.Equal(t, 3, len(cmd.Commands()))
+	require.Equal(t, "batch-cancel", cmd.Commands()[0].Name())
+	require.Equal(t, "cancel-order", cmd.Commands()[1].Name())
+	require.Equal(t, "place-order", cmd.Commands()[2].Name())
 }
 
 func TestAppModuleBasic_GetQueryCmd(t *testing.T) {

--- a/protocol/x/clob/types/message_batch_cancel_test.go
+++ b/protocol/x/clob/types/message_batch_cancel_test.go
@@ -101,6 +101,27 @@ func TestMsgBatchCancel_ValidateBasic(t *testing.T) {
 					{
 						ClobPairId: 0,
 						ClientIds: []uint32{
+							0, 1, 2, 3,
+						},
+					},
+					{
+						ClobPairId: 0,
+						ClientIds: []uint32{
+							2, 3, 4,
+						},
+					},
+				},
+				10,
+			),
+			err: types.ErrInvalidBatchCancel,
+		},
+		"duplicate client ids": {
+			msg: *types.NewMsgBatchCancel(
+				constants.Alice_Num0,
+				[]types.OrderBatch{
+					{
+						ClobPairId: 0,
+						ClientIds: []uint32{
 							0, 1, 2, 3, 1,
 						},
 					},


### PR DESCRIPTION
1. Batch cancel cli query

tested via
```
hyperon@Hyperon protocol % dydxprotocold tx clob batch-cancel dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4 0 0 50 --clientIds="0 3 4 5 9 8 7" --from alice
```


2. add validation for duplicate clob pair id across batches