### PR TITLE
Use sample rate with stream destroyed stats.

### DIFF
--- a/indexer/services/socks/src/helpers/wss.ts
+++ b/indexer/services/socks/src/helpers/wss.ts
@@ -111,6 +111,8 @@ export function sendMessageString(
         // Don't log an error as this can be expected if the client disconnects.
         stats.increment(
           `${config.SERVICE_NAME}.ws_send.write_epipe_errors`,
+          1,
+          config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
         );
       } else if (error?.message.includes?.('write ECONNRESET')) {
         // This error means that the client abruptly disconnected without sending a proper "close"
@@ -118,6 +120,8 @@ export function sendMessageString(
         // immediately.
         stats.increment(
           `${config.SERVICE_NAME}.ws_send.write_econn_reset_errors`,
+          1,
+          config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
         );
         try {
           ws.close(
@@ -138,6 +142,7 @@ export function sendMessageString(
             stats.increment(
               `${config.SERVICE_NAME}.ws_send.stream_destroyed_errors`,
               1,
+              config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
               { action: 'close' },
             );
           } else {
@@ -151,6 +156,7 @@ export function sendMessageString(
         stats.increment(
           `${config.SERVICE_NAME}.ws_send.stream_destroyed_errors`,
           1,
+          config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
           { action: 'send' },
         );
       } else {


### PR DESCRIPTION
### Changelist
Use sample rate with stats for messages sent to a destroyed stream to reduce # of stats sent.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
