### PR TITLE
[TRA-221] add OwnerShares and AllVaults query and cli

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/query.lcd.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/query.lcd.ts
@@ -1,5 +1,6 @@
+import { setPaginationParams } from "../../helpers";
 import { LCDClient } from "@osmonauts/lcd";
-import { QueryParamsRequest, QueryParamsResponseSDKType, QueryVaultRequest, QueryVaultResponseSDKType } from "./query";
+import { QueryParamsRequest, QueryParamsResponseSDKType, QueryVaultRequest, QueryVaultResponseSDKType, QueryAllVaultsRequest, QueryAllVaultsResponseSDKType, QueryOwnerSharesRequest, QueryOwnerSharesResponseSDKType } from "./query";
 export class LCDQueryClient {
   req: LCDClient;
 
@@ -11,6 +12,8 @@ export class LCDQueryClient {
     this.req = requestClient;
     this.params = this.params.bind(this);
     this.vault = this.vault.bind(this);
+    this.allVaults = this.allVaults.bind(this);
+    this.ownerShares = this.ownerShares.bind(this);
   }
   /* Queries the Params. */
 
@@ -25,6 +28,38 @@ export class LCDQueryClient {
   async vault(params: QueryVaultRequest): Promise<QueryVaultResponseSDKType> {
     const endpoint = `dydxprotocol/vault/vault/${params.type}/${params.number}`;
     return await this.req.get<QueryVaultResponseSDKType>(endpoint);
+  }
+  /* Queries all vaults. */
+
+
+  async allVaults(params: QueryAllVaultsRequest = {
+    pagination: undefined
+  }): Promise<QueryAllVaultsResponseSDKType> {
+    const options: any = {
+      params: {}
+    };
+
+    if (typeof params?.pagination !== "undefined") {
+      setPaginationParams(options, params.pagination);
+    }
+
+    const endpoint = `dydxprotocol/vault/vault`;
+    return await this.req.get<QueryAllVaultsResponseSDKType>(endpoint, options);
+  }
+  /* Queries owner shares of a vault. */
+
+
+  async ownerShares(params: QueryOwnerSharesRequest): Promise<QueryOwnerSharesResponseSDKType> {
+    const options: any = {
+      params: {}
+    };
+
+    if (typeof params?.pagination !== "undefined") {
+      setPaginationParams(options, params.pagination);
+    }
+
+    const endpoint = `dydxprotocol/vault/owner_shares/${params.type}/${params.number}`;
+    return await this.req.get<QueryOwnerSharesResponseSDKType>(endpoint, options);
   }
 
 }

--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/query.rpc.Query.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/query.rpc.Query.ts
@@ -1,7 +1,7 @@
 import { Rpc } from "../../helpers";
 import * as _m0 from "protobufjs/minimal";
 import { QueryClient, createProtobufRpcClient } from "@cosmjs/stargate";
-import { QueryParamsRequest, QueryParamsResponse, QueryVaultRequest, QueryVaultResponse } from "./query";
+import { QueryParamsRequest, QueryParamsResponse, QueryVaultRequest, QueryVaultResponse, QueryAllVaultsRequest, QueryAllVaultsResponse, QueryOwnerSharesRequest, QueryOwnerSharesResponse } from "./query";
 /** Query defines the gRPC querier service. */
 
 export interface Query {
@@ -10,6 +10,12 @@ export interface Query {
   /** Queries a Vault by type and number. */
 
   vault(request: QueryVaultRequest): Promise<QueryVaultResponse>;
+  /** Queries all vaults. */
+
+  allVaults(request?: QueryAllVaultsRequest): Promise<QueryAllVaultsResponse>;
+  /** Queries owner shares of a vault. */
+
+  ownerShares(request: QueryOwnerSharesRequest): Promise<QueryOwnerSharesResponse>;
 }
 export class QueryClientImpl implements Query {
   private readonly rpc: Rpc;
@@ -18,6 +24,8 @@ export class QueryClientImpl implements Query {
     this.rpc = rpc;
     this.params = this.params.bind(this);
     this.vault = this.vault.bind(this);
+    this.allVaults = this.allVaults.bind(this);
+    this.ownerShares = this.ownerShares.bind(this);
   }
 
   params(request: QueryParamsRequest = {}): Promise<QueryParamsResponse> {
@@ -32,6 +40,20 @@ export class QueryClientImpl implements Query {
     return promise.then(data => QueryVaultResponse.decode(new _m0.Reader(data)));
   }
 
+  allVaults(request: QueryAllVaultsRequest = {
+    pagination: undefined
+  }): Promise<QueryAllVaultsResponse> {
+    const data = QueryAllVaultsRequest.encode(request).finish();
+    const promise = this.rpc.request("dydxprotocol.vault.Query", "AllVaults", data);
+    return promise.then(data => QueryAllVaultsResponse.decode(new _m0.Reader(data)));
+  }
+
+  ownerShares(request: QueryOwnerSharesRequest): Promise<QueryOwnerSharesResponse> {
+    const data = QueryOwnerSharesRequest.encode(request).finish();
+    const promise = this.rpc.request("dydxprotocol.vault.Query", "OwnerShares", data);
+    return promise.then(data => QueryOwnerSharesResponse.decode(new _m0.Reader(data)));
+  }
+
 }
 export const createRpcQueryExtension = (base: QueryClient) => {
   const rpc = createProtobufRpcClient(base);
@@ -43,6 +65,14 @@ export const createRpcQueryExtension = (base: QueryClient) => {
 
     vault(request: QueryVaultRequest): Promise<QueryVaultResponse> {
       return queryService.vault(request);
+    },
+
+    allVaults(request?: QueryAllVaultsRequest): Promise<QueryAllVaultsResponse> {
+      return queryService.allVaults(request);
+    },
+
+    ownerShares(request: QueryOwnerSharesRequest): Promise<QueryOwnerSharesResponse> {
+      return queryService.ownerShares(request);
     }
 
   };

--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/query.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/query.ts
@@ -1,4 +1,5 @@
-import { VaultType, VaultTypeSDKType, VaultId, VaultIdSDKType } from "./vault";
+import { VaultType, VaultTypeSDKType, VaultId, VaultIdSDKType, NumShares, NumSharesSDKType } from "./vault";
+import { PageRequest, PageRequestSDKType, PageResponse, PageResponseSDKType } from "../../cosmos/base/query/v1beta1/pagination";
 import { Params, ParamsSDKType } from "./params";
 import { SubaccountId, SubaccountIdSDKType } from "../subaccounts/subaccount";
 import * as _m0 from "protobufjs/minimal";
@@ -48,6 +49,66 @@ export interface QueryVaultResponseSDKType {
   equity: Long;
   inventory: Long;
   total_shares: Long;
+}
+/** QueryAllVaultsRequest is a request type for the AllVaults RPC method. */
+
+export interface QueryAllVaultsRequest {
+  pagination?: PageRequest;
+}
+/** QueryAllVaultsRequest is a request type for the AllVaults RPC method. */
+
+export interface QueryAllVaultsRequestSDKType {
+  pagination?: PageRequestSDKType;
+}
+/** QueryAllVaultsResponse is a response type for the AllVaults RPC method. */
+
+export interface QueryAllVaultsResponse {
+  vaults: QueryVaultResponse[];
+  pagination?: PageResponse;
+}
+/** QueryAllVaultsResponse is a response type for the AllVaults RPC method. */
+
+export interface QueryAllVaultsResponseSDKType {
+  vaults: QueryVaultResponseSDKType[];
+  pagination?: PageResponseSDKType;
+}
+/** QueryOwnerSharesRequest is a request type for the OwnerShares RPC method. */
+
+export interface QueryOwnerSharesRequest {
+  type: VaultType;
+  number: number;
+  pagination?: PageRequest;
+}
+/** QueryOwnerSharesRequest is a request type for the OwnerShares RPC method. */
+
+export interface QueryOwnerSharesRequestSDKType {
+  type: VaultTypeSDKType;
+  number: number;
+  pagination?: PageRequestSDKType;
+}
+/** OwnerShare is a type for owner shares in a vault. */
+
+export interface OwnerShare {
+  owner: string;
+  shares?: NumShares;
+}
+/** OwnerShare is a type for owner shares in a vault. */
+
+export interface OwnerShareSDKType {
+  owner: string;
+  shares?: NumSharesSDKType;
+}
+/** QueryOwnerSharesResponse is a response type for the OwnerShares RPC method. */
+
+export interface QueryOwnerSharesResponse {
+  ownerShares: OwnerShare[];
+  pagination?: PageResponse;
+}
+/** QueryOwnerSharesResponse is a response type for the OwnerShares RPC method. */
+
+export interface QueryOwnerSharesResponseSDKType {
+  owner_shares: OwnerShareSDKType[];
+  pagination?: PageResponseSDKType;
 }
 
 function createBaseQueryParamsRequest(): QueryParamsRequest {
@@ -264,6 +325,281 @@ export const QueryVaultResponse = {
     message.equity = object.equity !== undefined && object.equity !== null ? Long.fromValue(object.equity) : Long.UZERO;
     message.inventory = object.inventory !== undefined && object.inventory !== null ? Long.fromValue(object.inventory) : Long.UZERO;
     message.totalShares = object.totalShares !== undefined && object.totalShares !== null ? Long.fromValue(object.totalShares) : Long.UZERO;
+    return message;
+  }
+
+};
+
+function createBaseQueryAllVaultsRequest(): QueryAllVaultsRequest {
+  return {
+    pagination: undefined
+  };
+}
+
+export const QueryAllVaultsRequest = {
+  encode(message: QueryAllVaultsRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryAllVaultsRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryAllVaultsRequest();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<QueryAllVaultsRequest>): QueryAllVaultsRequest {
+    const message = createBaseQueryAllVaultsRequest();
+    message.pagination = object.pagination !== undefined && object.pagination !== null ? PageRequest.fromPartial(object.pagination) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseQueryAllVaultsResponse(): QueryAllVaultsResponse {
+  return {
+    vaults: [],
+    pagination: undefined
+  };
+}
+
+export const QueryAllVaultsResponse = {
+  encode(message: QueryAllVaultsResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.vaults) {
+      QueryVaultResponse.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+
+    if (message.pagination !== undefined) {
+      PageResponse.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryAllVaultsResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryAllVaultsResponse();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.vaults.push(QueryVaultResponse.decode(reader, reader.uint32()));
+          break;
+
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<QueryAllVaultsResponse>): QueryAllVaultsResponse {
+    const message = createBaseQueryAllVaultsResponse();
+    message.vaults = object.vaults?.map(e => QueryVaultResponse.fromPartial(e)) || [];
+    message.pagination = object.pagination !== undefined && object.pagination !== null ? PageResponse.fromPartial(object.pagination) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseQueryOwnerSharesRequest(): QueryOwnerSharesRequest {
+  return {
+    type: 0,
+    number: 0,
+    pagination: undefined
+  };
+}
+
+export const QueryOwnerSharesRequest = {
+  encode(message: QueryOwnerSharesRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.type !== 0) {
+      writer.uint32(8).int32(message.type);
+    }
+
+    if (message.number !== 0) {
+      writer.uint32(16).uint32(message.number);
+    }
+
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(26).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryOwnerSharesRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryOwnerSharesRequest();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.type = (reader.int32() as any);
+          break;
+
+        case 2:
+          message.number = reader.uint32();
+          break;
+
+        case 3:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<QueryOwnerSharesRequest>): QueryOwnerSharesRequest {
+    const message = createBaseQueryOwnerSharesRequest();
+    message.type = object.type ?? 0;
+    message.number = object.number ?? 0;
+    message.pagination = object.pagination !== undefined && object.pagination !== null ? PageRequest.fromPartial(object.pagination) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseOwnerShare(): OwnerShare {
+  return {
+    owner: "",
+    shares: undefined
+  };
+}
+
+export const OwnerShare = {
+  encode(message: OwnerShare, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.owner !== "") {
+      writer.uint32(10).string(message.owner);
+    }
+
+    if (message.shares !== undefined) {
+      NumShares.encode(message.shares, writer.uint32(18).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): OwnerShare {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseOwnerShare();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+
+        case 2:
+          message.shares = NumShares.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<OwnerShare>): OwnerShare {
+    const message = createBaseOwnerShare();
+    message.owner = object.owner ?? "";
+    message.shares = object.shares !== undefined && object.shares !== null ? NumShares.fromPartial(object.shares) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseQueryOwnerSharesResponse(): QueryOwnerSharesResponse {
+  return {
+    ownerShares: [],
+    pagination: undefined
+  };
+}
+
+export const QueryOwnerSharesResponse = {
+  encode(message: QueryOwnerSharesResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.ownerShares) {
+      OwnerShare.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+
+    if (message.pagination !== undefined) {
+      PageResponse.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryOwnerSharesResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryOwnerSharesResponse();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.ownerShares.push(OwnerShare.decode(reader, reader.uint32()));
+          break;
+
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<QueryOwnerSharesResponse>): QueryOwnerSharesResponse {
+    const message = createBaseQueryOwnerSharesResponse();
+    message.ownerShares = object.ownerShares?.map(e => OwnerShare.fromPartial(e)) || [];
+    message.pagination = object.pagination !== undefined && object.pagination !== null ? PageResponse.fromPartial(object.pagination) : undefined;
     return message;
   }
 

--- a/proto/dydxprotocol/vault/query.proto
+++ b/proto/dydxprotocol/vault/query.proto
@@ -3,6 +3,8 @@ package dydxprotocol.vault;
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "cosmos_proto/cosmos.proto";
 import "dydxprotocol/subaccounts/subaccount.proto";
 import "dydxprotocol/vault/params.proto";
 import "dydxprotocol/vault/vault.proto";
@@ -18,6 +20,15 @@ service Query {
   // Queries a Vault by type and number.
   rpc Vault(QueryVaultRequest) returns (QueryVaultResponse) {
     option (google.api.http).get = "/dydxprotocol/vault/vault/{type}/{number}";
+  }
+  // Queries all vaults.
+  rpc AllVaults(QueryAllVaultsRequest) returns (QueryAllVaultsResponse) {
+    option (google.api.http).get = "/dydxprotocol/vault/vault";
+  }
+  // Queries owner shares of a vault.
+  rpc OwnerShares(QueryOwnerSharesRequest) returns (QueryOwnerSharesResponse) {
+    option (google.api.http).get =
+        "/dydxprotocol/vault/owner_shares/{type}/{number}";
   }
 }
 
@@ -43,4 +54,34 @@ message QueryVaultResponse {
   uint64 equity = 3;
   uint64 inventory = 4;
   uint64 total_shares = 5;
+}
+
+// QueryAllVaultsRequest is a request type for the AllVaults RPC method.
+message QueryAllVaultsRequest {
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
+
+// QueryAllVaultsResponse is a response type for the AllVaults RPC method.
+message QueryAllVaultsResponse {
+  repeated QueryVaultResponse vaults = 1;
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryOwnerSharesRequest is a request type for the OwnerShares RPC method.
+message QueryOwnerSharesRequest {
+  VaultType type = 1;
+  uint32 number = 2;
+  cosmos.base.query.v1beta1.PageRequest pagination = 3;
+}
+
+// OwnerShare is a type for owner shares in a vault.
+message OwnerShare {
+  string owner = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+  NumShares shares = 2;
+}
+
+// QueryOwnerSharesResponse is a response type for the OwnerShares RPC method.
+message QueryOwnerSharesResponse {
+  repeated OwnerShare owner_shares = 1;
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }

--- a/protocol/x/vault/client/cli/query.go
+++ b/protocol/x/vault/client/cli/query.go
@@ -25,6 +25,8 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 
 	cmd.AddCommand(CmdQueryParams())
 	cmd.AddCommand(CmdQueryVault())
+	cmd.AddCommand(CmdQueryListVault())
+	cmd.AddCommand(CmdQueryListOwnerShares())
 
 	return cmd
 }
@@ -88,6 +90,88 @@ func CmdQueryVault() *cobra.Command {
 		},
 	}
 
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdQueryListVault() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-vault",
+		Short: "list all vaults",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			request := &types.QueryAllVaultsRequest{
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.AllVaults(context.Background(), request)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdQueryListOwnerShares() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-owner-shares [type] [number]",
+		Short: "list owner shares of a vault by its type and number",
+		Long:  "list owner shares of a vault by its type and number. Current support types are: clob.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			// Parse vault type.
+			vaultType, err := GetVaultTypeFromString(args[0])
+			if err != nil {
+				return err
+			}
+
+			// Parse vault number.
+			vaultNumber, err := strconv.ParseUint(args[1], 10, 32)
+			if err != nil {
+				return err
+			}
+
+			request := &types.QueryOwnerSharesRequest{
+				Type:       vaultType,
+				Number:     uint32(vaultNumber),
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.OwnerShares(context.Background(), request)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd

--- a/protocol/x/vault/keeper/grpc_query_shares.go
+++ b/protocol/x/vault/keeper/grpc_query_shares.go
@@ -1,0 +1,56 @@
+package keeper
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+)
+
+func (k Keeper) OwnerShares(
+	c context.Context,
+	req *types.QueryOwnerSharesRequest,
+) (*types.QueryOwnerSharesResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	ctx := lib.UnwrapSDKContext(c, types.ModuleName)
+
+	vaultId := types.VaultId{
+		Type:   req.Type,
+		Number: req.Number,
+	}
+	_, exists := k.GetTotalShares(ctx, vaultId)
+	if !exists {
+		return nil, status.Error(codes.NotFound, "vault not found")
+	}
+
+	var ownerShares []*types.OwnerShare
+	ownerSharesStore := k.getVaultOwnerSharesStore(ctx, vaultId)
+	pageRes, err := query.Paginate(ownerSharesStore, req.Pagination, func(key []byte, value []byte) error {
+		owner := string(key)
+
+		var shares types.NumShares
+		k.cdc.MustUnmarshal(value, &shares)
+
+		ownerShares = append(ownerShares, &types.OwnerShare{
+			Owner:  owner,
+			Shares: &shares,
+		})
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &types.QueryOwnerSharesResponse{
+		OwnerShares: ownerShares,
+		Pagination:  pageRes,
+	}, nil
+}

--- a/protocol/x/vault/keeper/grpc_query_shares_test.go
+++ b/protocol/x/vault/keeper/grpc_query_shares_test.go
@@ -1,0 +1,117 @@
+package keeper_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOwnerShares(t *testing.T) {
+	tests := map[string]struct {
+		/* --- Setup --- */
+		// Request.
+		req *vaulttypes.QueryOwnerSharesRequest
+		// Vault ID.
+		vaultId vaulttypes.VaultId
+		// Owner shares.
+		ownerShares map[string]*big.Int
+
+		/* --- Expectations --- */
+		expectedOwnerShares []*vaulttypes.OwnerShare
+		expectedErr         string
+	}{
+		"Success": {
+			req: &vaulttypes.QueryOwnerSharesRequest{
+				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
+				Number: 0,
+			},
+			vaultId: constants.Vault_Clob_0,
+			ownerShares: map[string]*big.Int{
+				constants.Alice_Num0.Owner: big.NewInt(100),
+				constants.Bob_Num0.Owner:   big.NewInt(200),
+			},
+			expectedOwnerShares: []*vaulttypes.OwnerShare{
+				{
+					Owner: constants.Alice_Num0.Owner,
+					Shares: &vaulttypes.NumShares{
+						NumShares: dtypes.NewInt(100),
+					},
+				},
+				{
+					Owner: constants.Bob_Num0.Owner,
+					Shares: &vaulttypes.NumShares{
+						NumShares: dtypes.NewInt(200),
+					},
+				},
+			},
+		},
+		"Error: vault not found": {
+			req: &vaulttypes.QueryOwnerSharesRequest{
+				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
+				Number: 1,
+			},
+			vaultId: constants.Vault_Clob_0,
+			ownerShares: map[string]*big.Int{
+				constants.Alice_Num0.Owner: big.NewInt(100),
+				constants.Bob_Num0.Owner:   big.NewInt(200),
+			},
+			expectedErr: "vault not found",
+		},
+		"Error: nil request": {
+			req:     nil,
+			vaultId: constants.Vault_Clob_0,
+			ownerShares: map[string]*big.Int{
+				constants.Alice_Num0.Owner: big.NewInt(100),
+				constants.Bob_Num0.Owner:   big.NewInt(200),
+			},
+			expectedErr: "invalid request",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).Build()
+			ctx := tApp.InitChain()
+			k := tApp.App.VaultKeeper
+
+			// Set total and owner shares.
+			totalShares := big.NewInt(0)
+			for owner, shares := range tc.ownerShares {
+				err := k.SetOwnerShares(ctx, tc.vaultId, owner, vaulttypes.BigIntToNumShares(shares))
+				require.NoError(t, err)
+				totalShares.Add(totalShares, shares)
+			}
+
+			// Set total shares.
+			err := k.SetTotalShares(ctx, tc.vaultId, vaulttypes.BigIntToNumShares(totalShares))
+			require.NoError(t, err)
+
+			// Check Vault query response is as expected.
+			response, err := k.OwnerShares(ctx, tc.req)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(
+					t,
+					tc.expectedOwnerShares,
+					response.OwnerShares,
+				)
+				require.Equal(
+					t,
+					&query.PageResponse{
+						NextKey: nil,
+						Total:   uint64(len(tc.expectedOwnerShares)),
+					},
+					response.Pagination,
+				)
+			}
+		})
+	}
+}

--- a/protocol/x/vault/keeper/grpc_query_vault.go
+++ b/protocol/x/vault/keeper/grpc_query_vault.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"cosmossdk.io/store/prefix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
@@ -52,5 +54,47 @@ func (k Keeper) Vault(
 		Equity:       equity.Uint64(),
 		Inventory:    inventory.Uint64(),
 		TotalShares:  totalShares.NumShares.BigInt().Uint64(),
+	}, nil
+}
+
+func (k Keeper) AllVaults(
+	c context.Context,
+	req *types.QueryAllVaultsRequest,
+) (*types.QueryAllVaultsResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	ctx := lib.UnwrapSDKContext(c, types.ModuleName)
+
+	var vaults []*types.QueryVaultResponse
+
+	totalSharesStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.TotalSharesKeyPrefix))
+
+	pageRes, err := query.Paginate(totalSharesStore, req.Pagination, func(key []byte, value []byte) error {
+		vaultId, err := types.GetVaultIdFromStateKey(key)
+		if err != nil {
+			return err
+		}
+
+		vault, err := k.Vault(c, &types.QueryVaultRequest{
+			Type:   vaultId.Type,
+			Number: vaultId.Number,
+		})
+		if err != nil {
+			return err
+		}
+
+		vaults = append(vaults, vault)
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &types.QueryAllVaultsResponse{
+		Vaults:     vaults,
+		Pagination: pageRes,
 	}, nil
 }

--- a/protocol/x/vault/keeper/grpc_query_vault_test.go
+++ b/protocol/x/vault/keeper/grpc_query_vault_test.go
@@ -122,3 +122,129 @@ func TestVault(t *testing.T) {
 		})
 	}
 }
+
+func TestAllVaults(t *testing.T) {
+	tests := map[string]struct {
+		/* --- Setup --- */
+		// Query request.
+		req *vaulttypes.QueryAllVaultsRequest
+		// Vault IDs.
+		vaultIds []vaulttypes.VaultId
+		// Total shares for each vault.
+		totalShares map[vaulttypes.VaultId]*big.Int
+		// Asset position of each vault.
+		assets []*big.Int
+		// Inventory of each vault.
+		inventories []*big.Int
+		// Perpetual ID of each vault.
+		perpIds []uint32
+
+		/* --- Expectations --- */
+		expectedErr string
+	}{
+		"Success": {
+			req: &vaulttypes.QueryAllVaultsRequest{},
+			vaultIds: []vaulttypes.VaultId{
+				constants.Vault_Clob_0,
+				constants.Vault_Clob_1,
+			},
+			totalShares: map[vaulttypes.VaultId]*big.Int{
+				constants.Vault_Clob_0: big.NewInt(100),
+				constants.Vault_Clob_1: big.NewInt(200),
+			},
+			assets: []*big.Int{
+				big.NewInt(1_000),
+				big.NewInt(2_000),
+			},
+			inventories: []*big.Int{
+				big.NewInt(-555),
+				big.NewInt(666),
+			},
+			perpIds: []uint32{0, 1},
+		},
+		"Error: nil request": {
+			req: nil,
+			vaultIds: []vaulttypes.VaultId{
+				constants.Vault_Clob_0,
+				constants.Vault_Clob_1,
+			},
+			totalShares: map[vaulttypes.VaultId]*big.Int{
+				constants.Vault_Clob_0: big.NewInt(100),
+				constants.Vault_Clob_1: big.NewInt(200),
+			},
+			assets: []*big.Int{
+				big.NewInt(1_000),
+				big.NewInt(2_000),
+			},
+			inventories: []*big.Int{
+				big.NewInt(-555),
+				big.NewInt(666),
+			},
+			perpIds:     []uint32{0, 1},
+			expectedErr: "invalid request",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+				genesis = testapp.DefaultGenesis()
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *satypes.GenesisState) {
+						var subaccounts []satypes.Subaccount
+						for i, vaultId := range tc.vaultIds {
+							subaccounts = append(subaccounts, satypes.Subaccount{
+								Id: vaultId.ToSubaccountId(),
+								AssetPositions: []*satypes.AssetPosition{
+									{
+										AssetId:  assettypes.AssetUsdc.Id,
+										Quantums: dtypes.NewIntFromBigInt(tc.assets[i]),
+									},
+								},
+								PerpetualPositions: []*satypes.PerpetualPosition{
+									{
+										PerpetualId: tc.perpIds[i],
+										Quantums:    dtypes.NewIntFromBigInt(tc.inventories[i]),
+									},
+								},
+							})
+						}
+						genesisState.Subaccounts = subaccounts
+					},
+				)
+				return genesis
+			}).Build()
+			ctx := tApp.InitChain()
+			k := tApp.App.VaultKeeper
+
+			// Set total shares.
+			for _, vaultId := range tc.vaultIds {
+				err := k.SetTotalShares(ctx, vaultId, vaulttypes.BigIntToNumShares(tc.totalShares[vaultId]))
+				require.NoError(t, err)
+			}
+
+			// Check AllVaults query response is as expected.
+			response, err := k.AllVaults(ctx, tc.req)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				expectedVaults := make([]*vaulttypes.QueryVaultResponse, len(tc.vaultIds))
+				for i, vaultId := range tc.vaultIds {
+					vault, err := k.Vault(ctx, &vaulttypes.QueryVaultRequest{
+						Type:   vaultId.Type,
+						Number: vaultId.Number,
+					})
+					require.NoError(t, err)
+					expectedVaults[i] = vault
+				}
+				require.ElementsMatch(
+					t,
+					expectedVaults,
+					response.Vaults,
+				)
+			}
+		})
+	}
+}

--- a/protocol/x/vault/types/query.pb.go
+++ b/protocol/x/vault/types/query.pb.go
@@ -6,6 +6,8 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	_ "github.com/cosmos/cosmos-proto"
+	query "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 	proto "github.com/cosmos/gogoproto/proto"
@@ -242,49 +244,336 @@ func (m *QueryVaultResponse) GetTotalShares() uint64 {
 	return 0
 }
 
+// QueryAllVaultsRequest is a request type for the AllVaults RPC method.
+type QueryAllVaultsRequest struct {
+	Pagination *query.PageRequest `protobuf:"bytes,1,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (m *QueryAllVaultsRequest) Reset()         { *m = QueryAllVaultsRequest{} }
+func (m *QueryAllVaultsRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryAllVaultsRequest) ProtoMessage()    {}
+func (*QueryAllVaultsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_478fb8dc0ff21ea6, []int{4}
+}
+func (m *QueryAllVaultsRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryAllVaultsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryAllVaultsRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryAllVaultsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryAllVaultsRequest.Merge(m, src)
+}
+func (m *QueryAllVaultsRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryAllVaultsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryAllVaultsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryAllVaultsRequest proto.InternalMessageInfo
+
+func (m *QueryAllVaultsRequest) GetPagination() *query.PageRequest {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
+// QueryAllVaultsResponse is a response type for the AllVaults RPC method.
+type QueryAllVaultsResponse struct {
+	Vaults     []*QueryVaultResponse `protobuf:"bytes,1,rep,name=vaults,proto3" json:"vaults,omitempty"`
+	Pagination *query.PageResponse   `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (m *QueryAllVaultsResponse) Reset()         { *m = QueryAllVaultsResponse{} }
+func (m *QueryAllVaultsResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryAllVaultsResponse) ProtoMessage()    {}
+func (*QueryAllVaultsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_478fb8dc0ff21ea6, []int{5}
+}
+func (m *QueryAllVaultsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryAllVaultsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryAllVaultsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryAllVaultsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryAllVaultsResponse.Merge(m, src)
+}
+func (m *QueryAllVaultsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryAllVaultsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryAllVaultsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryAllVaultsResponse proto.InternalMessageInfo
+
+func (m *QueryAllVaultsResponse) GetVaults() []*QueryVaultResponse {
+	if m != nil {
+		return m.Vaults
+	}
+	return nil
+}
+
+func (m *QueryAllVaultsResponse) GetPagination() *query.PageResponse {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
+// QueryOwnerSharesRequest is a request type for the OwnerShares RPC method.
+type QueryOwnerSharesRequest struct {
+	Type       VaultType          `protobuf:"varint,1,opt,name=type,proto3,enum=dydxprotocol.vault.VaultType" json:"type,omitempty"`
+	Number     uint32             `protobuf:"varint,2,opt,name=number,proto3" json:"number,omitempty"`
+	Pagination *query.PageRequest `protobuf:"bytes,3,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (m *QueryOwnerSharesRequest) Reset()         { *m = QueryOwnerSharesRequest{} }
+func (m *QueryOwnerSharesRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryOwnerSharesRequest) ProtoMessage()    {}
+func (*QueryOwnerSharesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_478fb8dc0ff21ea6, []int{6}
+}
+func (m *QueryOwnerSharesRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryOwnerSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryOwnerSharesRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryOwnerSharesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryOwnerSharesRequest.Merge(m, src)
+}
+func (m *QueryOwnerSharesRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryOwnerSharesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryOwnerSharesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryOwnerSharesRequest proto.InternalMessageInfo
+
+func (m *QueryOwnerSharesRequest) GetType() VaultType {
+	if m != nil {
+		return m.Type
+	}
+	return VaultType_VAULT_TYPE_UNSPECIFIED
+}
+
+func (m *QueryOwnerSharesRequest) GetNumber() uint32 {
+	if m != nil {
+		return m.Number
+	}
+	return 0
+}
+
+func (m *QueryOwnerSharesRequest) GetPagination() *query.PageRequest {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
+// OwnerShare is a type for owner shares in a vault.
+type OwnerShare struct {
+	Owner  string     `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
+	Shares *NumShares `protobuf:"bytes,2,opt,name=shares,proto3" json:"shares,omitempty"`
+}
+
+func (m *OwnerShare) Reset()         { *m = OwnerShare{} }
+func (m *OwnerShare) String() string { return proto.CompactTextString(m) }
+func (*OwnerShare) ProtoMessage()    {}
+func (*OwnerShare) Descriptor() ([]byte, []int) {
+	return fileDescriptor_478fb8dc0ff21ea6, []int{7}
+}
+func (m *OwnerShare) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *OwnerShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_OwnerShare.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *OwnerShare) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OwnerShare.Merge(m, src)
+}
+func (m *OwnerShare) XXX_Size() int {
+	return m.Size()
+}
+func (m *OwnerShare) XXX_DiscardUnknown() {
+	xxx_messageInfo_OwnerShare.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_OwnerShare proto.InternalMessageInfo
+
+func (m *OwnerShare) GetOwner() string {
+	if m != nil {
+		return m.Owner
+	}
+	return ""
+}
+
+func (m *OwnerShare) GetShares() *NumShares {
+	if m != nil {
+		return m.Shares
+	}
+	return nil
+}
+
+// QueryOwnerSharesResponse is a response type for the OwnerShares RPC method.
+type QueryOwnerSharesResponse struct {
+	OwnerShares []*OwnerShare       `protobuf:"bytes,1,rep,name=owner_shares,json=ownerShares,proto3" json:"owner_shares,omitempty"`
+	Pagination  *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (m *QueryOwnerSharesResponse) Reset()         { *m = QueryOwnerSharesResponse{} }
+func (m *QueryOwnerSharesResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryOwnerSharesResponse) ProtoMessage()    {}
+func (*QueryOwnerSharesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_478fb8dc0ff21ea6, []int{8}
+}
+func (m *QueryOwnerSharesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryOwnerSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryOwnerSharesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryOwnerSharesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryOwnerSharesResponse.Merge(m, src)
+}
+func (m *QueryOwnerSharesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryOwnerSharesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryOwnerSharesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryOwnerSharesResponse proto.InternalMessageInfo
+
+func (m *QueryOwnerSharesResponse) GetOwnerShares() []*OwnerShare {
+	if m != nil {
+		return m.OwnerShares
+	}
+	return nil
+}
+
+func (m *QueryOwnerSharesResponse) GetPagination() *query.PageResponse {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*QueryParamsRequest)(nil), "dydxprotocol.vault.QueryParamsRequest")
 	proto.RegisterType((*QueryParamsResponse)(nil), "dydxprotocol.vault.QueryParamsResponse")
 	proto.RegisterType((*QueryVaultRequest)(nil), "dydxprotocol.vault.QueryVaultRequest")
 	proto.RegisterType((*QueryVaultResponse)(nil), "dydxprotocol.vault.QueryVaultResponse")
+	proto.RegisterType((*QueryAllVaultsRequest)(nil), "dydxprotocol.vault.QueryAllVaultsRequest")
+	proto.RegisterType((*QueryAllVaultsResponse)(nil), "dydxprotocol.vault.QueryAllVaultsResponse")
+	proto.RegisterType((*QueryOwnerSharesRequest)(nil), "dydxprotocol.vault.QueryOwnerSharesRequest")
+	proto.RegisterType((*OwnerShare)(nil), "dydxprotocol.vault.OwnerShare")
+	proto.RegisterType((*QueryOwnerSharesResponse)(nil), "dydxprotocol.vault.QueryOwnerSharesResponse")
 }
 
 func init() { proto.RegisterFile("dydxprotocol/vault/query.proto", fileDescriptor_478fb8dc0ff21ea6) }
 
 var fileDescriptor_478fb8dc0ff21ea6 = []byte{
-	// 497 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x92, 0xcf, 0x6f, 0xd3, 0x30,
-	0x14, 0xc7, 0xeb, 0xd2, 0x16, 0xf0, 0x36, 0x24, 0xcc, 0x84, 0xa2, 0x50, 0xb2, 0x12, 0x89, 0xd2,
-	0x09, 0x11, 0x6b, 0x05, 0x09, 0x0e, 0x9c, 0x76, 0xe3, 0x04, 0xcd, 0x10, 0x07, 0x0e, 0x4c, 0x6e,
-	0x6a, 0xa5, 0x91, 0x5a, 0x3b, 0x8d, 0x9d, 0x6a, 0xd1, 0xd4, 0x0b, 0x37, 0x6e, 0x08, 0xfe, 0xa9,
-	0x1d, 0x27, 0x71, 0xe1, 0x84, 0x50, 0xcb, 0xdf, 0x81, 0x50, 0x5e, 0x4c, 0x97, 0x6e, 0xad, 0x76,
-	0x89, 0xec, 0xef, 0xfb, 0xe6, 0xf3, 0x7e, 0xf8, 0x61, 0x67, 0x90, 0x0d, 0x4e, 0xe2, 0x44, 0x6a,
-	0x19, 0xc8, 0x11, 0x9d, 0xb2, 0x74, 0xa4, 0xe9, 0x24, 0xe5, 0x49, 0xe6, 0x81, 0x48, 0x48, 0x39,
-	0xee, 0x41, 0xdc, 0xde, 0x0d, 0x65, 0x28, 0x41, 0xa3, 0xf9, 0xa9, 0x70, 0xda, 0xcd, 0x50, 0xca,
-	0x70, 0xc4, 0x29, 0x8b, 0x23, 0xca, 0x84, 0x90, 0x9a, 0xe9, 0x48, 0x0a, 0x65, 0xa2, 0xfb, 0x2b,
-	0x79, 0x54, 0xda, 0x67, 0x41, 0x20, 0x53, 0xa1, 0x55, 0xe9, 0x6c, 0xac, 0x7b, 0x6b, 0x4a, 0x8a,
-	0x59, 0xc2, 0xc6, 0xff, 0x59, 0xeb, 0x6a, 0x86, 0x6f, 0x11, 0x77, 0x77, 0x31, 0xe9, 0xe5, 0x2d,
-	0xbc, 0x83, 0x9f, 0x7c, 0x3e, 0x49, 0xb9, 0xd2, 0xee, 0x5b, 0x7c, 0x6f, 0x45, 0x55, 0xb1, 0x14,
-	0x8a, 0x93, 0x57, 0xb8, 0x51, 0xc0, 0x2d, 0xd4, 0x42, 0x9d, 0xad, 0xae, 0xed, 0x5d, 0xed, 0xd8,
-	0x2b, 0xfe, 0x39, 0xac, 0x9d, 0xfd, 0xda, 0xab, 0xf8, 0xc6, 0xef, 0x7e, 0xc2, 0x77, 0x01, 0xf8,
-	0x21, 0xb7, 0x98, 0x2c, 0xe4, 0x00, 0xd7, 0x74, 0x16, 0x73, 0x80, 0xdd, 0xe9, 0x3e, 0x5c, 0x07,
-	0x03, 0xff, 0xfb, 0x2c, 0xe6, 0x3e, 0x58, 0xc9, 0x7d, 0xdc, 0x10, 0xe9, 0xb8, 0xcf, 0x13, 0xab,
-	0xda, 0x42, 0x9d, 0x1d, 0xdf, 0xdc, 0xdc, 0xbf, 0xc8, 0xf4, 0x61, 0x12, 0x98, 0x82, 0x5f, 0xe3,
-	0x5b, 0xc0, 0x39, 0x8e, 0x06, 0xa6, 0xe4, 0x07, 0x1b, 0xb3, 0xbc, 0x19, 0x98, 0x9a, 0x6f, 0x4e,
-	0x8b, 0x2b, 0xe9, 0xe1, 0x9d, 0x8b, 0x81, 0xe7, 0x88, 0x2a, 0x20, 0xda, 0xab, 0x88, 0xd2, 0xfb,
-	0x78, 0x47, 0xcb, 0xf3, 0x92, 0xb6, 0xad, 0x4a, 0x5a, 0x5e, 0x3f, 0x9f, 0xa4, 0x91, 0xce, 0xac,
-	0x1b, 0x2d, 0xd4, 0xa9, 0xf9, 0xe6, 0x46, 0x9a, 0xf8, 0x76, 0x24, 0xa6, 0x5c, 0x68, 0x99, 0x64,
-	0x56, 0x0d, 0x42, 0x17, 0x02, 0x79, 0x84, 0xb7, 0xb5, 0xd4, 0x6c, 0x74, 0xac, 0x86, 0x2c, 0xe1,
-	0xca, 0xaa, 0x83, 0x61, 0x0b, 0xb4, 0x23, 0x90, 0xba, 0xdf, 0xaa, 0xb8, 0x0e, 0x03, 0x20, 0x33,
-	0xdc, 0x28, 0x9e, 0x80, 0xb4, 0xd7, 0xf5, 0x7a, 0xf5, 0xb5, 0xed, 0x27, 0xd7, 0xfa, 0x8a, 0x71,
-	0xba, 0xee, 0xe7, 0x1f, 0x7f, 0xbe, 0x57, 0x9b, 0xc4, 0xa6, 0x1b, 0xd7, 0x8e, 0x7c, 0x41, 0xb8,
-	0x0e, 0xf3, 0x24, 0x8f, 0x37, 0x62, 0xcb, 0x5b, 0x60, 0xb7, 0xaf, 0xb3, 0x99, 0xe4, 0x07, 0x90,
-	0xfc, 0x29, 0xd9, 0xa7, 0x9b, 0x56, 0x9a, 0x9e, 0xe6, 0x3b, 0x32, 0xa3, 0xa7, 0xc5, 0x52, 0xcc,
-	0x0e, 0x7b, 0x67, 0x73, 0x07, 0x9d, 0xcf, 0x1d, 0xf4, 0x7b, 0xee, 0xa0, 0xaf, 0x0b, 0xa7, 0x72,
-	0xbe, 0x70, 0x2a, 0x3f, 0x17, 0x4e, 0xe5, 0xe3, 0xcb, 0x30, 0xd2, 0xc3, 0xb4, 0xef, 0x05, 0x72,
-	0x7c, 0x09, 0xf7, 0xe2, 0x59, 0x30, 0x64, 0x91, 0xa0, 0x4b, 0xe5, 0xc4, 0xc0, 0x73, 0xb6, 0xea,
-	0x37, 0x40, 0x7f, 0xfe, 0x2f, 0x00, 0x00, 0xff, 0xff, 0xa0, 0xa0, 0xa9, 0x4d, 0x0c, 0x04, 0x00,
-	0x00,
+	// 779 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0xcf, 0x4f, 0x13, 0x4d,
+	0x18, 0xee, 0x42, 0xdb, 0xef, 0x63, 0x0a, 0x5f, 0xf2, 0x8d, 0x88, 0xa5, 0xe0, 0x02, 0x9b, 0xc8,
+	0x4f, 0xd9, 0xb5, 0x55, 0x23, 0x07, 0x63, 0x02, 0x07, 0x8d, 0x17, 0x81, 0xc5, 0x78, 0xf0, 0x60,
+	0xb3, 0x6d, 0x27, 0xcb, 0x26, 0xed, 0x4e, 0xd9, 0x99, 0xad, 0x34, 0x84, 0x8b, 0x89, 0x07, 0x6f,
+	0x26, 0xfe, 0x05, 0x7a, 0xf0, 0xe4, 0xd1, 0xbb, 0x57, 0x8e, 0x44, 0x2f, 0x9e, 0x8c, 0x01, 0xff,
+	0x0e, 0x63, 0xf6, 0x9d, 0x97, 0x76, 0xfb, 0x2b, 0x10, 0xc3, 0x65, 0xb3, 0xf3, 0xce, 0x33, 0xcf,
+	0xfb, 0xcc, 0x33, 0xcf, 0x0c, 0xd1, 0x2b, 0xcd, 0xca, 0x7e, 0x3d, 0xe0, 0x92, 0x97, 0x79, 0xd5,
+	0x6a, 0x38, 0x61, 0x55, 0x5a, 0x7b, 0x21, 0x0b, 0x9a, 0x26, 0x14, 0x29, 0x8d, 0xcf, 0x9b, 0x30,
+	0x9f, 0x1b, 0x77, 0xb9, 0xcb, 0xa1, 0x66, 0x45, 0x7f, 0x0a, 0x99, 0x9b, 0x76, 0x39, 0x77, 0xab,
+	0xcc, 0x72, 0xea, 0x9e, 0xe5, 0xf8, 0x3e, 0x97, 0x8e, 0xf4, 0xb8, 0x2f, 0x70, 0x76, 0xb9, 0xcc,
+	0x45, 0x8d, 0x0b, 0xab, 0xe4, 0x08, 0xa6, 0x1a, 0x58, 0x8d, 0x7c, 0x89, 0x49, 0x27, 0x6f, 0xd5,
+	0x1d, 0xd7, 0xf3, 0x01, 0x8c, 0xd8, 0x49, 0x85, 0x2d, 0xaa, 0x16, 0x6a, 0x80, 0x53, 0x4b, 0x1d,
+	0x72, 0x45, 0x58, 0x72, 0xca, 0x65, 0x1e, 0xfa, 0x52, 0xc4, 0xfe, 0x11, 0x3a, 0xd3, 0x67, 0x67,
+	0x75, 0x27, 0x70, 0x6a, 0x67, 0x5c, 0xfd, 0xb6, 0x0e, 0x5f, 0x35, 0x6f, 0x8c, 0x13, 0xba, 0x1d,
+	0x09, 0xdd, 0x82, 0x45, 0x36, 0xdb, 0x0b, 0x99, 0x90, 0xc6, 0x26, 0xb9, 0xd2, 0x51, 0x15, 0x75,
+	0xee, 0x0b, 0x46, 0xd7, 0x48, 0x5a, 0x91, 0x67, 0xb5, 0x59, 0x6d, 0x31, 0x53, 0xc8, 0x99, 0xbd,
+	0xc6, 0x99, 0x6a, 0xcd, 0x46, 0xf2, 0xe8, 0xc7, 0x4c, 0xc2, 0x46, 0xbc, 0xf1, 0x82, 0xfc, 0x0f,
+	0x84, 0xcf, 0x22, 0x08, 0x76, 0xa1, 0x79, 0x92, 0x94, 0xcd, 0x3a, 0x03, 0xb2, 0xff, 0x0a, 0xd7,
+	0xfb, 0x91, 0x01, 0xfe, 0x69, 0xb3, 0xce, 0x6c, 0x80, 0xd2, 0x09, 0x92, 0xf6, 0xc3, 0x5a, 0x89,
+	0x05, 0xd9, 0xa1, 0x59, 0x6d, 0x71, 0xcc, 0xc6, 0x91, 0xf1, 0x5b, 0xc3, 0x7d, 0x60, 0x03, 0x14,
+	0x7c, 0x9f, 0xfc, 0x0b, 0x3c, 0x45, 0xaf, 0x82, 0x92, 0xa7, 0x06, 0x76, 0x79, 0x5c, 0x41, 0xcd,
+	0xff, 0x34, 0xd4, 0x90, 0x6e, 0x93, 0xb1, 0xb6, 0xe1, 0x11, 0xc5, 0x10, 0x50, 0xcc, 0x77, 0x52,
+	0xc4, 0xce, 0xc7, 0xdc, 0x69, 0xfd, 0xb7, 0xd8, 0x46, 0x45, 0xac, 0x16, 0xe9, 0x67, 0x7b, 0xa1,
+	0x27, 0x9b, 0xd9, 0xe1, 0x59, 0x6d, 0x31, 0x69, 0xe3, 0x88, 0x4e, 0x93, 0x11, 0xcf, 0x6f, 0x30,
+	0x5f, 0xf2, 0xa0, 0x99, 0x4d, 0xc2, 0x54, 0xbb, 0x40, 0xe7, 0xc8, 0xa8, 0xe4, 0xd2, 0xa9, 0x16,
+	0xc5, 0xae, 0x13, 0x30, 0x91, 0x4d, 0x01, 0x20, 0x03, 0xb5, 0x1d, 0x28, 0x19, 0x45, 0x72, 0x15,
+	0xf6, 0xbf, 0x5e, 0xad, 0xc2, 0x6e, 0xce, 0x8e, 0x92, 0x3e, 0x24, 0xa4, 0x9d, 0x3d, 0x34, 0x61,
+	0xde, 0xc4, 0xbc, 0x45, 0x41, 0x35, 0xd5, 0x4d, 0xc0, 0xa0, 0x9a, 0x5b, 0x8e, 0xcb, 0x70, 0xad,
+	0x1d, 0x5b, 0x69, 0xbc, 0xd7, 0xc8, 0x44, 0x77, 0x07, 0x74, 0xf9, 0x01, 0x49, 0x83, 0x65, 0x51,
+	0x2c, 0x86, 0x7b, 0x0d, 0x52, 0x1e, 0xf7, 0x9e, 0x8e, 0x8d, 0xab, 0xe8, 0xa3, 0x0e, 0x89, 0xca,
+	0xe4, 0x85, 0x73, 0x25, 0x22, 0x49, 0x5c, 0xe3, 0x27, 0x8d, 0x5c, 0x83, 0x3e, 0x9b, 0x2f, 0x7d,
+	0x16, 0x28, 0x67, 0x2e, 0x3f, 0x6c, 0x5d, 0x96, 0x0e, 0xff, 0xb5, 0xa5, 0x82, 0x90, 0xb6, 0x50,
+	0x6a, 0x92, 0x14, 0x8f, 0x46, 0xa0, 0x70, 0x64, 0x23, 0xfb, 0xf5, 0xf3, 0xea, 0x38, 0x72, 0xae,
+	0x57, 0x2a, 0x01, 0x13, 0x62, 0x47, 0x06, 0x9e, 0xef, 0xda, 0x0a, 0x46, 0xef, 0x92, 0x34, 0xc6,
+	0x41, 0x39, 0xd6, 0x77, 0x4b, 0x4f, 0xc2, 0x1a, 0xda, 0x80, 0x60, 0xe3, 0xa3, 0x46, 0xb2, 0xbd,
+	0x1e, 0xe1, 0x49, 0xae, 0x93, 0x51, 0x20, 0x3f, 0x0b, 0x9a, 0x3a, 0x4f, 0xbd, 0x1f, 0x73, 0x7b,
+	0xb9, 0x9d, 0xe1, 0x6d, 0xaa, 0x4b, 0x3b, 0xcc, 0xc2, 0x97, 0x24, 0x49, 0x81, 0x50, 0x7a, 0x48,
+	0xd2, 0xea, 0x51, 0xa1, 0x83, 0x93, 0xd5, 0xf1, 0x7e, 0xe5, 0x16, 0xce, 0xc5, 0xa9, 0x86, 0x86,
+	0xf1, 0xea, 0xdb, 0xaf, 0x77, 0x43, 0xd3, 0x34, 0x67, 0x0d, 0x7c, 0x48, 0xe9, 0x1b, 0x8d, 0xa4,
+	0x20, 0x1a, 0xf4, 0xc6, 0x79, 0xc1, 0x56, 0xdd, 0x2f, 0x98, 0x7f, 0x23, 0x0f, 0xcd, 0x57, 0xe8,
+	0x92, 0x35, 0xe8, 0x91, 0xb6, 0x0e, 0xa2, 0x20, 0x1e, 0x5a, 0x07, 0x2a, 0x79, 0x87, 0xf4, 0xb5,
+	0x46, 0x46, 0x5a, 0x17, 0x90, 0x2e, 0x0d, 0x6c, 0xd4, 0xfd, 0x0c, 0xe4, 0x96, 0x2f, 0x02, 0x45,
+	0x5d, 0x73, 0xa0, 0x6b, 0x8a, 0x4e, 0x0e, 0xd4, 0x45, 0x3f, 0x68, 0x24, 0x13, 0x0b, 0x10, 0x5d,
+	0x19, 0x48, 0xdf, 0x7b, 0x15, 0x73, 0x37, 0x2f, 0x06, 0x46, 0x35, 0x6b, 0xa0, 0xa6, 0x40, 0x6f,
+	0xf5, 0x53, 0x13, 0x4f, 0x6b, 0xb7, 0x59, 0x1b, 0xdb, 0x47, 0x27, 0xba, 0x76, 0x7c, 0xa2, 0x6b,
+	0x3f, 0x4f, 0x74, 0xed, 0xed, 0xa9, 0x9e, 0x38, 0x3e, 0xd5, 0x13, 0xdf, 0x4f, 0xf5, 0xc4, 0xf3,
+	0x7b, 0xae, 0x27, 0x77, 0xc3, 0x92, 0x59, 0xe6, 0xb5, 0x2e, 0xd6, 0x3b, 0xab, 0xe5, 0x5d, 0xc7,
+	0xf3, 0xad, 0x56, 0x65, 0x1f, 0x3b, 0x45, 0xdc, 0xa2, 0x94, 0x86, 0xfa, 0xed, 0x3f, 0x01, 0x00,
+	0x00, 0xff, 0xff, 0x36, 0x27, 0x20, 0x64, 0x52, 0x08, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -303,6 +592,10 @@ type QueryClient interface {
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
 	// Queries a Vault by type and number.
 	Vault(ctx context.Context, in *QueryVaultRequest, opts ...grpc.CallOption) (*QueryVaultResponse, error)
+	// Queries all vaults.
+	AllVaults(ctx context.Context, in *QueryAllVaultsRequest, opts ...grpc.CallOption) (*QueryAllVaultsResponse, error)
+	// Queries owner shares of a vault.
+	OwnerShares(ctx context.Context, in *QueryOwnerSharesRequest, opts ...grpc.CallOption) (*QueryOwnerSharesResponse, error)
 }
 
 type queryClient struct {
@@ -331,12 +624,34 @@ func (c *queryClient) Vault(ctx context.Context, in *QueryVaultRequest, opts ...
 	return out, nil
 }
 
+func (c *queryClient) AllVaults(ctx context.Context, in *QueryAllVaultsRequest, opts ...grpc.CallOption) (*QueryAllVaultsResponse, error) {
+	out := new(QueryAllVaultsResponse)
+	err := c.cc.Invoke(ctx, "/dydxprotocol.vault.Query/AllVaults", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) OwnerShares(ctx context.Context, in *QueryOwnerSharesRequest, opts ...grpc.CallOption) (*QueryOwnerSharesResponse, error) {
+	out := new(QueryOwnerSharesResponse)
+	err := c.cc.Invoke(ctx, "/dydxprotocol.vault.Query/OwnerShares", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Queries the Params.
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)
 	// Queries a Vault by type and number.
 	Vault(context.Context, *QueryVaultRequest) (*QueryVaultResponse, error)
+	// Queries all vaults.
+	AllVaults(context.Context, *QueryAllVaultsRequest) (*QueryAllVaultsResponse, error)
+	// Queries owner shares of a vault.
+	OwnerShares(context.Context, *QueryOwnerSharesRequest) (*QueryOwnerSharesResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -348,6 +663,12 @@ func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsReq
 }
 func (*UnimplementedQueryServer) Vault(ctx context.Context, req *QueryVaultRequest) (*QueryVaultResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Vault not implemented")
+}
+func (*UnimplementedQueryServer) AllVaults(ctx context.Context, req *QueryAllVaultsRequest) (*QueryAllVaultsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AllVaults not implemented")
+}
+func (*UnimplementedQueryServer) OwnerShares(ctx context.Context, req *QueryOwnerSharesRequest) (*QueryOwnerSharesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method OwnerShares not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -390,6 +711,42 @@ func _Query_Vault_Handler(srv interface{}, ctx context.Context, dec func(interfa
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_AllVaults_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryAllVaultsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).AllVaults(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/dydxprotocol.vault.Query/AllVaults",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).AllVaults(ctx, req.(*QueryAllVaultsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_OwnerShares_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryOwnerSharesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).OwnerShares(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/dydxprotocol.vault.Query/OwnerShares",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).OwnerShares(ctx, req.(*QueryOwnerSharesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "dydxprotocol.vault.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -401,6 +758,14 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Vault",
 			Handler:    _Query_Vault_Handler,
+		},
+		{
+			MethodName: "AllVaults",
+			Handler:    _Query_AllVaults_Handler,
+		},
+		{
+			MethodName: "OwnerShares",
+			Handler:    _Query_OwnerShares_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -554,6 +919,226 @@ func (m *QueryVaultResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryAllVaultsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryAllVaultsRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryAllVaultsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryAllVaultsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryAllVaultsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryAllVaultsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Vaults) > 0 {
+		for iNdEx := len(m.Vaults) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Vaults[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryOwnerSharesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryOwnerSharesRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryOwnerSharesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Number != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.Number))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Type != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OwnerShare) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OwnerShare) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *OwnerShare) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Shares != nil {
+		{
+			size, err := m.Shares.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Owner) > 0 {
+		i -= len(m.Owner)
+		copy(dAtA[i:], m.Owner)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Owner)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryOwnerSharesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryOwnerSharesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryOwnerSharesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.OwnerShares) > 0 {
+		for iNdEx := len(m.OwnerShares) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.OwnerShares[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -618,6 +1203,93 @@ func (m *QueryVaultResponse) Size() (n int) {
 	}
 	if m.TotalShares != 0 {
 		n += 1 + sovQuery(uint64(m.TotalShares))
+	}
+	return n
+}
+
+func (m *QueryAllVaultsRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryAllVaultsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Vaults) > 0 {
+		for _, e := range m.Vaults {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryOwnerSharesRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Type != 0 {
+		n += 1 + sovQuery(uint64(m.Type))
+	}
+	if m.Number != 0 {
+		n += 1 + sovQuery(uint64(m.Number))
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *OwnerShare) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Owner)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	if m.Shares != nil {
+		l = m.Shares.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryOwnerSharesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.OwnerShares) > 0 {
+		for _, e := range m.OwnerShares {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
 }
@@ -1001,6 +1673,574 @@ func (m *QueryVaultResponse) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryAllVaultsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryAllVaultsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryAllVaultsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageRequest{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryAllVaultsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryAllVaultsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryAllVaultsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Vaults", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Vaults = append(m.Vaults, &QueryVaultResponse{})
+			if err := m.Vaults[len(m.Vaults)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageResponse{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryOwnerSharesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryOwnerSharesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryOwnerSharesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= VaultType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Number", wireType)
+			}
+			m.Number = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Number |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageRequest{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *OwnerShare) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: OwnerShare: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: OwnerShare: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Owner", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Owner = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Shares", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Shares == nil {
+				m.Shares = &NumShares{}
+			}
+			if err := m.Shares.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryOwnerSharesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryOwnerSharesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryOwnerSharesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OwnerShares", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.OwnerShares = append(m.OwnerShares, &OwnerShare{})
+			if err := m.OwnerShares[len(m.OwnerShares)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageResponse{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipQuery(dAtA[iNdEx:])

--- a/protocol/x/vault/types/query.pb.gw.go
+++ b/protocol/x/vault/types/query.pb.gw.go
@@ -133,6 +133,142 @@ func local_request_Query_Vault_0(ctx context.Context, marshaler runtime.Marshale
 
 }
 
+var (
+	filter_Query_AllVaults_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
+
+func request_Query_AllVaults_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryAllVaultsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_AllVaults_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.AllVaults(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_AllVaults_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryAllVaultsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_AllVaults_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.AllVaults(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+var (
+	filter_Query_OwnerShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"type": 0, "number": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+)
+
+func request_Query_OwnerShares_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryOwnerSharesRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		e   int32
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["type"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "type")
+	}
+
+	e, err = runtime.Enum(val, VaultType_value)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "type", err)
+	}
+
+	protoReq.Type = VaultType(e)
+
+	val, ok = pathParams["number"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "number")
+	}
+
+	protoReq.Number, err = runtime.Uint32(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "number", err)
+	}
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_OwnerShares_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.OwnerShares(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_OwnerShares_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryOwnerSharesRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		e   int32
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["type"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "type")
+	}
+
+	e, err = runtime.Enum(val, VaultType_value)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "type", err)
+	}
+
+	protoReq.Type = VaultType(e)
+
+	val, ok = pathParams["number"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "number")
+	}
+
+	protoReq.Number, err = runtime.Uint32(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "number", err)
+	}
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_OwnerShares_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.OwnerShares(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -182,6 +318,52 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Vault_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_AllVaults_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_AllVaults_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_AllVaults_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_OwnerShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_OwnerShares_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_OwnerShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -266,6 +448,46 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_AllVaults_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_AllVaults_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_AllVaults_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_OwnerShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_OwnerShares_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_OwnerShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -273,10 +495,18 @@ var (
 	pattern_Query_Params_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"dydxprotocol", "vault", "params"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_Query_Vault_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"dydxprotocol", "vault", "type", "number"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_AllVaults_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 1}, []string{"dydxprotocol", "vault"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_OwnerShares_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4}, []string{"dydxprotocol", "vault", "owner_shares", "type", "number"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (
 	forward_Query_Params_0 = runtime.ForwardResponseMessage
 
 	forward_Query_Vault_0 = runtime.ForwardResponseMessage
+
+	forward_Query_AllVaults_0 = runtime.ForwardResponseMessage
+
+	forward_Query_OwnerShares_0 = runtime.ForwardResponseMessage
 )


### PR DESCRIPTION
### Changelist
1. OwnerShares query: list all owner shares of a vault (paginated)
2. AllVaults query: list all vaults (paginated)
3. add CLI for these 2 queries

### Test Plan
1. unit tests
2. local manual testing

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functionalities to query all vaults and owner shares within the vault system, enhancing user capabilities to interact with and manage vault data.
	- Added commands for listing all vaults and listing owner shares of a vault, improving navigation and data accessibility for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->