### PR TITLE
[SKI-18] Fix localnet

### DIFF
--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -113,17 +113,10 @@ services:
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
   slinky0:
-    image: local:dydxprotocol
-    entrypoint:
-      - slinky
-      - -oracle-config-path
-      - /etc/oracle.json
-      - -market-config-path
-      - /etc/market.json
-      - -host
-      - "0.0.0.0"
-      - -port
-      - "8080"
+    image: ghcr.io/skip-mev/slinky-sidecar:v0.3.1
+    entrypoint: >
+      sh -c "slinky-config --chain dydx --node-http-url http://dydxprotocold0:1317 --oracle-config-path /etc/oracle.json &&
+             slinky --oracle-config-path /etc/oracle.json --update-market-config-path /etc/market.json"
     ports:
       - "8080:8080"
 

--- a/protocol/testing/testnet-local/local.sh
+++ b/protocol/testing/testnet-local/local.sh
@@ -101,7 +101,7 @@ create_validators() {
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
 		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
-		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
+		# update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "30"
 
 		echo "${MNEMONICS[$i]}" | dydxprotocold keys add "${MONIKERS[$i]}" --recover --keyring-backend=test --home "$VAL_HOME_DIR"


### PR DESCRIPTION
### Changelist
Fix localnet run by using the slinky docker image.  
I ended up having to disable the test volatile network because slinky doesn't know about this network and grabbing markets will fail on it. We can have a follow up issue tracking adding this in the sidecar and re-enabling here.

### Test Plan
make localnet-start

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
