### PR TITLE
Restore prior API ordering when page param is not specified

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
@@ -125,10 +125,13 @@ describe('fills-controller#V4', () => {
       );
     });
 
-    it('Get /fills with market gets fills ordered by createdAtHeight descending', async () => {
+    it('Get /fills with market gets correctly ordered fills', async () => {
       // Order and fill for BTC-USD
       await OrderTable.create(testConstants.defaultOrder);
-      await FillTable.create(testConstants.defaultFill);
+      await FillTable.create({
+        ...testConstants.defaultFill,
+        eventId: testConstants.defaultTendermintEventId2,
+      });
 
       // Order and fill for ETH-USD
       const ethOrder: OrderFromDatabase = await OrderTable.create({
@@ -140,11 +143,10 @@ describe('fills-controller#V4', () => {
         ...testConstants.defaultFill,
         orderId: ethOrder.id,
         clobPairId: testConstants.defaultPerpetualMarket2.clobPairId,
-        eventId: testConstants.defaultTendermintEventId2,
         createdAtHeight: '1',
       });
 
-      const response: request.Response = await sendRequest({
+      let response: request.Response = await sendRequest({
         type: RequestMethod.GET,
         path: `/v4/fills?address=${testConstants.defaultAddress}` +
           `&subaccountNumber=${testConstants.defaultSubaccount.subaccountNumber}`,
@@ -179,7 +181,8 @@ describe('fills-controller#V4', () => {
         },
       ];
 
-      // Fills should be returned sorted by createdAtHeight in descending order.
+      // Page is not specified, so fills should be returned sorted by createdAtHeight
+      // in descending order.
       expect(response.body.fills).toHaveLength(2);
       expect(response.body.fills).toEqual(
         expect.arrayContaining([
@@ -188,6 +191,24 @@ describe('fills-controller#V4', () => {
           }),
           expect.objectContaining({
             ...expected[1],
+          }),
+        ]),
+      );
+
+      response = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/fills?address=${testConstants.defaultAddress}` +
+          `&subaccountNumber=${testConstants.defaultSubaccount.subaccountNumber}&page=1&limit=2`,
+      });
+      // Page is specified, so fills should be sorted by eventId in ascending order.
+      expect(response.body.fills).toHaveLength(2);
+      expect(response.body.fills).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            ...expected[1],
+          }),
+          expect.objectContaining({
+            ...expected[0],
           }),
         ]),
       );

--- a/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
@@ -185,14 +185,14 @@ describe('fills-controller#V4', () => {
       // in descending order.
       expect(response.body.fills).toHaveLength(2);
       expect(response.body.fills).toEqual(
-        expect.arrayContaining([
+        [
           expect.objectContaining({
             ...expected[0],
           }),
           expect.objectContaining({
             ...expected[1],
           }),
-        ]),
+        ],
       );
 
       response = await sendRequest({
@@ -203,14 +203,14 @@ describe('fills-controller#V4', () => {
       // Page is specified, so fills should be sorted by eventId in ascending order.
       expect(response.body.fills).toHaveLength(2);
       expect(response.body.fills).toEqual(
-        expect.arrayContaining([
+        [
           expect.objectContaining({
             ...expected[1],
           }),
           expect.objectContaining({
             ...expected[0],
           }),
-        ]),
+        ],
       );
     });
 

--- a/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
@@ -93,7 +93,7 @@ class FillsController extends Controller {
         page,
       },
       [QueryableField.LIMIT],
-      { orderBy: [[FillColumns.eventId, Ordering.ASC]] },
+      page !== undefined ? { orderBy: [[FillColumns.eventId, Ordering.ASC]] } : undefined,
     );
 
     const clobPairIdToPerpetualMarket: Record<
@@ -168,7 +168,7 @@ class FillsController extends Controller {
         page,
       },
       [QueryableField.LIMIT],
-      { orderBy: [[FillColumns.eventId, Ordering.ASC]] },
+      page !== undefined ? { orderBy: [[FillColumns.eventId, Ordering.ASC]] } : undefined,
     );
 
     const clobPairIdToPerpetualMarket: Record<

--- a/indexer/services/comlink/src/controllers/api/v4/trades-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/trades-controller.ts
@@ -73,7 +73,7 @@ class TradesController extends Controller {
         page,
       },
       [QueryableField.LIQUIDITY, QueryableField.CLOB_PAIR_ID, QueryableField.LIMIT],
-      { orderBy: [[FillColumns.eventId, Ordering.ASC]] },
+      page !== undefined ? { orderBy: [[FillColumns.eventId, Ordering.ASC]] } : undefined,
     );
 
     return {


### PR DESCRIPTION
### Changelist
Restore prior API ordering when page param is not specified

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
