### PR TITLE
[TRA-219] emit transfer indexer event on vault deposit

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1082,6 +1082,7 @@ func New(
 		app.ClobKeeper,
 		app.PerpetualsKeeper,
 		app.PricesKeeper,
+		app.SendingKeeper,
 		app.SubaccountsKeeper,
 		[]string{
 			lib.GovModuleAddress.String(),

--- a/protocol/testutil/keeper/vault.go
+++ b/protocol/testutil/keeper/vault.go
@@ -56,6 +56,7 @@ func createVaultKeeper(
 		&mocks.ClobKeeper{},
 		&mocks.PerpetualsKeeper{},
 		&mocks.PricesKeeper{},
+		&mocks.SendingKeeper{},
 		&mocks.SubaccountsKeeper{},
 		[]string{
 			lib.GovModuleAddress.String(),

--- a/protocol/x/vault/keeper/keeper.go
+++ b/protocol/x/vault/keeper/keeper.go
@@ -18,6 +18,7 @@ type (
 		clobKeeper        types.ClobKeeper
 		perpetualsKeeper  types.PerpetualsKeeper
 		pricesKeeper      types.PricesKeeper
+		sendingKeeper     types.SendingKeeper
 		subaccountsKeeper types.SubaccountsKeeper
 		authorities       map[string]struct{}
 	}
@@ -29,6 +30,7 @@ func NewKeeper(
 	clobKeeper types.ClobKeeper,
 	perpetualsKeeper types.PerpetualsKeeper,
 	pricesKeeper types.PricesKeeper,
+	sendingKeeper types.SendingKeeper,
 	subaccountsKeeper types.SubaccountsKeeper,
 	authorities []string,
 ) *Keeper {
@@ -38,6 +40,7 @@ func NewKeeper(
 		clobKeeper:        clobKeeper,
 		perpetualsKeeper:  perpetualsKeeper,
 		pricesKeeper:      pricesKeeper,
+		sendingKeeper:     sendingKeeper,
 		subaccountsKeeper: subaccountsKeeper,
 		authorities:       lib.UniqueSliceToSet(authorities),
 	}

--- a/protocol/x/vault/keeper/msg_server_deposit_to_vault.go
+++ b/protocol/x/vault/keeper/msg_server_deposit_to_vault.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/lib/log"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
@@ -31,12 +32,14 @@ func (k msgServer) DepositToVault(
 	// Transfer from sender subaccount to vault.
 	// Note: Transfer should take place after minting shares for
 	// shares calculation to be correct.
-	err = k.subaccountsKeeper.TransferFundsFromSubaccountToSubaccount(
+	err = k.sendingKeeper.ProcessTransfer(
 		ctx,
-		*msg.SubaccountId,
-		*msg.VaultId.ToSubaccountId(),
-		assettypes.AssetUsdc.Id,
-		msg.QuoteQuantums.BigInt(),
+		&sendingtypes.Transfer{
+			Sender:    *msg.SubaccountId,
+			Recipient: *msg.VaultId.ToSubaccountId(),
+			AssetId:   assettypes.AssetUsdc.Id,
+			Amount:    msg.QuoteQuantums.BigInt().Uint64(),
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/protocol/x/vault/types/expected_keepers.go
+++ b/protocol/x/vault/types/expected_keepers.go
@@ -7,6 +7,7 @@ import (
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -48,6 +49,13 @@ type PricesKeeper interface {
 	) (pricestypes.MarketPrice, error)
 }
 
+type SendingKeeper interface {
+	ProcessTransfer(
+		ctx sdk.Context,
+		pendingTransfer *sendingtypes.Transfer,
+	) (err error)
+}
+
 type SubaccountsKeeper interface {
 	GetNetCollateralAndMarginRequirements(
 		ctx sdk.Context,
@@ -62,11 +70,4 @@ type SubaccountsKeeper interface {
 		ctx sdk.Context,
 		id satypes.SubaccountId,
 	) satypes.Subaccount
-	TransferFundsFromSubaccountToSubaccount(
-		ctx sdk.Context,
-		senderSubaccountId satypes.SubaccountId,
-		recipientSubaccountId satypes.SubaccountId,
-		assetId uint32,
-		quantums *big.Int,
-	) (err error)
 }


### PR DESCRIPTION
### Changelist
use `ProcessTransfer` instead of `TransferFundsFromSubaccountToSubaccount` to emit a transfer indexer event on vault deposit. PnL roundtable task picks up transfer indexer events to show portfolio chart on the front-end

### Test Plan
existing unit tests / integ tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
