### PR TITLE
[SKI-27]: Open prometheus port for Oracle to be exposed

### DIFF
--- a/protocol/testing/testnet-dev/dev.sh
+++ b/protocol/testing/testnet-dev/dev.sh
@@ -210,6 +210,10 @@ edit_config() {
 
 	# Disable pex
 	dasel put -t bool -f "$CONFIG_FOLDER"/config.toml '.p2p.pex' -v 'false'
+
+  # Enable Sidecar Prometheus
+	dasel put -t bool -f "$CONFIG_FOLDER"/app.toml '.oracle.metrics_enabled' -v 'true'
+	dasel put -t string -f "$CONFIG_FOLDER"/app.toml '.oracle.prometheus_server_address' -v 'localhost:8001'
 }
 
 install_prerequisites

--- a/protocol/testing/testnet-local/local.sh
+++ b/protocol/testing/testnet-local/local.sh
@@ -156,12 +156,9 @@ setup_cosmovisor() {
 
 use_slinky() {
   CONFIG_FOLDER=$1
-  # Disable pricefeed-daemon
-  dasel put -t bool -f "$CONFIG_FOLDER"/app.toml 'price-daemon-enabled' -v false
   # Enable slinky daemon
   dasel put -t bool -f "$CONFIG_FOLDER"/app.toml 'oracle.enabled' -v true
 	dasel put -t string -f "$VAL_CONFIG_DIR"/app.toml 'oracle.oracle_address' -v 'slinky0:8080'
-	dasel put -t string -f "$VAL_CONFIG_DIR"/app.toml 'slinky-vote-extension-oracle-enabled' -v 'true'
 }
 
 # TODO(DEC-1894): remove this function once we migrate off of persistent peers.
@@ -176,6 +173,10 @@ edit_config() {
 	# Default `timeout_commit` is 999ms. For local testnet, use a larger value to make 
 	# block time longer for easier troubleshooting.
 	dasel put -t string -f "$CONFIG_FOLDER"/config.toml '.consensus.timeout_commit' -v '5s'
+
+  # Enable Sidecar Prometheus
+	dasel put -t bool -f "$CONFIG_FOLDER"/app.toml '.oracle.metrics_enabled' -v 'true'
+	dasel put -t string -f "$CONFIG_FOLDER"/app.toml '.oracle.prometheus_server_address' -v 'localhost:8001'
 }
 
 install_prerequisites

--- a/protocol/testing/testnet-staging/staging.sh
+++ b/protocol/testing/testnet-staging/staging.sh
@@ -264,6 +264,10 @@ edit_config() {
 
 	# Disable pex
 	dasel put -t bool -f "$CONFIG_FOLDER"/config.toml '.p2p.pex' -v 'false'
+
+  # Enable Sidecar Prometheus
+	dasel put -t bool -f "$CONFIG_FOLDER"/app.toml '.oracle.metrics_enabled' -v 'true'
+	dasel put -t string -f "$CONFIG_FOLDER"/app.toml '.oracle.prometheus_server_address' -v 'localhost:8001'
 }
 
 install_prerequisites


### PR DESCRIPTION
### Changelist
- Delete unused flags
- Enable oracle prometheus metrics

### Test Plan
Deployed to dev2

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
