### PR TITLE
[OTE-278] [OTE-279]Send timestamp from protocol for order place/remove

### DIFF
--- a/protocol/indexer/off_chain_updates/off_chain_updates.go
+++ b/protocol/indexer/off_chain_updates/off_chain_updates.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/cosmos/gogoproto/proto"
 
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/msgsender"
 	ocutypes "github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates/types"
@@ -246,12 +248,14 @@ func newOrderPlaceMessage(
 	order clobtypes.Order,
 ) ([]byte, error) {
 	indexerOrder := v1.OrderToIndexerOrder(order)
+	updateTimestamp := time.Now()
 	update := ocutypes.OffChainUpdateV1{
 		UpdateMessage: &ocutypes.OffChainUpdateV1_OrderPlace{
 			OrderPlace: &ocutypes.OrderPlaceV1{
 				Order: &indexerOrder,
 				// Protocol will always send best effort opened messages to indexer.
 				PlacementStatus: ocutypes.OrderPlaceV1_ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+				TimeStamp:       &updateTimestamp,
 			},
 		},
 	}
@@ -267,12 +271,14 @@ func newOrderRemoveMessage(
 	status ocutypes.OrderRemoveV1_OrderRemovalStatus,
 ) ([]byte, error) {
 	indexerOrderId := v1.OrderIdToIndexerOrderId(orderId)
+	updateTimestamp := time.Now()
 	update := ocutypes.OffChainUpdateV1{
 		UpdateMessage: &ocutypes.OffChainUpdateV1_OrderRemove{
 			OrderRemove: &ocutypes.OrderRemoveV1{
 				RemovedOrderId: &indexerOrderId,
 				Reason:         reason,
 				RemovalStatus:  status,
+				TimeStamp:      &updateTimestamp,
 			},
 		},
 	}

--- a/protocol/indexer/off_chain_updates/off_chain_updates_test.go
+++ b/protocol/indexer/off_chain_updates/off_chain_updates_test.go
@@ -71,13 +71,13 @@ func TestCreateOrderPlaceMessage(t *testing.T) {
 	)
 	require.True(t, success)
 
-	updateBytes, err := proto.Marshal(&offchainUpdateOrderPlace)
+	actualUpdate := &ocutypes.OffChainUpdateV1{}
+	err := proto.Unmarshal(actualMessage.Value, actualUpdate)
 	require.NoError(t, err)
-	expectedMessage := msgsender.Message{
-		Key:   orderIdHash,
-		Value: updateBytes,
-	}
-	require.Equal(t, expectedMessage, actualMessage)
+	require.Equal(t, actualMessage.Key, orderIdHash)
+	require.Equal(t, offchainUpdateOrderPlace.GetOrderPlace().Order, actualUpdate.GetOrderPlace().Order)
+	require.Equal(t, offchainUpdateOrderPlace.GetOrderPlace().PlacementStatus, actualUpdate.GetOrderPlace().PlacementStatus)
+	require.NotNil(t, actualUpdate.GetOrderPlace().TimeStamp)
 }
 
 func TestCreateOrderUpdateMessage(t *testing.T) {
@@ -107,13 +107,18 @@ func TestCreateOrderRemoveWithReason(t *testing.T) {
 	)
 	require.True(t, success)
 
-	updateBytes, err := proto.Marshal(&offchainUpdateOrderRemove)
+	orderRemoveMessage := &ocutypes.OffChainUpdateV1{}
+	err := proto.Unmarshal(actualMessage.Value, orderRemoveMessage)
 	require.NoError(t, err)
-	expectedMessage := msgsender.Message{
-		Key:   orderIdHash,
-		Value: updateBytes,
-	}
-	require.Equal(t, expectedMessage, actualMessage)
+	checkOrderRemoveMessagesEqual(t, actualMessage, orderRemoveMessage, offchainUpdateOrderRemove)
+}
+
+func checkOrderRemoveMessagesEqual(t *testing.T, actualMessage msgsender.Message, orderRemoveMessage *ocutypes.OffChainUpdateV1, offchainOrderRemoveUpdate ocutypes.OffChainUpdateV1) {
+	require.Equal(t, actualMessage.Key, orderIdHash)
+	require.Equal(t, offchainOrderRemoveUpdate.GetOrderRemove().RemovedOrderId, orderRemoveMessage.GetOrderRemove().RemovedOrderId)
+	require.Equal(t, offchainOrderRemoveUpdate.GetOrderRemove().Reason, orderRemoveMessage.GetOrderRemove().Reason)
+	require.Equal(t, offchainOrderRemoveUpdate.GetOrderRemove().RemovalStatus, orderRemoveMessage.GetOrderRemove().RemovalStatus)
+	require.NotNil(t, orderRemoveMessage.GetOrderRemove().TimeStamp)
 }
 
 func TestCreateOrderRemoveMessageWithDefaultReason_HappyPath(t *testing.T) {
@@ -135,13 +140,10 @@ func TestCreateOrderRemoveMessageWithDefaultReason_HappyPath(t *testing.T) {
 	)
 	require.True(t, success)
 
-	updateBytes, err := proto.Marshal(&offchainUpdateOrderRemove)
+	orderRemoveMessage := &ocutypes.OffChainUpdateV1{}
+	err := proto.Unmarshal(actualMessage.Value, orderRemoveMessage)
 	require.NoError(t, err)
-	expectedMessage := msgsender.Message{
-		Key:   orderIdHash,
-		Value: updateBytes,
-	}
-	require.Equal(t, expectedMessage, actualMessage)
+	checkOrderRemoveMessagesEqual(t, actualMessage, orderRemoveMessage, offchainUpdateOrderRemove)
 }
 
 func TestCreateOrderRemoveMessageWithDefaultReason_DefaultReasonReturned(t *testing.T) {
@@ -156,13 +158,10 @@ func TestCreateOrderRemoveMessageWithDefaultReason_DefaultReasonReturned(t *test
 	)
 	require.True(t, success)
 
-	updateBytes, err := proto.Marshal(&offchainUpdateOrderRemoveWithDefaultRemovalReason)
+	orderRemoveMessage := &ocutypes.OffChainUpdateV1{}
+	err := proto.Unmarshal(actualMessage.Value, orderRemoveMessage)
 	require.NoError(t, err)
-	expectedMessage := msgsender.Message{
-		Key:   orderIdHash,
-		Value: updateBytes,
-	}
-	require.Equal(t, expectedMessage, actualMessage)
+	checkOrderRemoveMessagesEqual(t, actualMessage, orderRemoveMessage, offchainUpdateOrderRemoveWithDefaultRemovalReason)
 }
 
 func TestCreateOrderRemoveMessageWithDefaultReason_InvalidDefault(t *testing.T) {
@@ -195,13 +194,10 @@ func TestCreateOrderRemoveWithReasonMessage(t *testing.T) {
 	)
 	require.True(t, success)
 
-	updateBytes, err := proto.Marshal(&offchainUpdateOrderRemove)
+	orderRemoveMessage := &ocutypes.OffChainUpdateV1{}
+	err := proto.Unmarshal(actualMessage.Value, orderRemoveMessage)
 	require.NoError(t, err)
-	expectedMessage := msgsender.Message{
-		Key:   orderIdHash,
-		Value: updateBytes,
-	}
-	require.Equal(t, expectedMessage, actualMessage)
+	checkOrderRemoveMessagesEqual(t, actualMessage, orderRemoveMessage, offchainUpdateOrderRemove)
 }
 
 func TestNewOrderPlaceMessage(t *testing.T) {
@@ -220,12 +216,10 @@ func TestNewOrderPlaceMessage(t *testing.T) {
 		err,
 		"Decoding OffchainUpdateV1 proto bytes should not result in an error.",
 	)
-	require.Equal(
-		t,
-		offchainUpdateOrderPlace,
-		*actualUpdate,
-		"Decoded OffchainUpdateV1 value should be equal to the expected OffchainUpdate proto message",
-	)
+
+	require.Equal(t, actualUpdate.GetOrderPlace().Order, offchainUpdateOrderPlace.GetOrderPlace().Order)
+	require.Equal(t, actualUpdate.GetOrderPlace().PlacementStatus, offchainUpdateOrderPlace.GetOrderPlace().PlacementStatus)
+	require.NotNil(t, actualUpdate.GetOrderPlace().TimeStamp)
 }
 
 func TestNewOrderUpdateMessage(t *testing.T) {
@@ -264,12 +258,11 @@ func TestNewOrderRemoveMessage(t *testing.T) {
 		err,
 		"Decoding OffchainUpdateV1 proto bytes should not result in an error.",
 	)
-	require.Equal(
-		t,
-		offchainUpdateOrderRemove,
-		*actualUpdate,
-		"Decoded OffchainUpdateV1 value should be equal to the expected OffchainUpdate proto message",
-	)
+
+	require.Equal(t, actualUpdate.GetOrderRemove().RemovedOrderId, offchainUpdateOrderRemove.GetOrderRemove().RemovedOrderId)
+	require.Equal(t, actualUpdate.GetOrderRemove().Reason, offchainUpdateOrderRemove.GetOrderRemove().Reason)
+	require.Equal(t, actualUpdate.GetOrderRemove().RemovalStatus, offchainUpdateOrderRemove.GetOrderRemove().RemovalStatus)
+	require.NotNil(t, actualUpdate.GetOrderRemove().TimeStamp)
 }
 
 func TestGetOrderIdHash(t *testing.T) {


### PR DESCRIPTION
### Changelist
- adds timestamps to order place and removal and forwards it to indexer

### Test Plan
- updates unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
