### PR TITLE
Add blockHeight to subaccount websocket msg contents

### DIFF
--- a/indexer/services/socks/__tests__/helpers/from-kafka-helpers.test.ts
+++ b/indexer/services/socks/__tests__/helpers/from-kafka-helpers.test.ts
@@ -81,7 +81,10 @@ describe('from-kafka-helpers', () => {
 
       expect(messageToForward.channel).toEqual(Channel.V4_ACCOUNTS);
       expect(messageToForward.id).toEqual(`${defaultOwner}/${defaultAccNumber}`);
-      expect(messageToForward.contents).toEqual(defaultContents);
+      expect(messageToForward.contents).toEqual({
+        ...defaultContents,
+        blockHeight: subaccountMessage.blockHeight,
+      });
     });
 
     it('gets correct MessageToForward for candles message', () => {

--- a/indexer/services/socks/__tests__/lib/message-forwarder.test.ts
+++ b/indexer/services/socks/__tests__/lib/message-forwarder.test.ts
@@ -359,6 +359,7 @@ describe('message-forwarder', () => {
           id,
           SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
           subaccountMessages,
+          baseSubaccountMessage.blockHeight,
         );
         done();
       }
@@ -430,6 +431,7 @@ describe('message-forwarder', () => {
           id,
           SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
           childSubaccountMessages,
+          baseSubaccountMessage.blockHeight,
           defaultChildAccNumber,
         );
       }
@@ -446,6 +448,7 @@ describe('message-forwarder', () => {
           id,
           SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
           childSubaccount2Messages,
+          baseSubaccountMessage.blockHeight,
           defaultChildAccNumber2,
         );
         done();
@@ -558,6 +561,7 @@ function checkBatchMessage(
   id: string,
   version: string,
   expectedMessages: {contents: string}[],
+  blockHeight: string,
   subaccountNumber?: number,
 ): void {
   expect(batchMsg.connection_id).toBe(connectionId);
@@ -569,7 +573,11 @@ function checkBatchMessage(
   expect(batchMsg.subaccountNumber).toBe(subaccountNumber);
   batchMsg.contents.forEach(
     (individualMessage: Object, idx: number) => {
-      expect(individualMessage).toEqual(JSON.parse(expectedMessages[idx].contents));
+      expect(individualMessage).toEqual(
+        {
+          ...JSON.parse(expectedMessages[idx].contents),
+          blockHeight,
+        });
     },
   );
 }

--- a/indexer/services/socks/src/helpers/from-kafka-helpers.ts
+++ b/indexer/services/socks/src/helpers/from-kafka-helpers.ts
@@ -39,10 +39,14 @@ export function getMessageToForward(
   switch (channel) {
     case Channel.V4_ACCOUNTS: {
       const subaccountMessage: SubaccountMessage = SubaccountMessage.decode(messageBinary);
+      const contents = JSON.parse(subaccountMessage.contents);
+      if (subaccountMessage.blockHeight !== '') {
+        contents.blockHeight = subaccountMessage.blockHeight;
+      }
       return {
         channel,
         id: getSubaccountMessageId(subaccountMessage),
-        contents: JSON.parse(subaccountMessage.contents),
+        contents,
         version: subaccountMessage.version,
       };
     }


### PR DESCRIPTION
### Changelist
Add blockHeight to subaccount websocket msg contents

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message forwarding by including the `blockHeight` property in message contents, ensuring more accurate data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->