### PR TITLE
[SKI-41] Separate healthcheck for Slinky Client and reduce logs

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -824,7 +824,8 @@ func New(
 					appFlags,
 					logger,
 				)
-				app.RegisterDaemonWithHealthMonitor(app.SlinkyClient, maxDaemonUnhealthyDuration)
+				app.RegisterDaemonWithHealthMonitor(app.SlinkyClient.GetMarketPairHC(), maxDaemonUnhealthyDuration)
+				app.RegisterDaemonWithHealthMonitor(app.SlinkyClient.GetPriceHC(), maxDaemonUnhealthyDuration)
 			}
 		}
 

--- a/protocol/daemons/pricefeed/client/constants/logger.go
+++ b/protocol/daemons/pricefeed/client/constants/logger.go
@@ -9,6 +9,7 @@ const (
 	ErrorLogKey      = "error"
 	ExchangeIdLogKey = "exchangeId"
 	MarketIdLogKey   = "marketId"
+	MarketIdsLogKey  = "marketIds"
 	PriceLogKey      = "Price"
 	ReasonLogKey     = "reason"
 

--- a/protocol/daemons/slinky/client/client_test.go
+++ b/protocol/daemons/slinky/client/client_test.go
@@ -73,7 +73,7 @@ func TestClient(t *testing.T) {
 	)
 	waitTime := time.Second * 5
 	require.Eventually(t, func() bool {
-		return cli.HealthCheck() == nil
+		return cli.GetMarketPairHC().HealthCheck() == nil || cli.GetPriceHC().HealthCheck() == nil
 	}, waitTime, time.Millisecond*500, "Slinky daemon failed to become healthy within %s", waitTime)
 	cli.Stop()
 }

--- a/protocol/daemons/slinky/client/client_test.go
+++ b/protocol/daemons/slinky/client/client_test.go
@@ -73,7 +73,7 @@ func TestClient(t *testing.T) {
 	)
 	waitTime := time.Second * 5
 	require.Eventually(t, func() bool {
-		return cli.GetMarketPairHC().HealthCheck() == nil || cli.GetPriceHC().HealthCheck() == nil
+		return cli.GetMarketPairHC().HealthCheck() == nil && cli.GetPriceHC().HealthCheck() == nil
 	}, waitTime, time.Millisecond*500, "Slinky daemon failed to become healthy within %s", waitTime)
 	cli.Stop()
 }

--- a/protocol/daemons/slinky/client/constants.go
+++ b/protocol/daemons/slinky/client/constants.go
@@ -16,5 +16,7 @@ var (
 
 const (
 	// SlinkyClientDaemonModuleName is the module name used in logging.
-	SlinkyClientDaemonModuleName = "slinky-client-daemon"
+	SlinkyClientDaemonModuleName                  = "slinky-client-daemon"
+	SlinkyClientPriceFetcherDaemonModuleName      = "slinky-client-price-fetcher-daemon"
+	SlinkyClientMarketPairFetcherDaemonModuleName = "slinky-client-market-pair-fetcher-daemon"
 )

--- a/protocol/daemons/types/health_checkable.go
+++ b/protocol/daemons/types/health_checkable.go
@@ -1,11 +1,12 @@
 package types
 
 import (
-	"cosmossdk.io/log"
 	"fmt"
-	libtime "github.com/dydxprotocol/v4-chain/protocol/lib/time"
 	"sync"
 	"time"
+
+	"cosmossdk.io/log"
+	libtime "github.com/dydxprotocol/v4-chain/protocol/lib/time"
 )
 
 const (

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -523,17 +523,14 @@ func (k Keeper) sampleAllPerpetuals(ctx sdk.Context) (
 
 	marketIdToIndexPrice := k.pricesKeeper.GetMarketIdToValidIndexPrice(ctx)
 
+	invalidPerpetualIndexPrices := []uint32{}
 	for _, perp := range allPerpetuals {
 		indexPrice, exists := marketIdToIndexPrice[perp.Params.MarketId]
 		// Valid index price is missing
 		if !exists {
 			// Only log and increment stats if height is passed initialization period.
 			if ctx.BlockHeight() > pricestypes.PriceDaemonInitializationBlocks {
-				log.ErrorLog(
-					ctx,
-					"Perpetual does not have valid index price. Skipping premium",
-					constants.MarketIdLogKey, perp.Params.MarketId,
-				)
+				invalidPerpetualIndexPrices = append(invalidPerpetualIndexPrices, perp.Params.MarketId)
 				telemetry.IncrCounterWithLabels(
 					[]string{
 						types.ModuleName,
@@ -551,6 +548,13 @@ func (k Keeper) sampleAllPerpetuals(ctx sdk.Context) (
 			}
 			// Skip this market, effectively emitting a zero premium.
 			continue
+		}
+		if len(invalidPerpetualIndexPrices) > 0 {
+			log.ErrorLog(
+				ctx,
+				"Perpetuals do not have valid index price. Skipping premium",
+				constants.MarketIdsLogKey, invalidPerpetualIndexPrices,
+			)
 		}
 
 		// Get impact notional corresponding to this perpetual market (panic if its liquidity tier doesn't exist).

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -549,13 +549,6 @@ func (k Keeper) sampleAllPerpetuals(ctx sdk.Context) (
 			// Skip this market, effectively emitting a zero premium.
 			continue
 		}
-		if len(invalidPerpetualIndexPrices) > 0 {
-			log.ErrorLog(
-				ctx,
-				"Perpetuals do not have valid index price. Skipping premium",
-				constants.MarketIdsLogKey, invalidPerpetualIndexPrices,
-			)
-		}
 
 		// Get impact notional corresponding to this perpetual market (panic if its liquidity tier doesn't exist).
 		liquidityTier, err := k.GetLiquidityTier(ctx, perp.Params.LiquidityTier)
@@ -603,6 +596,13 @@ func (k Keeper) sampleAllPerpetuals(ctx sdk.Context) (
 				perp.Params.Id,
 				premiumPpm,
 			),
+		)
+	}
+	if len(invalidPerpetualIndexPrices) > 0 {
+		log.ErrorLog(
+			ctx,
+			"Perpetuals do not have valid index price. Skipping premium",
+			constants.MarketIdsLogKey, invalidPerpetualIndexPrices,
 		)
 	}
 	return samples, nil

--- a/protocol/x/prices/keeper/update_price.go
+++ b/protocol/x/prices/keeper/update_price.go
@@ -64,6 +64,7 @@ func (k Keeper) GetValidMarketPriceUpdates(
 
 	// 3. Collect all "valid" price updates.
 	updates := make([]*types.MsgUpdateMarketPrices_MarketPrice, 0, len(allMarketParamPrices))
+	nonExistentMarkets := []uint32{}
 	for _, marketParamPrice := range allMarketParamPrices {
 		marketId := marketParamPrice.Param.Id
 		indexPrice, indexPriceExists := allIndexPrices[marketId]
@@ -77,14 +78,17 @@ func (k Keeper) GetValidMarketPriceUpdates(
 			// there will be a delay in populating index prices after network genesis or a network restart, or when a
 			// market is created, it takes the daemon some time to warm up.
 			if !k.IsRecentlyAvailable(ctx, marketId) {
-				log.ErrorLog(
-					ctx,
-					"Index price for market does not exist",
-					constants.MarketIdLogKey,
-					marketId,
-				)
+				nonExistentMarkets = append(nonExistentMarkets, marketId)
 			}
 			continue
+		}
+		if len(nonExistentMarkets) > 0 {
+			log.ErrorLog(
+				ctx,
+				"Index price for markets does not exist",
+				constants.MarketIdsLogKey,
+				nonExistentMarkets,
+			)
 		}
 
 		// Index prices of 0 are unexpected. In this scenario, we skip the proposal logic for the market and report an


### PR DESCRIPTION
### Changelist
Separate healthcheck for Slinky Client and reduce logs. Separate healthchecks are required so that if either fetcher is broken, that the validator should panic.

### Test Plan
Tested in dev

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Enhanced health monitoring by integrating market pair and price health checks.
  - Added new logging constants for better traceability.

- **Improvements**
  - Improved error handling by logging collective errors for invalid perpetual index prices and non-existent market prices.

- **Bug Fixes**
  - Refined health check methods to ensure accurate status reporting.

- **Tests**
  - Updated test cases to validate new health check methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->