### PR TITLE
Remove use of `big.Rat` from x/vest

### DIFF
--- a/protocol/x/vest/keeper/keeper.go
+++ b/protocol/x/vest/keeper/keeper.go
@@ -93,19 +93,18 @@ func (k Keeper) ProcessVesting(ctx sdk.Context) {
 		// Given `block_time > prev_block_time` and `block_time > start_time` ===> `block_time > last_vest_time`
 		// Given `end_time > prev_block_time` and `end_time > start_time` ===> `end_time > last_vest_time`
 		// Therefore, both numerator and denominator are positive.
-		bigRatVestProportion := big.NewRat(blockTimeMilli-lastVestTimeMilli, endTimeMilli-lastVestTimeMilli)
+		timeNum := lib.BigI(blockTimeMilli-lastVestTimeMilli)
+		timeDen := lib.BigI(endTimeMilli-lastVestTimeMilli)
 
 		// Get vester account remaining balance.
 		vesterBalance := k.bankKeeper.GetBalance(ctx, authtypes.NewModuleAddress(entry.VesterAccount), entry.Denom)
+
+		// Determine the vesting amount.
 		vestAmount := vesterBalance.Amount
-		if bigRatVestProportion.Cmp(lib.BigRat1()) < 0 {
+		if timeNum.Cmp(timeDen) < 0 {
 			// vestProportion < 1, so vest_amount = vester_balance * vestProportion
-			bigRatBalance := new(big.Rat).SetInt(vesterBalance.Amount.BigInt())
-			bigRatVestAmount := new(big.Rat).Mul(
-				bigRatBalance,
-				bigRatVestProportion,
-			)
-			vestAmount = sdkmath.NewIntFromBigInt(lib.BigRatRound(bigRatVestAmount, false))
+			a := vesterBalance.Amount.BigInt()
+			vestAmount = sdkmath.NewIntFromBigInt(a.Mul(a, timeNum).Quo(a, timeDen))
 		}
 
 		if !vestAmount.IsZero() {

--- a/protocol/x/vest/keeper/keeper.go
+++ b/protocol/x/vest/keeper/keeper.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"fmt"
-	"math/big"
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
@@ -93,8 +92,8 @@ func (k Keeper) ProcessVesting(ctx sdk.Context) {
 		// Given `block_time > prev_block_time` and `block_time > start_time` ===> `block_time > last_vest_time`
 		// Given `end_time > prev_block_time` and `end_time > start_time` ===> `end_time > last_vest_time`
 		// Therefore, both numerator and denominator are positive.
-		timeNum := lib.BigI(blockTimeMilli-lastVestTimeMilli)
-		timeDen := lib.BigI(endTimeMilli-lastVestTimeMilli)
+		timeNum := lib.BigI(blockTimeMilli - lastVestTimeMilli)
+		timeDen := lib.BigI(endTimeMilli - lastVestTimeMilli)
 
 		// Get vester account remaining balance.
 		vesterBalance := k.bankKeeper.GetBalance(ctx, authtypes.NewModuleAddress(entry.VesterAccount), entry.Denom)


### PR DESCRIPTION
### Changelist
- Remove use of `big.Rat` in `x/vest` module

### Test Plan
- `ProcessVesting()` (the affected function) has unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the accuracy and efficiency of vesting amount calculations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->