### PR TITLE
Remove rate-limiting on pings in socks

### DIFF
--- a/indexer/services/socks/src/lib/ping.ts
+++ b/indexer/services/socks/src/lib/ping.ts
@@ -1,59 +1,14 @@
-import { logger } from '@dydxprotocol-indexer/base';
-
-import config from '../config';
-import { createErrorMessage, createPongMessage } from '../helpers/message';
+import { createPongMessage } from '../helpers/message';
 import { sendMessage } from '../helpers/wss';
-import {
-  Connection,
-  PingMessage,
-} from '../types';
-import { WS_CLOSE_CODE_POLICY_VIOLATION } from './constants';
-import { RateLimiter } from './rate-limit';
+import { Connection, PingMessage } from '../types';
 
 export class PingHandler {
-  private rateLimiter: RateLimiter;
-
-  constructor() {
-    this.rateLimiter = new RateLimiter({
-      points: config.RATE_LIMIT_PING_POINTS,
-      durationMs: config.RATE_LIMIT_PING_DURATION_MS,
-    });
-  }
 
   public handlePing(
     pingMessage: PingMessage,
     connection: Connection,
     connectionId: string,
   ): void {
-    const duration: number = this.rateLimiter.rateLimit({
-      connectionId,
-      key: 'ping',
-    });
-    if (duration > 0) {
-      sendMessage(
-        connection.ws,
-        connectionId,
-        createErrorMessage(
-          'Too many ping messages. Please reconnect and try again.',
-          connectionId,
-          connection.messageId,
-        ),
-      );
-
-      // Violated rate-limit; disconnect.
-      connection.ws.close(
-        WS_CLOSE_CODE_POLICY_VIOLATION,
-        JSON.stringify({ message: 'Rate limited' }),
-      );
-
-      logger.info({
-        at: 'ping#handlePing',
-        message: 'Connection closed due to violating rate limit',
-        connectionId,
-      });
-      return;
-    }
-
     sendMessage(
       connection.ws,
       connectionId,
@@ -63,11 +18,5 @@ export class PingHandler {
         pingMessage.id,
       ),
     );
-  }
-
-  public handleDisconnect(
-    connectionId: string,
-  ): void {
-    this.rateLimiter.removeConnection(connectionId);
   }
 }

--- a/indexer/services/socks/src/websocket/index.ts
+++ b/indexer/services/socks/src/websocket/index.ts
@@ -396,7 +396,6 @@ export class Index {
 
       // Delete subscription data.
       this.subscriptions.remove(connectionId);
-      this.pingHandler.handleDisconnect(connectionId);
       this.invalidMessageHandler.handleDisconnect(connectionId);
       delete this.connections[connectionId];
     } catch (error) {


### PR DESCRIPTION
### Changelist

Remove rate-limiting on pings in socks.

From this [group by query](https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-172800~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*2fConnection*20closed*20due*20to*20violating*20rate*20limit*2f*0a*7c*20stats*20count*28*29*20by*20*60at*60*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*201000~queryId~'b1846cbe51f0458d-2b2f6e28-4e93fd-128abca3-a1b1e9cd74b448e125de1f7~source~(~'*2fecs*2fmainnet-indexer-apne1-socks))$26tab$3Dlogs), 99% of rate-limit violations are from pings.

### Test Plan


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
