### PR TITLE
Fix upgrade rate limit config logic, add helpful logs

### DIFF
--- a/protocol/app/upgrades/v5.0.0/upgrade.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade.go
@@ -85,7 +85,7 @@ func blockRateLimitConfigUpdate(
 	}
 	ctx.Logger().Info(
 		fmt.Sprintf(
-			"Attempting to set rate limiting config to newly combined config: %+v\n\n",
+			"Attempting to set rate limiting config to newly combined config: %+v\n",
 			blockRateLimitConfig,
 		),
 	)
@@ -93,7 +93,7 @@ func blockRateLimitConfigUpdate(
 		panic(fmt.Sprintf("failed to update the block rate limit configuration: %s", err))
 	}
 	ctx.Logger().Info(
-		"Successfully upgraded block rate limit configuration to: %+v\n\n",
+		"Successfully upgraded block rate limit configuration to: %+v\n",
 		clobKeeper.GetBlockRateLimitConfiguration(ctx),
 	)
 }


### PR DESCRIPTION
```
8:18PM INF Combining the short term order placement and cancellation limits of previous config: {MaxShortTermOrdersPerNBlocks:[{NumBlocks:1 Limit:200}] MaxStatefulOrdersPerNBlocks:[{NumBlocks:1 Limit:2} {NumBlocks:100 Limit:20}] MaxShortTermOrderCancellationsPerNBlocks:[{NumBlocks:1 Limit:200}] MaxShortTermOrdersAndCancelsPerNBlocks:[]}
 module=x/app/upgrades request_id=482b618d61d19ca567a7
8:18PM INF Attempting to set rate limiting config to newly combined config: {MaxShortTermOrdersPerNBlocks:[] MaxStatefulOrdersPerNBlocks:[{NumBlocks:1 Limit:2} {NumBlocks:100 Limit:20}] MaxShortTermOrderCancellationsPerNBlocks:[] MaxShortTermOrdersAndCancelsPerNBlocks:[{NumBlocks:5 Limit:2000}]}
```