### PR TITLE
Remove unnecessary message serialization in clob AnteHandle

### DIFF
--- a/protocol/app/ante.go
+++ b/protocol/app/ante.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"sync"
+
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/store/cachemulti"
 	storetypes "cosmossdk.io/store/types"
@@ -9,10 +11,11 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
-	"sync"
 
 	customante "github.com/dydxprotocol/v4-chain/protocol/app/ante"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	libante "github.com/dydxprotocol/v4-chain/protocol/lib/ante"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/log"
 	clobante "github.com/dydxprotocol/v4-chain/protocol/x/clob/ante"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
@@ -135,6 +138,11 @@ type lockingAnteHandler struct {
 }
 
 func (h *lockingAnteHandler) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+	ctx = log.AddPersistentTagsToLogger(ctx,
+		log.Callback, lib.TxMode(ctx),
+		log.BlockHeight, ctx.BlockHeight()+1,
+	)
+
 	isClob, err := clobante.IsSingleClobMsgTx(tx)
 	if err != nil {
 		return ctx, err

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -63,20 +63,8 @@ func (cd ClobDecorator) AnteHandle(
 	msgs := tx.GetMsgs()
 	var msg = msgs[0]
 
-	// Set request-level logging tags
-	ctx = log.AddPersistentTagsToLogger(ctx,
-		log.Module, log.Clob,
-		log.Callback, lib.TxMode(ctx),
-		log.BlockHeight, ctx.BlockHeight()+1,
-		log.Msg, msg,
-	)
-
 	switch msg := msg.(type) {
 	case *types.MsgCancelOrder:
-		ctx = log.AddPersistentTagsToLogger(ctx,
-			log.Handler, log.CancelOrder,
-		)
-
 		if msg.OrderId.IsStatefulOrder() {
 			err = cd.clobKeeper.CancelStatefulOrder(ctx, msg)
 		} else {
@@ -96,9 +84,6 @@ func (cd ClobDecorator) AnteHandle(
 		)
 
 	case *types.MsgPlaceOrder:
-		ctx = log.AddPersistentTagsToLogger(ctx,
-			log.Handler, log.PlaceOrder,
-		)
 		if msg.Order.OrderId.IsStatefulOrder() {
 			err = cd.clobKeeper.PlaceStatefulOrder(ctx, msg)
 
@@ -136,11 +121,6 @@ func (cd ClobDecorator) AnteHandle(
 		if ctx.IsReCheckTx() {
 			return next(ctx, tx, simulate)
 		}
-
-		ctx = log.AddPersistentTagsToLogger(
-			ctx,
-			log.Handler, log.MsgBatchCancel,
-		)
 
 		success, failures, err := cd.clobKeeper.BatchCancelShortTermOrder(
 			ctx,


### PR DESCRIPTION
### Changelist
Especially due to message serialization, this is more expensive than it should be. If msg is necessary, it can be serialized in individual logs.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
