### PR TITLE
[SKI-26]: Prevent funding index update with no oracle prices from halting indexer

### DIFF
--- a/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_funding_handler.sql
@@ -55,7 +55,8 @@ BEGIN
                          ORDER BY "effectiveAtHeight"
                          DESC LIMIT 1;
                 IF NOT FOUND THEN
-                    RAISE EXCEPTION 'price not found for marketId %', perpetual_market_record."marketId";
+                    errors_response = array_append(errors_response, '"oracle_price not found for marketId."'::jsonb);
+                    CONTINUE;
                 END IF;
 
                 event_id = dydx_event_id_from_parts(block_height, transaction_index, event_index);


### PR DESCRIPTION
### Changelist
Ignore funding if no oracle prices

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
