### PR TITLE
[OTE-278] [OTE-279] handle timestamps for order place and removal in indexer

### DIFF
--- a/indexer/packages/kafka/src/websocket-helper.ts
+++ b/indexer/packages/kafka/src/websocket-helper.ts
@@ -46,6 +46,7 @@ export function generateSubaccountMessageContents(
   order: OrderFromDatabase | undefined,
   perpetualMarket: PerpetualMarketFromDatabase,
   placementStatus: OrderPlaceV1_OrderPlacementStatus,
+  orderTimestamp: Date | undefined = undefined,
 ): SubaccountMessageContents {
   const orderTIF: TimeInForce = protocolTranslations.protocolOrderTIFToTIF(
     redisOrder.order!.timeInForce,
@@ -87,6 +88,7 @@ export function generateSubaccountMessageContents(
         ...(updatedAtHeight && { updatedAtHeight }),
         clientMetadata: redisOrder.order!.clientMetadata.toString(),
         triggerPrice: getTriggerPrice(redisOrder.order!, perpetualMarket),
+        orderTimestamp: orderTimestamp ?? undefined,
       },
     ],
   };
@@ -98,12 +100,14 @@ export function createSubaccountWebsocketMessage(
   order: OrderFromDatabase | undefined,
   perpetualMarket: PerpetualMarketFromDatabase,
   placementStatus: OrderPlaceV1_OrderPlacementStatus,
+  orderTimestamp: Date | undefined,
 ): Buffer {
   const contents: SubaccountMessageContents = generateSubaccountMessageContents(
     redisOrder,
     order,
     perpetualMarket,
     placementStatus,
+    orderTimestamp,
   );
 
   const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -126,6 +126,7 @@ export interface OrderSubaccountMessageContents {
   // This will only be set for stateful orders
   createdAtHeight?: string;
   clientMetadata: string;
+  orderTimestamp?: Date;
 }
 
 export interface FillSubaccountMessageContents {

--- a/indexer/services/comlink/public/websocket-documentation.md
+++ b/indexer/services/comlink/public/websocket-documentation.md
@@ -183,6 +183,7 @@ export interface OrderSubaccountMessageContents {
   triggerPrice?: string;
   updatedAt?: IsoString;
   updatedAtHeight?: string;
+  orderTimestamp?: Date;
 }
 
 export enum OrderSide {

--- a/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
@@ -179,7 +179,6 @@ describe('order-place-handler', () => {
           OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
       },
     };
-    const defaultTimestamp: Date = DateTime.fromISO('2021-01-01T00:00:00.000Z').toJSDate();
     const replacementMessage: KafkaMessage = createKafkaMessage(
       Buffer.from(Uint8Array.from(OffChainUpdateV1.encode(replacementUpdate).finish())),
     );
@@ -1130,7 +1129,7 @@ describe('order-place-handler', () => {
           order: redisTestConstants.defaultOrder,
           placementStatus:
             OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
-          timeStamp: orderTimestamp
+          timeStamp: orderTimestamp,
         },
       });
 
@@ -1253,7 +1252,7 @@ function expectWebsocketMessagesSent(
           ...(isStateful && { updatedAtHeight: dbOrder.updatedAtHeight }),
           clientMetadata: redisOrder.order!.clientMetadata.toString(),
           triggerPrice: getTriggerPrice(redisOrder.order!, perpetualMarket),
-          orderTimestamp: orderTimestamp ?? undefined
+          orderTimestamp: orderTimestamp ?? undefined,
         },
       ],
     };

--- a/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
@@ -111,7 +111,7 @@ describe('OrderRemoveHandler', () => {
     reason: OrderRemovalReason.ORDER_REMOVAL_REASON_EXPIRED,
     removalStatus: OrderRemoveV1_OrderRemovalStatus.ORDER_REMOVAL_STATUS_CANCELED,
     // timestamp in Date format
-    timeStamp: DateTime.fromISO('2024-01-01T00:00:00.000Z').toJSDate()
+    timeStamp: DateTime.fromISO('2024-01-01T00:00:00.000Z').toJSDate(),
   };
 
   const statefulCancelationOrderRemove: OrderRemoveV1 = {

--- a/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
@@ -110,6 +110,8 @@ describe('OrderRemoveHandler', () => {
     removedOrderId: redisTestConstants.defaultOrderId,
     reason: OrderRemovalReason.ORDER_REMOVAL_REASON_EXPIRED,
     removalStatus: OrderRemoveV1_OrderRemovalStatus.ORDER_REMOVAL_STATUS_CANCELED,
+    // timestamp in Date format
+    timeStamp: DateTime.fromISO('2024-01-01T00:00:00.000Z').toJSDate()
   };
 
   const statefulCancelationOrderRemove: OrderRemoveV1 = {
@@ -399,6 +401,7 @@ describe('OrderRemoveHandler', () => {
             updatedAtHeight: removedOrder.updatedAtHeight,
             clientMetadata: removedRedisOrder.order!.clientMetadata.toString(),
             triggerPrice,
+            orderTimestamp: defaultOrderRemove.timeStamp,
           },
         ],
       };
@@ -540,6 +543,7 @@ describe('OrderRemoveHandler', () => {
             updatedAtHeight: removedOrder.updatedAtHeight,
             clientMetadata: removedRedisOrder.order!.clientMetadata.toString(),
             triggerPrice,
+            orderTimestamp: defaultOrderRemove.timeStamp,
           },
         ],
       };
@@ -681,6 +685,7 @@ describe('OrderRemoveHandler', () => {
             updatedAtHeight: removedOrder.updatedAtHeight,
             clientMetadata: removedRedisOrder.order!.clientMetadata.toString(),
             triggerPrice,
+            orderTimestamp: defaultOrderRemove.timeStamp,
           }],
         };
         expectWebsocketMessagesSent(
@@ -823,6 +828,7 @@ describe('OrderRemoveHandler', () => {
             updatedAtHeight: removedOrder.updatedAtHeight,
             clientMetadata: removedRedisOrder.order!.clientMetadata.toString(),
             triggerPrice,
+            orderTimestamp: defaultOrderRemove.timeStamp,
           }],
         };
         expectWebsocketMessagesSent(

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -63,7 +63,7 @@ export class OrderPlaceHandler extends Handler {
     this.validateOrderPlace(update.orderPlace!);
     const order: IndexerOrder = orderPlace.order!;
     const placementStatus: OrderPlaceV1_OrderPlacementStatus = orderPlace.placementStatus;
-    const timestamp: Date | undefined  = orderPlace.timeStamp;
+    const timestamp: Date | undefined = orderPlace.timeStamp;
 
     const perpetualMarket: PerpetualMarketFromDatabase | undefined = perpetualMarketRefresher
       .getPerpetualMarketFromClobPairId(order.orderId!.clobPairId.toString());

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -63,6 +63,7 @@ export class OrderPlaceHandler extends Handler {
     this.validateOrderPlace(update.orderPlace!);
     const order: IndexerOrder = orderPlace.order!;
     const placementStatus: OrderPlaceV1_OrderPlacementStatus = orderPlace.placementStatus;
+    const timestamp: Date | undefined  = orderPlace.timeStamp;
 
     const perpetualMarket: PerpetualMarketFromDatabase | undefined = perpetualMarketRefresher
       .getPerpetualMarketFromClobPairId(order.orderId!.clobPairId.toString());
@@ -150,6 +151,7 @@ export class OrderPlaceHandler extends Handler {
           dbOrder,
           perpetualMarket,
           placementStatus,
+          timestamp,
         ),
         headers,
       };

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -132,7 +132,8 @@ export class OrderRemoveHandler extends Handler {
     }
 
     if (this.isStatefulOrderCancelation(orderRemove)) {
-      await this.handleStatefulOrderCancelation(orderRemove, removeOrderResult, headers, orderTimestamp);
+      await this.handleStatefulOrderCancelation(orderRemove, removeOrderResult,
+        headers, orderTimestamp);
       return;
     }
 
@@ -312,7 +313,7 @@ export class OrderRemoveHandler extends Handler {
         canceledOrder,
         orderRemove,
         perpetualMarket,
-        orderTimestamp
+        orderTimestamp,
       ),
       headers,
     };


### PR DESCRIPTION
### Changelist
- gets timestamps from order place and order remove and forwards it to websockets

### Testing
- adds unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
