### PR TITLE
[TRA-109] Filter out transfers between child subaccounts of same parent.

### DIFF
--- a/indexer/services/socks/__tests__/constants.ts
+++ b/indexer/services/socks/__tests__/constants.ts
@@ -6,6 +6,8 @@ import {
   TRADES_WEBSOCKET_MESSAGE_VERSION,
 } from '@dydxprotocol-indexer/kafka';
 import {
+  TransferSubaccountMessageContents,
+  TransferType,
   MAX_PARENT_SUBACCOUNTS,
 } from '@dydxprotocol-indexer/postgres';
 import {
@@ -101,4 +103,21 @@ export const childSubaccountMessage: SubaccountMessage = {
   subaccountId: defaultChildSubaccountId,
   contents: defaultContentsString,
   version: SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
+};
+
+export const defaultTransferContents: TransferSubaccountMessageContents = {
+  sender: {
+    address: defaultOwner,
+    subaccountNumber: defaultAccNumber,
+  },
+  recipient: {
+    address: defaultOwner,
+    subaccountNumber: defaultChildAccNumber,
+  },
+  symbol: 'USDC',
+  size: '1',
+  type: TransferType.TRANSFER_IN,
+  transactionHash: '0x1',
+  createdAt: '2023-10-05T14:48:00.000Z',
+  createdAtHeight: '10',
 };

--- a/indexer/services/socks/__tests__/helpers/from-kafka-helpers.test.ts
+++ b/indexer/services/socks/__tests__/helpers/from-kafka-helpers.test.ts
@@ -156,7 +156,7 @@ describe('from-kafka-helpers', () => {
       expect(messageToForward.subaccountNumber).toEqual(defaultChildAccNumber);
     });
 
-    it('filters out transfers between child subaccounts for parent subaccout channel', () => {
+    it('filters out transfers between child subaccounts for parent subaccount channel', () => {
       const transferContents: SubaccountMessageContents = {
         transfers: {
           ...defaultTransferContents,

--- a/indexer/services/socks/src/helpers/from-kafka-helpers.ts
+++ b/indexer/services/socks/src/helpers/from-kafka-helpers.ts
@@ -138,6 +138,7 @@ function getCandleMessageId(candleMessage: CandleMessage): string {
 }
 
 function getParentSubaccountContents(msg: SubaccountMessage): SubaccountMessageContents {
+  // Filter out transfers between child subaccounts of the same parent subaccount.
   const contents: SubaccountMessageContents = JSON.parse(msg.contents) as SubaccountMessageContents;
   if (contents.transfers === undefined) {
     return contents;

--- a/indexer/services/socks/src/helpers/from-kafka-helpers.ts
+++ b/indexer/services/socks/src/helpers/from-kafka-helpers.ts
@@ -3,13 +3,16 @@ import {
   perpetualMarketRefresher,
   PROTO_TO_CANDLE_RESOLUTION,
   parentSubaccountHelpers,
+  SubaccountMessageContents,
 } from '@dydxprotocol-indexer/postgres';
+import { getParentSubaccountNum } from '@dydxprotocol-indexer/postgres/build/src/lib/parent-subaccount-helpers';
 import {
   CandleMessage,
   MarketMessage,
   OrderbookMessage,
   TradeMessage,
-  SubaccountMessage, CandleMessage_Resolution,
+  SubaccountMessage,
+  CandleMessage_Resolution,
 } from '@dydxprotocol-indexer/v4-protos';
 import { KafkaMessage } from 'kafkajs';
 
@@ -91,7 +94,7 @@ export function getMessageToForward(
         channel,
         id: getParentSubaccountMessageId(subaccountMessage),
         subaccountNumber: subaccountMessage.subaccountId!.number,
-        contents: JSON.parse(subaccountMessage.contents),
+        contents: getParentSubaccountContents(subaccountMessage),
         version: subaccountMessage.version,
       };
     }
@@ -132,4 +135,35 @@ function getCandleMessageId(candleMessage: CandleMessage): string {
     return `${ticker}/`;
   }
   return `${ticker}/${PROTO_TO_CANDLE_RESOLUTION[candleMessage.resolution]}`;
+}
+
+function getParentSubaccountContents(msg: SubaccountMessage): SubaccountMessageContents {
+  const contents: SubaccountMessageContents = JSON.parse(msg.contents) as SubaccountMessageContents;
+  if (contents.transfers === undefined) {
+    return contents;
+  }
+
+  const senderAddress: string = contents.transfers.sender.address;
+  const recipientAddress: string = contents.transfers.recipient.address;
+
+  if (senderAddress !== recipientAddress) {
+    return contents;
+  }
+
+  const senderSubaccount: number | undefined = contents.transfers.sender.subaccountNumber;
+  const recipientSubaccount: number | undefined = contents.transfers.recipient.subaccountNumber;
+
+  if (senderSubaccount === undefined || recipientSubaccount === undefined) {
+    return contents;
+  }
+
+  const senderParentSubaccountNumber: number = getParentSubaccountNum(senderSubaccount);
+  const recipientParentSubaccountNumber: number = getParentSubaccountNum(recipientSubaccount);
+
+  if (senderParentSubaccountNumber !== recipientParentSubaccountNumber) {
+    return contents;
+  }
+
+  delete contents.transfers;
+  return contents;
 }


### PR DESCRIPTION
### Changelist
Update `socks` to filter out transfers between child subaccounts for the same parent subaccount for the parent subaccount websocket channel.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced transfer functionality to handle transfers between child subaccounts of the same parent subaccount.
  
- **Tests**
  - Added tests for filtering transfers between child subaccounts for the parent subaccount channel.
  - Added tests for various transfer scenarios including transfers between other parent/child subaccounts, deposits, and withdrawals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->