### PR TITLE
workflows: go1.21 -> go1.22

### DIFF
--- a/.github/workflows/protocol-container-tests.yml
+++ b/.github/workflows/protocol-container-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Build images
         run: DOCKER_BUILDKIT=1 make test-container-build
       - name: Run container tests

--- a/.github/workflows/protocol-exchange-tests.yml
+++ b/.github/workflows/protocol-exchange-tests.yml
@@ -30,7 +30,7 @@ jobs:
         name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       -
         name: Display go version
         run: go version

--- a/.github/workflows/protocol-lint.yml
+++ b/.github/workflows/protocol-lint.yml
@@ -45,6 +45,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Run golangci-lint
         run: make lint

--- a/.github/workflows/protocol-sim.yml
+++ b/.github/workflows/protocol-sim.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Display go version
         run: go version
       - run: make build
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Display go version
         run: go version
       - name: Install runsim
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Display go version
         run: go version
       - uses: actions/cache@v2.1.3
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Display go version
         run: go version
       - uses: actions/cache@v2.1.3
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Display go version
         run: go version
       - uses: actions/cache@v2.1.3
@@ -209,7 +209,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Display go version
         run: go version
       - uses: actions/cache@v2.1.3

--- a/.github/workflows/protocol-test.yml
+++ b/.github/workflows/protocol-test.yml
@@ -30,7 +30,7 @@ jobs:
         name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       -
         name: Ensure `go.mod` is up to date
         run: go mod tidy && git diff --exit-code
@@ -52,7 +52,7 @@ jobs:
         name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       -
         name: Ensure `go.mod` is up to date
         run: go mod tidy && git diff --exit-code
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - uses: actions/checkout@v3
       - name: Install goveralls
         run: go install github.com/mattn/goveralls@latest
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: start localnet
         run: |
           DOCKER_BUILDKIT=1 make localnet-startd


### PR DESCRIPTION
### Changelist
Workflows to use go@1.22 since this is the version needed. Currently it's installing v1.21 then installing v1.22

### Test Plan
Look at workflows and make sure expected behavior is only installing a single version

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Go version from 1.21 to 1.22 in multiple GitHub Actions workflows for enhanced compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->