### PR TITLE
generate unique market names in simulation

### DIFF
--- a/protocol/x/prices/simulation/genesis.go
+++ b/protocol/x/prices/simulation/genesis.go
@@ -40,8 +40,12 @@ func genMarketExponent(r *rand.Rand, isReasonableGenesis bool) int {
 }
 
 // genMarketName return randomized market name.
-func genMarketName(r *rand.Rand) string {
-	return simtypes.RandStringOfLength(r, simtypes.RandIntBetween(r, 3, 6)) + "-USD"
+func genMarketName(r *rand.Rand, existingMarketNames map[string]bool) string {
+	marketName := simtypes.RandStringOfLength(r, simtypes.RandIntBetween(r, 3, 6)) + "-USD"
+	for existingMarketNames[marketName] {
+		marketName = simtypes.RandStringOfLength(r, simtypes.RandIntBetween(r, 3, 6)) + "-USD"
+	}
+	return marketName
 }
 
 // genMarketPrice returns randomized market price.
@@ -63,7 +67,12 @@ func RandomizedGenState(simState *module.SimulationState) {
 	marketParams := make([]types.MarketParam, numMarkets)
 	marketPrices := make([]types.MarketPrice, numMarkets)
 
+	marketNames := make(map[string]bool)
+
 	for i := 0; i < numMarkets; i++ {
+		marketName := genMarketName(r, marketNames)
+		marketNames[marketName] = true
+
 		var minExchanges = genMinExchanges(r, isReasonableGenesis)
 		if minExchanges < minExchangesPerMarket {
 			minExchanges = minExchangesPerMarket
@@ -73,7 +82,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 
 		marketParams[i] = types.MarketParam{
 			Id:                uint32(i),
-			Pair:              genMarketName(r),
+			Pair:              marketName,
 			Exponent:          int32(marketExponent),
 			MinExchanges:      uint32(minExchanges),
 			MinPriceChangePpm: uint32(simtypes.RandIntBetween(r, 1, int(lib.MaxPriceChangePpm))),


### PR DESCRIPTION
### Changelist
generate unique market names in simulation

### Test Plan
existing simulation test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the market name generation process to ensure uniqueness during simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->