### PR TITLE
[CT-727] avoid state reads when sending updates

### DIFF
--- a/protocol/x/clob/keeper/order_state.go
+++ b/protocol/x/clob/keeper/order_state.go
@@ -6,6 +6,7 @@ import (
 
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/log"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -296,8 +297,13 @@ func (k Keeper) PruneStateFillAmountsForShortTermOrders(
 		allUpdates := types.NewOffchainUpdates()
 		for _, orderId := range prunedOrderIds {
 			if _, exists := k.MemClob.GetOrder(ctx, orderId); exists {
-				orderbookUpdate := k.MemClob.GetOrderbookUpdatesForOrderUpdate(ctx, orderId)
-				allUpdates.Append(orderbookUpdate)
+				if message, success := off_chain_updates.CreateOrderUpdateMessage(
+					ctx,
+					orderId,
+					0, // Total filled quantums is zero because it's been pruned from state.
+				); success {
+					allUpdates.AddUpdateMessage(orderId, message)
+				}
 			}
 		}
 		k.SendOrderbookUpdates(ctx, allUpdates, false)


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
