### PR TITLE
Add script to create full node

### DIFF
--- a/protocol/scripts/create_full_node.sh
+++ b/protocol/scripts/create_full_node.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-# version needs to be changed on new releases
+if [ $(nproc) -lt 8 ]; then
+  echo "This device has less than 8 cpus, recommended to use a device with at least 8 cpus"
+fi
+
+if [ $(free -g | grep Mem | awk '{print $2}') -lt 64 ]; then
+  echo "This device has lass than 64 gigs of ram, recommended to use a device with at least 64 gigs of ram"
+fi
+
 VERSION="v4.0.5"
-WORKDIR=$HOME/dydxprotocol
+WORKDIR=$HOME/.dydxprotocol
 CHAIN_ID="dydx-mainnet-1"
-DATA_DIR=$WORKDIR/data
 SEED_NODES=("ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:23856", 
 "65b740ee326c9260c30af1f044e9cda63c73f7c1@seeds.kingnodes.net:23856", 
 "f04a77b92d0d86725cdb2d6b7a7eb0eda8c27089@dydx-mainnet-seed.bwarelabs.com:36656",
@@ -18,76 +24,90 @@ BASE_SNAPSHOT_URL="https://snapshots.polkachu.com/snapshots/"
 # Add random number to the end of name to keep a unique name for the node
 NODE_NAME="FullNodeMainnet-$RANDOM" 
 
+# Update system and install dependencies
 
-if [ $(nproc) -lt 8 ]; then
-  echo "This device has less than 8 cpus, recommended to use a device with at least 8 cpus"
+sudo apt-get -y update
+sudo apt-get install -y curl jq lz4
+
+
+# Get architecture
+if [ $(uname -m) = "aarch64" ]; then
+ARCH=arm64
+elif [ $(uname -m) = "x86_64" ]; then
+ARCH=amd64
+else
+echo "This device is not arm64 or amd64, please use a device with arm64 or amd64 architecture"
 fi
 
-if [ $(free -g | grep Mem | awk '{print $2}') -lt 64 ]; then
-  echo "This device has lass than 64 gigs of ram, recommended to use a device with at least 64 gigs of ram"
-fi
+# Install go
+wget https://golang.org/dl/go1.22.2.linux-$ARCH.tar.gz 
+sudo tar -C /usr/local -xzf go1.22.2.linux-$ARCH.tar.gz
+rm go1.22.2.linux-$ARCH.tar.gz
+echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin' >> $HOME/.bashrc
+eval "$(cat $HOME/.bashrc | tail -n +10)"
 
-# Check if dydxprotocold is not installed
-if [ ! $(which dydxprotocold) ]; then
-  echo "dydxprotocold is not installed, installing dydxprotocold"
-    mkdir -p $WORKDIR
-    cd $WORKDIR
+# Install Cosmovisor
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
 
-    # check arch of the device
-    if [ $(uname -m) = "aarch64" ]; then
-    ARCH=arm64
-    elif [ $(uname -m) = "x86_64" ]; then
-    ARCH=amd64
-    else
-    echo "This device is not arm64 or amd64, please use a device with arm64 or amd64 architecture"
-    fi
-    FILE_REGEX="dydxprotocold-v[0-9]+\.[0-9]+\.[0-9]+-linux-$ARCH.tar.gz"
+# Download dydxprotocold binaries and initialize node
+mkdir -p $WORKDIR
+cd $WORKDIR
+FILE_REGEX="dydxprotocold-v[0-9]+\.[0-9]+\.[0-9]+-linux-$ARCH.tar.gz"
+curl -s "https://api.github.com/repos/dydxprotocol/v4-chain/releases/tags/protocol/$VERSION" \
+| grep -E $FILE_REGEX \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -qi -
+tar -xvf dydxprotocold-v*-linux-$ARCH.tar.gz && rm dydxprotocold-v*-linux-$ARCH.tar.gz
+cd $WORKDIR/build
+mv dydxprotocold-*-linux-$ARCH dydxprotocold
+chmod +x dydxprotocold
+./dydxprotocold init --chain-id=$CHAIN_ID $NODE_NAME
 
-    #Download latest github release for repo
-    curl -s "https://api.github.com/repos/dydxprotocol/v4-chain/releases/tags/protocol/$VERSION" \
-    | grep -E $FILE_REGEX \
-    | cut -d : -f 2,3 \
-    | tr -d \" \
-    | wget -qi -
+# Create cosmovisor directories and move binaries
+mkdir -p $HOME/.dydxprotocol/cosmovisor/genesis/bin
+mkdir -p $HOME/.dydxprotocol/cosmovisor/upgrades
+mv dydxprotocold $HOME/.dydxprotocol/cosmovisor/genesis/bin/
 
-    tar -xvf dydxprotocold-v*-linux-$ARCH.tar.gz
-    rm dydxprotocold-v*-linux-$ARCH.tar.gz
-    cd $WORKDIR/build
-    mv dydxprotocold-*-linux-$ARCH dydxprotocold
-    chmod +x dydxprotocold
+# Update config
+curl https://dydx-rpc.lavenderfive.com/genesis | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin)["result"]["genesis"], indent=2))' > $WORKDIR/config/genesis.json
+sed -i 's/seeds = ""/seeds = "'"${SEED_NODES[*]}"'"/' $WORKDIR/config/config.toml
 
-    # check if is not in path
-    if [ ! $(echo $PATH | grep "$HOME/.local/bin") ]; then
-        # if .local/bin does not exist, create it
-        if [ ! -d "$HOME/.local/bin" ]; then
-        mkdir -p $HOME/.local/bin
-        fi
-        echo "export PATH=$HOME/.local/bin:$PATH" >> $HOME/.bashrc
-        eval "$(cat $HOME/.bashrc | tail -n +10)"
-    fi
-    cp dydxprotocold $HOME/.local/bin
-    rm -rf $WORKDIR/build
+# Create Service
+sudo tee /etc/systemd/system/dydxprotocold.service > /dev/null << EOF
+[Unit]
+Description=osmosis node service
+After=network-online.target
 
-    mkdir $DATA_DIR 
-    dydxprotocold init --chain-id=$CHAIN_ID --home=$DATA_DIR $NODE_NAME
-fi
+[Service]
+User=$USER
+ExecStart=/$HOME/go/bin/cosmovisor run start --non-validating-full-node=true
+WorkingDirectory=$HOME/.dydxprotocol
+Restart=always
+RestartSec=5
+LimitNOFILE=4096
+Environment="DAEMON_HOME=$HOME/.dydxprotocol"
+Environment="DAEMON_NAME=dydxprotocold"
+Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
+Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+Environment="UNSAFE_SKIP_BACKUP=true"
 
-# Move the priv_validator_key.json to the workdir while getting the snapshot
-mv $DATA_DIR/config/priv_validator_key.json $WORKDIR
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable dydxprotocold
+
 
 # Get snapshot
-cd $DATA_DIR
+cd $WORKDIR
 xml_content=$(curl -s "${BASE_SNAPSHOT_URL}")
 file_key=$(echo "$xml_content" | grep -oP '<Key>dydx/dydx_\d+\.tar\.lz4</Key>' | head -1 | sed 's/<[^>]*>//g')
 file_url="${BASE_SNAPSHOT_URL}${file_key}"
 wget -O "snapshot.tar.lz4" "${file_url}"
-lz4 -c -d snapshot.tar.lz4 | tar -x -C $DATA_DIR
+lz4 -c -d snapshot.tar.lz4 | tar -x -C $WORKDIR
 rm snapshot.tar.lz4
 
-# Move the priv_validator_key.json back to the config folder
-mv $WORKDIR/priv_validator_key.json $DATA_DIR/config
-
-# Get genesis file
-curl https://dydx-rpc.lavenderfive.com/genesis | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin)["result"]["genesis"], indent=2))' > $DATA_DIR/config/genesis.json
-
-dydxprotocold start --p2p.seeds="${SEED_NODES[*]}" --home=$DATA_DIR --non-validating-full-node=true
+# Start service
+sudo systemctl start dydxprotocold

--- a/protocol/scripts/create_full_node.sh
+++ b/protocol/scripts/create_full_node.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# version needs to be changed on new releases
+VERSION="v4.0.5"
+WORKDIR=$HOME/dydxprotocol
+CHAIN_ID="dydx-mainnet-1"
+DATA_DIR=$WORKDIR/data
+SEED_NODES=("ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:23856", 
+"65b740ee326c9260c30af1f044e9cda63c73f7c1@seeds.kingnodes.net:23856", 
+"f04a77b92d0d86725cdb2d6b7a7eb0eda8c27089@dydx-mainnet-seed.bwarelabs.com:36656",
+"20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:23856",
+"c2c2fcb5e6e4755e06b83b499aff93e97282f8e8@tenderseed.ccvalidators.com:26401",
+"a9cae4047d5c34772442322b10ef5600d8e54900@dydx-mainnet-seednode.allthatnode.com:26656",
+"802607c6db8148b0c68c8a9ec1a86fd3ba606af6@64.227.38.88:26656",
+"ebc272824924ea1a27ea3183dd0b9ba713494f83@dydx-mainnet-seed.autostake.com:27366"
+)
+BASE_SNAPSHOT_URL="https://snapshots.polkachu.com/snapshots/"
+# Add random number to the end of name to keep a unique name for the node
+NODE_NAME="FullNodeMainnet-$RANDOM" 
+
+
+if [ $(nproc) -lt 8 ]; then
+  echo "This device has less than 8 cpus, recommended to use a device with at least 8 cpus"
+fi
+
+if [ $(free -g | grep Mem | awk '{print $2}') -lt 64 ]; then
+  echo "This device has lass than 64 gigs of ram, recommended to use a device with at least 64 gigs of ram"
+fi
+
+# Check if dydxprotocold is not installed
+if [ ! $(which dydxprotocold) ]; then
+  echo "dydxprotocold is not installed, installing dydxprotocold"
+    mkdir -p $WORKDIR
+    cd $WORKDIR
+
+    # check arch of the device
+    if [ $(uname -m) = "aarch64" ]; then
+    ARCH=arm64
+    elif [ $(uname -m) = "x86_64" ]; then
+    ARCH=amd64
+    else
+    echo "This device is not arm64 or amd64, please use a device with arm64 or amd64 architecture"
+    fi
+    FILE_REGEX="dydxprotocold-v[0-9]+\.[0-9]+\.[0-9]+-linux-$ARCH.tar.gz"
+
+    #Download latest github release for repo
+    curl -s "https://api.github.com/repos/dydxprotocol/v4-chain/releases/tags/protocol/$VERSION" \
+    | grep -E $FILE_REGEX \
+    | cut -d : -f 2,3 \
+    | tr -d \" \
+    | wget -qi -
+
+    tar -xvf dydxprotocold-v*-linux-$ARCH.tar.gz
+    rm dydxprotocold-v*-linux-$ARCH.tar.gz
+    cd $WORKDIR/build
+    mv dydxprotocold-*-linux-$ARCH dydxprotocold
+    chmod +x dydxprotocold
+
+    # check if is not in path
+    if [ ! $(echo $PATH | grep "$HOME/.local/bin") ]; then
+        # if .local/bin does not exist, create it
+        if [ ! -d "$HOME/.local/bin" ]; then
+        mkdir -p $HOME/.local/bin
+        fi
+        echo "export PATH=$HOME/.local/bin:$PATH" >> $HOME/.bashrc
+        eval "$(cat $HOME/.bashrc | tail -n +10)"
+    fi
+    cp dydxprotocold $HOME/.local/bin
+    rm -rf $WORKDIR/build
+
+    mkdir $DATA_DIR 
+    dydxprotocold init --chain-id=$CHAIN_ID --home=$DATA_DIR $NODE_NAME
+fi
+
+# Move the priv_validator_key.json to the workdir while getting the snapshot
+mv $DATA_DIR/config/priv_validator_key.json $WORKDIR
+
+# Get snapshot
+cd $DATA_DIR
+xml_content=$(curl -s "${BASE_SNAPSHOT_URL}")
+file_key=$(echo "$xml_content" | grep -oP '<Key>dydx/dydx_\d+\.tar\.lz4</Key>' | head -1 | sed 's/<[^>]*>//g')
+file_url="${BASE_SNAPSHOT_URL}${file_key}"
+wget -O "snapshot.tar.lz4" "${file_url}"
+lz4 -c -d snapshot.tar.lz4 | tar -x -C $DATA_DIR
+rm snapshot.tar.lz4
+
+# Move the priv_validator_key.json back to the config folder
+mv $WORKDIR/priv_validator_key.json $DATA_DIR/config
+
+# Get genesis file
+curl https://dydx-rpc.lavenderfive.com/genesis | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin)["result"]["genesis"], indent=2))' > $DATA_DIR/config/genesis.json
+
+dydxprotocold start --p2p.seeds="${SEED_NODES[*]}" --home=$DATA_DIR --non-validating-full-node=true


### PR DESCRIPTION
### Changelist
Adds a script which can be used to create a full node. Assumes user can download the script and pipe the output as needed

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a script for easy setup of a non-validating full node on the dydx protocol, including automated dependency installation, node initialization, and service setup.
  - Accelerated node syncing process through an automated snapshot download and setup feature.

- **Enhancements**
  - Updated various script variables such as `VERSION`, `WORKDIR`, and `CHAIN_ID` for improved customization and flexibility.
  - Enhanced service configuration for better stability and performance.

- **Bug Fixes**
  - Added a new function `read_yes_or_exit` to ensure robust user confirmation steps during the script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->