### PR TITLE
reduce use of `big.Rat` in various modules

### DIFF
--- a/protocol/x/clob/types/quantums.go
+++ b/protocol/x/clob/types/quantums.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
-	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -79,37 +78,5 @@ func GetAveragePriceSubticks(
 	return result.Quo(
 		result,
 		new(big.Rat).SetInt(bigBaseQuantums),
-	)
-}
-
-// NotionalToCoinAmount returns the coin amount (e.g. `uatom`) that has equal worth to the notional (in quote quantums).
-// For example, given price of 9.5 USDC/ATOM, notional of 9_500_000 quote quantums, return 1_000_000 `uatom` (since
-// `tokenDenomExp“=-6).
-// Note the return value is in coin amount, which is different from base quantums.
-//
-// Given the below by definitions:
-//
-//	quote_quantums * 10^quote_atomic_resolution = full_quote_coin_amount (e.g. 2_000_000 quote quantums * 10^-6 = 2 USDC)
-//	coin_amount * 10^denom_exponent = full_coin_amount (e.g. 1_000_000 uatom * 10^-6 = 1 ATOM)
-//	full_coin_amount * coin_price = full_quote_coin_amount (e.g. 1 ATOM * 9.5 USDC/ATOM = 9.5 USDC)
-//
-// Therefore:
-//
-//	coin_amount * 10^denom_exponent * coin_price = quote_quantums * 10^quote_atomic_resolution
-//	coin_amount = quote_quantums * 10^(quote_atomic_resolution - denom_exponent) / coin_price
-func NotionalToCoinAmount(
-	notionalQuoteQuantums *big.Int,
-	quoteAtomicResolution int32,
-	denomExp int32,
-	marketPrice pricestypes.MarketPrice,
-) *big.Rat {
-	fullCoinPrice := lib.BigMulPow10(
-		new(big.Int).SetUint64(marketPrice.Price),
-		marketPrice.Exponent,
-	)
-	ret := lib.BigMulPow10(notionalQuoteQuantums, quoteAtomicResolution-denomExp)
-	return ret.Quo(
-		ret,
-		fullCoinPrice,
 	)
 }

--- a/protocol/x/clob/types/quantums_test.go
+++ b/protocol/x/clob/types/quantums_test.go
@@ -6,10 +6,8 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	big_testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/big"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
 )
@@ -135,66 +133,6 @@ func TestGetAveragePriceSubticks(t *testing.T) {
 			require.Equal(t,
 				tc.bigRatExpectedSubticks,
 				bigRatSubticks,
-			)
-		})
-	}
-}
-
-func TestNotionalToCoinAmount(t *testing.T) {
-	tests := map[string]struct {
-		notionalQuoteQuantums    *big.Int
-		denomExp                 int32
-		marketPrice              pricestypes.MarketPrice
-		bigRatExpectedCoinAmount *big.Rat
-	}{
-		"$9.5 notional, ATOM price at $9.5, get amount in `uatom` (exp = -6)": {
-			notionalQuoteQuantums: big.NewInt(9_500_000),
-			marketPrice: pricestypes.MarketPrice{
-				Price:    95_000,
-				Exponent: -4,
-			},
-			denomExp:                 -6,
-			bigRatExpectedCoinAmount: big.NewRat(1_000_000, 1),
-		},
-		"$4.75 notional, ATOM price at $9.5, get amount in `uatom` (exp = -6)": {
-			notionalQuoteQuantums: big.NewInt(4_750_000),
-			marketPrice: pricestypes.MarketPrice{
-				Price:    95_000,
-				Exponent: -4,
-			},
-			denomExp:                 -6,
-			bigRatExpectedCoinAmount: big.NewRat(500_000, 1),
-		},
-		"$10.5 notional, ETH price at $2000, get amount in `gwei` (exp = -9)": {
-			notionalQuoteQuantums: big.NewInt(10_500_000),
-			marketPrice: pricestypes.MarketPrice{
-				Price:    20_000_000_000,
-				Exponent: -7,
-			},
-			denomExp:                 -9,
-			bigRatExpectedCoinAmount: big.NewRat(5_250_000, 1),
-		},
-		"$1000 notional, ETH price at $2001.57, get amount in `gwei` (exp = -9)": {
-			notionalQuoteQuantums: big.NewInt(1_000_000_000),
-			marketPrice: pricestypes.MarketPrice{
-				Price:    20_015_700_000,
-				Exponent: -7,
-			},
-			denomExp:                 -9,
-			bigRatExpectedCoinAmount: big.NewRat(100_000_000_000_000, 200157), // 499607807.871 Gwei, or 0.499607807871 Eth.
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			bigRatCoinAmount := types.NotionalToCoinAmount(
-				tc.notionalQuoteQuantums,
-				lib.QuoteCurrencyAtomicResolution,
-				tc.denomExp,
-				tc.marketPrice,
-			)
-			require.Equal(t,
-				tc.bigRatExpectedCoinAmount,
-				bigRatCoinAmount,
 			)
 		})
 	}

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -992,11 +992,9 @@ func GetMarginRequirementsInQuoteQuantums(
 		big.NewInt(0), // pass in 0 as open interest to get base IMR.
 	)
 	// Maintenance margin requirement quote quantums = IM in quote quantums * maintenance fraction PPM.
-	bigMaintenanceMarginQuoteQuantums = lib.BigRatRound(
-		lib.BigRatMulPpm(
-			new(big.Rat).SetInt(bigBaseInitialMarginQuoteQuantums),
-			liquidityTier.MaintenanceFractionPpm,
-		),
+	bigMaintenanceMarginQuoteQuantums = lib.BigMulPpm(
+		bigBaseInitialMarginQuoteQuantums,
+		lib.BigU(liquidityTier.MaintenanceFractionPpm),
 		true,
 	)
 

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -70,4 +70,9 @@ var (
 		13,
 		"ActivationThresholdQuoteQuantums must be non-negative",
 	)
+	ErrInvalidOrderSize = errorsmod.Register(
+		ModuleName,
+		14,
+		"OrderSize is invalid",
+	)
 )


### PR DESCRIPTION
### Changelist
- Remove `NotionalToCoinAmount()` in favor of using `QuoteToBaseQuantums()` since it seems to be duplicated logic
- `QuoteToBaseQuantums()` is also used in order-sizing for vaults since vaults was previously duplicating the logic

### Test Plan
- TODO