### PR TITLE
[TRA-241] Pricefeed Server: remove unnecessary metrics & only report invalid cases

### DIFF
--- a/protocol/daemons/pricefeed/client/client_integration_test.go
+++ b/protocol/daemons/pricefeed/client/client_integration_test.go
@@ -3,8 +3,12 @@
 package client_test
 
 import (
-	"cosmossdk.io/log"
 	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"cosmossdk.io/log"
 	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client"
@@ -26,9 +30,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
-	"net"
-	"sync"
-	"time"
 
 	"testing"
 )
@@ -365,7 +366,7 @@ func (s *PriceDaemonIntegrationTestSuite) expectPricesWithTimeout(
 		time.Sleep(100 * time.Millisecond)
 
 		// Check if the prices cache contains the expected prices.
-		prices := s.exchangePriceCache.GetValidMedianPrices(marketParams, time.Now())
+		prices := s.exchangePriceCache.GetValidMedianPrices(log.NewNopLogger(), marketParams, time.Now())
 		if len(prices) != len(expectedPrices) {
 			continue
 		}

--- a/protocol/daemons/server/types/pricefeed/exchange_to_price_test.go
+++ b/protocol/daemons/server/types/pricefeed/exchange_to_price_test.go
@@ -3,6 +3,8 @@ package types
 import (
 	"testing"
 
+	"cosmossdk.io/log"
+
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/stretchr/testify/assert"
@@ -113,7 +115,7 @@ func TestGetValidPrices(t *testing.T) {
 			constants.Exchange1_Price1_TimeT,
 		})
 
-	r := etp.GetValidPrices(constants.TimeT)
+	r := etp.GetValidPrices(log.NewNopLogger(), constants.TimeT)
 	require.Len(t, r, 1)
 	require.Equal(t, constants.Price1, r[0])
 }
@@ -121,7 +123,7 @@ func TestGetValidPrices(t *testing.T) {
 func TestGetValidPrices_Empty(t *testing.T) {
 	etp := NewExchangeToPrice(0)
 
-	r := etp.GetValidPrices(constants.TimeT)
+	r := etp.GetValidPrices(log.NewNopLogger(), constants.TimeT)
 	require.Empty(t, r)
 }
 
@@ -134,7 +136,7 @@ func TestGetValidPrices_OldPricesEmpty(t *testing.T) {
 			constants.Exchange2_Price2_TimeT,
 		})
 
-	r := etp.GetValidPrices(constants.TimeTPlus1)
+	r := etp.GetValidPrices(log.NewNopLogger(), constants.TimeTPlus1)
 	require.Empty(t, r)
 }
 
@@ -149,7 +151,7 @@ func TestGetValidPrices_ValidAndOldPrices(t *testing.T) {
 		})
 
 	// Exchange 1's Price is before cutoff, so it's ignored
-	r := etp.GetValidPrices(constants.TimeTPlus1)
+	r := etp.GetValidPrices(log.NewNopLogger(), constants.TimeTPlus1)
 	require.Len(t, r, 2)
 
 	expected := []uint64{constants.Price3, constants.Price4}

--- a/protocol/daemons/server/types/pricefeed/market_to_exchange_prices_test.go
+++ b/protocol/daemons/server/types/pricefeed/market_to_exchange_prices_test.go
@@ -1,9 +1,12 @@
 package types
 
 import (
-	pricefeed_types "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/types"
 	"testing"
 	"time"
+
+	"cosmossdk.io/log"
+
+	pricefeed_types "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/types"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/api"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -165,6 +168,7 @@ func TestGetValidMedianPrices_EmptyResult(t *testing.T) {
 			mte := NewMarketToExchangePrices(pricefeed_types.MaxPriceAge)
 			mte.UpdatePrices(tc.updatePriceInput)
 			r := mte.GetValidMedianPrices(
+				log.NewNopLogger(),
 				tc.getPricesInputMarketParams,
 				tc.getPricesInputTime,
 			)
@@ -179,7 +183,11 @@ func TestGetValidMedianPrices_MultiMarketSuccess(t *testing.T) {
 
 	mte.UpdatePrices(constants.MixedTimePriceUpdate)
 
-	r := mte.GetValidMedianPrices(constants.AllMarketParamsMinExchanges2, constants.TimeT)
+	r := mte.GetValidMedianPrices(
+		log.NewNopLogger(),
+		constants.AllMarketParamsMinExchanges2,
+		constants.TimeT,
+	)
 
 	require.Len(t, r, 3)
 	require.Equal(t, uint64(2002), r[constants.MarketId9]) // Median of 1001, 2002, 3003

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -371,8 +371,6 @@ const (
 	PriceUpdaterZeroPrices                  = "price_updater_zero_prices"
 
 	// Pricefeed Server.
-	GetValidPrices                = "get_valid_prices"
-	ValidPrices                   = "valid_prices"
 	NoMarketPrice                 = "no_market_price"
 	NoValidMedianPrice            = "no_valid_median_price"
 	PricefeedServer               = "pricefeed_server"

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -162,6 +162,7 @@ func (k Keeper) GetMarketIdToValidIndexPrice(
 ) map[uint32]types.MarketPrice {
 	allMarketParams := k.GetAllMarketParams(ctx)
 	marketIdToValidIndexPrice := k.indexPriceCache.GetValidMedianPrices(
+		k.Logger(ctx),
 		allMarketParams,
 		k.timeProvider.Now(),
 	)

--- a/protocol/x/prices/keeper/update_price.go
+++ b/protocol/x/prices/keeper/update_price.go
@@ -56,7 +56,11 @@ func (k Keeper) GetValidMarketPriceUpdates(
 	}
 
 	// 2. Get all index prices from in-memory cache.
-	allIndexPrices := k.indexPriceCache.GetValidMedianPrices(allMarketParams, k.timeProvider.Now())
+	allIndexPrices := k.indexPriceCache.GetValidMedianPrices(
+		k.Logger(ctx),
+		allMarketParams,
+		k.timeProvider.Now(),
+	)
 
 	// 3. Collect all "valid" price updates.
 	updates := make([]*types.MsgUpdateMarketPrices_MarketPrice, 0, len(allMarketParamPrices))

--- a/protocol/x/prices/keeper/validate_market_price_updates.go
+++ b/protocol/x/prices/keeper/validate_market_price_updates.go
@@ -103,7 +103,11 @@ func (k Keeper) performNonDeterministicStatefulValidation(
 		allMarketParams[i] = marketParamPrice.Param
 	}
 
-	idToIndexPrice := k.indexPriceCache.GetValidMedianPrices(allMarketParams, k.timeProvider.Now())
+	idToIndexPrice := k.indexPriceCache.GetValidMedianPrices(
+		k.Logger(ctx),
+		allMarketParams,
+		k.timeProvider.Now(),
+	)
 
 	for _, priceUpdate := range marketPriceUpdates.GetMarketPriceUpdates() {
 		// Check market exists.


### PR DESCRIPTION
### Changelist
1. convert unnecessary metrics into logs
2. only emit metrics on invalid cases

### Test Plan
Unit testing should be sufficient given that the changes are metrics only

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
