### PR TITLE
decouple grpc and non validating full node flags

### DIFF
--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -104,10 +104,6 @@ func (f *Flags) Validate() error {
 		if !f.GrpcEnable {
 			return fmt.Errorf("grpc.enable must be set to true - grpc streaming requires gRPC server")
 		}
-
-		if !f.NonValidatingFullNode {
-			return fmt.Errorf("grpc-streaming-enabled can only be set to true for non-validating full nodes")
-		}
 	}
 	return nil
 }

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -61,19 +61,18 @@ func TestValidate(t *testing.T) {
 				NonValidatingFullNode: true,
 			},
 		},
-		"failure - gRPC disabled": {
-			flags: flags.Flags{
-				GrpcEnable: false,
-			},
-			expectedErr: fmt.Errorf("grpc.enable must be set to true - validating requires gRPC server"),
-		},
-		"failure - gRPC streaming enabled for validating nodes": {
+		"success - gRPC streaming enabled for validating nodes": {
 			flags: flags.Flags{
 				NonValidatingFullNode: false,
 				GrpcEnable:            true,
 				GrpcStreamingEnabled:  true,
 			},
-			expectedErr: fmt.Errorf("grpc-streaming-enabled can only be set to true for non-validating full nodes"),
+		},
+		"failure - gRPC disabled": {
+			flags: flags.Flags{
+				GrpcEnable: false,
+			},
+			expectedErr: fmt.Errorf("grpc.enable must be set to true - validating requires gRPC server"),
 		},
 		"failure - gRPC streaming enabled with gRPC disabled": {
 			flags: flags.Flags{


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
