### PR TITLE
[CT-846] Send subaccount websocket message when cancel is received for non-existent order

### DIFF
--- a/indexer/packages/kafka/src/constants.ts
+++ b/indexer/packages/kafka/src/constants.ts
@@ -1,7 +1,7 @@
 export const TO_ENDER_TOPIC: string = 'to-ender';
 
 export const ORDERBOOKS_WEBSOCKET_MESSAGE_VERSION: string = '1.0.0';
-export const SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION: string = '2.4.0';
+export const SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION: string = '2.4.1';
 export const TRADES_WEBSOCKET_MESSAGE_VERSION: string = '2.1.0';
 export const MARKETS_WEBSOCKET_MESSAGE_VERSION: string = '1.0.0';
 export const CANDLES_WEBSOCKET_MESSAGE_VERSION: string = '1.0.0';

--- a/indexer/packages/kafka/src/constants.ts
+++ b/indexer/packages/kafka/src/constants.ts
@@ -1,7 +1,7 @@
 export const TO_ENDER_TOPIC: string = 'to-ender';
 
 export const ORDERBOOKS_WEBSOCKET_MESSAGE_VERSION: string = '1.0.0';
-export const SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION: string = '2.4.1';
+export const SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION: string = '3.0.0';
 export const TRADES_WEBSOCKET_MESSAGE_VERSION: string = '2.1.0';
 export const MARKETS_WEBSOCKET_MESSAGE_VERSION: string = '1.0.0';
 export const CANDLES_WEBSOCKET_MESSAGE_VERSION: string = '1.0.0';

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -125,7 +125,7 @@ export interface OrderSubaccountMessageContents {
   removalReason?: string;
   // This will only be set for stateful orders
   createdAtHeight?: string;
-  clientMetadata: string;
+  clientMetadata?: string;
 }
 
 export interface FillSubaccountMessageContents {

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -101,15 +101,15 @@ export interface OrderSubaccountMessageContents {
   id: string;
   subaccountId: string;
   clientId: string;
-  clobPairId: string;
-  side: OrderSide;
-  size: string;
-  ticker: string,
-  price: string;
-  type: OrderType;
-  timeInForce: APITimeInForce;
-  postOnly: boolean;
-  reduceOnly: boolean;
+  clobPairId?: string;
+  side?: OrderSide;
+  size?: string;
+  ticker?: string,
+  price?: string;
+  type?: OrderType;
+  timeInForce?: APITimeInForce;
+  postOnly?: boolean;
+  reduceOnly?: boolean;
   status: APIOrderStatus;
   orderFlags: string;
 

--- a/indexer/services/comlink/public/websocket-documentation.md
+++ b/indexer/services/comlink/public/websocket-documentation.md
@@ -162,27 +162,27 @@ export interface OrderSubaccountMessageContents {
   id: string;
   subaccountId: string;
   clientId: string;
-  clobPairId: string;
-  side: OrderSide;
-  size: string;
-  ticker: string,
-  price: string;
-  type: OrderType;
-  timeInForce: APITimeInForce;
-  postOnly: boolean;
-  reduceOnly: boolean;
+  clobPairId?: string;
+  side?: OrderSide;
+  size?: string;
+  ticker?: string,
+  price?: string;
+  type?: OrderType;
+  timeInForce?: APITimeInForce;
+  postOnly?: boolean;
+  reduceOnly?: boolean;
   status: APIOrderStatus;
   orderFlags: string;
   totalFilled?: string;
   totalOptimisticFilled?: string;
   goodTilBlock?: string;
   goodTilBlockTime?: string;
-  removalReason?: string;
-  createdAtHeight?: string;
-  clientMetadata: string;
   triggerPrice?: string;
   updatedAt?: IsoString;
   updatedAtHeight?: string;
+  removalReason?: string;
+  createdAtHeight?: string;
+  clientMetadata?: string;
 }
 
 export enum OrderSide {

--- a/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
@@ -281,11 +281,11 @@ describe('OrderRemoveHandler', () => {
               price: testConstants.defaultOrder.price,
               size: testConstants.defaultOrder.size,
               clientMetadata: testConstants.defaultOrder.clientMetadata,
-              type: testConstants.defaultOrder.type,
-              goodTilBlock: testConstants.defaultOrder.goodTilBlock,
               side: testConstants.defaultOrder.side,
               timeInForce: apiTranslations.orderTIFToAPITIF(testConstants.defaultOrder.timeInForce),
               totalFilled: testConstants.defaultOrder.totalFilled,
+              goodTilBlock: testConstants.defaultOrder.goodTilBlock,
+              type: testConstants.defaultOrder.type,
             },
           ],
         };

--- a/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
@@ -235,10 +235,10 @@ describe('OrderRemoveHandler', () => {
         defaultKafkaHeaders,
       );
 
-      const ticker: string = testConstants.defaultPerpetualMarket.ticker;
+      const clobPairId: string = testConstants.defaultPerpetualMarket.clobPairId;
       expect(logger.error).toHaveBeenCalledWith({
         at: 'orderRemoveHandler#handle',
-        message: `Unable to find perpetual market with ticker: ${ticker}`,
+        message: `Unable to find perpetual market with clobPairId: ${clobPairId}`,
       });
       expectTimingStats();
     });

--- a/indexer/services/vulcan/src/config.ts
+++ b/indexer/services/vulcan/src/config.ts
@@ -37,6 +37,9 @@ export const configSchema = {
   SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS: parseBoolean({
     default: true,
   }),
+  SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_CANCELS_MISSING_ORDERS: parseBoolean({
+    default: false,
+  }),
 };
 
 export default parseSchema(configSchema);

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -14,6 +14,9 @@ import {
   apiTranslations,
   TimeInForce,
   IsoString,
+  OrderSide,
+  APITimeInForce,
+  OrderType,
 } from '@dydxprotocol-indexer/postgres';
 import {
   OpenOrdersCache,
@@ -569,6 +572,19 @@ export class OrderRemoveHandler extends Handler {
     const createdAtHeight: string | undefined = canceledOrder?.createdAtHeight;
     const updatedAt: IsoString | undefined = canceledOrder?.updatedAt;
     const updatedAtHeight: string | undefined = canceledOrder?.updatedAtHeight;
+    const price: string | undefined = canceledOrder?.price;
+    const size: string | undefined = canceledOrder?.size;
+    const clientMetadata: string | undefined = canceledOrder?.clientMetadata;
+    const reduceOnly: boolean | undefined = canceledOrder?.reduceOnly;
+    const side: OrderSide | undefined = canceledOrder?.side;
+    const timeInForce: APITimeInForce | undefined = canceledOrder
+      ? apiTranslations.orderTIFToAPITIF(canceledOrder.timeInForce) : undefined;
+    const totalFilled: string | undefined = canceledOrder?.totalFilled;
+    const goodTilBlock: string | undefined = canceledOrder?.goodTilBlock;
+    const goodTilBlockTime: string | undefined = canceledOrder?.goodTilBlockTime;
+    const triggerPrice: string | undefined = canceledOrder?.triggerPrice;
+    const type: OrderType | undefined = canceledOrder?.type;
+
     const contents: SubaccountMessageContents = {
       orders: [
         {
@@ -585,6 +601,17 @@ export class OrderRemoveHandler extends Handler {
           ...(createdAtHeight && { createdAtHeight }),
           ...(updatedAt && { updatedAt }),
           ...(updatedAtHeight && { updatedAtHeight }),
+          ...(price && { price }),
+          ...(size && { size }),
+          ...(clientMetadata && { clientMetadata }),
+          ...(reduceOnly && { reduceOnly }),
+          ...(side && { side }),
+          ...(timeInForce && { timeInForce }),
+          ...(totalFilled && { totalFilled }),
+          ...(goodTilBlock && { goodTilBlock }),
+          ...(goodTilBlockTime && { goodTilBlockTime }),
+          ...(triggerPrice && { triggerPrice }),
+          ...(type && { type }),
         },
       ],
     };


### PR DESCRIPTION
### Changelist
Send subaccount websocket message when cancel is received for non-existent order

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for non-existent orders, providing detailed information in subaccount websocket messages.

- **Bug Fixes**
  - Improved the accuracy of order-related messages by updating variable names for clarity.

- **Tests**
  - Added new test cases to ensure subaccount websocket messages are sent correctly when orders are not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->