### PR TITLE
[TRA-233] Fix IsIsolatedPerpetual function orientation

### DIFF
--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -33,8 +33,12 @@ import (
 )
 
 func (k Keeper) IsIsolatedPerpetual(ctx sdk.Context, perpetualId uint32) (bool, error) {
-	insuranceFundName, err := k.GetInsuranceFundName(ctx, perpetualId)
-	return insuranceFundName == types.InsuranceFundName, err
+	perpetual, err := k.GetPerpetual(ctx, perpetualId)
+	if err != nil {
+		return false, err
+	}
+
+	return perpetual.Params.MarketType == types.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED, nil
 }
 
 // GetInsuranceFundName returns the name of the insurance fund account for a given perpetual.

--- a/protocol/x/perpetuals/keeper/perpetual_test.go
+++ b/protocol/x/perpetuals/keeper/perpetual_test.go
@@ -3542,3 +3542,35 @@ func TestModifyOpenInterest_store(t *testing.T) {
 		require.Equal(t, perpetualObject.OpenInterest, serializedOpenInterest)
 	}
 }
+
+func TestIsIsolatedPerpetual(t *testing.T) {
+	testCases := map[string]struct {
+		perp     types.Perpetual
+		expected bool
+	}{
+		"Isolated Perpetual": {
+			perp: *perptest.GeneratePerpetual(
+				perptest.WithMarketType(types.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED),
+			),
+			expected: true,
+		},
+		"Cross Perpetual": {
+			perp: *perptest.GeneratePerpetual(
+				perptest.WithMarketType(types.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS),
+			),
+			expected: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(
+			name, func(t *testing.T) {
+				pc := keepertest.PerpetualsKeepers(t)
+				pc.PerpetualsKeeper.SetPerpetual(pc.Ctx, tc.perp)
+				isIsolated, err := pc.PerpetualsKeeper.IsIsolatedPerpetual(pc.Ctx, tc.perp.Params.Id)
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, isIsolated)
+			},
+		)
+	}
+}

--- a/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
+++ b/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
@@ -112,9 +112,9 @@ func (k Keeper) getNegativeTncSubaccountStoreSuffix(
 		return "", err
 	}
 	if isIsolated {
-		return types.CrossCollateralSuffix, nil
-	} else {
 		return lib.UintToString(perpetualId), nil
+	} else {
+		return types.CrossCollateralSuffix, nil
 	}
 }
 


### PR DESCRIPTION
### Changelist
Currently, IsIsolatedPerpetual returns True for cross perpetuals and its callers expect the same, which is the wrong orientation for the function. This change fixes this behavior

### Test Plan
Existing tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
