### PR TITLE
Stop passing in app PreBlocker to slinky VE handler

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1542,7 +1542,15 @@ func (app *App) initOracle(pricesTxDecoder process.UpdateMarketPriceTxDecoder) {
 			compression.NewDefaultVoteExtensionCodec(),
 			compression.NewZLibCompressor(),
 		),
-		app.PreBlocker,
+		// We are not using the slinky PreBlocker, so there is no need to pass in PreBlocker here for
+		// VE handler to work properly.
+		// Currently the clob PreBlocker assumes that it will only be called during the normal ABCI
+		// PreBlocker step. Passing in the app PreBlocker here will break that assumption by causing
+		// the clob PreBlocker to be called unexpectedly. This to leads improperly initialized clob state
+		// which results in the next block being committed incorrectly.
+		func(_ sdk.Context, _ *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
+			return nil, nil
+		},
 		app.oracleMetrics,
 	)
 


### PR DESCRIPTION
### Changelist
Slinky and clob both depend on invariants of preblocker, but they violate each other's assumptions. Slinky assumes that preblocker only mutates the context it's passed, so it's safe to use it on a cached context. Clob assumes preblocker is only called during the normal abci path, so it uses mutates state kept in the clobkeeper instance to ensure it's only called once ever.

The quickest fix is to just stop calling app PreBlocker in slinky VE handler.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Enhanced the initialization process in the app for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->