### PR TITLE
Convert error from isolated subaccount constraints to order removal reason.

### DIFF
--- a/protocol/indexer/shared/order_removal_reason.go
+++ b/protocol/indexer/shared/order_removal_reason.go
@@ -51,6 +51,8 @@ func GetOrderRemovalReason(
 		return sharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_FOK_ORDER_COULD_NOT_BE_FULLY_FULLED, nil
 	case errors.Is(orderError, clobtypes.ErrOrderWouldExceedMaxOpenOrdersEquityTierLimit):
 		return sharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_EQUITY_TIER, nil
+	case errors.Is(orderError, clobtypes.ErrWouldViolateIsolatedSubaccountConstraints):
+		return sharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_VIOLATES_ISOLATED_SUBACCOUNT_CONSTRAINTS, nil
 	}
 
 	switch orderStatus {

--- a/protocol/indexer/shared/order_removal_reason_test.go
+++ b/protocol/indexer/shared/order_removal_reason_test.go
@@ -55,7 +55,7 @@ func TestGetOrderRemovalReason_Success(t *testing.T) {
 			expectedReason: sharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_REDUCE_ONLY_RESIZE,
 			expectedErr:    nil,
 		},
-		"Gets order removal reason for order error ErrReduceOnlyWouldIncreasePositionSize": {
+		"Gets order removal reason for order error ErrWouldViolateIsolatedSubaccountConstraints": {
 			orderError:     clobtypes.ErrWouldViolateIsolatedSubaccountConstraints,
 			expectedReason: sharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_VIOLATES_ISOLATED_SUBACCOUNT_CONSTRAINTS,
 			expectedErr:    nil,

--- a/protocol/indexer/shared/order_removal_reason_test.go
+++ b/protocol/indexer/shared/order_removal_reason_test.go
@@ -55,6 +55,11 @@ func TestGetOrderRemovalReason_Success(t *testing.T) {
 			expectedReason: sharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_REDUCE_ONLY_RESIZE,
 			expectedErr:    nil,
 		},
+		"Gets order removal reason for order error ErrReduceOnlyWouldIncreasePositionSize": {
+			orderError:     clobtypes.ErrWouldViolateIsolatedSubaccountConstraints,
+			expectedReason: sharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_VIOLATES_ISOLATED_SUBACCOUNT_CONSTRAINTS,
+			expectedErr:    nil,
+		},
 		"Returns error for order status Success": {
 			orderStatus:    clobtypes.Success,
 			orderError:     clobtypes.ErrNotImplemented,


### PR DESCRIPTION
### Changelist
Handle the new error that can be returned if an order would violate isolated subaccount constraints when creating order removal off-chain update.

Example of error:
```
Exception: unrecognized order status 0 and error "Order would violate isolated subaccount constraints."
```

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced order removal functionality to handle specific subaccount constraint violations.
  
- **Tests**
  - Added a test case to verify the new order removal reason for subaccount constraint violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->