### PR TITLE
Add benchmark and optimize `ContainsDuplicates`

### DIFF
--- a/protocol/lib/collections.go
+++ b/protocol/lib/collections.go
@@ -7,13 +7,16 @@ import (
 
 // ContainsDuplicates returns true if the slice contains duplicates, false if not.
 func ContainsDuplicates[V comparable](values []V) bool {
-	seenValues := make(map[V]bool)
-	for _, val := range values {
-		if _, exists := seenValues[val]; exists {
+	// Store each value as a key in the mapping.
+	seenValues := make(map[V]struct{}, len(values))
+	for i, val := range values {
+		// Add the value to the mapping.
+		seenValues[val] = struct{}{}
+
+		// Return early if the size of the mapping did not grow.
+		if len(seenValues) <= i {
 			return true
 		}
-
-		seenValues[val] = true
 	}
 
 	return false

--- a/protocol/lib/collections_test.go
+++ b/protocol/lib/collections_test.go
@@ -67,6 +67,24 @@ func TestDedupeSlice(t *testing.T) {
 	}
 }
 
+func BenchmarkContainsDuplicates_True(b *testing.B) {
+	var result bool
+	input := []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 3, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+	for i := 0; i < b.N; i++ {
+		result = lib.ContainsDuplicates(input)
+	}
+	require.True(b, result)
+}
+
+func BenchmarkContainsDuplicates_False(b *testing.B) {
+	var result bool
+	input := []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+	for i := 0; i < b.N; i++ {
+		result = lib.ContainsDuplicates(input)
+	}
+	require.False(b, result)
+}
+
 func TestContainsDuplicates(t *testing.T) {
 	tests := map[string]struct {
 		input    []uint32
@@ -80,11 +98,11 @@ func TestContainsDuplicates(t *testing.T) {
 			input:    []uint32{},
 			expected: false,
 		},
-		"True": {
+		"False": {
 			input:    []uint32{1, 2, 3, 4},
 			expected: false,
 		},
-		"False": {
+		"True": {
 			input:    []uint32{1, 2, 3, 4, 3},
 			expected: true,
 		},


### PR DESCRIPTION
### Changelist
`ContainsDuplicates` accounts for over 10% of the time when placing vault orders on testnet. Optimize the runtime by around 50%, especially in the almost-always case of no duplicates. Therefore this should speed up placement of vault orders by around 5%.

### Test Plan
- Added benchmarks

```
Before
BenchmarkContainsDuplicates_True-4    	12939104	       459.6 ns/op	     114 B/op	       1 allocs/op
BenchmarkContainsDuplicates_False-4   	 5010406	      1185 ns/op	     385 B/op	       3 allocs/op

After
BenchmarkContainsDuplicates_True-4    	21472302	       271.8 ns/op	     192 B/op	       1 allocs/op
BenchmarkContainsDuplicates_False-4   	11044560	       534.5 ns/op	     208 B/op	       1 allocs/op
```
