### PR TITLE
[TRA-104] Add subaccountNumber to the OrderResponseObject

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/orders-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/orders-controller.test.ts
@@ -76,6 +76,7 @@ describe('orders-controller#V4', () => {
           ...testConstants.defaultOrder,
           id: testConstants.defaultOrderId,
         },
+        testConstants.defaultSubaccount.subaccountNumber,
       ));
     });
 
@@ -117,6 +118,7 @@ describe('orders-controller#V4', () => {
             ...testConstants.defaultOrder,
             id: testConstants.defaultOrderId,
           },
+          testConstants.defaultSubaccount.subaccountNumber,
           redisTestConstants.defaultRedisOrder,
         ),
       );
@@ -391,19 +393,20 @@ describe('orders-controller#V4', () => {
         postgresOrderToResponseObject({
           ...testConstants.defaultOrderGoodTilBlockTime,
           id: getUuidForTest(testConstants.defaultOrderGoodTilBlockTime),
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
         postgresOrderToResponseObject({
           ...secondOrderGoodTilBlockTime,
           id: getUuidForTest(secondOrderGoodTilBlockTime),
-        }),
+        },
+        testConstants.defaultSubaccount.subaccountNumber),
         postgresOrderToResponseObject({
           ...secondOrder,
           id: getUuidForTest(secondOrder),
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
         postgresOrderToResponseObject({
           ...testConstants.defaultOrder,
           id: testConstants.defaultOrderId,
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
       ]);
 
       const response2: request.Response = await sendRequest({
@@ -418,19 +421,19 @@ describe('orders-controller#V4', () => {
         postgresOrderToResponseObject({
           ...testConstants.defaultOrder,
           id: testConstants.defaultOrderId,
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
         postgresOrderToResponseObject({
           ...secondOrder,
           id: getUuidForTest(secondOrder),
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
         postgresOrderToResponseObject({
           ...secondOrderGoodTilBlockTime,
           id: getUuidForTest(secondOrderGoodTilBlockTime),
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
         postgresOrderToResponseObject({
           ...testConstants.defaultOrderGoodTilBlockTime,
           id: getUuidForTest(testConstants.defaultOrderGoodTilBlockTime),
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
       ]);
     });
 
@@ -449,11 +452,11 @@ describe('orders-controller#V4', () => {
         postgresOrderToResponseObject({
           ...testConstants.defaultOrder,
           id: testConstants.defaultOrderId,
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
         postgresOrderToResponseObject({
           ...untriggeredOrder,
           id: untriggeredOrderId,
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
       ]);
 
       const response2 = await sendRequest({
@@ -469,7 +472,7 @@ describe('orders-controller#V4', () => {
         postgresOrderToResponseObject({
           ...untriggeredOrder,
           id: untriggeredOrderId,
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
       ]);
     });
 
@@ -503,6 +506,7 @@ describe('orders-controller#V4', () => {
             ...testConstants.defaultOrder,
             id: testConstants.defaultOrderId,
           },
+          testConstants.defaultSubaccount.subaccountNumber,
           redisTestConstants.defaultRedisOrder,
         ),
       ]);
@@ -525,7 +529,7 @@ describe('orders-controller#V4', () => {
             filledOrder.clobPairId,
             filledOrder.orderFlags,
           ),
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
       ]);
 
       response = await sendRequest({
@@ -554,7 +558,7 @@ describe('orders-controller#V4', () => {
         postgresOrderToResponseObject({
           ...untriggeredOrder,
           id: untriggeredOrderId,
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
       ]);
 
       response = await sendRequest({
@@ -572,12 +576,13 @@ describe('orders-controller#V4', () => {
             ...testConstants.defaultOrder,
             id: testConstants.defaultOrderId,
           },
+          testConstants.defaultSubaccount.subaccountNumber,
           redisTestConstants.defaultRedisOrder,
         ),
         postgresOrderToResponseObject({
           ...untriggeredOrder,
           id: untriggeredOrderId,
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
       ]);
     });
 
@@ -614,25 +619,27 @@ describe('orders-controller#V4', () => {
         postgresOrderToResponseObject({
           ...secondOrderGoodTilBlockTime,
           id: getUuidForTest(secondOrderGoodTilBlockTime),
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
         redisOrderToResponseObject(newerRedisOrderGoodTilBlockTime),
         postgresAndRedisOrderToResponseObject(
           {
             ...testConstants.defaultOrderGoodTilBlockTime,
             id: getUuidForTest(testConstants.defaultOrderGoodTilBlockTime),
           },
+          testConstants.defaultSubaccount.subaccountNumber,
           redisTestConstants.defaultRedisOrderGoodTilBlockTime,
         ),
         postgresOrderToResponseObject({
           ...secondOrder,
           id: getUuidForTest(secondOrder),
-        }),
+        }, testConstants.defaultSubaccount.subaccountNumber),
         redisOrderToResponseObject(redisOrderWithDifferentMarket),
         postgresAndRedisOrderToResponseObject(
           {
             ...testConstants.defaultOrder,
             id: testConstants.defaultOrderId,
           },
+          testConstants.defaultSubaccount.subaccountNumber,
           redisTestConstants.defaultRedisOrder,
         ),
       ]);

--- a/indexer/services/comlink/__tests__/lib/request-helpers/request-transformer.test.ts
+++ b/indexer/services/comlink/__tests__/lib/request-helpers/request-transformer.test.ts
@@ -119,6 +119,7 @@ describe('request-transformer', () => {
       };
       const responseObject: OrderResponseObject | undefined = postgresAndRedisOrderToResponseObject(
         filledOrder,
+        testConstants.defaultSubaccount.subaccountNumber,
         redisTestConstants.defaultRedisOrder,
       );
       const expectedRedisOrderTIF: TimeInForce = protocolTranslations.protocolOrderTIFToTIF(
@@ -127,13 +128,19 @@ describe('request-transformer', () => {
 
       expect(responseObject).not.toBeUndefined();
       expect(responseObject).not.toEqual(
-        postgresOrderToResponseObject(filledOrder),
+        postgresOrderToResponseObject(
+          filledOrder,
+          testConstants.defaultSubaccount.subaccountNumber,
+        ),
       );
       expect(responseObject).not.toEqual(
         redisOrderToResponseObject(redisTestConstants.defaultRedisOrder),
       );
       expect(responseObject).toEqual({
-        ...postgresOrderToResponseObject(filledOrder),
+        ...postgresOrderToResponseObject(
+          filledOrder,
+          testConstants.defaultSubaccount.subaccountNumber,
+        ),
         size: redisTestConstants.defaultRedisOrder.size,
         price: redisTestConstants.defaultRedisOrder.price,
         timeInForce: apiTranslations.orderTIFToAPITIF(expectedRedisOrderTIF),
@@ -152,7 +159,7 @@ describe('request-transformer', () => {
     it('successfully converts a postgres order to a response object', () => {
       const responseObject: OrderResponseObject | undefined = postgresAndRedisOrderToResponseObject(
         order,
-        null,
+        testConstants.defaultSubaccount.subaccountNumber,
       );
 
       expect(responseObject).not.toBeUndefined();
@@ -160,19 +167,20 @@ describe('request-transformer', () => {
         redisOrderToResponseObject(redisTestConstants.defaultRedisOrder),
       );
       expect(responseObject).toEqual(
-        postgresOrderToResponseObject(order),
+        postgresOrderToResponseObject(order, testConstants.defaultSubaccount.subaccountNumber),
       );
     });
 
     it('successfully converts a redis order to a response object', () => {
       const responseObject: OrderResponseObject | undefined = postgresAndRedisOrderToResponseObject(
         undefined,
+        testConstants.defaultSubaccount.subaccountNumber,
         redisTestConstants.defaultRedisOrder,
       );
 
       expect(responseObject).not.toBeUndefined();
       expect(responseObject).not.toEqual(
-        postgresOrderToResponseObject(order),
+        postgresOrderToResponseObject(order, testConstants.defaultSubaccount.subaccountNumber),
       );
       expect(responseObject).toEqual(
         redisOrderToResponseObject(redisTestConstants.defaultRedisOrder),
@@ -182,6 +190,7 @@ describe('request-transformer', () => {
     it('successfully converts undefined postgres order and null redis orderto undefined', () => {
       const responseObject: OrderResponseObject | undefined = postgresAndRedisOrderToResponseObject(
         undefined,
+        testConstants.defaultSubaccount.subaccountNumber,
         null,
       );
 
@@ -193,13 +202,17 @@ describe('request-transformer', () => {
     it(
       'successfully converts a postgres order with null `goodTilBlockTime` to a response object',
       () => {
-        const responseObject: OrderResponseObject = postgresOrderToResponseObject(order);
+        const responseObject: OrderResponseObject = postgresOrderToResponseObject(
+          order,
+          testConstants.defaultSubaccount.subaccountNumber,
+        );
 
         expect(responseObject).toEqual({
           ...order,
           timeInForce: apiTranslations.orderTIFToAPITIF(order.timeInForce),
           postOnly: apiTranslations.isOrderTIFPostOnly(order.timeInForce),
           ticker,
+          subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
         });
       },
     );
@@ -213,6 +226,7 @@ describe('request-transformer', () => {
         };
         const responseObject: OrderResponseObject = postgresOrderToResponseObject(
           orderWithGoodTilBlockTime,
+          testConstants.defaultSubaccount.subaccountNumber,
         );
 
         expect(responseObject).toEqual({
@@ -220,6 +234,7 @@ describe('request-transformer', () => {
           timeInForce: apiTranslations.orderTIFToAPITIF(order.timeInForce),
           postOnly: apiTranslations.isOrderTIFPostOnly(order.timeInForce),
           ticker,
+          subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
         });
       },
     );
@@ -303,6 +318,7 @@ describe('request-transformer', () => {
         goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(redisOrder.order!),
         ticker,
         clientMetadata: redisOrder.order!.clientMetadata.toString(),
+        subaccountNumber: redisOrder.order!.orderId!.subaccountId!.number,
       });
     });
   });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1480,7 +1480,8 @@ fetch('https://dydx-testnet.imperator.co/v4/orders?address=string&subaccountNumb
     "postOnly": true,
     "ticker": "string",
     "updatedAt": "string",
-    "updatedAtHeight": "string"
+    "updatedAtHeight": "string",
+    "subaccountNumber": 0
   }
 ]
 ```
@@ -1537,6 +1538,7 @@ Status Code **200**
 |» ticker|string|true|none|none|
 |» updatedAt|[IsoString](#schemaisostring)|false|none|none|
 |» updatedAtHeight|string|false|none|none|
+|» subaccountNumber|number(double)|true|none|none|
 
 #### Enumerated Values
 
@@ -1641,7 +1643,8 @@ fetch('https://dydx-testnet.imperator.co/v4/orders/{orderId}',
   "postOnly": true,
   "ticker": "string",
   "updatedAt": "string",
-  "updatedAtHeight": "string"
+  "updatedAtHeight": "string",
+  "subaccountNumber": 0
 }
 ```
 
@@ -3777,7 +3780,8 @@ or
   "postOnly": true,
   "ticker": "string",
   "updatedAt": "string",
-  "updatedAtHeight": "string"
+  "updatedAtHeight": "string",
+  "subaccountNumber": 0
 }
 
 ```
@@ -3808,6 +3812,7 @@ or
 |ticker|string|true|none|none|
 |updatedAt|[IsoString](#schemaisostring)|false|none|none|
 |updatedAtHeight|string|false|none|none|
+|subaccountNumber|number(double)|true|none|none|
 
 ## PerpetualMarketStatus
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -845,6 +845,10 @@
           },
           "updatedAtHeight": {
             "type": "string"
+          },
+          "subaccountNumber": {
+            "type": "number",
+            "format": "double"
           }
         },
         "required": [
@@ -863,7 +867,8 @@
           "timeInForce",
           "status",
           "postOnly",
-          "ticker"
+          "ticker",
+          "subaccountNumber"
         ],
         "type": "object",
         "additionalProperties": false

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -294,6 +294,7 @@ export interface OrderResponseObject extends Omit<OrderFromDatabase, 'timeInForc
   ticker: string;
   updatedAt?: IsoString;
   updatedAtHeight?: string
+  subaccountNumber: number;
 }
 
 export type RedisOrderMap = { [orderId: string]: RedisOrder };


### PR DESCRIPTION
### Changelist
Add subaccountNumber field to the OrderResponseObject struct

### Test Plan
Modified existing tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
