### PR TITLE
Enable isolated perpetuals in sim tests.

### DIFF
--- a/protocol/x/perpetuals/simulation/genesis.go
+++ b/protocol/x/perpetuals/simulation/genesis.go
@@ -189,7 +189,12 @@ func RandomizedGenState(simState *module.SimulationState) {
 	for i := 0; i < numPerpetuals; i++ {
 		marketId := marketsForPerp[i]
 
-		marketType := types.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS
+		var marketType types.PerpetualMarketType
+		if simtypes.RandIntBetween(r, 0, 2) == 0 {
+			marketType = types.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS
+		} else {
+			marketType = types.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED
+		}
 		// TODO: add isolated markets when order placements for isolated markets are supported
 
 		perpetuals[i] = types.Perpetual{

--- a/protocol/x/perpetuals/simulation/genesis.go
+++ b/protocol/x/perpetuals/simulation/genesis.go
@@ -190,12 +190,13 @@ func RandomizedGenState(simState *module.SimulationState) {
 		marketId := marketsForPerp[i]
 
 		var marketType types.PerpetualMarketType
+		// RandIntBetween generates integers in the range [min, max), so need [0, 2) to generate integers that are
+		// 0 or 1.
 		if simtypes.RandIntBetween(r, 0, 2) == 0 {
 			marketType = types.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS
 		} else {
 			marketType = types.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED
 		}
-		// TODO: add isolated markets when order placements for isolated markets are supported
 
 		perpetuals[i] = types.Perpetual{
 			Params: types.PerpetualParams{


### PR DESCRIPTION
### Changelist
Updated randomization of perpetuals genesis for simulation to include generating isolated perpetuals.

### Test Plan
Ran non-determinism test multiple times locally.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
