### PR TITLE
[TRA-93] initialize vault module params in v5.0.0 upgrade handler

### DIFF
--- a/protocol/app/upgrades.go
+++ b/protocol/app/upgrades.go
@@ -34,6 +34,7 @@ func (app *App) setupUpgradeHandlers() {
 			app.ClobKeeper,
 			app.SubaccountsKeeper,
 			app.ConsensusParamsKeeper,
+			app.VaultKeeper,
 		),
 	)
 }

--- a/protocol/app/upgrades/v5.0.0/upgrade.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade.go
@@ -11,6 +11,7 @@ import (
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -300,6 +301,19 @@ func initializePerpOpenInterest(
 	}
 }
 
+// Initialize vault module parameters.
+func initializeVaultModuleParams(
+	ctx sdk.Context,
+	vaultKeeper vaulttypes.VaultKeeper,
+) {
+	// Set vault module parameters to default values.
+	vaultParams := vaulttypes.DefaultParams()
+	if err := vaultKeeper.SetParams(ctx, vaultParams); err != nil {
+		panic(fmt.Sprintf("failed to set vault module parameters: %s", err))
+	}
+	ctx.Logger().Info("Successfully set vault module parameters")
+}
+
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
@@ -307,6 +321,7 @@ func CreateUpgradeHandler(
 	clobKeeper clobtypes.ClobKeeper,
 	subaccountsKeeper satypes.SubaccountsKeeper,
 	consensusParamKeeper consensusparamkeeper.Keeper,
+	vaultKeeper vaulttypes.VaultKeeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		sdkCtx := lib.UnwrapSDKContext(ctx, "app/upgrades")
@@ -335,7 +350,8 @@ func CreateUpgradeHandler(
 		// Set vote extension enable height
 		voteExtensionsUpgrade(sdkCtx, consensusParamKeeper)
 
-		// TODO(TRA-93): Initialize `x/vault` module.
+		// Initialize `x/vault` module params.
+		initializeVaultModuleParams(sdkCtx, vaultKeeper)
 
 		return mm.RunMigrations(ctx, configurator, vm)
 	}

--- a/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
@@ -14,6 +14,7 @@ import (
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	perpetuals "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,6 +56,7 @@ func postUpgradeChecks(node *containertest.Node, t *testing.T) {
 	postUpgradeCheckLiquidityTiers(node, t)
 	postUpgradePerpetualOIs(node, t)
 	postUpgradeCheckVoteExtensions(node, t)
+	postUpgradeCheckVaultParams(node, t)
 	// Add test for your upgrade handler logic below
 }
 
@@ -249,4 +251,20 @@ func postUpgradeCheckLiquidityTiers(node *containertest.Node, t *testing.T) {
 		OpenInterestLowerCap:   uint64(2_000_000_000_000),
 		OpenInterestUpperCap:   uint64(5_000_000_000_000),
 	}, liquidityTiersResponse.LiquidityTiers[3])
+}
+
+func postUpgradeCheckVaultParams(node *containertest.Node, t *testing.T) {
+	resp, err := containertest.Query(
+		node,
+		vaulttypes.NewQueryClient,
+		vaulttypes.QueryClient.Params,
+		&vaulttypes.QueryParamsRequest{},
+	)
+	require.NoError(t, err)
+
+	paramsResponse := &vaulttypes.QueryParamsResponse{}
+	err = proto.UnmarshalText(resp.String(), paramsResponse)
+	require.NoError(t, err)
+
+	assert.Equal(t, vaulttypes.DefaultParams(), paramsResponse.Params)
 }

--- a/protocol/x/vault/types/types.go
+++ b/protocol/x/vault/types/types.go
@@ -24,6 +24,15 @@ type VaultKeeper interface {
 		vaultId VaultId,
 	) (err error)
 
+	// Params.
+	GetParams(
+		ctx sdk.Context,
+	) Params
+	SetParams(
+		ctx sdk.Context,
+		params Params,
+	) error
+
 	// Shares.
 	GetTotalShares(
 		ctx sdk.Context,


### PR DESCRIPTION
### Changelist
initialize vault module params in v5.0.0 upgrade handler

### Test Plan
container test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced Vault Module initialization and parameter management in the latest upgrade.
- **Tests**
	- Added tests to ensure vault parameters are correctly set post-upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->