### PR TITLE
[CT-712] send fill amount updates for reverted operations in prepare check state

### DIFF
--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -169,7 +169,26 @@ func PrepareCheckState(
 	// For orders that are filled in the last block, send an orderbook update to the grpc streams.
 	if keeper.GetGrpcStreamingManager().Enabled() {
 		allUpdates := types.NewOffchainUpdates()
+		orderIdsToSend := make(map[types.OrderId]bool)
+
+		// Send an update for reverted local operations.
+		for _, operation := range localValidatorOperationsQueue {
+			if match := operation.GetMatch(); match != nil {
+				orderIdsToSend[match.GetMatchOrders().TakerOrderId] = true
+
+				for _, fill := range match.GetMatchOrders().Fills {
+					orderIdsToSend[fill.MakerOrderId] = true
+				}
+			}
+		}
+
+		// Send an update for orders that were proposed.
 		for _, orderId := range processProposerMatchesEvents.OrderIdsFilledInLastBlock {
+			orderIdsToSend[orderId] = true
+		}
+
+		// Send update.
+		for orderId := range orderIdsToSend {
 			if _, exists := keeper.MemClob.GetOrder(ctx, orderId); exists {
 				orderbookUpdate := keeper.MemClob.GetOrderbookUpdatesForOrderUpdate(ctx, orderId)
 				allUpdates.Append(orderbookUpdate)


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
