### PR TITLE
move open interest handler to block handler map

### DIFF
--- a/indexer/services/ender/__tests__/handlers/open-interest-update-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/open-interest-update-handler.test.ts
@@ -58,7 +58,7 @@ describe('openInterestUpdateHandler', () => {
   });
 
   it('update open interest', async () => {
-    const transactionIndex: number = 0;
+    const transactionIndex: number = -1;
     const openInterestUpdateEvent: OpenInterestUpdateEventV1 = defaultOpenInterestUpdateEvent;
     const kafkaMessage: KafkaMessage = createKafkaEventForOpenInterestUpdateEvent({
       openInterestUpdateEvent,

--- a/indexer/services/ender/src/lib/block-processor.ts
+++ b/indexer/services/ender/src/lib/block-processor.ts
@@ -49,13 +49,13 @@ const TXN_EVENT_SUBTYPE_VERSION_TO_VALIDATOR_MAPPING: Record<string, ValidatorIn
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.UPDATE_PERPETUAL.toString(), 1)]: UpdatePerpetualValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.UPDATE_CLOB_PAIR.toString(), 1)]: UpdateClobPairValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.DELEVERAGING.toString(), 1)]: DeleveragingValidator,
-  [serializeSubtypeAndVersion(DydxIndexerSubtypes.OPEN_INTEREST_UPDATE.toString(), 1)]: OpenInterestUpdateValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.LIQUIDITY_TIER.toString(), 2)]: LiquidityTierValidatorV2,
 };
 
 const BLOCK_EVENT_SUBTYPE_VERSION_TO_VALIDATOR_MAPPING: Record<string, ValidatorInitializer> = {
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.FUNDING.toString(), 1)]: FundingValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.TRADING_REWARD.toString(), 1)]: TradingRewardsValidator,
+  [serializeSubtypeAndVersion(DydxIndexerSubtypes.OPEN_INTEREST_UPDATE.toString(), 1)]: OpenInterestUpdateValidator,
 };
 
 function serializeSubtypeAndVersion(


### PR DESCRIPTION
### Changelist
protocol sends a block event whereas indexer handles a transaction event. Changing indexer to handle block event

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the organization of event validators in the indexing service for better clarity and management.

- **Tests**
	- Updated test configurations to align with recent changes in the indexing service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->