### PR TITLE
Increase the number of allowed connections to 8000

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/config.go
+++ b/protocol/cmd/dydxprotocold/cmd/config.go
@@ -93,8 +93,8 @@ func initTendermintConfig() *tmcfg.Config {
 	// goroutine profiling showed that we were using exactly 900 threads (the default) which was throttling
 	// the maximum amount of load that the process could take. As of the last load test, at max QPS we were
 	// seeing ~1700 threads being used.
-	cfg.RPC.MaxOpenConnections = 4000
-	cfg.RPC.GRPCMaxOpenConnections = 4000
+	cfg.RPC.MaxOpenConnections = 8000
+	cfg.RPC.GRPCMaxOpenConnections = 8000
 
 	// Mempool config.
 	// We specifically are using a number greater than max QPS (currently set at 5000) * ShortBlockWindow to prevent


### PR DESCRIPTION
### Changelist
Increase this by a bit since it's the current bottleneck.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
