### PR TITLE
Fix subaccount validation to account for updated subaccount limit.

### DIFF
--- a/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
+++ b/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
@@ -22,13 +22,13 @@ describe('schemas', () => {
         'missing subaccountNumber',
         { address: defaultAddress },
         'subaccountNumber',
-        'subaccountNumber must be a non-negative integer less than 128',
+        'subaccountNumber must be a non-negative integer less than 128001',
       ],
       [
         'non-integer subaccountNumber',
         { address: defaultAddress, subaccountNumber: positiveNonInteger },
         'subaccountNumber',
-        'subaccountNumber must be a non-negative integer less than 128',
+        'subaccountNumber must be a non-negative integer less than 128001',
       ],
       [
         'negative subaccountNumber',

--- a/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
+++ b/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
@@ -3,8 +3,11 @@ import { getQueryString, sendRequestToApp } from '../../helpers/helpers';
 import { schemaTestApp } from './helpers';
 import request from 'supertest';
 import config from '../../../src/config';
-import { testConstants } from '@dydxprotocol-indexer/postgres';
-import { MAX_SUBACCOUNT_NUMBER } from '../../../src/constants';
+import {
+  testConstants,
+  MAX_PARENT_SUBACCOUNTS,
+  CHILD_SUBACCOUNT_MULTIPLIER,
+} from '@dydxprotocol-indexer/postgres';
 
 describe('schemas', () => {
   const positiveNonInteger: number = 3.2;
@@ -31,13 +34,16 @@ describe('schemas', () => {
         'negative subaccountNumber',
         { address: defaultAddress, subaccountNumber: negativeInteger },
         'subaccountNumber',
-        'subaccountNumber must be a non-negative integer less than 128',
+        'subaccountNumber must be a non-negative integer less than 128001',
       ],
       [
         'subaccountNumber greater than maximum subaccount number',
-        { address: defaultAddress, subaccountNumber: MAX_SUBACCOUNT_NUMBER + 1 },
+        {
+          address: defaultAddress,
+          subaccountNumber: MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER + 1,
+        },
         'subaccountNumber',
-        'subaccountNumber must be a non-negative integer less than 128',
+        'subaccountNumber must be a non-negative integer less than 128001',
       ],
     ])('Returns 400 when validation fails: %s', async (
       _reason: string,

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -29,7 +29,7 @@ export const CheckParentSubaccountSchema = checkSchema({
   parentSubaccountNumber: {
     in: ['params', 'query'],
     isInt: {
-      options: { gt: -1, lt: MAX_PARENT_SUBACCOUNTS + 1 },
+      options: { gt: -1, lt: MAX_PARENT_SUBACCOUNTS },
     },
     errorMessage: 'parentSubaccountNumber must be a non-negative integer less than 128',
   },

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -1,8 +1,11 @@
-import { perpetualMarketRefresher } from '@dydxprotocol-indexer/postgres';
+import {
+  perpetualMarketRefresher,
+  MAX_PARENT_SUBACCOUNTS,
+  CHILD_SUBACCOUNT_MULTIPLIER,
+} from '@dydxprotocol-indexer/postgres';
 import { checkSchema, ParamSchema } from 'express-validator';
 
 import config from '../../config';
-import { MAX_SUBACCOUNT_NUMBER } from '../../constants';
 
 export const CheckSubaccountSchema = checkSchema({
   address: {
@@ -12,9 +15,9 @@ export const CheckSubaccountSchema = checkSchema({
   subaccountNumber: {
     in: ['params', 'query'],
     isInt: {
-      options: { gt: -1, lt: MAX_SUBACCOUNT_NUMBER + 1 },
+      options: { gt: -1, lt: MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER + 1 },
     },
-    errorMessage: 'subaccountNumber must be a non-negative integer less than 128',
+    errorMessage: 'subaccountNumber must be a non-negative integer less than 128001',
   },
 });
 
@@ -26,7 +29,7 @@ export const CheckParentSubaccountSchema = checkSchema({
   parentSubaccountNumber: {
     in: ['params', 'query'],
     isInt: {
-      options: { gt: -1, lt: MAX_SUBACCOUNT_NUMBER + 1 },
+      options: { gt: -1, lt: MAX_PARENT_SUBACCOUNTS + 1 },
     },
     errorMessage: 'parentSubaccountNumber must be a non-negative integer less than 128',
   },


### PR DESCRIPTION
### Changelist
Update schema checks for subaccounts endpoint to use updated limit.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced validation logic for subaccounts to support new limits.

- **Bug Fixes**
  - Updated error messages to provide clearer guidance on subaccount number constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->