### PR TITLE
Bump slinky sidecar, re-enabled volatile market

### DIFF
--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
   slinky0:
-    image: ghcr.io/skip-mev/slinky-sidecar:v0.3.1
+    image: ghcr.io/skip-mev/slinky-sidecar:v0.3.2
     entrypoint: >
       sh -c "slinky-config --chain dydx --node-http-url http://dydxprotocold0:1317 --oracle-config-path /etc/oracle.json &&
              slinky --oracle-config-path /etc/oracle.json --update-market-config-path /etc/market.json"

--- a/protocol/testing/testnet-dev/dev.sh
+++ b/protocol/testing/testnet-dev/dev.sh
@@ -135,7 +135,7 @@ create_validators() {
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
 		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
-		# update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
+		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "600"
 
 		for acct in "${TEST_ACCOUNTS[@]}"; do

--- a/protocol/testing/testnet-local/local.sh
+++ b/protocol/testing/testnet-local/local.sh
@@ -101,7 +101,7 @@ create_validators() {
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
 		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
-		# update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
+		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "30"
 
 		echo "${MNEMONICS[$i]}" | dydxprotocold keys add "${MONIKERS[$i]}" --recover --keyring-backend=test --home "$VAL_HOME_DIR"

--- a/protocol/testing/testnet-staging/staging.sh
+++ b/protocol/testing/testnet-staging/staging.sh
@@ -189,7 +189,7 @@ create_validators() {
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
 		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
-		# update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
+		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "600"
 
 		for acct in "${TEST_ACCOUNTS[@]}"; do


### PR DESCRIPTION
### Changelist
Bumps slinky sidecar to use `v0.3.2` docker image which allows us to re-enable the volatile market.

Will need to be updated in dev deployments. I don't have access to that.

### Test Plan
Ran localnet and got prices for TEST/USD.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
