### PR TITLE
[TRA-105] Add subaccountNumber to PerpetualPositionResponseObject

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
@@ -106,6 +106,7 @@ describe('addresses-controller#V4', () => {
               createdAtHeight: testConstants.defaultPerpetualPosition.createdAtHeight,
               exitPrice: null,
               closedAt: null,
+              subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
             },
           },
           assetPositions: {
@@ -266,6 +267,7 @@ describe('addresses-controller#V4', () => {
                 createdAtHeight: testConstants.defaultPerpetualPosition.createdAtHeight,
                 exitPrice: null,
                 closedAt: null,
+                subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
               },
             },
             assetPositions: {
@@ -453,6 +455,7 @@ describe('addresses-controller#V4', () => {
                   createdAtHeight: testConstants.defaultPerpetualPosition.createdAtHeight,
                   exitPrice: null,
                   closedAt: null,
+                  subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
                 },
               },
               assetPositions: {

--- a/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-positions-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-positions-controller.test.ts
@@ -89,6 +89,7 @@ describe('perpetual-positions-controller#V4', () => {
         createdAt: testConstants.createdDateTime.toISO(),
         closedAt: null,
         createdAtHeight: testConstants.createdHeight,
+        subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
       };
 
       expect(response.body.positions).toEqual(
@@ -140,6 +141,7 @@ describe('perpetual-positions-controller#V4', () => {
         createdAt: testConstants.createdDateTime.toISO(),
         closedAt: null,
         createdAtHeight: testConstants.createdHeight,
+        subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
       };
 
       expect(response.body.positions).toEqual(
@@ -189,6 +191,7 @@ describe('perpetual-positions-controller#V4', () => {
         createdAt: testConstants.createdDateTime.toISO(),
         closedAt: null,
         createdAtHeight: testConstants.createdHeight,
+        subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
       };
 
       expect(response.body.positions).toEqual(

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -85,7 +85,8 @@ fetch('https://dydx-testnet.imperator.co/v4/addresses/{address}',
           "netFunding": "string",
           "unrealizedPnl": "string",
           "closedAt": null,
-          "exitPrice": "string"
+          "exitPrice": "string",
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -102,7 +103,8 @@ fetch('https://dydx-testnet.imperator.co/v4/addresses/{address}',
           "netFunding": "string",
           "unrealizedPnl": "string",
           "closedAt": null,
-          "exitPrice": "string"
+          "exitPrice": "string",
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -211,7 +213,8 @@ fetch('https://dydx-testnet.imperator.co/v4/addresses/{address}/subaccountNumber
       "netFunding": "string",
       "unrealizedPnl": "string",
       "closedAt": "string",
-      "exitPrice": "string"
+      "exitPrice": "string",
+      "subaccountNumber": 0
     },
     "property2": {
       "market": "string",
@@ -228,7 +231,8 @@ fetch('https://dydx-testnet.imperator.co/v4/addresses/{address}/subaccountNumber
       "netFunding": "string",
       "unrealizedPnl": "string",
       "closedAt": "string",
-      "exitPrice": "string"
+      "exitPrice": "string",
+      "subaccountNumber": 0
     }
   },
   "assetPositions": {
@@ -340,7 +344,8 @@ fetch('https://dydx-testnet.imperator.co/v4/addresses/{address}/parentSubaccount
           "netFunding": "string",
           "unrealizedPnl": "string",
           "closedAt": null,
-          "exitPrice": "string"
+          "exitPrice": "string",
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -357,7 +362,8 @@ fetch('https://dydx-testnet.imperator.co/v4/addresses/{address}/parentSubaccount
           "netFunding": "string",
           "unrealizedPnl": "string",
           "closedAt": null,
-          "exitPrice": "string"
+          "exitPrice": "string",
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -1838,7 +1844,8 @@ fetch('https://dydx-testnet.imperator.co/v4/perpetualPositions?address=string&su
       "netFunding": "string",
       "unrealizedPnl": "string",
       "closedAt": "string",
-      "exitPrice": "string"
+      "exitPrice": "string",
+      "subaccountNumber": 0
     }
   ]
 }
@@ -2348,7 +2355,8 @@ This operation does not require authentication
   "netFunding": "string",
   "unrealizedPnl": "string",
   "closedAt": "string",
-  "exitPrice": "string"
+  "exitPrice": "string",
+  "subaccountNumber": 0
 }
 
 ```
@@ -2372,6 +2380,7 @@ This operation does not require authentication
 |unrealizedPnl|string|true|none|none|
 |closedAt|[IsoString](#schemaisostring)¦null|false|none|none|
 |exitPrice|string¦null|false|none|none|
+|subaccountNumber|number(double)|true|none|none|
 
 ## PerpetualPositionsMap
 
@@ -2397,7 +2406,8 @@ This operation does not require authentication
     "netFunding": "string",
     "unrealizedPnl": "string",
     "closedAt": "string",
-    "exitPrice": "string"
+    "exitPrice": "string",
+    "subaccountNumber": 0
   },
   "property2": {
     "market": "string",
@@ -2414,7 +2424,8 @@ This operation does not require authentication
     "netFunding": "string",
     "unrealizedPnl": "string",
     "closedAt": "string",
-    "exitPrice": "string"
+    "exitPrice": "string",
+    "subaccountNumber": 0
   }
 }
 
@@ -2516,7 +2527,8 @@ This operation does not require authentication
       "netFunding": "string",
       "unrealizedPnl": "string",
       "closedAt": "string",
-      "exitPrice": "string"
+      "exitPrice": "string",
+      "subaccountNumber": 0
     },
     "property2": {
       "market": "string",
@@ -2533,7 +2545,8 @@ This operation does not require authentication
       "netFunding": "string",
       "unrealizedPnl": "string",
       "closedAt": "string",
-      "exitPrice": "string"
+      "exitPrice": "string",
+      "subaccountNumber": 0
     }
   },
   "assetPositions": {
@@ -2600,7 +2613,8 @@ This operation does not require authentication
           "netFunding": "string",
           "unrealizedPnl": "string",
           "closedAt": null,
-          "exitPrice": "string"
+          "exitPrice": "string",
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -2617,7 +2631,8 @@ This operation does not require authentication
           "netFunding": "string",
           "unrealizedPnl": "string",
           "closedAt": null,
-          "exitPrice": "string"
+          "exitPrice": "string",
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -2686,7 +2701,8 @@ This operation does not require authentication
           "netFunding": "string",
           "unrealizedPnl": "string",
           "closedAt": null,
-          "exitPrice": "string"
+          "exitPrice": "string",
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -2703,7 +2719,8 @@ This operation does not require authentication
           "netFunding": "string",
           "unrealizedPnl": "string",
           "closedAt": null,
-          "exitPrice": "string"
+          "exitPrice": "string",
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -3856,7 +3873,8 @@ or
       "netFunding": "string",
       "unrealizedPnl": "string",
       "closedAt": "string",
-      "exitPrice": "string"
+      "exitPrice": "string",
+      "subaccountNumber": 0
     }
   ]
 }

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -76,6 +76,10 @@
           "exitPrice": {
             "type": "string",
             "nullable": true
+          },
+          "subaccountNumber": {
+            "type": "number",
+            "format": "double"
           }
         },
         "required": [
@@ -91,7 +95,8 @@
           "sumOpen",
           "sumClose",
           "netFunding",
-          "unrealizedPnl"
+          "unrealizedPnl",
+          "subaccountNumber"
         ],
         "type": "object",
         "additionalProperties": false

--- a/indexer/services/comlink/src/controllers/api/v4/addresses-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/addresses-controller.ts
@@ -509,6 +509,7 @@ async function getSubaccountResponse(
         perpetualPosition,
         perpetualMarketsMap,
         marketIdToMarket,
+        subaccount.subaccountNumber,
       );
     },
   );

--- a/indexer/services/comlink/src/controllers/api/v4/perpetual-positions-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/perpetual-positions-controller.ts
@@ -141,7 +141,12 @@ class PerpetualPositionsController extends Controller {
 
     return {
       positions: updatedPerpetualPositions.map((position: PerpetualPositionWithFunding) => {
-        return perpetualPositionToResponseObject(position, perpetualMarketsMap, marketIdToMarket);
+        return perpetualPositionToResponseObject(
+          position,
+          perpetualMarketsMap,
+          marketIdToMarket,
+          subaccountNumber,
+        );
       }),
     };
   }
@@ -179,11 +184,14 @@ router.get(
       createdBeforeOrAt,
     }: PerpetualPositionRequest = matchedData(req) as PerpetualPositionRequest;
 
+    // The schema checks allow subaccountNumber to be a string, but we know it's a number here.
+    const subaccountNum: number = +subaccountNumber;
+
     try {
       const controller: PerpetualPositionsController = new PerpetualPositionsController();
       const response: PerpetualPositionResponse = await controller.listPositions(
         address,
-        subaccountNumber,
+        subaccountNum,
         status,
         limit,
         createdBeforeOrAtHeight,

--- a/indexer/services/comlink/src/request-helpers/request-transformer.ts
+++ b/indexer/services/comlink/src/request-helpers/request-transformer.ts
@@ -73,6 +73,7 @@ export function perpetualPositionToResponseObject(
   position: PerpetualPositionWithFunding,
   perpetualMarketsMap: PerpetualMarketsMap,
   marketsMap: MarketsMap,
+  subaccountNumber: number,
 ): PerpetualPositionResponseObject {
   // Realized pnl is calculated from the difference in price between the average entry/exit price
   // (order depending on side of the position) multiplied by amount of the position that was closed
@@ -104,6 +105,7 @@ export function perpetualPositionToResponseObject(
     sumOpen: position.sumOpen,
     sumClose: position.sumClose,
     netFunding: netFunding.toFixed(),
+    subaccountNumber,
   };
 }
 

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -100,6 +100,7 @@ export interface PerpetualPositionResponseObject {
   unrealizedPnl: string;
   closedAt?: IsoString | null;
   exitPrice?: string | null;
+  subaccountNumber: number;
 }
 
 export type PerpetualPositionsMap = { [market: string]: PerpetualPositionResponseObject };


### PR DESCRIPTION
### Changelist
Add subaccountNumber field to PerpetualPositionResponseObject

### Test Plan
Existing unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
