### PR TITLE
[CT-755] implement logic for FIRST_STRIKE_CLOSE_ONLY mode

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/compliance-status-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/compliance-status-table.test.ts
@@ -191,7 +191,7 @@ describe('Compliance status store', () => {
         compliantUpsertStatusData,
         {
           ...noncompliantStatusUpsertData,
-          status: ComplianceStatus.FIRST_STRIKE,
+          status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
         },
         {
           ...noncompliantStatusUpsertData,
@@ -217,7 +217,7 @@ describe('Compliance status store', () => {
       }),
       expect.objectContaining({
         ...noncompliantStatusUpsertData,
-        status: ComplianceStatus.FIRST_STRIKE,
+        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
       }),
       expect.objectContaining({
         ...noncompliantStatusUpsertData,

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240410111632_add_compliance_status_status_first_strike_close_only.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240410111632_add_compliance_status_status_first_strike_close_only.ts
@@ -1,0 +1,19 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.raw(`
+    ALTER TABLE "compliance_status"
+    DROP CONSTRAINT "compliance_status_status_check",
+    ADD CONSTRAINT "compliance_status_status_check" 
+    CHECK (status IN ('COMPLIANT', 'FIRST_STRIKE_CLOSE_ONLY', 'FIRST_STRIKE', 'CLOSE_ONLY', 'BLOCKED'))
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.raw(`
+    ALTER TABLE "compliance_status"
+    DROP CONSTRAINT "compliance_status_status_check",
+    ADD CONSTRAINT "compliance_status_status_check" 
+    CHECK (status IN ('COMPLIANT', 'FIRST_STRIKE', 'CLOSE_ONLY', 'BLOCKED'))
+  `);
+}

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240410111632_add_compliance_status_status_first_strike_close_only.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240410111632_add_compliance_status_status_first_strike_close_only.ts
@@ -1,19 +1,19 @@
 import * as Knex from 'knex';
 
+import { formatAlterTableEnumSql } from '../helpers';
+
 export async function up(knex: Knex): Promise<void> {
-  return knex.schema.raw(`
-    ALTER TABLE "compliance_status"
-    DROP CONSTRAINT "compliance_status_status_check",
-    ADD CONSTRAINT "compliance_status_status_check" 
-    CHECK (status IN ('COMPLIANT', 'FIRST_STRIKE_CLOSE_ONLY', 'FIRST_STRIKE', 'CLOSE_ONLY', 'BLOCKED'))
-  `);
+  return knex.raw(formatAlterTableEnumSql(
+    'compliance_status',
+    'status',
+    ['COMPLIANT', 'FIRST_STRIKE_CLOSE_ONLY', 'FIRST_STRIKE', 'CLOSE_ONLY', 'BLOCKED'],
+  ));
 }
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema.raw(`
-    ALTER TABLE "compliance_status"
-    DROP CONSTRAINT "compliance_status_status_check",
-    ADD CONSTRAINT "compliance_status_status_check" 
-    CHECK (status IN ('COMPLIANT', 'FIRST_STRIKE', 'CLOSE_ONLY', 'BLOCKED'))
-  `);
+  return knex.raw(formatAlterTableEnumSql(
+    'compliance_status',
+    'status',
+    ['COMPLIANT', 'FIRST_STRIKE', 'CLOSE_ONLY', 'BLOCKED'],
+  ));
 }

--- a/indexer/packages/postgres/src/types/compliance-status-types.ts
+++ b/indexer/packages/postgres/src/types/compliance-status-types.ts
@@ -12,6 +12,7 @@ export enum ComplianceReason {
 
 export enum ComplianceStatus {
   COMPLIANT = 'COMPLIANT',
+  FIRST_STRIKE_CLOSE_ONLY = 'FIRST_STRIKE_CLOSE_ONLY',
   FIRST_STRIKE = 'FIRST_STRIKE',
   CLOSE_ONLY = 'CLOSE_ONLY',
   BLOCKED = 'BLOCKED',

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
@@ -524,5 +524,71 @@ describe('ComplianceV2Controller', () => {
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
       expect(response.body.updatedAt).toBeDefined();
     });
+
+    it('should update status to CLOSE_ONLY for INVALID_SURVEY action with existing FIRST_STRIKE_CLOSE_ONLY status', async () => {
+      await ComplianceStatusTable.create({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
+        reason: ComplianceReason.US_GEO,
+      });
+      (Secp256k1.verifySignature as jest.Mock).mockResolvedValueOnce(true);
+      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
+      isRestrictedCountryHeadersSpy.mockReturnValue(true);
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: '/v4/compliance/geoblock',
+        body: {
+          ...body,
+          action: ComplianceAction.INVALID_SURVEY,
+        },
+        expectedStatus: 200,
+      });
+
+      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
+      expect(data).toHaveLength(1);
+      expect(data[0]).toEqual(expect.objectContaining({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.CLOSE_ONLY,
+        reason: ComplianceReason.US_GEO,
+      }));
+
+      expect(response.body.status).toEqual(ComplianceStatus.CLOSE_ONLY);
+      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
+      expect(response.body.updatedAt).toBeDefined();
+    });
+
+    it('should update status to FIRST_STRIKE for VALID_SURVEY action with existing FIRST_STRIKE_CLOSE_ONLY status', async () => {
+      await ComplianceStatusTable.create({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
+        reason: ComplianceReason.US_GEO,
+      });
+      (Secp256k1.verifySignature as jest.Mock).mockResolvedValueOnce(true);
+      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
+      isRestrictedCountryHeadersSpy.mockReturnValue(true);
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: '/v4/compliance/geoblock',
+        body: {
+          ...body,
+          action: ComplianceAction.VALID_SURVEY,
+        },
+        expectedStatus: 200,
+      });
+
+      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
+      expect(data).toHaveLength(1);
+      expect(data[0]).toEqual(expect.objectContaining({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.FIRST_STRIKE,
+        reason: ComplianceReason.US_GEO,
+      }));
+
+      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
+      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
+      expect(response.body.updatedAt).toBeDefined();
+    });
   });
 });

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
@@ -212,7 +212,7 @@ describe('ComplianceV2Controller', () => {
       }));
     });
 
-    it('should update exisitng db row for dydx address', async () => {
+    it('should update existing db row for dydx address', async () => {
       await ComplianceStatusTable.create({
         address: testConstants.defaultAddress,
         status: ComplianceStatus.FIRST_STRIKE,
@@ -347,7 +347,7 @@ describe('ComplianceV2Controller', () => {
       expect(response.body.updatedAt).toBeDefined();
     });
 
-    it('should set status to FIRST_STRIKE for CONNECT action from a restricted country with no existing compliance status', async () => {
+    it('should set status to FIRST_STRIKE_CLOSE_ONLY for CONNECT action from a restricted country with no existing compliance status', async () => {
       (Secp256k1.verifySignature as jest.Mock).mockResolvedValueOnce(true);
       getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
       isRestrictedCountryHeadersSpy.mockReturnValue(true);
@@ -366,11 +366,11 @@ describe('ComplianceV2Controller', () => {
       expect(data).toHaveLength(1);
       expect(data[0]).toEqual(expect.objectContaining({
         address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE,
+        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
         reason: ComplianceReason.US_GEO,
       }));
 
-      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
+      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
       expect(response.body.updatedAt).toBeDefined();
     });
@@ -396,7 +396,7 @@ describe('ComplianceV2Controller', () => {
       expect(response.body.status).toEqual(ComplianceStatus.COMPLIANT);
     });
 
-    it('should update status to FIRST_STRIKE for CONNECT action from a restricted country with existing COMPLIANT status', async () => {
+    it('should update status to FIRST_STRIKE_CLOSE_ONLY for CONNECT action from a restricted country with existing COMPLIANT status', async () => {
       await ComplianceStatusTable.create({
         address: testConstants.defaultAddress,
         status: ComplianceStatus.COMPLIANT,
@@ -419,11 +419,11 @@ describe('ComplianceV2Controller', () => {
       expect(data).toHaveLength(1);
       expect(data[0]).toEqual(expect.objectContaining({
         address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE,
+        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
         reason: ComplianceReason.US_GEO,
       }));
 
-      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
+      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
       expect(response.body.updatedAt).toBeDefined();
     });
@@ -458,11 +458,11 @@ describe('ComplianceV2Controller', () => {
       expect(response.body.status).toEqual(ComplianceStatus.COMPLIANT);
     });
 
-    it('should be a no-op for ONBOARD action with existing FIRST_STRIKE status', async () => {
+    it('should be a no-op for ONBOARD action with existing FIRST_STRIKE_CLOSE_ONLY status', async () => {
       const loggerError = jest.spyOn(logger, 'error');
       await ComplianceStatusTable.create({
         address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE,
+        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
         reason: ComplianceReason.US_GEO,
       });
       (Secp256k1.verifySignature as jest.Mock).mockResolvedValueOnce(true);
@@ -479,7 +479,7 @@ describe('ComplianceV2Controller', () => {
       expect(data).toHaveLength(1);
       expect(data[0]).toEqual(expect.objectContaining({
         address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE,
+        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
         reason: ComplianceReason.US_GEO,
       }));
 
@@ -487,7 +487,7 @@ describe('ComplianceV2Controller', () => {
         at: 'ComplianceV2Controller POST /geoblock',
         message: 'Invalid action for current compliance status',
       }));
-      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
+      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
       expect(response.body.updatedAt).toBeDefined();
     });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -3238,6 +3238,7 @@ This operation does not require authentication
 |Property|Value|
 |---|---|
 |*anonymous*|COMPLIANT|
+|*anonymous*|FIRST_STRIKE_CLOSE_ONLY|
 |*anonymous*|FIRST_STRIKE|
 |*anonymous*|CLOSE_ONLY|
 |*anonymous*|BLOCKED|

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -349,6 +349,7 @@
       "ComplianceStatus": {
         "enum": [
           "COMPLIANT",
+          "FIRST_STRIKE_CLOSE_ONLY",
           "FIRST_STRIKE",
           "CLOSE_ONLY",
           "BLOCKED"

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -234,7 +234,8 @@ router.post(
        *  - set the status to FIRST_STRIKE_CLOSE_ONLY
        *
        * if the address is FIRST_STRIKE_CLOSE_ONLY:
-       * - the ONLY actions should be VALID_SURVEY/INVALID_SURVEY. ONBOARD/CONNECT are no-ops.
+       * - the ONLY actions should be VALID_SURVEY/INVALID_SURVEY/CONNECT. ONBOARD/CONNECT
+       * are no-ops.
        * - if the action is VALID_SURVEY:
        *   - set the status to FIRST_STRIKE
        * - if the action is INVALID_SURVEY:
@@ -304,7 +305,7 @@ router.post(
         } else if (
           complianceStatus[0].status === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY
         ) {
-          if (action === ComplianceAction.ONBOARD || action === ComplianceAction.CONNECT) {
+          if (action === ComplianceAction.ONBOARD) {
             logger.error({
               at: 'ComplianceV2Controller POST /geoblock',
               message: 'Invalid action for current compliance status',

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -34,10 +34,12 @@ const controllerName: string = 'compliance-v2-controller';
 export enum ComplianceAction {
   ONBOARD = 'ONBOARD',
   CONNECT = 'CONNECT',
+  VALID_SURVEY = 'VALID_SURVEY',
+  INVALID_SURVEY = 'INVALID_SURVEY',
 }
 
 const COMPLIANCE_PROGRESSION: Partial<Record<ComplianceStatus, ComplianceStatus>> = {
-  [ComplianceStatus.COMPLIANT]: ComplianceStatus.FIRST_STRIKE,
+  [ComplianceStatus.COMPLIANT]: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
   [ComplianceStatus.FIRST_STRIKE]: ComplianceStatus.CLOSE_ONLY,
 };
 
@@ -222,17 +224,24 @@ router.post(
        * If the address doesn't exist in the compliance table:
        * - if the request is from a restricted country:
        *  - if the action is ONBOARD, set the status to BLOCKED
-       *  - if the action is CONNECT, set the status to FIRST_STRIKE
+       *  - if the action is CONNECT, set the status to FIRST_STRIKE_CLOSE_ONLY
        * - else if the request is from a non-restricted country:
        *  - set the status to COMPLIANT
        *
        * if the address is COMPLIANT:
-       * - the ONLY action should be CONNECT. ONBOARD is a no-op.
+       * - the ONLY action should be CONNECT. ONBOARD/VALID_SURVEY/INVALID_SURVEY are no-ops.
        * - if the request is from a restricted country:
-       *  - set the status to FIRST_STRIKE
+       *  - set the status to FIRST_STRIKE_CLOSE_ONLY
+       *
+       * if the address is FIRST_STRIKE_CLOSE_ONLY:
+       * - the ONLY actions should be VALID_SURVEY/INVALID_SURVEY. ONBOARD/CONNECT are no-ops.
+       * - if the action is VALID_SURVEY:
+       *   - set the status to FIRST_STRIKE
+       * - if the action is INVALID_SURVEY:
+       *   - set the status to CLOSE_ONLY
        *
        * if the address is FIRST_STRIKE:
-       * - the ONLY action should be CONNECT. ONBOARD is a no-op.
+       * - the ONLY action should be CONNECT. ONBOARD/VALID_SURVEY/INVALID_SURVEY are no-ops.
        * - if the request is from a restricted country:
        *  - set the status to CLOSE_ONLY
        */
@@ -255,7 +264,7 @@ router.post(
           } else if (action === ComplianceAction.CONNECT) {
             complianceStatusFromDatabase = await ComplianceStatusTable.upsert({
               address,
-              status: ComplianceStatus.FIRST_STRIKE,
+              status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
               reason: getGeoComplianceReason(req.headers as CountryHeaders)!,
               updatedAt,
             });
@@ -289,6 +298,30 @@ router.post(
               address,
               status: COMPLIANCE_PROGRESSION[complianceStatus[0].status],
               reason: getGeoComplianceReason(req.headers as CountryHeaders)!,
+              updatedAt,
+            });
+          }
+        } else if (
+          complianceStatus[0].status === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY
+        ) {
+          if (action === ComplianceAction.ONBOARD || action === ComplianceAction.CONNECT) {
+            logger.error({
+              at: 'ComplianceV2Controller POST /geoblock',
+              message: 'Invalid action for current compliance status',
+              address,
+              action,
+              complianceStatus: complianceStatus[0],
+            });
+          } else if (action === ComplianceAction.VALID_SURVEY) {
+            complianceStatusFromDatabase = await ComplianceStatusTable.update({
+              address,
+              status: ComplianceStatus.FIRST_STRIKE,
+              updatedAt,
+            });
+          } else if (action === ComplianceAction.INVALID_SURVEY) {
+            complianceStatusFromDatabase = await ComplianceStatusTable.update({
+              address,
+              status: ComplianceStatus.CLOSE_ONLY,
               updatedAt,
             });
           }


### PR DESCRIPTION
### Changelist

Context: If a previously compliant user connects from a geo-restricted country, they will first be put into FIRST_STRIKE_CLOSE_ONLY. They will then receive a survey where they will answer their place of residence. Based on their response, they can transition from FIRST_STRIKE_CLOSE_ONLY -> (FIRST_STRIKE, CLOSE_ONLY).

### Test Plan

Unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



## Summary by CodeRabbit

- **New Features**
	- Introduced a new compliance status "FIRST_STRIKE_CLOSE_ONLY" to enhance tracking capabilities.
- **Refactor**
	- Updated test descriptions to reflect the new compliance status accurately.
- **Database Changes**
	- Implemented a database migration to include the new compliance status in the "compliance_status" table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->