### PR TITLE
[OTE-256] Add upgrade handler to initialize OI during upgrade handler

### DIFF
--- a/protocol/testing/containertest/preupgrade_genesis.json
+++ b/protocol/testing/containertest/preupgrade_genesis.json
@@ -2149,6 +2149,20 @@
             {
               "asset_id": 0,
               "index": 0,
+              "quantums": "100000000000000000"
+            }
+          ],
+          "id": {
+            "number": 0,
+            "owner": "dydx10fx7sy6ywd5senxae9dwytf8jxek3t2gcen2vs"
+          },
+          "margin_enabled": true
+        },
+        {
+          "asset_positions": [
+            {
+              "asset_id": 0,
+              "index": 0,
               "quantums": "900000000000000000"
             }
           ],


### PR DESCRIPTION
### Changelist
- Upgrade handler logic to aggregate OI for each perp market and initialize it. 
- Requires backporting 
-
### Test Plan
Container test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
