### PR TITLE
OIMF: Simplify interface for `GetDeltaOpenInterestFromUpdates`

### DIFF
--- a/protocol/x/subaccounts/keeper/oimf.go
+++ b/protocol/x/subaccounts/keeper/oimf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -43,13 +44,19 @@ func getDeltaLongFromSettledUpdate(
 	)
 }
 
-// Returns the delta open_interest for a pair of Match updates if they were applied.
-func GetDeltaOpenInterestFromPerpMatchUpdates(
+// For `Match` updates:
+//   - returns the delta_open_interest if input updates were applied. returns nil if delta is zero.
+//   - panics if update format is invalid.
+//
+// For other update types, returns nil.
+func GetDeltaOpenInterestFromUpdates(
 	settledUpdates []SettledUpdate,
-) (
-	updatedPerpId uint32,
-	deltaOpenInterest *big.Int,
-) {
+	updateType types.UpdateType,
+) (ret *perptypes.OpenInterestDelta) {
+	if updateType != types.Match {
+		return nil
+	}
+
 	if len(settledUpdates) != 2 {
 		panic(
 			fmt.Sprintf(
@@ -78,9 +85,9 @@ func GetDeltaOpenInterestFromPerpMatchUpdates(
 				settledUpdates,
 			),
 		)
-	} else {
-		updatedPerpId = settledUpdates[0].PerpetualUpdates[0].PerpetualId
 	}
+
+	updatedPerpId := settledUpdates[0].PerpetualUpdates[0].PerpetualId
 
 	if (perpUpdate0.BigQuantumsDelta.Sign()*perpUpdate1.BigQuantumsDelta.Sign() > 0) ||
 		perpUpdate0.BigQuantumsDelta.CmpAbs(perpUpdate1.BigQuantumsDelta) != 0 {
@@ -92,11 +99,21 @@ func GetDeltaOpenInterestFromPerpMatchUpdates(
 		)
 	}
 
-	deltaOpenInterest = big.NewInt(0)
+	baseQuantumsDelta := big.NewInt(0)
 	for _, u := range settledUpdates {
 		deltaLong := getDeltaLongFromSettledUpdate(u, updatedPerpId)
-		deltaOpenInterest.Add(deltaOpenInterest, deltaLong)
+		baseQuantumsDelta.Add(
+			baseQuantumsDelta,
+			deltaLong,
+		)
 	}
 
-	return updatedPerpId, deltaOpenInterest
+	if baseQuantumsDelta.Sign() == 0 {
+		return nil
+	}
+
+	return &perptypes.OpenInterestDelta{
+		PerpetualId:       updatedPerpId,
+		BaseQuantumsDelta: baseQuantumsDelta,
+	}
 }

--- a/protocol/x/subaccounts/keeper/oimf.go
+++ b/protocol/x/subaccounts/keeper/oimf.go
@@ -45,7 +45,8 @@ func getDeltaLongFromSettledUpdate(
 }
 
 // For `Match` updates:
-//   - returns the delta_open_interest if input updates were applied. returns nil if delta is zero.
+//   - returns a struct `OpenInterestDelta` if input updates results in OI delta.
+//   - returns nil if OI delta is zero.
 //   - panics if update format is invalid.
 //
 // For other update types, returns nil.

--- a/protocol/x/subaccounts/keeper/oimf_test.go
+++ b/protocol/x/subaccounts/keeper/oimf_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	keeper "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
@@ -20,14 +21,15 @@ var (
 	}
 )
 
-func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
+func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 	tests := map[string]struct {
-		settledUpdates        []keeper.SettledUpdate
-		expectedDelta         *big.Int
-		expectedUpdatedPerpId uint32
-		panicErr              string
+		settledUpdates []keeper.SettledUpdate
+		updateType     types.UpdateType
+		expectedVal    *perptypes.OpenInterestDelta
+		panicErr       string
 	}{
 		"Invalid: 1 update": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{},
@@ -42,6 +44,7 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 			panicErr: types.ErrMatchUpdatesMustHaveTwoUpdates,
 		},
 		"Invalid: one of the updates contains no perp update": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -63,6 +66,7 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 			panicErr: types.ErrMatchUpdatesMustUpdateOnePerp,
 		},
 		"Invalid: updates are on different perpetuals": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -90,6 +94,7 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 			panicErr: types.ErrMatchUpdatesMustBeSamePerpId,
 		},
 		"Invalid: updates don't have opposite signs": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -117,6 +122,7 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 			panicErr: types.ErrMatchUpdatesInvalidSize,
 		},
 		"Invalid: updates don't have equal absolute base quantums": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -144,6 +150,7 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 			panicErr: types.ErrMatchUpdatesInvalidSize,
 		},
 		"Valid: 0 -> -500, 0 -> 500, delta = 500": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -168,10 +175,13 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 					},
 				},
 			},
-			expectedUpdatedPerpId: 1,
-			expectedDelta:         big.NewInt(500),
+			expectedVal: &perptypes.OpenInterestDelta{
+				PerpetualId:       1,
+				BaseQuantumsDelta: big.NewInt(500),
+			},
 		},
 		"Valid: 500 -> 0, 0 -> 500, delta = 0": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -203,10 +213,28 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 					},
 				},
 			},
-			expectedUpdatedPerpId: 1000,
-			expectedDelta:         big.NewInt(0),
+			expectedVal: nil, // delta is 0
+		},
+		"Not Match update, return nil": {
+			updateType: types.CollatCheck,
+			settledUpdates: []keeper.SettledUpdate{
+				{
+					SettledSubaccount: types.Subaccount{
+						Id:                 aliceSubaccountId,
+						PerpetualPositions: []*types.PerpetualPosition{},
+					},
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      1000,
+							BigQuantumsDelta: big.NewInt(500),
+						},
+					},
+				},
+			},
+			expectedVal: nil,
 		},
 		"Valid: 500 -> 350, 0 -> 150, delta = 0": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -238,10 +266,10 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 					},
 				},
 			},
-			expectedUpdatedPerpId: 1000,
-			expectedDelta:         big.NewInt(0),
+			expectedVal: nil, // delta is 0
 		},
 		"Valid: -100 -> 200, 250 -> -50, delta = -50": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -278,10 +306,13 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 					},
 				},
 			},
-			expectedUpdatedPerpId: 1000,
-			expectedDelta:         big.NewInt(-50),
+			expectedVal: &perptypes.OpenInterestDelta{
+				PerpetualId:       1000,
+				BaseQuantumsDelta: big.NewInt(-50),
+			},
 		},
 		"Valid: -3100 -> -5000, 1000 -> 2900, delta = 1900": {
+			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
@@ -318,8 +349,10 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 					},
 				},
 			},
-			expectedUpdatedPerpId: 1000,
-			expectedDelta:         big.NewInt(1900),
+			expectedVal: &perptypes.OpenInterestDelta{
+				PerpetualId:       1000,
+				BaseQuantumsDelta: big.NewInt(1900),
+			},
 		},
 	}
 
@@ -331,24 +364,23 @@ func TestGetDeltaOpenInterestFromPerpMatchUpdates(t *testing.T) {
 						tc.panicErr,
 						tc.settledUpdates,
 					), func() {
-						keeper.GetDeltaOpenInterestFromPerpMatchUpdates(tc.settledUpdates)
+						keeper.GetDeltaOpenInterestFromUpdates(
+							tc.settledUpdates,
+							tc.updateType,
+						)
 					},
 				)
 				return
 			}
 
-			updatedPerpId, deltaOpenInterest := keeper.GetDeltaOpenInterestFromPerpMatchUpdates(tc.settledUpdates)
+			perpOpenInterestDelta := keeper.GetDeltaOpenInterestFromUpdates(
+				tc.settledUpdates,
+				tc.updateType,
+			)
 			require.Equal(
 				t,
-				tc.expectedUpdatedPerpId,
-				updatedPerpId,
-			)
-			require.Zerof(
-				t,
-				tc.expectedDelta.Cmp(deltaOpenInterest),
-				"deltaOpenInterest: %v, tc.expectedDelta: %v",
-				deltaOpenInterest,
-				tc.expectedDelta,
+				tc.expectedVal,
+				perpOpenInterestDelta,
 			)
 		})
 	}

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -642,16 +642,10 @@ func (k Keeper) internalCanUpdateSubaccounts(
 		}
 	}
 
-	var perpOpenInterestDelta *perptypes.OpenInterestDelta
-	// If update type is `Match`, calculate the open interest delta for the updated perpetual.
-	// Note: this assumes that `Match` can only happen for perpetuals.
-	if updateType == types.Match {
-		updatedPerpId, deltaOpenInterest := GetDeltaOpenInterestFromPerpMatchUpdates(settledUpdates)
-		perpOpenInterestDelta = &perptypes.OpenInterestDelta{
-			PerpetualId:       updatedPerpId,
-			BaseQuantumsDelta: deltaOpenInterest,
-		}
-	}
+	// Get delta open interest from the updates.
+	// `perpOpenInterestDelta` is nil if the update type is not `Match` or if the updates
+	// do not result in OI changes.
+	perpOpenInterestDelta := GetDeltaOpenInterestFromUpdates(settledUpdates, updateType)
 
 	bigCurNetCollateral := make(map[string]*big.Int)
 	bigCurInitialMargin := make(map[string]*big.Int)


### PR DESCRIPTION
### Changelist
Simply `GetDeltaOpenInterestFromUpdates` interface as well as upstream usage
### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
