### PR TITLE
Fix message_time_since_received_post_processing stat

### DIFF
--- a/indexer/services/vulcan/src/lib/on-message.ts
+++ b/indexer/services/vulcan/src/lib/on-message.ts
@@ -129,7 +129,7 @@ export async function onMessage(message: KafkaMessage): Promise<void> {
         STATS_NO_SAMPLING,
         {
           topic: KafkaTopics.TO_VULCAN,
-          event_type: String(message.headers?.event_type),
+          event_type: String(headers?.event_type),
         },
       );
     }


### PR DESCRIPTION
### Changelist
message_time_since_received_post_processing stat is not being populated for short term orders.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved access method for `event_type` property in message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->