### PR TITLE
[OTE-266]Update OI caps to new values

### DIFF
--- a/protocol/app/upgrades/v5.0.0/upgrade.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade.go
@@ -170,16 +170,16 @@ func initializeOIMFCaps(
 			tier.OpenInterestUpperCap = 0
 		} else if tier.Id == 1 {
 			// Mid cap
-			tier.OpenInterestLowerCap = 25_000_000_000_000 // 25 million USDC
+			tier.OpenInterestLowerCap = 20_000_000_000_000 // 20 million USDC
 			tier.OpenInterestUpperCap = 50_000_000_000_000 // 50 million USDC
 		} else if tier.Id == 2 {
 			// Long tail
-			tier.OpenInterestLowerCap = 10_000_000_000_000 // 10 million USDC
-			tier.OpenInterestUpperCap = 20_000_000_000_000 // 20 million USDC
+			tier.OpenInterestLowerCap = 5_000_000_000_000  // 5 million USDC
+			tier.OpenInterestUpperCap = 10_000_000_000_000 // 10 million USDC
 		} else {
 			// Safety
-			tier.OpenInterestLowerCap = 500_000_000_000   // 0.5 million USDC
-			tier.OpenInterestUpperCap = 1_000_000_000_000 // 1 million USDC
+			tier.OpenInterestLowerCap = 2_000_000_000_000 // 2 million USDC
+			tier.OpenInterestUpperCap = 5_000_000_000_000 // 5 million USDC
 		}
 
 		lt, err := perpetualsKeeper.SetLiquidityTier(

--- a/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
@@ -226,7 +226,7 @@ func postUpgradeCheckLiquidityTiers(node *containertest.Node, t *testing.T) {
 		InitialMarginPpm:       100_000,
 		MaintenanceFractionPpm: 500_000,
 		ImpactNotional:         5_000_000_000,
-		OpenInterestLowerCap:   uint64(25_000_000_000_000),
+		OpenInterestLowerCap:   uint64(20_000_000_000_000),
 		OpenInterestUpperCap:   uint64(50_000_000_000_000),
 	}, liquidityTiersResponse.LiquidityTiers[1])
 
@@ -236,8 +236,8 @@ func postUpgradeCheckLiquidityTiers(node *containertest.Node, t *testing.T) {
 		InitialMarginPpm:       200_000,
 		MaintenanceFractionPpm: 500_000,
 		ImpactNotional:         2_500_000_000,
-		OpenInterestLowerCap:   uint64(10_000_000_000_000),
-		OpenInterestUpperCap:   uint64(20_000_000_000_000),
+		OpenInterestLowerCap:   uint64(5_000_000_000_000),
+		OpenInterestUpperCap:   uint64(10_000_000_000_000),
 	}, liquidityTiersResponse.LiquidityTiers[2])
 
 	assert.Equal(t, perpetuals.LiquidityTier{
@@ -246,7 +246,7 @@ func postUpgradeCheckLiquidityTiers(node *containertest.Node, t *testing.T) {
 		InitialMarginPpm:       1_000_000,
 		MaintenanceFractionPpm: 200_000,
 		ImpactNotional:         2_500_000_000,
-		OpenInterestLowerCap:   uint64(500_000_000_000),
-		OpenInterestUpperCap:   uint64(1_000_000_000_000),
+		OpenInterestLowerCap:   uint64(2_000_000_000_000),
+		OpenInterestUpperCap:   uint64(5_000_000_000_000),
 	}, liquidityTiersResponse.LiquidityTiers[3])
 }


### PR DESCRIPTION
### Changelist
Values of OI caps have changed to these new values. Context: https://dydx-team.slack.com/archives/C064G4BBJJ3/p1712259896528359

### Test Plan
Updated values in upgrade test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted the Open Interest Market Fee Caps to better distribute caps across different tiers, enhancing the market's efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->