### PR TITLE
Enable rate limiting in socks by default

### DIFF
--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -33,7 +33,7 @@ export const configSchema = {
   WS_HEARTBEAT_INTERVAL_MS: parseInteger(),
   WS_HEARTBEAT_TIMEOUT_MS: parseInteger(),
 
-  RATE_LIMIT_ENABLED: parseBoolean({ default: false }),
+  RATE_LIMIT_ENABLED: parseBoolean({ default: true }),
   RATE_LIMIT_SUBSCRIBE_POINTS: parseNumber({ default: 2 }),
   RATE_LIMIT_SUBSCRIBE_DURATION_MS: parseInteger({ default: 1000 }),
   RATE_LIMIT_PING_POINTS: parseNumber({ default: 5 }),


### PR DESCRIPTION
### Changelist
Enable rate limiting in socks by default

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
