### PR TITLE
validate that vault deposit does not exceed max uint64

### DIFF
--- a/protocol/x/vault/keeper/msg_server_deposit_to_vault.go
+++ b/protocol/x/vault/keeper/msg_server_deposit_to_vault.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 
-	errorsmod "cosmossdk.io/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/log"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
@@ -34,9 +33,6 @@ func (k msgServer) DepositToVault(
 	// Transfer from sender subaccount to vault.
 	// Note: Transfer should take place after minting shares for
 	// shares calculation to be correct.
-	if !quoteQuantums.IsUint64() {
-		return nil, errorsmod.Wrap(types.ErrInvalidDepositAmount, "quote quantums must be strictly less than 2^64")
-	}
 	err = k.sendingKeeper.ProcessTransfer(
 		ctx,
 		&sendingtypes.Transfer{

--- a/protocol/x/vault/keeper/msg_server_deposit_to_vault_test.go
+++ b/protocol/x/vault/keeper/msg_server_deposit_to_vault_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 	"testing"
 
@@ -198,7 +199,7 @@ func TestMsgDepositToVault(t *testing.T) {
 				big.NewInt(1_000),
 			},
 		},
-		"Two failed deposits due to non-positive amounts": {
+		"Three failed deposits due to invalid deposit amount": {
 			vaultId: constants.Vault_Clob_1,
 			depositorSetups: []DepositorSetup{
 				{
@@ -227,12 +228,25 @@ func TestMsgDepositToVault(t *testing.T) {
 					checkTxResponseContains: "Deposit amount is invalid",
 					expectedOwnerShares:     nil,
 				},
+				{
+					depositor: constants.Bob_Num0,
+					depositAmount: new(big.Int).Add(
+						new(big.Int).SetUint64(math.MaxUint64),
+						big.NewInt(1),
+					),
+					msgSigner:               constants.Bob_Num0.Owner,
+					checkTxFails:            true,
+					checkTxResponseContains: "Deposit amount is invalid",
+					expectedOwnerShares:     nil,
+				},
 			},
 			totalSharesHistory: []*big.Int{
 				big.NewInt(0),
 				big.NewInt(0),
+				big.NewInt(0),
 			},
 			vaultEquityHistory: []*big.Int{
+				big.NewInt(0),
 				big.NewInt(0),
 				big.NewInt(0),
 			},

--- a/protocol/x/vault/types/msg_deposit_to_vault.go
+++ b/protocol/x/vault/types/msg_deposit_to_vault.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 )
@@ -16,7 +17,7 @@ func (msg *MsgDepositToVault) ValidateBasic() error {
 
 	// Validate that quote quantums is positive.
 	if msg.QuoteQuantums.Cmp(dtypes.NewInt(0)) <= 0 {
-		return ErrInvalidDepositAmount
+		return errorsmod.Wrap(ErrInvalidDepositAmount, "quote quantums must be strictly positive")
 	}
 
 	return nil

--- a/protocol/x/vault/types/msg_deposit_to_vault.go
+++ b/protocol/x/vault/types/msg_deposit_to_vault.go
@@ -15,9 +15,9 @@ func (msg *MsgDepositToVault) ValidateBasic() error {
 		return err
 	}
 
-	// Validate that quote quantums is positive.
-	if msg.QuoteQuantums.Cmp(dtypes.NewInt(0)) <= 0 {
-		return errorsmod.Wrap(ErrInvalidDepositAmount, "quote quantums must be strictly positive")
+	// Validate that quote quantums is positive and an uint64.
+	if msg.QuoteQuantums.Cmp(dtypes.NewInt(0)) <= 0 || !msg.QuoteQuantums.BigInt().IsUint64() {
+		return errorsmod.Wrap(ErrInvalidDepositAmount, "quote quantums must be strictly positive and less than 2^64")
 	}
 
 	return nil

--- a/protocol/x/vault/types/msg_deposit_to_vault.go
+++ b/protocol/x/vault/types/msg_deposit_to_vault.go
@@ -3,7 +3,6 @@ package types
 import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 )
 
 var _ sdk.Msg = &MsgDepositToVault{}
@@ -16,7 +15,8 @@ func (msg *MsgDepositToVault) ValidateBasic() error {
 	}
 
 	// Validate that quote quantums is positive and an uint64.
-	if msg.QuoteQuantums.Cmp(dtypes.NewInt(0)) <= 0 || !msg.QuoteQuantums.BigInt().IsUint64() {
+	quoteQuantums := msg.QuoteQuantums.BigInt()
+	if quoteQuantums.Sign() <= 0 || !quoteQuantums.IsUint64() {
 		return errorsmod.Wrap(ErrInvalidDepositAmount, "quote quantums must be strictly positive and less than 2^64")
 	}
 

--- a/protocol/x/vault/types/msg_deposit_to_vault_test.go
+++ b/protocol/x/vault/types/msg_deposit_to_vault_test.go
@@ -1,6 +1,8 @@
 package types_test
 
 import (
+	"math"
+	"math/big"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
@@ -21,6 +23,26 @@ func TestMsgDepositToVault_ValidateBasic(t *testing.T) {
 				SubaccountId:  &constants.Alice_Num0,
 				QuoteQuantums: dtypes.NewInt(1),
 			},
+		},
+		"Success: max uint64 quote quantums": {
+			msg: types.MsgDepositToVault{
+				VaultId:       &constants.Vault_Clob_0,
+				SubaccountId:  &constants.Alice_Num0,
+				QuoteQuantums: dtypes.NewIntFromUint64(math.MaxUint64),
+			},
+		},
+		"Failure: quote quantums greater than max uint64": {
+			msg: types.MsgDepositToVault{
+				VaultId:      &constants.Vault_Clob_0,
+				SubaccountId: &constants.Alice_Num0,
+				QuoteQuantums: dtypes.NewIntFromBigInt(
+					new(big.Int).Add(
+						new(big.Int).SetUint64(math.MaxUint64),
+						new(big.Int).SetUint64(1),
+					),
+				),
+			},
+			expectedErr: "Deposit amount is invalid",
 		},
 		"Failure: zero quote quantums": {
 			msg: types.MsgDepositToVault{


### PR DESCRIPTION
### Changelist
A deposit to vault should not exceed `MaxUint64` as [transfer expects a uint64](https://github.com/dydxprotocol/v4-chain/blob/main/protocol/x/vault/keeper/msg_server_deposit_to_vault.go#L41)

### Test Plan
added unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced deposit validation to ensure amounts are positive and within valid range.

- **Bug Fixes**
  - Improved error handling for invalid deposit amounts.

- **Tests**
  - Added test cases for maximum allowable deposit amounts and invalid deposits exceeding limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->