### PR TITLE
Fix bugs in pruneable order migration

### DIFF
--- a/protocol/x/clob/keeper/order_state.go
+++ b/protocol/x/clob/keeper/order_state.go
@@ -250,10 +250,11 @@ func (k Keeper) MigratePruneableOrders(ctx sdk.Context) {
 			continue
 		}
 
-		height := binary.BigEndian.Uint32(it.Value())
+		height := binary.BigEndian.Uint32(it.Key())
 		var potentiallyPrunableOrders types.PotentiallyPrunableOrders
 		k.cdc.MustUnmarshal(it.Value(), &potentiallyPrunableOrders)
 		k.AddOrdersForPruning(ctx, potentiallyPrunableOrders.OrderIds, height)
+		store.Delete(it.Key())
 	}
 }
 


### PR DESCRIPTION
### Changelist
- Bug: Wriiting to incorrect height
- Bug: Didn't delete old keys

### Test Plan
- Fixed unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
