### PR TITLE
[OTE-245] Update OI after fill and added unit tests

### DIFF
--- a/protocol/testutil/constants/perpetuals.go
+++ b/protocol/testutil/constants/perpetuals.go
@@ -104,12 +104,12 @@ var LiquidityTiers = []perptypes.LiquidityTier{
 // Perpetual OI setup in tests
 var (
 	BtcUsd_OpenInterest1_AtomicRes8 = perptypes.OpenInterestDelta{
-		PerpetualId:       0,
-		BaseQuantumsDelta: big.NewInt(100_000_000),
+		PerpetualId:  0,
+		BaseQuantums: big.NewInt(100_000_000),
 	}
 	EthUsd_OpenInterest1_AtomicRes9 = perptypes.OpenInterestDelta{
-		PerpetualId:       1,
-		BaseQuantumsDelta: big.NewInt(1_000_000_000),
+		PerpetualId:  1,
+		BaseQuantums: big.NewInt(1_000_000_000),
 	}
 	DefaultTestPerpOIs = []perptypes.OpenInterestDelta{
 		BtcUsd_OpenInterest1_AtomicRes8,
@@ -277,6 +277,19 @@ var (
 		FundingIndex: dtypes.ZeroInt(),
 		OpenInterest: dtypes.NewInt(100_000_000),
 	}
+	BtcUsd_20PercentInitial_10PercentMaintenance_OpenInterest2 = perptypes.Perpetual{
+		Params: perptypes.PerpetualParams{
+			Id:                0,
+			Ticker:            "BTC-USD 20/10 margin requirements",
+			MarketId:          uint32(0),
+			AtomicResolution:  int32(-8),
+			DefaultFundingPpm: int32(0),
+			LiquidityTier:     uint32(3),
+			MarketType:        perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS,
+		},
+		FundingIndex: dtypes.ZeroInt(),
+		OpenInterest: dtypes.NewInt(200_000_000),
+	}
 	BtcUsd_20PercentInitial_10PercentMaintenance_25mmLowerCap_50mmUpperCap = perptypes.Perpetual{
 		Params: perptypes.PerpetualParams{
 			Id:                0,
@@ -379,6 +392,7 @@ var (
 			MarketType:        perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED,
 		},
 		FundingIndex: dtypes.ZeroInt(),
+		OpenInterest: dtypes.ZeroInt(),
 	}
 	Iso2Usd_IsolatedMarket = perptypes.Perpetual{
 		Params: perptypes.PerpetualParams{
@@ -391,6 +405,7 @@ var (
 			MarketType:        perptypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED,
 		},
 		FundingIndex: dtypes.ZeroInt(),
+		OpenInterest: dtypes.ZeroInt(),
 	}
 )
 

--- a/protocol/testutil/perpetuals/perpetuals.go
+++ b/protocol/testutil/perpetuals/perpetuals.go
@@ -137,7 +137,7 @@ func SetUpDefaultPerpOIsForTest(
 				k.ModifyOpenInterest(
 					ctx,
 					perp.Params.Id,
-					perpOI.BaseQuantumsDelta,
+					perpOI.BaseQuantums,
 				),
 			)
 		}

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -57,7 +57,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 		expectedMultiStoreWrites []string
 		expectedOrderStatus      types.OrderStatus
 		expectedFilledSize       satypes.BaseQuantums
-		expectedErr              error
+		// Expected remaining OI after test.
+		// The test initializes each perp with default open interest of 1 full coin.
+		expectedOpenInterests map[uint32]*big.Int
+		expectedErr           error
 	}{
 		"Can place an order on the orderbook closing a position": {
 			perpetuals: []perptypes.Perpetual{
@@ -73,6 +76,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 
 			expectedOrderStatus: types.Success,
 			expectedFilledSize:  0,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Can place an order on the orderbook in a different market than their current perpetual position": {
 			perpetuals: []perptypes.Perpetual{
@@ -92,6 +99,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 
 			expectedOrderStatus: types.Success,
 			expectedFilledSize:  0,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Can place an order and the order is fully matched": {
 			perpetuals: []perptypes.Perpetual{
@@ -142,6 +153,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 				// Update maker order fill amount in memStore
 				types.OrderAmountFilledKeyPrefix,
 			},
+			expectedOpenInterests: map[uint32]*big.Int{
+				// positions fully closed
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(0),
+			},
 		},
 		"Cannot place an order on the orderbook if the account would be undercollateralized": {
 			perpetuals: []perptypes.Perpetual{
@@ -161,6 +176,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 
 			expectedOrderStatus: types.Undercollateralized,
 			expectedFilledSize:  0,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Can place an order on the orderbook if the subaccount is right at the initial margin ratio": {
 			perpetuals: []perptypes.Perpetual{
@@ -178,6 +197,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 
 			expectedOrderStatus: types.Success,
 			expectedFilledSize:  0,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Cannot place an order on the orderbook if the account would be undercollateralized due to fees paid": {
 			perpetuals: []perptypes.Perpetual{
@@ -196,6 +219,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 
 			expectedOrderStatus: types.Undercollateralized,
 			expectedFilledSize:  0,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Can place an order on the orderbook if the account would be collateralized due to rebate": {
 			perpetuals: []perptypes.Perpetual{
@@ -215,6 +242,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 
 			expectedOrderStatus: types.Success,
 			expectedFilledSize:  0,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Cannot open an order if it doesn't reference a valid CLOB": {
 			perpetuals: []perptypes.Perpetual{
@@ -232,6 +263,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			order: constants.Order_Carl_Num0_Id3_Clob1_Buy1ETH_Price3000,
 
 			expectedErr: types.ErrInvalidClob,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Cannot open an order if the subticks are invalid": {
 			perpetuals: []perptypes.Perpetual{
@@ -254,6 +289,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			},
 
 			expectedErr: types.ErrInvalidPlaceOrder,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Cannot open an order that is smaller than the minimum base quantums": {
 			perpetuals: []perptypes.Perpetual{
@@ -276,6 +315,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			},
 
 			expectedErr: types.ErrInvalidPlaceOrder,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Cannot open an order that is not divisible by the step size base quantums": {
 			perpetuals: []perptypes.Perpetual{
@@ -296,6 +339,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			},
 
 			expectedErr: types.ErrInvalidPlaceOrder,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Cannot open an order with a GoodTilBlock in the past": {
 			perpetuals: []perptypes.Perpetual{
@@ -317,6 +364,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			},
 
 			expectedErr: types.ErrHeightExceedsGoodTilBlock,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		"Cannot open an order with a GoodTilBlock greater than ShortBlockWindow blocks in the future": {
 			perpetuals: []perptypes.Perpetual{
@@ -338,6 +389,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			},
 
 			expectedErr: types.ErrGoodTilBlockExceedsShortBlockWindow,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// unchanged, no match happened
+				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
+			},
 		},
 		// This is a regression test for an issue whereby orders that had been previously matched were being checked for
 		// collateralization as if the subticks of the order were `0`. This resulted in always using `0`
@@ -401,6 +456,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			// and a perpetual of size 0.01 BTC ($500), and the perpetual has a 100% margin requirement.
 			order:               constants.Order_Carl_Num1_Id1_Clob0_Buy1kQtBTC_Price50000,
 			expectedOrderStatus: types.Undercollateralized,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// 1 BTC + 0.01 BTC filled
+				constants.BtcUsd_100PercentMarginRequirement.Params.Id: big.NewInt(101_000_000),
+			},
 		},
 		`New order should be undercollateralized when matching when previous fills make it undercollateralized when using
 				maker orders subticks, but would be collateralized if using taker order subticks`: {
@@ -458,6 +517,10 @@ func TestPlaceShortTermOrder(t *testing.T) {
 				// Update maker order fill amount in memStore
 				types.OrderAmountFilledKeyPrefix,
 			},
+			expectedOpenInterests: map[uint32]*big.Int{
+				// 1 BTC + 0.01 BTC + 0.01 BTC filled
+				constants.BtcUsd_50PercentInitial_40PercentMaintenance.Params.Id: big.NewInt(102_000_000),
+			},
 		},
 		// This is a regression test for an issue whereby orders that had been previously matched were being checked for
 		// collateralization as if the CLOB pair ID of the order was `0`. This resulted in always using `0`
@@ -508,6 +571,12 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			// quantums required to open the previous buy order and fail.
 			order:               constants.Order_Carl_Num0_Id4_Clob1_Buy01ETH_Price3000,
 			expectedOrderStatus: types.Success,
+			expectedOpenInterests: map[uint32]*big.Int{
+				// Unchanged, no BTC match happened
+				constants.BtcUsd_NoMarginRequirement.Params.Id: big.NewInt(100_000_000),
+				// 1 ETH + 1 ETH filled
+				constants.EthUsd_20PercentInitial_10PercentMaintenance.Params.Id: big.NewInt(2_000_000_000),
+			},
 		},
 		`Subaccount cannot place maker buy order for 1 BTC at 5 subticks with 0 collateral`: {
 			perpetuals: []perptypes.Perpetual{
@@ -753,6 +822,19 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			}
 
 			traceDecoder.RequireKeyPrefixesWritten(t, tc.expectedMultiStoreWrites)
+
+			for _, perp := range tc.perpetuals {
+				if expectedOI, exists := tc.expectedOpenInterests[perp.Params.Id]; exists {
+					gotPerp, err := ks.PerpetualsKeeper.GetPerpetual(ks.Ctx, perp.Params.Id)
+					require.NoError(t, err)
+					require.Zero(t,
+						expectedOI.Cmp(gotPerp.OpenInterest.BigInt()),
+						"expected open interest %s, got %s",
+						expectedOI.String(),
+						gotPerp.OpenInterest.String(),
+					)
+				}
+			}
 		})
 	}
 }

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1247,6 +1247,11 @@ func (k Keeper) ModifyOpenInterest(
 ) (
 	err error,
 ) {
+	// No-op if delta is zero.
+	if openInterestDeltaBaseQuantums.Sign() == 0 {
+		return nil
+	}
+
 	// Get perpetual.
 	perpetual, err := k.GetPerpetual(ctx, perpetualId)
 	if err != nil {
@@ -1271,6 +1276,8 @@ func (k Keeper) ModifyOpenInterest(
 
 	perpetual.OpenInterest = dtypes.NewIntFromBigInt(bigOpenInterest)
 	k.SetPerpetual(ctx, perpetual)
+
+	// TODO(OTE-247): add indexer update logic for open interest change.
 	return nil
 }
 

--- a/protocol/x/perpetuals/keeper/perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/perpetual_test.go
@@ -568,7 +568,7 @@ func TestModifyOpenInterest_Failure(t *testing.T) {
 		"Non-existent perp Id": {
 			id:                1111,
 			initOpenInterest:  big.NewInt(1_000),
-			openInterestDelta: big.NewInt(0),
+			openInterestDelta: big.NewInt(100),
 			err:               types.ErrPerpetualDoesNotExist,
 		},
 	}

--- a/protocol/x/perpetuals/types/types.go
+++ b/protocol/x/perpetuals/types/types.go
@@ -120,9 +120,10 @@ type PerpetualsKeeper interface {
 	) []Perpetual
 }
 
+// OpenInterestDelta represents a (perpId, openInterestDelta) tuple.
 type OpenInterestDelta struct {
 	// The `Id` of the `Perpetual`.
 	PerpetualId uint32
 	// Delta of open interest (in base quantums).
-	BaseQuantumsDelta *big.Int
+	BaseQuantums *big.Int
 }

--- a/protocol/x/subaccounts/keeper/oimf.go
+++ b/protocol/x/subaccounts/keeper/oimf.go
@@ -45,7 +45,7 @@ func getDeltaLongFromSettledUpdate(
 }
 
 // For `Match` updates:
-//   - returns a struct `OpenInterestDelta` if input updates results in OI delta.
+//   - returns a struct `OpenInterest` if input updates results in OI delta.
 //   - returns nil if OI delta is zero.
 //   - panics if update format is invalid.
 //
@@ -114,7 +114,7 @@ func GetDeltaOpenInterestFromUpdates(
 	}
 
 	return &perptypes.OpenInterestDelta{
-		PerpetualId:       updatedPerpId,
-		BaseQuantumsDelta: baseQuantumsDelta,
+		PerpetualId:  updatedPerpId,
+		BaseQuantums: baseQuantumsDelta,
 	}
 }

--- a/protocol/x/subaccounts/keeper/oimf_test.go
+++ b/protocol/x/subaccounts/keeper/oimf_test.go
@@ -176,8 +176,8 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 				},
 			},
 			expectedVal: &perptypes.OpenInterestDelta{
-				PerpetualId:       1,
-				BaseQuantumsDelta: big.NewInt(500),
+				PerpetualId:  1,
+				BaseQuantums: big.NewInt(500),
 			},
 		},
 		"Valid: 500 -> 0, 0 -> 500, delta = 0": {
@@ -307,8 +307,8 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 				},
 			},
 			expectedVal: &perptypes.OpenInterestDelta{
-				PerpetualId:       1000,
-				BaseQuantumsDelta: big.NewInt(-50),
+				PerpetualId:  1000,
+				BaseQuantums: big.NewInt(-50),
 			},
 		},
 		"Valid: -3100 -> -5000, 1000 -> 2900, delta = 1900": {
@@ -350,8 +350,8 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 				},
 			},
 			expectedVal: &perptypes.OpenInterestDelta{
-				PerpetualId:       1000,
-				BaseQuantumsDelta: big.NewInt(1900),
+				PerpetualId:  1000,
+				BaseQuantums: big.NewInt(1900),
 			},
 		},
 	}

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -103,7 +103,8 @@ func assertSubaccountUpdateEventsInIndexerBlock(
 		)
 
 		for _, gotUpdate := range subaccountUpdates {
-			if gotUpdate.SubaccountId.Owner == expectedSubaccountUpdateEvent.SubaccountId.Owner {
+			if gotUpdate.SubaccountId.Owner == expectedSubaccountUpdateEvent.SubaccountId.Owner &&
+				gotUpdate.SubaccountId.Number == expectedSubaccountUpdateEvent.SubaccountId.Number {
 				require.Equal(t,
 					expectedSubaccountUpdateEvent,
 					gotUpdate,

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -95,13 +95,21 @@ func assertSubaccountUpdateEventsInIndexerBlock(
 
 	// For each update, verify that the expected SubaccountUpdateEvent is emitted.
 	for _, update := range updates {
-		expecetedSubaccountUpdateEvent := indexerevents.NewSubaccountUpdateEvent(
+		expectedSubaccountUpdateEvent := indexerevents.NewSubaccountUpdateEvent(
 			&update.SubaccountId,
 			expectedUpdatedPerpetualPositions[update.SubaccountId],
 			expectedUpdatedAssetPositions[update.SubaccountId],
 			expectedSubaccoundIdToFundingPayments[update.SubaccountId],
 		)
-		require.Contains(t, subaccountUpdates, expecetedSubaccountUpdateEvent)
+
+		for _, gotUpdate := range subaccountUpdates {
+			if gotUpdate.SubaccountId.Owner == expectedSubaccountUpdateEvent.SubaccountId.Owner {
+				require.Equal(t,
+					expectedSubaccountUpdateEvent,
+					gotUpdate,
+				)
+			}
+		}
 	}
 }
 
@@ -297,6 +305,9 @@ func TestUpdateSubaccounts(t *testing.T) {
 		newFundingIndices []*big.Int // 1:1 mapped to perpetuals list
 		assets            []*asstypes.Asset
 		marketParamPrices []pricestypes.MarketParamPrice
+		// If not specified, default to `CollatCheck`
+		updateType                types.UpdateType
+		additionalTestSubaccounts []types.Subaccount
 
 		// subaccount state
 		perpetualPositions []*types.PerpetualPosition
@@ -316,6 +327,9 @@ func TestUpdateSubaccounts(t *testing.T) {
 		expectedSuccess                    bool
 		expectedSuccessPerUpdate           []types.UpdateResult
 		expectedErr                        error
+		// List of expected open interest.
+		// If not specified, this means OI is default value.
+		expectedOpenInterest map[uint32]*big.Int
 
 		// Only contains the updated perpetual positions, to assert against the events included.
 		expectedUpdatedPerpetualPositions     map[types.SubaccountId][]*types.PerpetualPosition
@@ -2461,6 +2475,313 @@ func TestUpdateSubaccounts(t *testing.T) {
 			expectedErr:      sdkerrors.ErrInsufficientFunds,
 			msgSenderEnabled: true,
 		},
+		"Match updates increase OI: 0 -> 0.9, 0 -> -0.9": {
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance_OpenInterest1,
+			},
+			updates: []types.Update{
+				{
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      uint32(0),
+							BigQuantumsDelta: big.NewInt(9_000_000_000), // 90 BTC
+						},
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          uint32(0),
+							BigQuantumsDelta: big.NewInt(-4_500_000_000_000), // -4,500,000 USDC
+						},
+					},
+					SubaccountId: constants.Bob_Num0,
+				},
+				{
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      uint32(0),
+							BigQuantumsDelta: big.NewInt(-9_000_000_000), // 9 BTC
+						},
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          uint32(0),
+							BigQuantumsDelta: big.NewInt(4_500_000_000_000), // 4,500,000 USDC
+						},
+					},
+				},
+			},
+			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(900_000_000_000)), // 900_000 USDC
+			additionalTestSubaccounts: []types.Subaccount{
+				{
+					Id: &constants.Bob_Num0,
+					AssetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(
+						900_000_000_000,
+					)), // 900_000 USDC
+				},
+			},
+			updateType: types.Match,
+			expectedAssetPositions: []*types.AssetPosition{
+				{
+					AssetId:  uint32(0),
+					Quantums: dtypes.NewInt(5_400_000_000_000),
+				},
+			},
+			expectedUpdatedAssetPositions: map[types.SubaccountId][]*types.AssetPosition{
+				defaultSubaccountId: {
+					{
+						AssetId:  uint32(0),
+						Quantums: dtypes.NewInt(5_400_000_000_000),
+					},
+				},
+				constants.Bob_Num0: {
+					{
+						AssetId:  uint32(0),
+						Quantums: dtypes.NewInt(-3_600_000_000_000),
+					},
+				},
+			},
+			expectedPerpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId:  uint32(0),
+					Quantums:     dtypes.NewInt(-9_000_000_000),
+					FundingIndex: dtypes.NewInt(0),
+				},
+			},
+			expectedUpdatedPerpetualPositions: map[types.SubaccountId][]*types.PerpetualPosition{
+				defaultSubaccountId: {
+					{
+						PerpetualId:  uint32(0),
+						Quantums:     dtypes.NewInt(-9_000_000_000),
+						FundingIndex: dtypes.NewInt(0),
+					},
+				},
+				constants.Bob_Num0: {
+					{
+						PerpetualId:  uint32(0),
+						Quantums:     dtypes.NewInt(9_000_000_000),
+						FundingIndex: dtypes.NewInt(0),
+					},
+				},
+			},
+			expectedSuccess:          true,
+			expectedSuccessPerUpdate: []types.UpdateResult{types.Success, types.Success},
+			expectedOpenInterest: map[uint32]*big.Int{
+				0: big.NewInt(9_100_000_000), // 1 + 90 = 91 BTC
+			},
+			msgSenderEnabled: true,
+		},
+		"Match updates decreases OI: 1 -> 0.1, -2 -> -1.1": {
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance_OpenInterest2,
+			},
+			perpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId: uint32(0),
+					Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				},
+			},
+			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(-40_000_000_000)), // -40_000 USDC
+			updates: []types.Update{
+				{
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      uint32(0),
+							BigQuantumsDelta: big.NewInt(90_000_000), // 0.9 BTC
+						},
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          uint32(0),
+							BigQuantumsDelta: big.NewInt(-45_000_000_000), // -45,000 USDC
+						},
+					},
+					SubaccountId: constants.Bob_Num0,
+				},
+				{
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      uint32(0),
+							BigQuantumsDelta: big.NewInt(-90_000_000), // -0.9 BTC
+						},
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          uint32(0),
+							BigQuantumsDelta: big.NewInt(45_000_000_000), // 45,000 USDC
+						},
+					},
+				},
+			},
+			additionalTestSubaccounts: []types.Subaccount{
+				{
+					Id: &constants.Bob_Num0,
+					AssetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(
+						120_000_000_000,
+					)), // 120_000 USDC
+					PerpetualPositions: []*types.PerpetualPosition{
+						{
+							PerpetualId: uint32(0),
+							Quantums:    dtypes.NewInt(-200_000_000), // -2 BTC
+						},
+					},
+				},
+			},
+			updateType: types.Match,
+			expectedAssetPositions: []*types.AssetPosition{
+				{
+					AssetId:  uint32(0),
+					Quantums: dtypes.NewInt(5_000_000_000), // 5_000 USDC
+				},
+			},
+			expectedUpdatedAssetPositions: map[types.SubaccountId][]*types.AssetPosition{
+				defaultSubaccountId: {
+					{
+						AssetId:  uint32(0),
+						Quantums: dtypes.NewInt(5_000_000_000), // 5_000 USDC
+					},
+				},
+				constants.Bob_Num0: {
+					{
+						AssetId:  uint32(0),
+						Quantums: dtypes.NewInt(75_000_000_000), // 75_000 USDC
+					},
+				},
+			},
+			expectedPerpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId:  uint32(0),
+					Quantums:     dtypes.NewInt(10_000_000), // 0.1 BTC
+					FundingIndex: dtypes.NewInt(0),
+				},
+			},
+			expectedUpdatedPerpetualPositions: map[types.SubaccountId][]*types.PerpetualPosition{
+				defaultSubaccountId: {
+					{
+						PerpetualId:  uint32(0),
+						Quantums:     dtypes.NewInt(10_000_000), // 0.1 BTC
+						FundingIndex: dtypes.NewInt(0),
+					},
+				},
+				constants.Bob_Num0: {
+					{
+						PerpetualId:  uint32(0),
+						Quantums:     dtypes.NewInt(-110_000_000), // -1.1 BTC
+						FundingIndex: dtypes.NewInt(0),
+					},
+				},
+			},
+			expectedSuccess:          true,
+			expectedSuccessPerUpdate: []types.UpdateResult{types.Success, types.Success},
+			expectedOpenInterest: map[uint32]*big.Int{
+				0: big.NewInt(110_000_000), // 2 - 0.9 = 1.1 BTC
+			},
+			msgSenderEnabled: true,
+		},
+		"Match updates does not change OI: 1 -> 0.1, 0.1 -> 1": {
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_20PercentInitial_10PercentMaintenance_OpenInterest1,
+			},
+			perpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId: uint32(0),
+					Quantums:    dtypes.NewInt(100_000_000), // 1 BTC
+				},
+			},
+			assetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(-40_000_000_000)), // -40_000 USDC
+			updates: []types.Update{
+				{
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      uint32(0),
+							BigQuantumsDelta: big.NewInt(90_000_000), // 0.9 BTC
+						},
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          uint32(0),
+							BigQuantumsDelta: big.NewInt(-45_000_000_000), // -45,000 USDC
+						},
+					},
+					SubaccountId: constants.Bob_Num0,
+				},
+				{
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      uint32(0),
+							BigQuantumsDelta: big.NewInt(-90_000_000), // -0.9 BTC
+						},
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          uint32(0),
+							BigQuantumsDelta: big.NewInt(45_000_000_000), // 45,000 USDC
+						},
+					},
+				},
+			},
+			additionalTestSubaccounts: []types.Subaccount{
+				{
+					Id:             &constants.Bob_Num0,
+					AssetPositions: testutil.CreateUsdcAssetPosition(big.NewInt(5_000_000_000)), // 5000 USDC
+					PerpetualPositions: []*types.PerpetualPosition{
+						{
+							PerpetualId: uint32(0),
+							Quantums:    dtypes.NewInt(10_000_000), // 0.1 BTC
+						},
+					},
+				},
+			},
+			updateType: types.Match,
+			expectedAssetPositions: []*types.AssetPosition{
+				{
+					AssetId:  uint32(0),
+					Quantums: dtypes.NewInt(5_000_000_000), // 5_000 USDC
+				},
+			},
+			expectedUpdatedAssetPositions: map[types.SubaccountId][]*types.AssetPosition{
+				defaultSubaccountId: {
+					{
+						AssetId:  uint32(0),
+						Quantums: dtypes.NewInt(5_000_000_000), // 5_000 USDC
+					},
+				},
+				constants.Bob_Num0: {
+					{
+						AssetId:  uint32(0),
+						Quantums: dtypes.NewInt(-40_000_000_000), // -40_000 USDC
+					},
+				},
+			},
+			expectedPerpetualPositions: []*types.PerpetualPosition{
+				{
+					PerpetualId:  uint32(0),
+					Quantums:     dtypes.NewInt(10_000_000), // 0.1 BTC
+					FundingIndex: dtypes.NewInt(0),
+				},
+			},
+			expectedUpdatedPerpetualPositions: map[types.SubaccountId][]*types.PerpetualPosition{
+				defaultSubaccountId: {
+					{
+						PerpetualId:  uint32(0),
+						Quantums:     dtypes.NewInt(10_000_000), // 0.1 BTC
+						FundingIndex: dtypes.NewInt(0),
+					},
+				},
+				constants.Bob_Num0: {
+					{
+						PerpetualId:  uint32(0),
+						Quantums:     dtypes.NewInt(100_000_000), // 1 BTC
+						FundingIndex: dtypes.NewInt(0),
+					},
+				},
+			},
+			expectedSuccess:          true,
+			expectedSuccessPerUpdate: []types.UpdateResult{types.Success, types.Success},
+			expectedOpenInterest: map[uint32]*big.Int{
+				0: big.NewInt(100_000_000), // 1 BTC
+			},
+			msgSenderEnabled: true,
+		},
 	}
 
 	for name, tc := range tests {
@@ -2499,23 +2820,16 @@ func TestUpdateSubaccounts(t *testing.T) {
 			}
 
 			for i, p := range tc.perpetuals {
-				perp, err := perpetualsKeeper.CreatePerpetual(
+				perpetualsKeeper.SetPerpetual(
 					ctx,
-					p.Params.Id,
-					p.Params.Ticker,
-					p.Params.MarketId,
-					p.Params.AtomicResolution,
-					p.Params.DefaultFundingPpm,
-					p.Params.LiquidityTier,
-					p.Params.MarketType,
+					p,
 				)
-				require.NoError(t, err)
 
 				// Update FundingIndex for testing settlements.
 				if i < len(tc.newFundingIndices) {
-					err = perpetualsKeeper.ModifyFundingIndex(
+					err := perpetualsKeeper.ModifyFundingIndex(
 						ctx,
-						perp.Params.Id,
+						p.Params.Id,
 						tc.newFundingIndices[i],
 					)
 					require.NoError(t, err)
@@ -2540,6 +2854,10 @@ func TestUpdateSubaccounts(t *testing.T) {
 			keeper.SetSubaccount(ctx, subaccount)
 			subaccountId := *subaccount.Id
 
+			for _, sa := range tc.additionalTestSubaccounts {
+				keeper.SetSubaccount(ctx, sa)
+			}
+
 			for i, u := range tc.updates {
 				if u.SubaccountId == (types.SubaccountId{}) {
 					u.SubaccountId = subaccountId
@@ -2547,7 +2865,11 @@ func TestUpdateSubaccounts(t *testing.T) {
 				tc.updates[i] = u
 			}
 
-			success, successPerUpdate, err := keeper.UpdateSubaccounts(ctx, tc.updates, types.CollatCheck)
+			updateType := types.CollatCheck
+			if tc.updateType != types.UpdateTypeUnspecified {
+				updateType = tc.updateType
+			}
+			success, successPerUpdate, err := keeper.UpdateSubaccounts(ctx, tc.updates, updateType)
 			if tc.expectedErr != nil {
 				require.ErrorIs(t, tc.expectedErr, err)
 			} else {
@@ -2597,6 +2919,20 @@ func TestUpdateSubaccounts(t *testing.T) {
 					sdk.NewCoin(asstypes.AssetUsdc.Denom, sdkmath.NewInt(expectedUsdcBal)),
 					usdcBal,
 				)
+			}
+
+			for _, perp := range tc.perpetuals {
+				gotPerp, err := perpetualsKeeper.GetPerpetual(ctx, perp.GetId())
+				require.NoError(t, err)
+
+				if expectedOI, exists := tc.expectedOpenInterest[perp.GetId()]; exists {
+					require.Equal(t, expectedOI, gotPerp.OpenInterest.BigInt())
+				} else {
+					// If no specified expected OI, then check OI is unchanged.
+					require.Zero(t, perp.OpenInterest.BigInt().Cmp(
+						gotPerp.OpenInterest.BigInt(),
+					))
+				}
 			}
 		})
 	}
@@ -4150,7 +4486,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 				{
 					PerpetualId: uint32(0),
 					// 500 BTC. At $50,000, this is $25,000,000 of OI.
-					BaseQuantumsDelta: big.NewInt(50_000_000_000),
+					BaseQuantums: big.NewInt(50_000_000_000),
 				},
 			},
 			updates: []types.Update{
@@ -4220,7 +4556,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 					// (Only difference from prevoius test case)
 					// 410 BTC. At $50,000, this is $20,500,000 of OI.
 					// OI would be $25,000,000 after the Match updates, so OIMF is still at base IMF.
-					BaseQuantumsDelta: big.NewInt(41_000_000_000),
+					BaseQuantums: big.NewInt(41_000_000_000),
 				},
 			},
 			updates: []types.Update{
@@ -4290,7 +4626,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 					// (Only difference from prevoius test case)
 					// 410 BTC + 1 base quantum. At $50,000, this is > $20,500,000 of OI.
 					// OI would be just past $25,000,000 after the Match updates, so OIMF > IMF = 20%
-					BaseQuantumsDelta: big.NewInt(41_000_000_001),
+					BaseQuantums: big.NewInt(41_000_000_001),
 				},
 			},
 			updates: []types.Update{
@@ -4357,7 +4693,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 				{
 					PerpetualId: uint32(0),
 					// 10_000 BTC. At $50,000, this is $500mm of OI which way past upper cap
-					BaseQuantumsDelta: big.NewInt(1_000_000_000_000),
+					BaseQuantums: big.NewInt(1_000_000_000_000),
 				},
 			},
 			updates: []types.Update{
@@ -5052,7 +5388,7 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 				require.NoError(t, perpetualsKeeper.ModifyOpenInterest(
 					ctx,
 					openInterest.PerpetualId,
-					openInterest.BaseQuantumsDelta,
+					openInterest.BaseQuantums,
 				))
 			}
 
@@ -5095,9 +5431,9 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 				perp, err := perpetualsKeeper.GetPerpetual(ctx, openInterest.PerpetualId)
 				require.NoError(t, err)
 				require.Zerof(t,
-					openInterest.BaseQuantumsDelta.Cmp(perp.OpenInterest.BigInt()),
+					openInterest.BaseQuantums.Cmp(perp.OpenInterest.BigInt()),
 					"expected: %s, got: %s",
-					openInterest.BaseQuantumsDelta.String(),
+					openInterest.BaseQuantums.String(),
 					perp.OpenInterest.String(),
 				)
 			}

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -58,7 +58,7 @@ var (
 	ErrCannotModifyPerpOpenInterestForOIMF = errorsmod.Register(
 		ModuleName,
 		402,
-		"cannot temporarily modify perpetual open interest for OIMF calculation",
+		"cannot modify perpetual open interest for OIMF calculation",
 	)
 	ErrCannotRevertPerpOpenInterestForOIMF = errorsmod.Register(
 		ModuleName,


### PR DESCRIPTION
### Changelist
In `UpdateSubaccounts`, update OI for a perpetual. 

### Test Plan
Added new/modified current unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
