### PR TITLE
feat: add a prometheus instance to the dydx local network

### DIFF
--- a/protocol/contrib/prometheus/prometheus.yml
+++ b/protocol/contrib/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 100ms  # Adjust this as necessary
+  evaluation_interval: 1s
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["slinky0:8002"] # ingest side-car metrics in accordance w/ docker-compose env

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -113,13 +113,19 @@ services:
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
   slinky0:
-    image: ghcr.io/skip-mev/slinky-sidecar:v0.3.2
+    image: ghcr.io/skip-mev/slinky-sidecar:v0.4.1
     entrypoint: >
       sh -c "slinky-config --chain dydx --node-http-url http://dydxprotocold0:1317 --oracle-config-path /etc/oracle.json &&
              slinky --oracle-config-path /etc/oracle.json --update-market-config-path /etc/market.json"
     ports:
       - "8080:8080"
-
+      - "8002:8002" # metrics
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./contrib/prometheus:/etc/prometheus/
+    ports:
+      - "9091:9090"
   datadog-agent:
     image: public.ecr.aws/datadog/agent:7
     environment:


### PR DESCRIPTION
## In This PR
- I introduce a prometheus data-base to the local-network in dydx
- I export metrics from the slinky-sidecar in the network + export metrics to the prometheus DB
- I change the sidecar version used in the local network to 0.4.1
- This [PR](https://github.com/dydxprotocol/v4-web/pull/489) to validate changes to the research-json against a slinky instance, depends on this PR