### PR TITLE
[CT-804] Fix stateful order removal event ordering.

### DIFF
--- a/indexer/services/ender/__tests__/handlers/stateful-order/conditional-order-placement-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/conditional-order-placement-handler.test.ts
@@ -122,9 +122,16 @@ describe('conditionalOrderPlacementHandler', () => {
     });
   });
 
-  it('successfully places order', async () => {
+  it.each([
+    ['transaction event', 0],
+    ['block event', -1],
+  ])('successfully places order (as %s)', async (
+    _name: string,
+    transactionIndex: number,
+  ) => {
     const kafkaMessage: KafkaMessage = createKafkaMessageFromStatefulOrderEvent(
       defaultStatefulOrderEvent,
+      transactionIndex,
     );
 
     await onMessage(kafkaMessage);
@@ -155,6 +162,8 @@ describe('conditionalOrderPlacementHandler', () => {
       producerSendMock,
       defaultOrder.orderId!.subaccountId!,
       order!,
+      defaultHeight.toString(),
+      transactionIndex,
     );
   });
 

--- a/indexer/services/ender/__tests__/handlers/stateful-order/conditional-order-triggered-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/conditional-order-triggered-handler.test.ts
@@ -107,7 +107,13 @@ describe('conditionalOrderTriggeredHandler', () => {
     });
   });
 
-  it('successfully triggers order and sends to vulcan', async () => {
+  it.each([
+    ['transaction event', 0],
+    ['block event', -1],
+  ])('successfully triggers order and sends to vulcan (as %s)', async (
+    _name: string,
+    transactionIndex: number,
+  ) => {
     await OrderTable.create({
       ...testConstants.defaultOrderGoodTilBlockTime,
       orderFlags: conditionalOrderId.orderFlags.toString(),
@@ -117,6 +123,7 @@ describe('conditionalOrderTriggeredHandler', () => {
     });
     const kafkaMessage: KafkaMessage = createKafkaMessageFromStatefulOrderEvent(
       defaultStatefulOrderEvent,
+      transactionIndex,
     );
 
     await onMessage(kafkaMessage);

--- a/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-placement-handler.test.ts
@@ -138,18 +138,24 @@ describe('statefulOrderPlacementHandler', () => {
 
   it.each([
     // TODO(IND-334): Remove after deprecating StatefulOrderPlacementEvent
-    ['stateful order placement', defaultStatefulOrderEvent, false],
-    ['stateful long term order placement', defaultStatefulOrderLongTermEvent, false],
-    ['stateful order placement', defaultStatefulOrderEvent, true],
-    ['stateful long term order placement', defaultStatefulOrderLongTermEvent, true],
+    ['stateful order placement as txn event', defaultStatefulOrderEvent, false, 0],
+    ['stateful long term order placement as txn event', defaultStatefulOrderLongTermEvent, false, 0],
+    ['stateful order placement as txn event', defaultStatefulOrderEvent, true, 0],
+    ['stateful long term order placement as txn event', defaultStatefulOrderLongTermEvent, true, 0],
+    ['stateful order placement as block event', defaultStatefulOrderEvent, false, -1],
+    ['stateful long term order placement as block event', defaultStatefulOrderLongTermEvent, false, -1],
+    ['stateful order placement as block event', defaultStatefulOrderEvent, true, -1],
+    ['stateful long term order placement as block event', defaultStatefulOrderLongTermEvent, true, -1],
   ])('successfully places order with %s (emit subaccount websocket msg: %s)', async (
     _name: string,
     statefulOrderEvent: StatefulOrderEventV1,
     emitSubaccountMessage: boolean,
+    transactionIndex: number,
   ) => {
     config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS = emitSubaccountMessage;
     const kafkaMessage: KafkaMessage = createKafkaMessageFromStatefulOrderEvent(
       statefulOrderEvent,
+      transactionIndex,
     );
 
     await onMessage(kafkaMessage);
@@ -194,6 +200,8 @@ describe('statefulOrderPlacementHandler', () => {
         producerSendMock,
         defaultOrder.orderId!.subaccountId!,
         order!,
+        defaultHeight.toString(),
+        transactionIndex,
       );
     }
   });

--- a/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-removal-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/stateful-order/stateful-order-removal-handler.test.ts
@@ -104,13 +104,20 @@ describe('statefulOrderRemovalHandler', () => {
     });
   });
 
-  it('successfully cancels and removes order', async () => {
+  it.each([
+    ['transaction event', 0],
+    ['block event', -1],
+  ])('successfully cancels and removes order (as %s)', async (
+    _name: string,
+    transactionIndex: number,
+  ) => {
     await OrderTable.create({
       ...testConstants.defaultOrder,
       clientId: '0',
     });
     const kafkaMessage: KafkaMessage = createKafkaMessageFromStatefulOrderEvent(
       defaultStatefulOrderEvent,
+      transactionIndex,
     );
 
     await onMessage(kafkaMessage);

--- a/indexer/services/ender/src/lib/block-processor.ts
+++ b/indexer/services/ender/src/lib/block-processor.ts
@@ -49,13 +49,14 @@ const TXN_EVENT_SUBTYPE_VERSION_TO_VALIDATOR_MAPPING: Record<string, ValidatorIn
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.UPDATE_PERPETUAL.toString(), 1)]: UpdatePerpetualValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.UPDATE_CLOB_PAIR.toString(), 1)]: UpdateClobPairValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.DELEVERAGING.toString(), 1)]: DeleveragingValidator,
-  [serializeSubtypeAndVersion(DydxIndexerSubtypes.OPEN_INTEREST_UPDATE.toString(), 1)]: OpenInterestUpdateValidator,
+  [serializeSubtypeAndVersion(DydxIndexerSubtypes.OPEN_INTEREST_UPDATE, 1)]: OpenInterestUpdateValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.LIQUIDITY_TIER.toString(), 2)]: LiquidityTierValidatorV2,
 };
 
 const BLOCK_EVENT_SUBTYPE_VERSION_TO_VALIDATOR_MAPPING: Record<string, ValidatorInitializer> = {
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.FUNDING.toString(), 1)]: FundingValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.TRADING_REWARD.toString(), 1)]: TradingRewardsValidator,
+  [serializeSubtypeAndVersion(DydxIndexerSubtypes.STATEFUL_ORDER.toString(), 1)]: StatefulOrderValidator,
 };
 
 function serializeSubtypeAndVersion(

--- a/indexer/services/ender/src/lib/block-processor.ts
+++ b/indexer/services/ender/src/lib/block-processor.ts
@@ -49,7 +49,7 @@ const TXN_EVENT_SUBTYPE_VERSION_TO_VALIDATOR_MAPPING: Record<string, ValidatorIn
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.UPDATE_PERPETUAL.toString(), 1)]: UpdatePerpetualValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.UPDATE_CLOB_PAIR.toString(), 1)]: UpdateClobPairValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.DELEVERAGING.toString(), 1)]: DeleveragingValidator,
-  [serializeSubtypeAndVersion(DydxIndexerSubtypes.OPEN_INTEREST_UPDATE, 1)]: OpenInterestUpdateValidator,
+  [serializeSubtypeAndVersion(DydxIndexerSubtypes.OPEN_INTEREST_UPDATE.toString(), 1)]: OpenInterestUpdateValidator,
   [serializeSubtypeAndVersion(DydxIndexerSubtypes.LIQUIDITY_TIER.toString(), 2)]: LiquidityTierValidatorV2,
 };
 

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -69,9 +69,10 @@ func EndBlocker(
 		keeper.DeleteLongTermOrderPlacement(ctx, orderId)
 
 		// Emit an on-chain indexer event for Stateful Order Expiration.
-		keeper.GetIndexerEventManager().AddTxnEvent(
+		keeper.GetIndexerEventManager().AddBlockEvent(
 			ctx,
 			indexerevents.SubtypeStatefulOrder,
+			indexer_manager.IndexerTendermintEvent_BLOCK_EVENT_END_BLOCK,
 			indexerevents.StatefulOrderEventVersion,
 			indexer_manager.GetBytes(
 				indexerevents.NewStatefulOrderRemovalEvent(

--- a/protocol/x/clob/abci_test.go
+++ b/protocol/x/clob/abci_test.go
@@ -116,9 +116,10 @@ func TestEndBlocker_Failure(t *testing.T) {
 			ctx := ks.Ctx.WithBlockHeight(int64(blockHeight)).WithBlockTime(tc.blockTime)
 
 			for _, orderId := range tc.expiredStatefulOrderIds {
-				mockIndexerEventManager.On("AddTxnEvent",
+				mockIndexerEventManager.On("AddBlockEvent",
 					ctx,
 					indexerevents.SubtypeStatefulOrder,
+					indexer_manager.IndexerTendermintEvent_BLOCK_EVENT_END_BLOCK,
 					indexerevents.StatefulOrderEventVersion,
 					indexer_manager.GetBytes(
 						indexerevents.NewStatefulOrderRemovalEvent(
@@ -739,9 +740,10 @@ func TestEndBlocker_Success(t *testing.T) {
 
 			// Assert that the indexer events for Expired Stateful Orders were emitted.
 			for _, orderId := range tc.expectedProcessProposerMatchesEvents.ExpiredStatefulOrderIds {
-				mockIndexerEventManager.On("AddTxnEvent",
+				mockIndexerEventManager.On("AddBlockEvent",
 					ctx,
 					indexerevents.SubtypeStatefulOrder,
+					indexer_manager.IndexerTendermintEvent_BLOCK_EVENT_END_BLOCK,
 					indexerevents.StatefulOrderEventVersion,
 					indexer_manager.GetBytes(
 						indexerevents.NewStatefulOrderRemovalEvent(


### PR DESCRIPTION
### Changelist
Add stateful order removals as block events rather than transaction events to fix their ordering in the produced indexer block message.

### Test Plan
Tested in staging upgrading from v4.1 to v5.x

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced test cases for order placement, triggering, and removal with parameterized testing for various event scenarios.
- **Tests**
	- Improved reliability and coverage of testing for transaction and block event handling.
- **Documentation**
	- Updated internal documentation to align with revised testing strategies and event handling procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->