### PR TITLE
[TRA-108] Update indexer to ingest and return market type for perpetuals

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -41,6 +41,7 @@ import {
   OrderType,
   PerpetualMarketCreateObject,
   PerpetualMarketStatus,
+  PerpetualMarketType,
   PerpetualPositionCreateObject,
   PerpetualPositionStatus,
   PnlTicksCreateObject,
@@ -208,6 +209,7 @@ export const defaultPerpetualMarket: PerpetualMarketCreateObject = {
   subticksPerTick: 100,
   stepBaseQuantums: 10,
   liquidityTierId: 0,
+  marketType: PerpetualMarketType.CROSS,
 };
 export const defaultPerpetualMarket2: PerpetualMarketCreateObject = {
   id: '1',
@@ -225,6 +227,7 @@ export const defaultPerpetualMarket2: PerpetualMarketCreateObject = {
   subticksPerTick: 10,
   stepBaseQuantums: 1,
   liquidityTierId: 0,
+  marketType: PerpetualMarketType.CROSS,
 };
 export const defaultPerpetualMarket3: PerpetualMarketCreateObject = {
   id: '2',
@@ -242,6 +245,7 @@ export const defaultPerpetualMarket3: PerpetualMarketCreateObject = {
   subticksPerTick: 10,
   stepBaseQuantums: 1,
   liquidityTierId: 0,
+  marketType: PerpetualMarketType.CROSS,
 };
 
 export const isolatedPerpetualMarket: PerpetualMarketCreateObject = {
@@ -260,6 +264,7 @@ export const isolatedPerpetualMarket: PerpetualMarketCreateObject = {
   subticksPerTick: 10,
   stepBaseQuantums: 1,
   liquidityTierId: 0,
+  marketType: PerpetualMarketType.ISOLATED,
 };
 
 export const isolatedPerpetualMarket2: PerpetualMarketCreateObject = {
@@ -278,6 +283,7 @@ export const isolatedPerpetualMarket2: PerpetualMarketCreateObject = {
   subticksPerTick: 10,
   stepBaseQuantums: 1,
   liquidityTierId: 0,
+  marketType: PerpetualMarketType.ISOLATED,
 };
 
 // ============== Orders ==============

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240327144524_add_perpetual_markets_market_type.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240327144524_add_perpetual_markets_market_type.ts
@@ -1,0 +1,13 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('perpetual_markets', (table) => {
+    table.string('marketType').notNullable().defaultTo('CROSS');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('perpetual_markets', (table) => {
+    table.dropColumn('marketType');
+  });
+}

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240327144524_add_perpetual_markets_market_type.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240327144524_add_perpetual_markets_market_type.ts
@@ -2,7 +2,7 @@ import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.table('perpetual_markets', (table) => {
-    table.string('marketType').notNullable().defaultTo('CROSS');
+    table.enum('marketType', ['CROSS', 'ISOLATED']).notNullable().defaultTo('CROSS');
   });
 }
 

--- a/indexer/packages/postgres/src/models/perpetual-market-model.ts
+++ b/indexer/packages/postgres/src/models/perpetual-market-model.ts
@@ -8,7 +8,7 @@ import {
   NumericPattern,
 } from '../lib/validators';
 import {
-  PerpetualMarketStatus,
+  PerpetualMarketStatus, PerpetualMarketType,
 } from '../types';
 
 export default class PerpetualMarketModel extends Model {
@@ -66,6 +66,7 @@ export default class PerpetualMarketModel extends Model {
         'subticksPerTick',
         'stepBaseQuantums',
         'liquidityTierId',
+        'marketType',
       ],
       properties: {
         id: { type: 'string', pattern: IntegerPattern },
@@ -83,6 +84,7 @@ export default class PerpetualMarketModel extends Model {
         subticksPerTick: { type: 'integer' },
         stepBaseQuantums: { type: 'integer' },
         liquidityTierId: { type: 'integer' },
+        marketType: { type: 'string' },
       },
     };
   }
@@ -110,6 +112,7 @@ export default class PerpetualMarketModel extends Model {
       subticksPerTick: 'integer',
       stepBaseQuantums: 'integer',
       liquidityTierId: 'integer',
+      marketType: 'string',
     };
   }
 
@@ -142,4 +145,6 @@ export default class PerpetualMarketModel extends Model {
   stepBaseQuantums!: number;
 
   liquidityTierId!: number;
+
+  marketType!: PerpetualMarketType;
 }

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -7,7 +7,7 @@ import { FillType, Liquidity } from './fill-types';
 import {
   OrderSide, OrderStatus, OrderType, TimeInForce,
 } from './order-types';
-import { PerpetualMarketStatus } from './perpetual-market-types';
+import { PerpetualMarketStatus, PerpetualMarketType } from './perpetual-market-types';
 import { PerpetualPositionStatus } from './perpetual-position-types';
 import { PositionSide } from './position-types';
 import { TradingRewardAggregationPeriod } from './trading-reward-aggregation-types';
@@ -91,6 +91,7 @@ export interface PerpetualMarketFromDatabase {
   subticksPerTick: number;
   stepBaseQuantums: number;
   liquidityTierId: number;
+  marketType: PerpetualMarketType;
 }
 
 export interface FillFromDatabase {

--- a/indexer/packages/postgres/src/types/perpetual-market-types.ts
+++ b/indexer/packages/postgres/src/types/perpetual-market-types.ts
@@ -16,6 +16,7 @@ export interface PerpetualMarketCreateObject {
   subticksPerTick: number;
   stepBaseQuantums: number;
   liquidityTierId: number;
+  marketType: PerpetualMarketType;
 }
 
 export interface PerpetualMarketUpdateObject {
@@ -61,4 +62,9 @@ export enum PerpetualMarketStatus {
   POST_ONLY = 'POST_ONLY',
   INITIALIZING = 'INITIALIZING',
   FINAL_SETTLEMENT = 'FINAL_SETTLEMENT',
+}
+
+export enum PerpetualMarketType {
+  CROSS = 'CROSS',
+  ISOLATED = 'ISOLATED',
 }

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -5,7 +5,7 @@ import {
   OrderStatus,
   OrderType,
 } from './order-types';
-import { PerpetualMarketStatus } from './perpetual-market-types';
+import { PerpetualMarketStatus, PerpetualMarketType } from './perpetual-market-types';
 import { PerpetualPositionStatus } from './perpetual-position-types';
 import { PositionSide } from './position-types';
 import { TradeType } from './trade-types';
@@ -212,6 +212,7 @@ export interface TradingPerpetualMarketMessage {
   atomicResolution?: number;
   subticksPerTick?: number;
   stepBaseQuantums?: number;
+  marketType?: PerpetualMarketType;
 
   // Fields that are likely to change
   priceChange24H?: string;

--- a/indexer/services/comlink/__tests__/lib/request-helpers/request-transformer.test.ts
+++ b/indexer/services/comlink/__tests__/lib/request-helpers/request-transformer.test.ts
@@ -77,6 +77,7 @@ describe('request-transformer', () => {
           stepSize: Big(10).pow(-9).toFixed(), // 10 * 1e-10 = 1e-9
           stepBaseQuantums: perpetualMarket.stepBaseQuantums,
           subticksPerTick: perpetualMarket.subticksPerTick,
+          marketType: perpetualMarket.marketType,
         },
       );
     });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1720,7 +1720,8 @@ fetch('https://dydx-testnet.imperator.co/v4/perpetualMarkets',
       "tickSize": "string",
       "stepSize": "string",
       "stepBaseQuantums": 0,
-      "subticksPerTick": 0
+      "subticksPerTick": 0,
+      "marketType": "CROSS"
     },
     "property2": {
       "clobPairId": "string",
@@ -1739,7 +1740,8 @@ fetch('https://dydx-testnet.imperator.co/v4/perpetualMarkets',
       "tickSize": "string",
       "stepSize": "string",
       "stepBaseQuantums": 0,
-      "subticksPerTick": 0
+      "subticksPerTick": 0,
+      "marketType": "CROSS"
     }
   }
 }
@@ -3719,6 +3721,31 @@ or
 |*anonymous*|INITIALIZING|
 |*anonymous*|FINAL_SETTLEMENT|
 
+## PerpetualMarketType
+
+<a id="schemaperpetualmarkettype"></a>
+<a id="schema_PerpetualMarketType"></a>
+<a id="tocSperpetualmarkettype"></a>
+<a id="tocsperpetualmarkettype"></a>
+
+```json
+"CROSS"
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string|false|none|none|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|*anonymous*|CROSS|
+|*anonymous*|ISOLATED|
+
 ## PerpetualMarketResponseObject
 
 <a id="schemaperpetualmarketresponseobject"></a>
@@ -3744,7 +3771,8 @@ or
   "tickSize": "string",
   "stepSize": "string",
   "stepBaseQuantums": 0,
-  "subticksPerTick": 0
+  "subticksPerTick": 0,
+  "marketType": "CROSS"
 }
 
 ```
@@ -3770,6 +3798,7 @@ or
 |stepSize|string|true|none|none|
 |stepBaseQuantums|number(double)|true|none|none|
 |subticksPerTick|number(double)|true|none|none|
+|marketType|[PerpetualMarketType](#schemaperpetualmarkettype)|true|none|none|
 
 ## PerpetualMarketResponse
 
@@ -3798,7 +3827,8 @@ or
       "tickSize": "string",
       "stepSize": "string",
       "stepBaseQuantums": 0,
-      "subticksPerTick": 0
+      "subticksPerTick": 0,
+      "marketType": "CROSS"
     },
     "property2": {
       "clobPairId": "string",
@@ -3817,7 +3847,8 @@ or
       "tickSize": "string",
       "stepSize": "string",
       "stepBaseQuantums": 0,
-      "subticksPerTick": 0
+      "subticksPerTick": 0,
+      "marketType": "CROSS"
     }
   }
 }

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -874,6 +874,13 @@
         ],
         "type": "string"
       },
+      "PerpetualMarketType": {
+        "enum": [
+          "CROSS",
+          "ISOLATED"
+        ],
+        "type": "string"
+      },
       "PerpetualMarketResponseObject": {
         "properties": {
           "clobPairId": {
@@ -931,6 +938,9 @@
           "subticksPerTick": {
             "type": "number",
             "format": "double"
+          },
+          "marketType": {
+            "$ref": "#/components/schemas/PerpetualMarketType"
           }
         },
         "required": [
@@ -950,7 +960,8 @@
           "tickSize",
           "stepSize",
           "stepBaseQuantums",
-          "subticksPerTick"
+          "subticksPerTick",
+          "marketType"
         ],
         "type": "object",
         "additionalProperties": false

--- a/indexer/services/comlink/src/request-helpers/request-transformer.ts
+++ b/indexer/services/comlink/src/request-helpers/request-transformer.ts
@@ -354,6 +354,7 @@ export function perpetualMarketToResponseObject(
     stepSize: protocolTranslations.getStepSize(perpetualMarket),
     stepBaseQuantums: perpetualMarket.stepBaseQuantums,
     subticksPerTick: perpetualMarket.subticksPerTick,
+    marketType: perpetualMarket.marketType,
   };
 }
 

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -15,6 +15,7 @@ import {
   OrderStatus,
   OrderType,
   PerpetualMarketStatus,
+  PerpetualMarketType,
   PerpetualPositionFromDatabase,
   PerpetualPositionStatus,
   PositionSide,
@@ -267,6 +268,7 @@ export interface PerpetualMarketResponseObject {
   stepSize: string;
   stepBaseQuantums: number;
   subticksPerTick: number;
+  marketType: PerpetualMarketType;
 }
 
 /* ------- ORDERBOOK TYPES ------- */

--- a/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
@@ -51,6 +51,9 @@ import {
   PerpetualMarketCreateEventV1,
   DeleveragingEventV1,
 } from '@dydxprotocol-indexer/v4-protos';
+import {
+  PerpetualMarketType,
+} from '@dydxprotocol-indexer/v4-protos/build/codegen/dydxprotocol/indexer/protocol/v1/perpetual';
 import { IHeaders, Message, ProducerRecord } from 'kafkajs';
 import _ from 'lodash';
 
@@ -902,5 +905,21 @@ export function expectPerpetualMarket(
     subticksPerTick: perpetual.subticksPerTick,
     stepBaseQuantums: Number(perpetual.stepBaseQuantums),
     liquidityTierId: perpetual.liquidityTier,
+    marketType: eventPerpetualMarketTypeToIndexerPerpetualMarketType(
+      perpetual.marketType,
+    ),
   }));
+}
+
+function eventPerpetualMarketTypeToIndexerPerpetualMarketType(
+  perpetualMarketType: PerpetualMarketType,
+): string {
+  switch (perpetualMarketType) {
+    case PerpetualMarketType.PERPETUAL_MARKET_TYPE_CROSS:
+      return 'CROSS';
+    case PerpetualMarketType.PERPETUAL_MARKET_TYPE_ISOLATED:
+      return 'ISOLATED';
+    default:
+      throw new Error(`Unknown perpetual market type: ${perpetualMarketType}`);
+  }
 }

--- a/indexer/services/ender/__tests__/helpers/postgres-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/postgres-helpers.ts
@@ -15,5 +15,6 @@ export function expectPerpetualMarketMatchesEvent(
     subticksPerTick: perpetual.subticksPerTick,
     stepBaseQuantums: Number(perpetual.stepBaseQuantums),
     liquidityTierId: perpetual.liquidityTier,
+    // marketType: perpetual.marketType,
   }));
 }

--- a/indexer/services/ender/__tests__/helpers/postgres-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/postgres-helpers.ts
@@ -15,6 +15,5 @@ export function expectPerpetualMarketMatchesEvent(
     subticksPerTick: perpetual.subticksPerTick,
     stepBaseQuantums: Number(perpetual.stepBaseQuantums),
     liquidityTierId: perpetual.liquidityTier,
-    // marketType: perpetual.marketType,
   }));
 }

--- a/indexer/services/ender/__tests__/validators/asset-validator.test.ts
+++ b/indexer/services/ender/__tests__/validators/asset-validator.test.ts
@@ -11,8 +11,14 @@ import {
 } from '../helpers/indexer-proto-helpers';
 import { expectDidntLogError } from '../helpers/validator-helpers';
 import { AssetValidator } from '../../src/validators/asset-validator';
+import { createPostgresFunctions } from '../../src/helpers/postgres/postgres-functions';
 
 describe('asset-validator', () => {
+  beforeAll(async () => {
+    await dbHelpers.migrate();
+    await createPostgresFunctions();
+  });
+
   beforeEach(async () => {
     await testMocks.seedData();
     jest.spyOn(logger, 'error');
@@ -21,6 +27,11 @@ describe('asset-validator', () => {
   afterEach(async () => {
     await dbHelpers.clearData();
     jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await dbHelpers.teardown();
+    jest.resetAllMocks();
   });
 
   describe('validate', () => {

--- a/indexer/services/ender/src/helpers/postgres/postgres-functions.ts
+++ b/indexer/services/ender/src/helpers/postgres/postgres-functions.ts
@@ -86,6 +86,7 @@ const HELPER_SCRIPTS: string[] = [
   'dydx_uuid_from_trading_rewards_parts.sql',
   'dydx_uuid_from_transaction_parts.sql',
   'dydx_uuid_from_transfer_parts.sql',
+  'dydx_protocol_market_type_to_perpetual_market_type.sql',
 ];
 
 const MAIN_SCRIPTS: string[] = [

--- a/indexer/services/ender/src/scripts/handlers/dydx_perpetual_market_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_perpetual_market_handler.sql
@@ -26,6 +26,7 @@ BEGIN
     perpetual_market_record."subticksPerTick" = (event_data->'subticksPerTick')::integer;
     perpetual_market_record."stepBaseQuantums" = dydx_from_jsonlib_long(event_data->'stepBaseQuantums');
     perpetual_market_record."liquidityTierId" = (event_data->'liquidityTier')::integer;
+    perpetual_market_record."marketType" = dydx_protocol_market_type_to_perpetual_market_type(event_data->'marketType');
 
     INSERT INTO perpetual_markets VALUES (perpetual_market_record.*) RETURNING * INTO perpetual_market_record;
 

--- a/indexer/services/ender/src/scripts/helpers/dydx_protocol_market_type_to_perpetual_market_type.sql
+++ b/indexer/services/ender/src/scripts/helpers/dydx_protocol_market_type_to_perpetual_market_type.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION dydx_protocol_market_type_to_perpetual_market_type(marketType jsonb)
+    RETURNS text AS $$
+
+BEGIN
+    CASE marketType
+        WHEN '1'::jsonb THEN RETURN 'CROSS'; /** MARKET_TYPE_CROSS */
+        WHEN '2'::jsonb THEN RETURN 'ISOLATED'; /** MARKET_TYPE_ISOLATED */
+        ELSE RAISE EXCEPTION 'Invalid market type: %', marketType;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;


### PR DESCRIPTION
### Changelist
Updates to postgres, ender and comlink to add market type for perpetuals

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
