### PR TITLE
[TRA-172] change vault state key to not use serialization

### DIFF
--- a/protocol/x/vault/keeper/orders.go
+++ b/protocol/x/vault/keeper/orders.go
@@ -38,8 +38,11 @@ func (k Keeper) RefreshAllVaultOrders(ctx sdk.Context) {
 	totalSharesIterator := k.getTotalSharesIterator(ctx)
 	defer totalSharesIterator.Close()
 	for ; totalSharesIterator.Valid(); totalSharesIterator.Next() {
-		var vaultId types.VaultId
-		k.cdc.MustUnmarshal(totalSharesIterator.Key(), &vaultId)
+		vaultId, err := types.GetVaultIdFromStateKey(totalSharesIterator.Key())
+		if err != nil {
+			log.ErrorLogWithError(ctx, "Failed to get vault ID from state key", err)
+			continue
+		}
 		var totalShares types.NumShares
 		k.cdc.MustUnmarshal(totalSharesIterator.Value(), &totalShares)
 
@@ -53,12 +56,12 @@ func (k Keeper) RefreshAllVaultOrders(ctx sdk.Context) {
 		// Currently only supported vault type is CLOB.
 		switch vaultId.Type {
 		case types.VaultType_VAULT_TYPE_CLOB:
-			err := k.RefreshVaultClobOrders(ctx, vaultId)
+			err := k.RefreshVaultClobOrders(ctx, *vaultId)
 			if err != nil {
-				log.ErrorLogWithError(ctx, "Failed to refresh vault clob orders", err, "vaultId", vaultId)
+				log.ErrorLogWithError(ctx, "Failed to refresh vault clob orders", err, "vaultId", *vaultId)
 			}
 		default:
-			log.ErrorLog(ctx, "Failed to refresh vault orders: unknown vault type", "vaultId", vaultId)
+			log.ErrorLog(ctx, "Failed to refresh vault orders: unknown vault type", "vaultId", *vaultId)
 		}
 	}
 }

--- a/protocol/x/vault/types/vault_id_test.go
+++ b/protocol/x/vault/types/vault_id_test.go
@@ -6,15 +6,114 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 	"github.com/stretchr/testify/require"
 )
 
-func TestToStateKey(t *testing.T) {
-	b, _ := constants.Vault_Clob_0.Marshal()
-	require.Equal(t, b, constants.Vault_Clob_0.ToStateKey())
+func TestToString(t *testing.T) {
+	tests := map[string]struct {
+		// Vault ID.
+		vaultId types.VaultId
+		// Expected string.
+		expectedStr string
+	}{
+		"Vault for Clob Pair 0": {
+			vaultId:     constants.Vault_Clob_0,
+			expectedStr: "VAULT_TYPE_CLOB-0",
+		},
+		"Vault for Clob Pair 1": {
+			vaultId:     constants.Vault_Clob_1,
+			expectedStr: "VAULT_TYPE_CLOB-1",
+		},
+		"Vault, missing type and number": {
+			vaultId:     types.VaultId{},
+			expectedStr: "VAULT_TYPE_UNSPECIFIED-0",
+		},
+		"Vault, missing type": {
+			vaultId: types.VaultId{
+				Number: 1,
+			},
+			expectedStr: "VAULT_TYPE_UNSPECIFIED-1",
+		},
+		"Vault, missing number": {
+			vaultId: types.VaultId{
+				Type: types.VaultType_VAULT_TYPE_CLOB,
+			},
+			expectedStr: "VAULT_TYPE_CLOB-0",
+		},
+	}
 
-	b, _ = constants.Vault_Clob_1.Marshal()
-	require.Equal(t, b, constants.Vault_Clob_1.ToStateKey())
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(
+				t,
+				tc.vaultId.ToString(),
+				tc.expectedStr,
+			)
+		})
+	}
+}
+
+func TestToStateKey(t *testing.T) {
+	require.Equal(
+		t,
+		[]byte("VAULT_TYPE_CLOB-0"),
+		constants.Vault_Clob_0.ToStateKey(),
+	)
+
+	require.Equal(
+		t,
+		[]byte("VAULT_TYPE_CLOB-1"),
+		constants.Vault_Clob_1.ToStateKey(),
+	)
+}
+
+func TestGetVaultIdFromStateKey(t *testing.T) {
+	tests := map[string]struct {
+		// State key.
+		stateKey []byte
+		// Expected vault ID.
+		expectedVaultId types.VaultId
+		// Expected error.
+		expectedErr string
+	}{
+		"Vault for Clob Pair 0": {
+			stateKey:        []byte("VAULT_TYPE_CLOB-0"),
+			expectedVaultId: constants.Vault_Clob_0,
+		},
+		"Vault for Clob Pair 1": {
+			stateKey:        []byte("VAULT_TYPE_CLOB-1"),
+			expectedVaultId: constants.Vault_Clob_1,
+		},
+		"Empty bytes": {
+			stateKey:    []byte{},
+			expectedErr: "stateKey in string must follow format <type>-<number>",
+		},
+		"Nil bytes": {
+			stateKey:    nil,
+			expectedErr: "stateKey in string must follow format <type>-<number>",
+		},
+		"Non-existent vault type": {
+			stateKey:    []byte("VAULT_TYPE_SPOT-1"),
+			expectedErr: "unknown vault type",
+		},
+		"Malformed vault number": {
+			stateKey:    []byte("VAULT_TYPE_CLOB-abc"),
+			expectedErr: "failed to parse number",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			vaultId, err := types.GetVaultIdFromStateKey(tc.stateKey)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedVaultId, *vaultId)
+			}
+		})
+	}
 }
 
 func TestToModuleAccountAddress(t *testing.T) {


### PR DESCRIPTION
### Changelist
Don't use serialization to generate state keys of vault IDs.

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
