### PR TITLE
Update upsert querybuilder and compliance table upsert function

### DIFF
--- a/indexer/packages/postgres/src/models/compliance-data-model.ts
+++ b/indexer/packages/postgres/src/models/compliance-data-model.ts
@@ -1,10 +1,9 @@
-import { Model } from 'objection';
-
 import { NumericPattern } from '../lib/validators';
 import UpsertQueryBuilder from '../query-builders/upsert';
 import { ComplianceProvider, IsoString } from '../types';
+import BaseModel from './base-model';
 
-export default class ComplianceDataModel extends Model {
+export default class ComplianceDataModel extends BaseModel {
   static get tableName() {
     return 'compliance_data';
   }

--- a/indexer/packages/postgres/src/query-builders/upsert.ts
+++ b/indexer/packages/postgres/src/query-builders/upsert.ts
@@ -14,7 +14,9 @@ export default class UpsertQueryBuilder<M extends Model, R = M[]> extends QueryB
   upsert(object: any) {
     const modelClass = this.modelClass();
 
-    const idColumn: string = modelClass.idColumn as string;
+    const idColumn = modelClass.idColumn;
+    const idColumns: string[] = Array.isArray(idColumn) ? idColumn : [idColumn];
+
 
     const tableDefinedId = `${modelClass.tableName}.${idColumn}`;
 
@@ -26,10 +28,15 @@ export default class UpsertQueryBuilder<M extends Model, R = M[]> extends QueryB
     const colBindings = cols.map(() => '??').join(', ');
     const valBindings = cols.map(() => '?').join(', ');
     const setBindings = cols.map(() => '?? = ?').join(', ');
+    const idConditionBindings = idColumns.map(() => '?? = ?').join(' AND ');
 
     const setValues: string[] = [];
     for (let i = 0; i < cols.length; ++i) {
       setValues.push(cols[i], values[i]);
+    }
+    const idValues: string[] = [];
+    for (let i = 0; i < idColumns.length; ++i) {
+      idValues.push(`${modelClass.tableName}.${idColumns[i]}`, object[idColumns[i]]);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,15 +47,14 @@ export default class UpsertQueryBuilder<M extends Model, R = M[]> extends QueryB
             `(${colBindings}) VALUES (${valBindings})`,
             'ON CONFLICT (??) DO',
             `UPDATE SET ${setBindings}`,
-            'WHERE ?? = ?',
+            `WHERE ${idConditionBindings}`,
           ].join(' '),
           [
             ...cols,
             ...values,
             modelClass.idColumn,
             ...setValues,
-            tableDefinedId,
-            object[idColumn],
+            ...idValues,
           ],
         ),
       );

--- a/indexer/packages/postgres/src/stores/compliance-table.ts
+++ b/indexer/packages/postgres/src/stores/compliance-table.ts
@@ -123,25 +123,12 @@ export async function upsert(
   complianceDataToUpsert: ComplianceDataCreateObject,
   options: Options = { txId: undefined },
 ): Promise<ComplianceDataFromDatabase> {
-  const complianceData: ComplianceDataFromDatabase | undefined = await findByAddressAndProvider(
-    complianceDataToUpsert.address,
-    complianceDataToUpsert.provider,
-  );
-  if (complianceData === undefined) {
-    return create({
-      ...complianceDataToUpsert,
-    }, options);
-  }
+  const updatedComplianceData: ComplianceDataModel[] = await ComplianceDataModel.query(
+    Transaction.get(options.txId),
+  ).upsert
+    (complianceDataToUpsert).returning('*');
 
-  const updatedComplianceData: ComplianceDataFromDatabase | undefined = await update({
-    ...complianceDataToUpsert,
-  }, options);
-
-  if (updatedComplianceData === undefined) {
-    throw Error('order must exist after update');
-  }
-
-  return updatedComplianceData;
+  return updatedComplianceData[0];
 }
 
 export async function findByAddressAndProvider(


### PR DESCRIPTION
### Changelist
- updates compliance table to use upsert query builder
- upsert query builder was updated to account for multiple ids

### Test Plan
- existing tests pass(upserting a new val and existing val)

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
