### PR TITLE
Improve `QuoteToBaseQuantums`

### DIFF
--- a/protocol/lib/quantums.go
+++ b/protocol/lib/quantums.go
@@ -63,19 +63,17 @@ func BaseToQuoteQuantums(
 //	  quoteQuantums / priceValue /
 //	  10^(priceExponent + baseCurrencyAtomicResolution - quoteCurrencyAtomicResolution)
 //
-// The result is rounded down. It is okay to do the divisions separately, as the result is the same.
+// The result is rounded towards zero.
 func QuoteToBaseQuantums(
 	bigQuoteQuantums *big.Int,
 	baseCurrencyAtomicResolution int32,
 	priceValue uint64,
 	priceExponent int32,
 ) (bigNotional *big.Int) {
-	// Determine the non-exponent part of the equation.
-	// We perform all calculations using positive rationals for consistent rounding.
-	isLong := bigQuoteQuantums.Sign() >= 0
-	result := new(big.Int).Abs(bigQuoteQuantums)
+	// Initialize result to quoteQuantums.
+	result := new(big.Int).Set(bigQuoteQuantums)
 
-	// Divide result (towards zero) by 10^(exponent)
+	// Divide result (towards zero) by 10^(exponent).
 	exponent := priceExponent + baseCurrencyAtomicResolution - QuoteCurrencyAtomicResolution
 	power10Exponent := BigPow10(uint64(AbsInt32(exponent)))
 	if exponent > 0 {
@@ -85,12 +83,9 @@ func QuoteToBaseQuantums(
 	}
 
 	// Divide result (towards zero) by priceValue.
+	// If there are two divisions, it is okay to do them separately as the result is the same.
 	result.Quo(result, new(big.Int).SetUint64(priceValue))
 
-	// Flip the sign of the return value if necessary.
-	if !isLong {
-		result.Neg(result)
-	}
 	return result
 }
 

--- a/protocol/lib/quantums_test.go
+++ b/protocol/lib/quantums_test.go
@@ -251,3 +251,33 @@ func BenchmarkBaseToQuoteQuantums(b *testing.B) {
 	expected2, _ := new(big.Int).SetString("2276555874282755105905825041901000000000", 10)
 	require.Equal(b, expected2, result2)
 }
+
+func BenchmarkQuoteToBaseQuantums(b *testing.B) {
+	value, _ := new(big.Int).SetString("18446744073709551610", 10)
+	baseCurrencyAtomicResolution := int32(-8)
+	priceValue := uint64(1234123412341)
+	priceExponent1 := int32(-10)
+	priceExponent2 := int32(6)
+	var result1 *big.Int
+	var result2 *big.Int
+
+	for i := 0; i < b.N; i++ {
+		result1 = lib.QuoteToBaseQuantums(
+			value,
+			baseCurrencyAtomicResolution,
+			priceValue,
+			priceExponent1,
+		)
+		result2 = lib.QuoteToBaseQuantums(
+			value,
+			baseCurrencyAtomicResolution,
+			priceValue,
+			priceExponent2,
+		)
+	}
+
+	expected1, _ := new(big.Int).SetString("14947244245790664347", 10)
+	require.Equal(b, expected1, result1)
+	expected2, _ := new(big.Int).SetString("1494", 10)
+	require.Equal(b, expected2, result2)
+}


### PR DESCRIPTION
### Changelist
- Add benchmark for function
- Improve function to not use `big.Rat`
- Some performance gains expected but the main point is to move further away from using `big.Rat` anywhere

### Test Plan
- New benchmark, existing unit tests cover any possible regression

```
Before
BenchmarkQuoteToBaseQuantums-4   	 3567890	      1678 ns/op	     936 B/op	      42 allocs/op

After
BenchmarkQuoteToBaseQuantums-4   	14310079	       409.8 ns/op	     248 B/op	      14 allocs/op
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Optimized the calculation logic in the `QuoteToBaseQuantums` function for better efficiency.

- **New Features**
  - Added benchmarking for `QuoteToBaseQuantums` to ensure performance under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->