### PR TITLE
fix: Fix v5 upgrade VE handler

### DIFF
--- a/protocol/app/upgrades/v5.0.0/upgrade.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade.go
@@ -267,11 +267,6 @@ func voteExtensionsUpgrade(
 	if err != nil || currentParams == nil || currentParams.Params == nil {
 		panic(fmt.Sprintf("failed to retrieve existing consensus params in VE upgrade handler: %s", err))
 	}
-	if currentParams.Params.Abci != nil && currentParams.Params.Abci.VoteExtensionsEnableHeight != 0 {
-		panic(fmt.Sprintf(
-			"unable to update VE Enable Height since its current value of %d is already non-zero",
-			currentParams.Params.Abci.VoteExtensionsEnableHeight))
-	}
 	currentParams.Params.Abci = &tenderminttypes.ABCIParams{
 		VoteExtensionsEnableHeight: ctx.BlockHeight() + VEEnableHeightDelta,
 	}

--- a/protocol/app/upgrades/v5.0.0/upgrade.go
+++ b/protocol/app/upgrades/v5.0.0/upgrade.go
@@ -3,9 +3,9 @@ package v_5_0_0
 import (
 	"context"
 	"fmt"
-	types2 "github.com/cometbft/cometbft/proto/tendermint/types"
 	"math/big"
 
+	tenderminttypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 
@@ -272,7 +272,7 @@ func voteExtensionsUpgrade(
 			"unable to update VE Enable Height since its current value of %d is already non-zero",
 			currentParams.Params.Abci.VoteExtensionsEnableHeight))
 	}
-	currentParams.Params.Abci = &types2.ABCIParams{
+	currentParams.Params.Abci = &tenderminttypes.ABCIParams{
 		VoteExtensionsEnableHeight: ctx.BlockHeight() + VEEnableHeightDelta,
 	}
 	_, err = keeper.UpdateParams(ctx, &consensustypes.MsgUpdateParams{


### PR DESCRIPTION
### Changelist
Add protections around nil VE ABCI Params

### Test Plan
Send to a single validator first on testnet.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
