### PR TITLE
Move atomic bool to state for hydration

### DIFF
--- a/protocol/mocks/ClobKeeper.go
+++ b/protocol/mocks/ClobKeeper.go
@@ -725,17 +725,17 @@ func (_m *ClobKeeper) InitializeNewGrpcStreams(ctx types.Context) {
 	_m.Called(ctx)
 }
 
-// IsInitialized provides a mock function with given fields:
-func (_m *ClobKeeper) IsInitialized() bool {
-	ret := _m.Called()
+// IsInitialized provides a mock function with given fields: ctx
+func (_m *ClobKeeper) IsInitialized(ctx types.Context) bool {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsInitialized")
 	}
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(types.Context) bool); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -61,7 +61,7 @@ func (cd ClobDecorator) AnteHandle(
 	}
 
 	// Disable order placement and cancelation processing if the clob keeper is not initialized.
-	if !cd.clobKeeper.IsInitialized() {
+	if !cd.clobKeeper.IsInitialized(ctx) {
 		return ctx, errorsmod.Wrap(
 			types.ErrClobNotInitialized,
 			"clob keeper is not initialized. Please wait for the next block.",

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -50,7 +50,7 @@ func runTestCase(t *testing.T, tc TestCase) {
 	// Setup AnteHandler.
 	mockClobKeeper := &mocks.ClobKeeper{}
 	mockClobKeeper.On("Logger", mock.Anything).Return(log.NewNopLogger()).Maybe()
-	mockClobKeeper.On("IsInitialized").Return(true).Maybe()
+	mockClobKeeper.On("IsInitialized", mock.Anything).Return(true).Maybe()
 	cd := ante.NewClobDecorator(mockClobKeeper)
 	antehandler := sdk.ChainAnteDecorators(cd)
 	if tc.setupMocks != nil {

--- a/protocol/x/clob/types/clob_keeper.go
+++ b/protocol/x/clob/types/clob_keeper.go
@@ -14,7 +14,7 @@ type ClobKeeper interface {
 	LiquidationsKeeper
 	LiquidationsConfigKeeper
 
-	IsInitialized() bool
+	IsInitialized(ctx sdk.Context) bool
 	Initialize(ctx sdk.Context)
 
 	AddOrderToOrderbookSubaccountUpdatesCheck(

--- a/protocol/x/clob/types/keys.go
+++ b/protocol/x/clob/types/keys.go
@@ -71,6 +71,9 @@ const (
 	// UntriggeredConditionalOrderKeyPrefix is the key to retrieve an untriggered conditional order and
 	// information about when it was placed.
 	UntriggeredConditionalOrderKeyPrefix = StatefulOrderKeyPrefix + "U:"
+
+	// Initialized is the key to determined whether clob keeper has been hydrated or not.
+	Initialized = "Initialized"
 )
 
 // Memstore


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the initialization check across various components by integrating a context parameter, improving the accuracy and reliability of state assessments.
- **New Features**
	- Introduced new methods for better management of initialization states, ensuring more robust application behavior.
- **Tests**
	- Updated tests to adapt to the new method signatures involving context parameters, maintaining consistency in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->