### PR TITLE
Improve the performance of `BaseToQuoteQuantums` & `BigRatMulPpm`

### DIFF
--- a/protocol/lib/big_math.go
+++ b/protocol/lib/big_math.go
@@ -92,13 +92,9 @@ func BigMax(a, b *big.Int) *big.Int {
 
 // BigRatMulPpm takes a `big.Rat` and returns the result of `input * ppm / 1_000_000`.
 func BigRatMulPpm(input *big.Rat, ppm uint32) *big.Rat {
-	return new(big.Rat).Mul(
-		input,
-		new(big.Rat).SetFrac64(
-			int64(ppm),
-			int64(OneMillion),
-		),
-	)
+	num := new(big.Int).Mul(input.Num(), big.NewInt(int64(ppm)))
+	den := new(big.Int).Mul(input.Denom(), big.NewInt(int64(OneMillion)))
+	return new(big.Rat).SetFrac(num, den)
 }
 
 // bigGenericClamp is a helper function for BigRatClamp and BigIntClamp

--- a/protocol/lib/big_math_test.go
+++ b/protocol/lib/big_math_test.go
@@ -378,6 +378,26 @@ func TestBigRatMulPpm(t *testing.T) {
 			ppm:            10_000,
 			expectedResult: big_testutil.MustFirst(new(big.Rat).SetString("10000000000000000000000")),
 		},
+		"Positive with a common divisor": {
+			input:          big.NewRat(3, 1),
+			ppm:            500_000,
+			expectedResult: big.NewRat(3, 2),
+		},
+		"Negative with a common divisor": {
+			input:          big.NewRat(-3, 1),
+			ppm:            500_000,
+			expectedResult: big.NewRat(-3, 2),
+		},
+		"Positive with no common divisor": {
+			input:          big.NewRat(117, 61),
+			ppm:            419,
+			expectedResult: big.NewRat(49023, 61000000),
+		},
+		"Negative with no common divisor": {
+			input:          big.NewRat(-117, 61),
+			ppm:            419,
+			expectedResult: big.NewRat(-49023, 61000000),
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/protocol/lib/quantums_test.go
+++ b/protocol/lib/quantums_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	big_testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/big"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBaseToQuoteQuantums(t *testing.T) {
@@ -219,4 +220,34 @@ func TestQuoteToBaseQuantums(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkBaseToQuoteQuantums(b *testing.B) {
+	value := big.NewInt(1234123412341)
+	baseCurrencyAtomicResolution := int32(-8)
+	priceValue := uint64(18446744073709551610)
+	priceExponent1 := int32(-10)
+	priceExponent2 := int32(10)
+	var result1 *big.Int
+	var result2 *big.Int
+
+	for i := 0; i < b.N; i++ {
+		result1 = lib.BaseToQuoteQuantums(
+			value,
+			baseCurrencyAtomicResolution,
+			priceValue,
+			priceExponent1,
+		)
+		result2 = lib.BaseToQuoteQuantums(
+			value,
+			baseCurrencyAtomicResolution,
+			priceValue,
+			priceExponent2,
+		)
+	}
+
+	expected1, _ := new(big.Int).SetString("22765558742827551059", 10)
+	require.Equal(b, expected1, result1)
+	expected2, _ := new(big.Int).SetString("2276555874282755105905825041901000000000", 10)
+	require.Equal(b, expected2, result2)
 }


### PR DESCRIPTION
### Changelist
- These are two of the most used function by the CPU at the moment.
- `BaseToQuoteQuantums` optimized by about 80% and `BigRatMulPpm` optimized by about 20%
- In a future PR, `multiplyByPrice` and `FundingRateToIndex` can be removed like in https://github.com/dydxprotocol/v4-chain/pull/1528, but am keeping this PR small for now to ensure it can be backported if needed

### Test Plan
- New benchmark test for `BaseToQuoteQuantums`
- Unit tests already exist for `BaseToQuoteQuantums` including rounding for negative numbers

### Benchmark Results

Before:
```
BenchmarkBigRatMulPpm-4          	16975401	       382.0 ns/op	     208 B/op	       9 allocs/op
BenchmarkBaseToQuoteQuantums-4   	 3997749	      1518 ns/op	    1056 B/op	      36 allocs/op
```

After:
```
BenchmarkBigRatMulPpm-4          	22503729	       289.2 ns/op	     192 B/op	       7 allocs/op
BenchmarkBaseToQuoteQuantums-4   	19702170	       266.7 ns/op	     184 B/op	       7 allocs/op

BenchmarkBigRatMulPpm-4: 24.3% improvement
BenchmarkBaseToQuoteQuantums-4: 82.4% improvement
```