### PR TITLE
Cherry-pick Vulcan change to not send subaccount websocket message

### DIFF
--- a/indexer/packages/kafka/package.json
+++ b/indexer/packages/kafka/package.json
@@ -32,6 +32,8 @@
   "homepage": "https://github.com/dydxprotocol/indexer#readme",
   "dependencies": {
     "@dydxprotocol-indexer/base": "workspace:^0.0.1",
+    "@dydxprotocol-indexer/postgres": "workspace:^0.0.1",
+    "@dydxprotocol-indexer/v4-protos": "workspace:^0.0.1",
     "dotenv-flow": "^3.2.0",
     "kafkajs": "^2.1.0",
     "lodash": "^4.17.21",

--- a/indexer/packages/kafka/src/index.ts
+++ b/indexer/packages/kafka/src/index.ts
@@ -5,6 +5,7 @@ export * from './kafka';
 export * from './constants';
 export * from './types';
 export * from './batch-kafka-producer';
+export * from './websocket-helper';
 export { kafkaConfigSchema } from './config';
 
 export * from '../__tests__/helpers/kafka';

--- a/indexer/packages/kafka/src/websocket-helper.ts
+++ b/indexer/packages/kafka/src/websocket-helper.ts
@@ -1,0 +1,116 @@
+import {
+  APIOrderStatus,
+  APIOrderStatusEnum,
+  apiTranslations,
+  IsoString,
+  OrderFromDatabase,
+  OrderTable,
+  PerpetualMarketFromDatabase,
+  protocolTranslations,
+  SubaccountMessageContents,
+  SubaccountTable,
+  TimeInForce,
+} from '@dydxprotocol-indexer/postgres';
+import {
+  IndexerOrder,
+  IndexerOrder_ConditionType,
+  OrderPlaceV1_OrderPlacementStatus,
+  RedisOrder,
+  SubaccountMessage,
+} from '@dydxprotocol-indexer/v4-protos';
+
+import { SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION } from './constants';
+
+/**
+ * Gets the trigger price for an order, returns undefined if the order has an unspecified condition
+ * type
+ * @param order
+ * @param perpetualMarket
+ * @returns
+ */
+export function getTriggerPrice(
+  order: IndexerOrder,
+  perpetualMarket: PerpetualMarketFromDatabase,
+): string | undefined {
+  if (order.conditionType !== IndexerOrder_ConditionType.CONDITION_TYPE_UNSPECIFIED) {
+    return protocolTranslations.subticksToPrice(
+      order.conditionalOrderTriggerSubticks.toString(),
+      perpetualMarket,
+    );
+  }
+  return undefined;
+}
+
+export function generateSubaccountMessageContents(
+  redisOrder: RedisOrder,
+  order: OrderFromDatabase | undefined,
+  perpetualMarket: PerpetualMarketFromDatabase,
+  placementStatus: OrderPlaceV1_OrderPlacementStatus,
+): SubaccountMessageContents {
+  const orderTIF: TimeInForce = protocolTranslations.protocolOrderTIFToTIF(
+    redisOrder.order!.timeInForce,
+  );
+  const status: APIOrderStatus = (
+    placementStatus === OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_OPENED
+      ? APIOrderStatusEnum.OPEN
+      : APIOrderStatusEnum.BEST_EFFORT_OPENED
+  );
+  const createdAtHeight: string | undefined = order?.createdAtHeight;
+  const updatedAt: IsoString | undefined = order?.updatedAt;
+  const updatedAtHeight: string | undefined = order?.updatedAtHeight;
+  const contents: SubaccountMessageContents = {
+    orders: [
+      {
+        id: OrderTable.orderIdToUuid(redisOrder.order!.orderId!),
+        subaccountId: SubaccountTable.subaccountIdToUuid(
+          redisOrder.order!.orderId!.subaccountId!,
+        ),
+        clientId: redisOrder.order!.orderId!.clientId.toString(),
+        clobPairId: perpetualMarket.clobPairId,
+        side: protocolTranslations.protocolOrderSideToOrderSide(redisOrder.order!.side),
+        size: redisOrder.size,
+        price: redisOrder.price,
+        status,
+        type: protocolTranslations.protocolConditionTypeToOrderType(
+          redisOrder.order!.conditionType,
+        ),
+        timeInForce: apiTranslations.orderTIFToAPITIF(orderTIF),
+        postOnly: apiTranslations.isOrderTIFPostOnly(orderTIF),
+        reduceOnly: redisOrder.order!.reduceOnly,
+        orderFlags: redisOrder.order!.orderId!.orderFlags.toString(),
+        goodTilBlock: protocolTranslations.getGoodTilBlock(redisOrder.order!)
+          ?.toString(),
+        goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(redisOrder.order!),
+        ticker: redisOrder.ticker,
+        ...(createdAtHeight && { createdAtHeight }),
+        ...(updatedAt && { updatedAt }),
+        ...(updatedAtHeight && { updatedAtHeight }),
+        clientMetadata: redisOrder.order!.clientMetadata.toString(),
+        triggerPrice: getTriggerPrice(redisOrder.order!, perpetualMarket),
+      },
+    ],
+  };
+  return contents;
+}
+
+export function createSubaccountWebsocketMessage(
+  redisOrder: RedisOrder,
+  order: OrderFromDatabase | undefined,
+  perpetualMarket: PerpetualMarketFromDatabase,
+  placementStatus: OrderPlaceV1_OrderPlacementStatus,
+): Buffer {
+  const contents: SubaccountMessageContents = generateSubaccountMessageContents(
+    redisOrder,
+    order,
+    perpetualMarket,
+    placementStatus,
+  );
+
+  const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({
+    contents: JSON.stringify(contents),
+    subaccountId: redisOrder.order!.orderId!.subaccountId!,
+    version: SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
+  });
+
+  return Buffer.from(Uint8Array.from(SubaccountMessage.encode(subaccountMessage).finish()));
+}

--- a/indexer/packages/redis/src/helpers/order-helper.ts
+++ b/indexer/packages/redis/src/helpers/order-helper.ts
@@ -1,0 +1,28 @@
+import { OrderTable, PerpetualMarketFromDatabase, protocolTranslations } from '@dydxprotocol-indexer/postgres';
+import { IndexerOrder, RedisOrder, RedisOrder_TickerType } from '@dydxprotocol-indexer/v4-protos';
+
+/**
+ * Creates a `RedisOrder` given an `Order` and the corresponding `PerpetualMarket` for the `Order`.
+ * @param order
+ * @param perpetualMarket
+ * @returns
+ */
+export function convertToRedisOrder(
+  order: IndexerOrder,
+  perpetualMarket: PerpetualMarketFromDatabase,
+): RedisOrder {
+  return {
+    order,
+    id: OrderTable.orderIdToUuid(order.orderId!),
+    ticker: perpetualMarket.ticker,
+    tickerType: RedisOrder_TickerType.TICKER_TYPE_PERPETUAL,
+    price: protocolTranslations.subticksToPrice(
+      order.subticks.toString(),
+      perpetualMarket,
+    ),
+    size: protocolTranslations.quantumsToHumanFixedString(
+      order.quantums.toString(),
+      perpetualMarket.atomicResolution,
+    ),
+  };
+}

--- a/indexer/packages/redis/src/index.ts
+++ b/indexer/packages/redis/src/index.ts
@@ -15,6 +15,7 @@ export * as StateFilledQuantumsCache from './caches/state-filled-quantums-cache'
 export { placeOrder } from './caches/place-order';
 export { removeOrder } from './caches/remove-order';
 export { updateOrder } from './caches/update-order';
+export * from './helpers/order-helper';
 
 export * from './types';
 export { redisConfigSchema } from './config';

--- a/indexer/packages/v4-proto-parser/__tests__/order-helpers.test.ts
+++ b/indexer/packages/v4-proto-parser/__tests__/order-helpers.test.ts
@@ -1,5 +1,5 @@
 import { IndexerOrderId } from '@dydxprotocol-indexer/v4-protos';
-import { getOrderIdHash, isStatefulOrder } from '../src/order-helpers';
+import { getOrderIdHash, isLongTermOrder, isStatefulOrder } from '../src/order-helpers';
 import { ORDER_FLAG_CONDITIONAL, ORDER_FLAG_LONG_TERM, ORDER_FLAG_SHORT_TERM } from '../src';
 
 describe('getOrderIdHash', () => {
@@ -63,5 +63,25 @@ describe('isStatefulOrder', () => {
     isStateful: boolean,
   ) => {
     expect(isStatefulOrder(flag)).toEqual(isStateful);
+  });
+});
+
+describe('isLongTermOrder', () => {
+  it.each([
+    [ORDER_FLAG_SHORT_TERM.toString(), 'string', false],
+    ['4', 'string', false],
+    [ORDER_FLAG_CONDITIONAL.toString(), 'string', false],
+    [ORDER_FLAG_LONG_TERM.toString(), 'string', true],
+    [ORDER_FLAG_SHORT_TERM, 'number', false],
+    [3, 'number', false],
+    [ORDER_FLAG_CONDITIONAL, 'number', false],
+    [ORDER_FLAG_LONG_TERM, 'number', true],
+    ['abc', 'string', false],
+  ])('Checks if flag %s with type %s is a long term order', (
+    flag: number | string,
+    _type: string,
+    isLongTerm: boolean,
+  ) => {
+    expect(isLongTermOrder(flag)).toEqual(isLongTerm);
   });
 });

--- a/indexer/packages/v4-proto-parser/src/order-helpers.ts
+++ b/indexer/packages/v4-proto-parser/src/order-helpers.ts
@@ -24,6 +24,15 @@ export function isStatefulOrder(orderFlag: number | String): boolean {
   return numberOrderFlag === ORDER_FLAG_CONDITIONAL || numberOrderFlag === ORDER_FLAG_LONG_TERM;
 }
 
+export function isLongTermOrder(orderFlag: number | String): boolean {
+  const numberOrderFlag: number = Number(orderFlag);
+  // A string that is not a number will be converted to NaN, and should return false.
+  if (Number.isNaN(numberOrderFlag)) {
+    return false;
+  }
+  return numberOrderFlag === ORDER_FLAG_LONG_TERM;
+}
+
 export function requiresImmediateExecution(tif: IndexerOrder_TimeInForce): boolean {
   return (
     tif === IndexerOrder_TimeInForce.TIME_IN_FORCE_FILL_OR_KILL ||

--- a/indexer/pnpm-lock.yaml
+++ b/indexer/pnpm-lock.yaml
@@ -121,6 +121,8 @@ importers:
     specifiers:
       '@dydxprotocol-indexer/base': workspace:^0.0.1
       '@dydxprotocol-indexer/dev': workspace:^0.0.1
+      '@dydxprotocol-indexer/postgres': workspace:^0.0.1
+      '@dydxprotocol-indexer/v4-protos': workspace:^0.0.1
       '@types/jest': ^28.1.4
       '@types/lodash': ^4.14.182
       '@types/node': ^18.0.3
@@ -133,6 +135,8 @@ importers:
       uuid: ^8.3.2
     dependencies:
       '@dydxprotocol-indexer/base': link:../base
+      '@dydxprotocol-indexer/postgres': link:../postgres
+      '@dydxprotocol-indexer/v4-protos': link:../v4-protos
       dotenv-flow: 3.2.0
       kafkajs: 2.1.0
       lodash: 4.17.21

--- a/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
@@ -36,6 +36,7 @@ import { updateBlockCache } from '../../../src/caches/block-cache';
 import {
   createIndexerTendermintBlock,
   createIndexerTendermintEvent,
+  expectOrderSubaccountKafkaMessage,
   expectVulcanKafkaMessage,
 } from '../../helpers/indexer-proto-helpers';
 import { StatefulOrderPlacementHandler } from '../../../src/handlers/stateful-order/stateful-order-placement-handler';
@@ -44,6 +45,7 @@ import { STATEFUL_ORDER_ORDER_FILL_EVENT_TYPE } from '../../../src/constants';
 import { producer } from '@dydxprotocol-indexer/kafka';
 import { ORDER_FLAG_LONG_TERM } from '@dydxprotocol-indexer/v4-proto-parser';
 import { createPostgresFunctions } from '../../../src/helpers/postgres/postgres-functions';
+import config from '../../../src/config';
 
 describe('statefulOrderPlacementHandler', () => {
   beforeAll(async () => {
@@ -61,6 +63,7 @@ describe('statefulOrderPlacementHandler', () => {
   afterEach(async () => {
     await dbHelpers.clearData();
     jest.clearAllMocks();
+    config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS = false;
   });
 
   afterAll(async () => {
@@ -135,12 +138,16 @@ describe('statefulOrderPlacementHandler', () => {
 
   it.each([
     // TODO(IND-334): Remove after deprecating StatefulOrderPlacementEvent
-    ['stateful order placement', defaultStatefulOrderEvent],
-    ['stateful long term order placement', defaultStatefulOrderLongTermEvent],
-  ])('successfully places order with %s', async (
+    ['stateful order placement', defaultStatefulOrderEvent, false],
+    ['stateful long term order placement', defaultStatefulOrderLongTermEvent, false],
+    ['stateful order placement', defaultStatefulOrderEvent, true],
+    ['stateful long term order placement', defaultStatefulOrderLongTermEvent, true],
+  ])('successfully places order with %s (emit subaccount websocket msg: %s)', async (
     _name: string,
     statefulOrderEvent: StatefulOrderEventV1,
+    emitSubaccountMessage: boolean,
   ) => {
+    config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS = emitSubaccountMessage;
     const kafkaMessage: KafkaMessage = createKafkaMessageFromStatefulOrderEvent(
       statefulOrderEvent,
     );
@@ -181,6 +188,13 @@ describe('statefulOrderPlacementHandler', () => {
       orderId: defaultOrder.orderId!,
       offchainUpdate: expectedOffchainUpdate,
     });
+    if (emitSubaccountMessage) {
+      expectOrderSubaccountKafkaMessage(
+        producerSendMock,
+        defaultOrder.orderId!.subaccountId!,
+        order!,
+      );
+    }
   });
 
   it.each([

--- a/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
@@ -29,7 +29,8 @@ import {
   PerpetualMarketFromDatabase,
   PerpetualMarketTable,
   IsoString,
-  fillTypeToTradeType, OrderSubaccountMessageContents,
+  fillTypeToTradeType,
+  OrderSubaccountMessageContents,
 } from '@dydxprotocol-indexer/postgres';
 import { getOrderIdHash, ORDER_FLAG_CONDITIONAL } from '@dydxprotocol-indexer/v4-proto-parser';
 import {

--- a/indexer/services/ender/src/config.ts
+++ b/indexer/services/ender/src/config.ts
@@ -26,6 +26,9 @@ export const configSchema = {
   IGNORE_NONEXISTENT_PERPETUAL_MARKET: parseBoolean({
     default: false,
   }),
+  SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS: parseBoolean({
+    default: false,
+  }),
 };
 
 export default parseSchema(configSchema);

--- a/indexer/services/ender/src/handlers/stateful-order/stateful-order-placement-handler.ts
+++ b/indexer/services/ender/src/handlers/stateful-order/stateful-order-placement-handler.ts
@@ -1,25 +1,34 @@
+import { generateSubaccountMessageContents } from '@dydxprotocol-indexer/kafka';
 import {
+  OrderFromDatabase, OrderModel,
   OrderTable,
+  PerpetualMarketFromDatabase,
+  perpetualMarketRefresher,
+  SubaccountMessageContents,
 } from '@dydxprotocol-indexer/postgres';
+import { convertToRedisOrder } from '@dydxprotocol-indexer/redis';
 import { getOrderIdHash } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
-  OrderPlaceV1_OrderPlacementStatus,
-  OffChainUpdateV1,
   IndexerOrder,
+  IndexerSubaccountId,
+  OffChainUpdateV1,
+  OrderPlaceV1_OrderPlacementStatus,
+  RedisOrder,
   StatefulOrderEventV1,
+  SubaccountId,
 } from '@dydxprotocol-indexer/v4-protos';
 import * as pg from 'pg';
 
+import config from '../../config';
 import { ConsolidatedKafkaEvent } from '../../lib/types';
 import { AbstractStatefulOrderHandler } from '../abstract-stateful-order-handler';
 
 // TODO(IND-334): Rename to LongTermOrderPlacementHandler after deprecating StatefulOrderPlacement
-export class StatefulOrderPlacementHandler extends
-  AbstractStatefulOrderHandler<StatefulOrderEventV1> {
+export class StatefulOrderPlacementHandler
+  extends AbstractStatefulOrderHandler<StatefulOrderEventV1> {
   eventType: string = 'StatefulOrderEvent';
 
-  public getParallelizationIds(): string[] {
-    // Stateful Order Events with the same orderId
+  public getOrderId(): string {
     let orderId: string;
     // TODO(IND-334): Remove after deprecating StatefulOrderPlacementEvent
     if (this.event.orderPlace !== undefined) {
@@ -27,11 +36,27 @@ export class StatefulOrderPlacementHandler extends
     } else {
       orderId = OrderTable.orderIdToUuid(this.event.longTermOrderPlacement!.order!.orderId!);
     }
-    return this.getParallelizationIdsFromOrderId(orderId);
+    return orderId;
+  }
+
+  public getSubaccountId(): IndexerSubaccountId {
+    let subaccountId: IndexerSubaccountId;
+    // TODO(IND-334): Remove after deprecating StatefulOrderPlacementEvent
+    if (this.event.orderPlace !== undefined) {
+      subaccountId = this.event.orderPlace!.order!.orderId!.subaccountId!;
+    } else {
+      subaccountId = this.event.longTermOrderPlacement!.order!.orderId!.subaccountId!;
+    }
+    return subaccountId;
+  }
+
+  public getParallelizationIds(): string[] {
+    // Stateful Order Events with the same orderId
+    return this.getParallelizationIdsFromOrderId(this.getOrderId());
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
-  public async internalHandle(_: pg.QueryResultRow): Promise<ConsolidatedKafkaEvent[]> {
+  public async internalHandle(resultRow: pg.QueryResultRow): Promise<ConsolidatedKafkaEvent[]> {
     let order: IndexerOrder;
     // TODO(IND-334): Remove after deprecating StatefulOrderPlacementEvent
     if (this.event.orderPlace !== undefined) {
@@ -39,11 +64,14 @@ export class StatefulOrderPlacementHandler extends
     } else {
       order = this.event.longTermOrderPlacement!.order!;
     }
-    return this.createKafkaEvents(order);
+    return this.createKafkaEvents(order, resultRow);
   }
 
-  private createKafkaEvents(order: IndexerOrder): ConsolidatedKafkaEvent[] {
-    const kafakEvents: ConsolidatedKafkaEvent[] = [];
+  private createKafkaEvents(
+    order: IndexerOrder,
+    resultRow: pg.QueryResultRow,
+  ): ConsolidatedKafkaEvent[] {
+    const kafkaEvents: ConsolidatedKafkaEvent[] = [];
 
     const offChainUpdate: OffChainUpdateV1 = OffChainUpdateV1.fromPartial({
       orderPlace: {
@@ -51,11 +79,35 @@ export class StatefulOrderPlacementHandler extends
         placementStatus: OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_OPENED,
       },
     });
-    kafakEvents.push(this.generateConsolidatedVulcanKafkaEvent(
+    kafkaEvents.push(this.generateConsolidatedVulcanKafkaEvent(
       getOrderIdHash(order.orderId!),
       offChainUpdate,
     ));
 
-    return kafakEvents;
+    if (config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS) {
+      const perpetualMarket: PerpetualMarketFromDatabase = perpetualMarketRefresher
+        .getPerpetualMarketFromClobPairId(order.orderId!.clobPairId.toString())!;
+      const dbOrder: OrderFromDatabase = OrderModel.fromJson(resultRow.order) as OrderFromDatabase;
+      const redisOrder: RedisOrder = convertToRedisOrder(order, perpetualMarket);
+      const subaccountContent: SubaccountMessageContents = generateSubaccountMessageContents(
+        redisOrder,
+        dbOrder,
+        perpetualMarket,
+        OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_OPENED,
+      );
+
+      const subaccountIdProto: SubaccountId = {
+        owner: this.getSubaccountId().owner,
+        number: this.getSubaccountId().number,
+      };
+      kafkaEvents.push(this.generateConsolidatedSubaccountKafkaEvent(
+        JSON.stringify(subaccountContent),
+        subaccountIdProto,
+        this.getOrderId(),
+        false,
+        subaccountContent,
+      ));
+    }
+    return kafkaEvents;
   }
 }

--- a/indexer/services/ender/src/handlers/stateful-order/stateful-order-placement-handler.ts
+++ b/indexer/services/ender/src/handlers/stateful-order/stateful-order-placement-handler.ts
@@ -1,6 +1,7 @@
 import { generateSubaccountMessageContents } from '@dydxprotocol-indexer/kafka';
 import {
-  OrderFromDatabase, OrderModel,
+  OrderFromDatabase,
+  OrderModel,
   OrderTable,
   PerpetualMarketFromDatabase,
   perpetualMarketRefresher,

--- a/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
@@ -10,6 +10,7 @@ import {
   ORDERBOOKS_WEBSOCKET_MESSAGE_VERSION,
   producer,
   SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
+  getTriggerPrice,
 } from '@dydxprotocol-indexer/kafka';
 import {
   APIOrderStatus,
@@ -55,7 +56,6 @@ import {
 } from '@dydxprotocol-indexer/v4-protos';
 import { KafkaMessage } from 'kafkajs';
 import Long from 'long';
-import { convertToRedisOrder, getTriggerPrice } from '../../src/handlers/helpers';
 import { redisClient, redisClient as client } from '../../src/helpers/redis/redis-controller';
 import { onMessage } from '../../src/lib/on-message';
 import { expectCanceledOrderStatus, expectOpenOrderIds, handleInitialOrderPlace } from '../helpers/helpers';
@@ -117,23 +117,23 @@ describe('order-place-handler', () => {
       quantums: Long.fromValue(500_000, true),
       subticks: Long.fromValue(1_000_000, true),
     };
-    const replacedOrder: RedisOrder = convertToRedisOrder(
+    const replacedOrder: RedisOrder = redisPackage.convertToRedisOrder(
       replacementOrder,
       testConstants.defaultPerpetualMarket,
     );
-    const replacedOrderGoodTilBlockTime: RedisOrder = convertToRedisOrder(
+    const replacedOrderGoodTilBlockTime: RedisOrder = redisPackage.convertToRedisOrder(
       replacementOrderGoodTilBlockTime,
       testConstants.defaultPerpetualMarket,
     );
-    const replacedOrderConditional: RedisOrder = convertToRedisOrder(
+    const replacedOrderConditional: RedisOrder = redisPackage.convertToRedisOrder(
       replacementOrderConditional,
       testConstants.defaultPerpetualMarket,
     );
-    const replacedOrderFok: RedisOrder = convertToRedisOrder(
+    const replacedOrderFok: RedisOrder = redisPackage.convertToRedisOrder(
       replacementOrderFok,
       testConstants.defaultPerpetualMarket,
     );
-    const replacedOrderIoc: RedisOrder = convertToRedisOrder(
+    const replacedOrderIoc: RedisOrder = redisPackage.convertToRedisOrder(
       replacementOrderIoc,
       testConstants.defaultPerpetualMarket,
     );
@@ -278,7 +278,7 @@ describe('order-place-handler', () => {
       expectedOrderUuid: string,
       expectSubaccountMessageSent: boolean,
     ) => {
-      const expectedOrder: RedisOrder = convertToRedisOrder(
+      const expectedOrder: RedisOrder = redisPackage.convertToRedisOrder(
         orderToPlace,
         testConstants.defaultPerpetualMarket,
       );

--- a/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
@@ -61,7 +61,8 @@ import { onMessage } from '../../src/lib/on-message';
 import { expectCanceledOrderStatus, expectOpenOrderIds, handleInitialOrderPlace } from '../helpers/helpers';
 import { expectOffchainUpdateMessage, expectWebsocketOrderbookMessage, expectWebsocketSubaccountMessage } from '../helpers/websocket-helpers';
 import { OrderbookSide } from '../../src/lib/types';
-import { getOrderIdHash, isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
+import { getOrderIdHash, isLongTermOrder, isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
+import config from '../../src/config';
 
 jest.mock('@dydxprotocol-indexer/base', () => ({
   ...jest.requireActual('@dydxprotocol-indexer/base'),
@@ -80,6 +81,10 @@ describe('order-place-handler', () => {
 
   afterAll(() => {
     jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS = true;
   });
 
   describe('handle', () => {
@@ -830,19 +835,38 @@ describe('order-place-handler', () => {
         redisTestConstants.defaultOrderGoodTilBlockTime,
         redisTestConstants.defaultRedisOrderGoodTilBlockTime,
         dbOrderGoodTilBlockTime,
+        false,
       ],
       [
         'conditional',
         redisTestConstants.defaultConditionalOrder,
         redisTestConstants.defaultRedisOrderConditional,
         dbConditionalOrder,
+        false,
+      ],
+      [
+        'good-til-block-time',
+        redisTestConstants.defaultOrderGoodTilBlockTime,
+        redisTestConstants.defaultRedisOrderGoodTilBlockTime,
+        dbOrderGoodTilBlockTime,
+        true,
+      ],
+      [
+        'conditional',
+        redisTestConstants.defaultConditionalOrder,
+        redisTestConstants.defaultRedisOrderConditional,
+        dbConditionalOrder,
+        true,
       ],
     ])('handles order place with OPEN placement status, exists initially (with %s)', async (
       _name: string,
       orderToPlace: IndexerOrder,
       expectedRedisOrder: RedisOrder,
       placedOrder: OrderFromDatabase,
+      sendSubaccountWebsocketMessage: boolean,
     ) => {
+      // eslint-disable-next-line max-len
+      config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS = sendSubaccountWebsocketMessage;
       synchronizeWrapBackgroundTask(wrapBackgroundTask);
       const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
       // Handle the order place event for the initial order with BEST_EFFORT_OPENED
@@ -883,7 +907,9 @@ describe('order-place-handler', () => {
         testConstants.defaultPerpetualMarket,
         APIOrderStatusEnum.OPEN,
         // Subaccount messages should be sent for stateful order with OPEN status
-        true,
+        !(
+          isLongTermOrder(expectedRedisOrder.order!.orderId!.orderFlags) &&
+          !sendSubaccountWebsocketMessage),
       );
 
       expect(logger.error).not.toHaveBeenCalled();

--- a/indexer/services/vulcan/src/config.ts
+++ b/indexer/services/vulcan/src/config.ts
@@ -30,6 +30,9 @@ export const configSchema = {
   SEND_WEBSOCKET_MESSAGES: parseBoolean({
     default: true,
   }),
+  SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS: parseBoolean({
+    default: true,
+  }),
 };
 
 export default parseSchema(configSchema);

--- a/indexer/services/vulcan/src/handlers/helpers.ts
+++ b/indexer/services/vulcan/src/handlers/helpers.ts
@@ -1,8 +1,4 @@
-import {
-  OrderTable,
-  PerpetualMarketFromDatabase,
-  protocolTranslations,
-} from '@dydxprotocol-indexer/postgres';
+import { OrderTable, PerpetualMarketFromDatabase, protocolTranslations } from '@dydxprotocol-indexer/postgres';
 import { subticksToPrice } from '@dydxprotocol-indexer/postgres/build/src/lib/protocol-translations';
 import { StateFilledQuantumsCache } from '@dydxprotocol-indexer/redis';
 import {
@@ -12,7 +8,6 @@ import {
   RedisOrder,
   RedisOrder_TickerType,
 } from '@dydxprotocol-indexer/v4-protos';
-import { IndexerOrder_Side, RedisOrder } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
 
 import { redisClient } from '../helpers/redis/redis-controller';

--- a/indexer/services/vulcan/src/handlers/helpers.ts
+++ b/indexer/services/vulcan/src/handlers/helpers.ts
@@ -12,6 +12,7 @@ import {
   RedisOrder,
   RedisOrder_TickerType,
 } from '@dydxprotocol-indexer/v4-protos';
+import { IndexerOrder_Side, RedisOrder } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
 
 import { redisClient } from '../helpers/redis/redis-controller';

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -18,6 +18,7 @@ import {
 } from '@dydxprotocol-indexer/redis';
 import {
   getOrderIdHash,
+  isLongTermOrder,
   isStatefulOrder,
   ORDER_FLAG_SHORT_TERM,
   requiresImmediateExecution,
@@ -120,7 +121,12 @@ export class OrderPlaceHandler extends Handler {
 
     // TODO(CLOB-597): Remove this logic and log erorrs once best-effort-open is not sent for
     // stateful orders in the protocol
-    if (this.shouldSendSubaccountMessage(orderPlace, placeOrderResult, placementStatus)) {
+    if (this.shouldSendSubaccountMessage(
+      orderPlace,
+      placeOrderResult,
+      placementStatus,
+      redisOrder,
+    )) {
       // TODO(IND-171): Determine whether we should always be sending a message, even when the cache
       // isn't updated.
       // For stateful and conditional orders, look the order up in the db for the createdAtHeight
@@ -273,7 +279,15 @@ export class OrderPlaceHandler extends Handler {
     orderPlace: OrderPlaceV1,
     placeOrderResult: PlaceOrderResult,
     placementStatus: OrderPlaceV1_OrderPlacementStatus,
+    redisOrder: RedisOrder,
   ): boolean {
+    if (
+      isLongTermOrder(redisOrder.order!.orderId!.orderFlags) &&
+      !config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS
+    ) {
+      return false;
+    }
+
     const orderFlags: number = orderPlace.order!.orderId!.orderFlags;
     const status: OrderPlaceV1_OrderPlacementStatus = orderPlace.placementStatus;
     // Best-effort-opened status should only be sent for short-term orders

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -1,42 +1,34 @@
+import { logger, runFuncWithTimingStat, stats } from '@dydxprotocol-indexer/base';
+import { createSubaccountWebsocketMessage, KafkaTopics } from '@dydxprotocol-indexer/kafka';
 import {
-  logger,
-  runFuncWithTimingStat,
-  stats,
-} from '@dydxprotocol-indexer/base';
-import { KafkaTopics, SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION } from '@dydxprotocol-indexer/kafka';
-import {
-  APIOrderStatus,
-  APIOrderStatusEnum,
+  OrderFromDatabase,
   OrderTable,
   PerpetualMarketFromDatabase,
-  SubaccountMessageContents,
-  SubaccountTable,
-  TimeInForce,
-  apiTranslations,
   perpetualMarketRefresher,
   protocolTranslations,
-  OrderFromDatabase,
-  IsoString,
 } from '@dydxprotocol-indexer/postgres';
 import {
+  CanceledOrdersCache,
   OpenOrdersCache,
   OrderbookLevelsCache,
-  PlaceOrderResult,
   placeOrder,
-  CanceledOrdersCache,
+  PlaceOrderResult,
   StatefulOrderUpdatesCache,
+  convertToRedisOrder,
 } from '@dydxprotocol-indexer/redis';
 import {
-  ORDER_FLAG_SHORT_TERM, getOrderIdHash, isStatefulOrder, requiresImmediateExecution,
+  getOrderIdHash,
+  isStatefulOrder,
+  ORDER_FLAG_SHORT_TERM,
+  requiresImmediateExecution,
 } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
-  OffChainUpdateV1,
   IndexerOrder,
+  OffChainUpdateV1,
   OrderPlaceV1,
   OrderPlaceV1_OrderPlacementStatus,
   OrderUpdateV1,
   RedisOrder,
-  SubaccountMessage,
 } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
 import { Message } from 'kafkajs';
@@ -45,7 +37,6 @@ import config from '../config';
 import { redisClient } from '../helpers/redis/redis-controller';
 import { sendMessageWrapper } from '../lib/send-message-helper';
 import { Handler } from './handler';
-import { convertToRedisOrder, getTriggerPrice } from './helpers';
 
 /**
  * Handler for OrderPlace messages.
@@ -148,7 +139,7 @@ export class OrderPlaceHandler extends Handler {
         await this.sendCachedOrderUpdate(orderUuid);
       }
       const subaccountMessage: Message = {
-        value: this.createSubaccountWebsocketMessage(
+        value: createSubaccountWebsocketMessage(
           redisOrder,
           dbOrder,
           perpetualMarket,
@@ -272,65 +263,6 @@ export class OrderPlaceHandler extends Handler {
     }
   }
 
-  protected createSubaccountWebsocketMessage(
-    redisOrder: RedisOrder,
-    order: OrderFromDatabase | undefined,
-    perpetualMarket: PerpetualMarketFromDatabase,
-    placementStatus: OrderPlaceV1_OrderPlacementStatus,
-  ): Buffer {
-    const orderTIF: TimeInForce = protocolTranslations.protocolOrderTIFToTIF(
-      redisOrder.order!.timeInForce,
-    );
-    const status: APIOrderStatus = (
-      placementStatus === OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_OPENED
-        ? APIOrderStatusEnum.OPEN
-        : APIOrderStatusEnum.BEST_EFFORT_OPENED
-    );
-    const createdAtHeight: string | undefined = order?.createdAtHeight;
-    const updatedAt: IsoString | undefined = order?.updatedAt;
-    const updatedAtHeight: string | undefined = order?.updatedAtHeight;
-    const contents: SubaccountMessageContents = {
-      orders: [
-        {
-          id: OrderTable.orderIdToUuid(redisOrder.order!.orderId!),
-          subaccountId: SubaccountTable.subaccountIdToUuid(
-            redisOrder.order!.orderId!.subaccountId!,
-          ),
-          clientId: redisOrder.order!.orderId!.clientId.toString(),
-          clobPairId: perpetualMarket.clobPairId,
-          side: protocolTranslations.protocolOrderSideToOrderSide(redisOrder.order!.side),
-          size: redisOrder.size,
-          price: redisOrder.price,
-          status,
-          type: protocolTranslations.protocolConditionTypeToOrderType(
-            redisOrder.order!.conditionType,
-          ),
-          timeInForce: apiTranslations.orderTIFToAPITIF(orderTIF),
-          postOnly: apiTranslations.isOrderTIFPostOnly(orderTIF),
-          reduceOnly: redisOrder.order!.reduceOnly,
-          orderFlags: redisOrder.order!.orderId!.orderFlags.toString(),
-          goodTilBlock: protocolTranslations.getGoodTilBlock(redisOrder.order!)
-            ?.toString(),
-          goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(redisOrder.order!),
-          ticker: redisOrder.ticker,
-          ...(createdAtHeight && { createdAtHeight }),
-          ...(updatedAt && { updatedAt }),
-          ...(updatedAtHeight && { updatedAtHeight }),
-          clientMetadata: redisOrder.order!.clientMetadata.toString(),
-          triggerPrice: getTriggerPrice(redisOrder.order!, perpetualMarket),
-        },
-      ],
-    };
-
-    const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({
-      contents: JSON.stringify(contents),
-      subaccountId: redisOrder.order!.orderId!.subaccountId!,
-      version: SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
-    });
-
-    return Buffer.from(Uint8Array.from(SubaccountMessage.encode(subaccountMessage).finish()));
-  }
-
   /**
    * Determine whether to send a subaccount websocket message given the order place.
    * @param orderPlace
@@ -358,7 +290,7 @@ export class OrderPlaceHandler extends Handler {
     if (placeOrderResult.placed === false &&
       placeOrderResult.replaced === false &&
       placementStatus ===
-        OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED) {
+      OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED) {
       return false;
     }
     return true;


### PR DESCRIPTION
### Changelist
Cherry-pick Vulcan change to not send subaccount websocket message

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
