### PR TITLE
Add updatedAt to compliance v2 API responses

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
@@ -111,6 +111,7 @@ describe('ComplianceV2Controller', () => {
         });
         expect(response.body.status).toEqual(ComplianceStatus.BLOCKED);
         expect(response.body.reason).toEqual(ComplianceReason.COMPLIANCE_PROVIDER);
+        expect(response.body.updatedAt).toBeDefined();
         data = await ComplianceStatusTable.findAll({}, [], {});
         expect(data).toHaveLength(1);
         expect(data[0]).toEqual(expect.objectContaining({
@@ -141,6 +142,7 @@ describe('ComplianceV2Controller', () => {
         });
         expect(response.body.status).toEqual(ComplianceStatus.CLOSE_ONLY);
         expect(response.body.reason).toEqual(ComplianceReason.COMPLIANCE_PROVIDER);
+        expect(response.body.updatedAt).toBeDefined();
         data = await ComplianceStatusTable.findAll({}, [], {});
         expect(data).toHaveLength(1);
         expect(data[0]).toEqual(expect.objectContaining({
@@ -342,6 +344,7 @@ describe('ComplianceV2Controller', () => {
 
       expect(response.body.status).toEqual(ComplianceStatus.BLOCKED);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
+      expect(response.body.updatedAt).toBeDefined();
     });
 
     it('should set status to FIRST_STRIKE for CONNECT action from a restricted country with no existing compliance status', async () => {
@@ -369,6 +372,7 @@ describe('ComplianceV2Controller', () => {
 
       expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
+      expect(response.body.updatedAt).toBeDefined();
     });
 
     it('should set status to COMPLIANT for any action from a non-restricted country with no existing compliance status', async () => {
@@ -421,6 +425,7 @@ describe('ComplianceV2Controller', () => {
 
       expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
+      expect(response.body.updatedAt).toBeDefined();
     });
 
     it('should be a no-op for ONBOARD action with existing COMPLIANT status', async () => {
@@ -484,6 +489,7 @@ describe('ComplianceV2Controller', () => {
       }));
       expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
+      expect(response.body.updatedAt).toBeDefined();
     });
 
     it('should update status to CLOSE_ONLY for CONNECT action from a restricted country with existing FIRST_STRIKE status', async () => {
@@ -516,6 +522,7 @@ describe('ComplianceV2Controller', () => {
 
       expect(response.body.status).toEqual(ComplianceStatus.CLOSE_ONLY);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
+      expect(response.body.updatedAt).toBeDefined();
     });
   });
 });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -704,7 +704,8 @@ fetch('https://dydx-testnet.imperator.co/v4/compliance/screen/{address}',
 ```json
 {
   "status": "COMPLIANT",
-  "reason": "MANUAL"
+  "reason": "MANUAL",
+  "updatedAt": "string"
 }
 ```
 
@@ -3275,7 +3276,8 @@ This operation does not require authentication
 ```json
 {
   "status": "COMPLIANT",
-  "reason": "MANUAL"
+  "reason": "MANUAL",
+  "updatedAt": "string"
 }
 
 ```
@@ -3286,6 +3288,7 @@ This operation does not require authentication
 |---|---|---|---|---|
 |status|[ComplianceStatus](#schemacompliancestatus)|true|none|none|
 |reason|[ComplianceReason](#schemacompliancereason)|false|none|none|
+|updatedAt|string|false|none|none|
 
 ## OrderSide
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -372,6 +372,9 @@
           },
           "reason": {
             "$ref": "#/components/schemas/ComplianceReason"
+          },
+          "updatedAt": {
+            "type": "string"
           }
         },
         "required": [

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -79,24 +79,26 @@ class ComplianceV2Controller extends Controller {
           [],
         );
         let complianceStatusFromDatabase: ComplianceStatusFromDatabase | undefined;
+        const updatedAt: string = DateTime.utc().toISO();
         if (complianceStatus.length === 0) {
           complianceStatusFromDatabase = await ComplianceStatusTable.upsert({
             address,
             status: ComplianceStatus.BLOCKED,
             reason: ComplianceReason.COMPLIANCE_PROVIDER,
-            updatedAt: DateTime.utc().toISO(),
+            updatedAt,
           });
         } else {
           complianceStatusFromDatabase = await ComplianceStatusTable.update({
             address,
             status: ComplianceStatus.CLOSE_ONLY,
             reason: ComplianceReason.COMPLIANCE_PROVIDER,
-            updatedAt: DateTime.utc().toISO(),
+            updatedAt,
           });
         }
         return {
           status: complianceStatusFromDatabase!.status,
           reason: complianceStatusFromDatabase!.reason,
+          updatedAt,
         };
       } else {
         return {
@@ -240,6 +242,7 @@ router.post(
         [],
       );
       let complianceStatusFromDatabase: ComplianceStatusFromDatabase | undefined;
+      const updatedAt: string = DateTime.utc().toISO();
       if (complianceStatus.length === 0) {
         if (isRestrictedCountryHeaders(req.headers as CountryHeaders)) {
           if (action === ComplianceAction.ONBOARD) {
@@ -247,21 +250,21 @@ router.post(
               address,
               status: ComplianceStatus.BLOCKED,
               reason: getGeoComplianceReason(req.headers as CountryHeaders)!,
-              updatedAt: DateTime.utc().toISO(),
+              updatedAt,
             });
           } else if (action === ComplianceAction.CONNECT) {
             complianceStatusFromDatabase = await ComplianceStatusTable.upsert({
               address,
               status: ComplianceStatus.FIRST_STRIKE,
               reason: getGeoComplianceReason(req.headers as CountryHeaders)!,
-              updatedAt: DateTime.utc().toISO(),
+              updatedAt,
             });
           }
         } else {
           complianceStatusFromDatabase = await ComplianceStatusTable.upsert({
             address,
             status: ComplianceStatus.COMPLIANT,
-            updatedAt: DateTime.utc().toISO(),
+            updatedAt,
           });
         }
       } else {
@@ -286,7 +289,7 @@ router.post(
               address,
               status: COMPLIANCE_PROGRESSION[complianceStatus[0].status],
               reason: getGeoComplianceReason(req.headers as CountryHeaders)!,
-              updatedAt: DateTime.utc().toISO(),
+              updatedAt,
             });
           }
         }
@@ -294,6 +297,7 @@ router.post(
       const response = {
         status: complianceStatusFromDatabase!.status,
         reason: complianceStatusFromDatabase!.reason,
+        updatedAt,
       };
 
       return res.send(response);

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -481,6 +481,7 @@ export enum BlockedCode {
 export interface ComplianceV2Response {
   status: ComplianceStatus;
   reason?: ComplianceReason;
+  updatedAt?: string;
 }
 
 /* ------- HISTORICAL TRADING REWARD TYPES ------- */


### PR DESCRIPTION
### Changelist
Add updatedAt to compliance v2 API responses. This is needed for CLOSE_ONLY to determine the date when the account will be put into BLOCKED state.

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `updatedAt` timestamp to the compliance reports, indicating the last update time.
- **Documentation**
	- Updated API documentation to include the new `updatedAt` field in compliance report responses.
- **Tests**
	- Enhanced test suites to validate the presence and correctness of the `updatedAt` field in compliance reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->