### PR TITLE
[CT-808] Add subaccount limit per pnl run

### DIFF
--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -112,6 +112,7 @@ export const configSchema = {
   // PNL ticks
   PNL_TICK_UPDATE_INTERVAL_MS: parseInteger({ default: ONE_HOUR_IN_MILLISECONDS }),
   PNL_TICK_MAX_ROWS_PER_UPSERT: parseInteger({ default: 1000 }),
+  PNL_TICK_MAX_ACCOUNTS_PER_RUN: parseInteger({ default: 200 }),
 
   // Remove expired orders
   BLOCKS_TO_DELAY_EXPIRY_BEFORE_SENDING_REMOVES: parseInteger({ default: 20 }),

--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -112,7 +112,7 @@ export const configSchema = {
   // PNL ticks
   PNL_TICK_UPDATE_INTERVAL_MS: parseInteger({ default: ONE_HOUR_IN_MILLISECONDS }),
   PNL_TICK_MAX_ROWS_PER_UPSERT: parseInteger({ default: 1000 }),
-  PNL_TICK_MAX_ACCOUNTS_PER_RUN: parseInteger({ default: 200 }),
+  PNL_TICK_MAX_ACCOUNTS_PER_RUN: parseInteger({ default: 65000 }),
 
   // Remove expired orders
   BLOCKS_TO_DELAY_EXPIRY_BEFORE_SENDING_REMOVES: parseInteger({ default: 20 }),

--- a/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
+++ b/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
@@ -81,7 +81,7 @@ export async function getPnlTicksCreateObjects(
   const accountsToUpdate: string[] = [
     ...getAccountsToUpdate(accountToLastUpdatedBlockTime, blockTime),
     ...newSubaccountIds,
-  ];
+  ].slice(0, config.PNL_TICK_MAX_ACCOUNTS_PER_RUN);
   stats.gauge(
     `${config.SERVICE_NAME}_get_ticks_accounts_to_update`,
     accountsToUpdate.length,

--- a/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
+++ b/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
@@ -53,6 +53,9 @@ export default async function runTask(): Promise<void> {
       at: 'create-pnl-ticks#runTask',
       message: 'Error when getting pnl ticks',
       error,
+      latestBlockHeight,
+      latestBlockTime,
+      txId,
     });
     return;
   } finally {


### PR DESCRIPTION
### Changelist
Context [here](https://dydx-team.slack.com/archives/C03GKH23YAZ/p1714765891832129)
Add subaccount limit per pnl run.

### Test Plan
Ran in testnet.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configuration constant to limit the number of accounts updated per run, improving system performance.
  
- **Enhancements**
  - Enhanced error logging in task execution by including more parameters for better traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->