### PR TITLE
Refactor perpetual upgrade handlers in `v5.0.0`

### DIFF
--- a/protocol/app/upgrades/v5.0.0/upgrade.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade.go
@@ -147,8 +147,10 @@ func blockRateLimitConfigUpdate(
 		panic(fmt.Sprintf("failed to update the block rate limit configuration: %s", err))
 	}
 	ctx.Logger().Info(
-		"Successfully upgraded block rate limit configuration to: %+v\n",
-		clobKeeper.GetBlockRateLimitConfiguration(ctx),
+		fmt.Sprintf(
+			"Successfully upgraded block rate limit configuration to: %+v\n",
+			clobKeeper.GetBlockRateLimitConfiguration(ctx),
+		),
 	)
 }
 

--- a/protocol/app/upgrades/v5.0.0/upgrade.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade.go
@@ -78,11 +78,10 @@ func perpetualsUpgrade(
 			))
 		}
 		ctx.Logger().Info(fmt.Sprintf(
-			"Successfully migrated perpetual %d: %v",
+			"Successfully migrated perpetual %d: %+v",
 			perp.GetId(),
 			perp,
 		))
-		ctx.Logger().Info(fmt.Sprintf("Perpetual %d has zero open interest at the time of upgrade", perp.GetId()))
 	}
 }
 

--- a/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
@@ -1,3 +1,5 @@
+//go:build all || container_test
+
 package v_5_0_0_test
 
 import (

--- a/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
@@ -1,5 +1,3 @@
-//go:build all || container_test
-
 package v_5_0_0_test
 
 import (

--- a/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade_container_test.go
@@ -21,6 +21,8 @@ import (
 
 const (
 	AliceBobBTCQuantums = 1_000_000
+	CarlDaveBTCQuantums = 2_000_000
+	CarlDaveETHQuantums = 4_000_000
 )
 
 func TestStateUpgrade(t *testing.T) {
@@ -119,6 +121,94 @@ func placeOrders(node *containertest.Node, t *testing.T) {
 		},
 		constants.BobAccAddress.String(),
 	))
+	require.NoError(t, containertest.BroadcastTx(
+		node,
+		&clobtypes.MsgPlaceOrder{
+			Order: clobtypes.Order{
+				OrderId: clobtypes.OrderId{
+					ClientId: 0,
+					SubaccountId: satypes.SubaccountId{
+						Owner:  constants.CarlAccAddress.String(),
+						Number: 0,
+					},
+					ClobPairId: 0,
+				},
+				Side:     clobtypes.Order_SIDE_BUY,
+				Quantums: CarlDaveBTCQuantums,
+				Subticks: 5_000_000,
+				GoodTilOneof: &clobtypes.Order_GoodTilBlock{
+					GoodTilBlock: 20,
+				},
+			},
+		},
+		constants.CarlAccAddress.String(),
+	))
+	require.NoError(t, containertest.BroadcastTx(
+		node,
+		&clobtypes.MsgPlaceOrder{
+			Order: clobtypes.Order{
+				OrderId: clobtypes.OrderId{
+					ClientId: 0,
+					SubaccountId: satypes.SubaccountId{
+						Owner:  constants.DaveAccAddress.String(),
+						Number: 0,
+					},
+					ClobPairId: 0,
+				},
+				Side:     clobtypes.Order_SIDE_SELL,
+				Quantums: CarlDaveBTCQuantums,
+				Subticks: 5_000_000,
+				GoodTilOneof: &clobtypes.Order_GoodTilBlock{
+					GoodTilBlock: 20,
+				},
+			},
+		},
+		constants.DaveAccAddress.String(),
+	))
+	require.NoError(t, containertest.BroadcastTx(
+		node,
+		&clobtypes.MsgPlaceOrder{
+			Order: clobtypes.Order{
+				OrderId: clobtypes.OrderId{
+					ClientId: 0,
+					SubaccountId: satypes.SubaccountId{
+						Owner:  constants.CarlAccAddress.String(),
+						Number: 0,
+					},
+					ClobPairId: 1,
+				},
+				Side:     clobtypes.Order_SIDE_BUY,
+				Quantums: CarlDaveETHQuantums,
+				Subticks: 5_000_000,
+				GoodTilOneof: &clobtypes.Order_GoodTilBlock{
+					GoodTilBlock: 20,
+				},
+			},
+		},
+		constants.CarlAccAddress.String(),
+	))
+	require.NoError(t, containertest.BroadcastTx(
+		node,
+		&clobtypes.MsgPlaceOrder{
+			Order: clobtypes.Order{
+				OrderId: clobtypes.OrderId{
+					ClientId: 0,
+					SubaccountId: satypes.SubaccountId{
+						Owner:  constants.DaveAccAddress.String(),
+						Number: 0,
+					},
+					ClobPairId: 1,
+				},
+				Side:     clobtypes.Order_SIDE_SELL,
+				Quantums: CarlDaveETHQuantums,
+				Subticks: 5_000_000,
+				GoodTilOneof: &clobtypes.Order_GoodTilBlock{
+					GoodTilBlock: 20,
+				},
+			},
+		},
+		constants.DaveAccAddress.String(),
+	))
 	err := node.Wait(2)
 	require.NoError(t, err)
 }
@@ -186,7 +276,9 @@ func postUpgradePerpetualOIs(node *containertest.Node, t *testing.T) {
 	for _, perp := range allPerpsResp.Perpetual {
 		expectedOI := 0
 		if perp.Params.Id == 0 {
-			expectedOI = AliceBobBTCQuantums
+			expectedOI = AliceBobBTCQuantums + CarlDaveBTCQuantums
+		} else if perp.Params.Id == 1 {
+			expectedOI = CarlDaveETHQuantums
 		}
 		assert.Equalf(t,
 			dtypes.NewInt(int64(expectedOI)),

--- a/protocol/mocks/PerpetualsKeeper.go
+++ b/protocol/mocks/PerpetualsKeeper.go
@@ -450,6 +450,24 @@ func (_m *PerpetualsKeeper) SetPerpetualMarketType(ctx types.Context, id uint32,
 	return r0, r1
 }
 
+// ValidateAndSetPerpetual provides a mock function with given fields: ctx, perpetual
+func (_m *PerpetualsKeeper) ValidateAndSetPerpetual(ctx types.Context, perpetual perpetualstypes.Perpetual) error {
+	ret := _m.Called(ctx, perpetual)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateAndSetPerpetual")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(types.Context, perpetualstypes.Perpetual) error); ok {
+		r0 = rf(ctx, perpetual)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewPerpetualsKeeper creates a new instance of PerpetualsKeeper. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewPerpetualsKeeper(t interface {

--- a/protocol/testing/containertest/preupgrade_genesis.json
+++ b/protocol/testing/containertest/preupgrade_genesis.json
@@ -2163,6 +2163,34 @@
             {
               "asset_id": 0,
               "index": 0,
+              "quantums": "100000000000000000"
+            }
+          ],
+          "id": {
+            "number": 0,
+            "owner": "dydx1fjg6zp6vv8t9wvy4lps03r5l4g7tkjw9wvmh70"
+          },
+          "margin_enabled": true
+        },
+        {
+          "asset_positions": [
+            {
+              "asset_id": 0,
+              "index": 0,
+              "quantums": "100000000000000000"
+            }
+          ],
+          "id": {
+            "number": 0,
+            "owner": "dydx1wau5mja7j7zdavtfq9lu7ejef05hm6ffenlcsn"
+          },
+          "margin_enabled": true
+        },
+        {
+          "asset_positions": [
+            {
+              "asset_id": 0,
+              "index": 0,
               "quantums": "900000000000000000"
             }
           ],

--- a/protocol/x/perpetuals/types/types.go
+++ b/protocol/x/perpetuals/types/types.go
@@ -124,6 +124,10 @@ type PerpetualsKeeper interface {
 	) []Perpetual
 	GetAllLiquidityTiers(ctx sdk.Context) (list []LiquidityTier)
 	SendOIUpdatesToIndexer(ctx sdk.Context)
+	ValidateAndSetPerpetual(
+		ctx sdk.Context,
+		perpetual Perpetual,
+	) error
 }
 
 // OpenInterestDelta represents a (perpId, openInterestDelta) tuple.


### PR DESCRIPTION
### Changelist
- Combine `MarketType` and `OpenInterest` initialization logic so that each perpetual are only written to state once. 
- Some slight refactoring of `OpenInterest` iniitializing logic
   - Don't check for `OpenInterest` pre-upgrade handler since it's expected to be `Nil`
   - Explicitly initialize `OpenInterest` to zero if market has no OI

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the upgrade process to initialize and aggregate open interest for perpetual markets, ensuring accurate and up-to-date financial data.
	- Improved trading functionality by introducing new quantum values for BTC and ETH, allowing for more precise order placements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->