### PR TITLE
[CT-839] Add blockHeight to subaccount websocket message

### DIFF
--- a/indexer/packages/kafka/src/websocket-helper.ts
+++ b/indexer/packages/kafka/src/websocket-helper.ts
@@ -46,6 +46,7 @@ export function generateSubaccountMessageContents(
   order: OrderFromDatabase | undefined,
   perpetualMarket: PerpetualMarketFromDatabase,
   placementStatus: OrderPlaceV1_OrderPlacementStatus,
+  blockHeight: string | undefined,
 ): SubaccountMessageContents {
   const orderTIF: TimeInForce = protocolTranslations.protocolOrderTIFToTIF(
     redisOrder.order!.timeInForce,
@@ -89,6 +90,7 @@ export function generateSubaccountMessageContents(
         triggerPrice: getTriggerPrice(redisOrder.order!, perpetualMarket),
       },
     ],
+    ...(blockHeight && { blockHeight }),
   };
   return contents;
 }
@@ -98,12 +100,14 @@ export function createSubaccountWebsocketMessage(
   order: OrderFromDatabase | undefined,
   perpetualMarket: PerpetualMarketFromDatabase,
   placementStatus: OrderPlaceV1_OrderPlacementStatus,
+  blockHeight: string | undefined,
 ): Buffer {
   const contents: SubaccountMessageContents = generateSubaccountMessageContents(
     redisOrder,
     order,
     perpetualMarket,
     placementStatus,
+    blockHeight,
   );
 
   const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({

--- a/indexer/packages/postgres/__tests__/loops/block-height-refresher.test.ts
+++ b/indexer/packages/postgres/__tests__/loops/block-height-refresher.test.ts
@@ -1,0 +1,39 @@
+import { clearData, migrate, teardown } from '../../src/helpers/db-helpers';
+import { clear, getLatestBlockHeight, updateBlockHeight } from '../../src/loops/block-height-refresher';
+import { defaultBlock2 } from '../helpers/constants';
+import { seedData } from '../helpers/mock-generators';
+import config from '../../src/config';
+
+describe('blockHeightRefresher', () => {
+  beforeAll(async () => {
+    await migrate();
+    await seedData();
+    await updateBlockHeight();
+  });
+
+  afterAll(async () => {
+    await clearData();
+    await teardown();
+  });
+
+  describe('getLatestBlockHeight', () => {
+    it('successfully gets the latest block height after update', async () => {
+      await updateBlockHeight();
+      expect(getLatestBlockHeight()).toBe(defaultBlock2.blockHeight);
+    });
+  });
+
+  describe('clear', () => {
+    it('throws an error if block height does not exist', () => {
+      clear();
+      expect(() => getLatestBlockHeight()).toThrowError('Unable to find latest block height');
+    });
+
+    it('throws an error when clear is called in non-test environment', () => {
+      const originalEnv = config.NODE_ENV;
+      config.NODE_ENV = 'production';
+      expect(() => clear()).toThrowError('clear cannot be used in non-test env');
+      config.NODE_ENV = originalEnv;
+    });
+  });
+});

--- a/indexer/packages/postgres/src/config.ts
+++ b/indexer/packages/postgres/src/config.ts
@@ -35,6 +35,7 @@ export const postgresConfigSchema = {
   ASSET_REFRESHER_INTERVAL_MS: parseInteger({ default: 30_000 }), // 30 seconds
   MARKET_REFRESHER_INTERVAL_MS: parseInteger({ default: 30_000 }), // 30 seconds
   LIQUIDITY_TIER_REFRESHER_INTERVAL_MS: parseInteger({ default: 30_000 }), // 30 seconds
+  BLOCK_HEIGHT_REFRESHER_INTERVAL_MS: parseInteger({ default: 1_000 }), // 1 second
   USE_READ_REPLICA: parseBoolean({ default: false }),
 
   // Optional environment variables.

--- a/indexer/packages/postgres/src/index.ts
+++ b/indexer/packages/postgres/src/index.ts
@@ -42,6 +42,7 @@ export * as TradingRewardAggregationTable from './stores/trading-reward-aggregat
 
 export * as perpetualMarketRefresher from './loops/perpetual-market-refresher';
 export * as assetRefresher from './loops/asset-refresher';
+export * as blockHeightRefresher from './loops/block-height-refresher';
 export * as liquidityTierRefresher from './loops/liquidity-tier-refresher';
 
 export * as uuid from './helpers/uuid';

--- a/indexer/packages/postgres/src/loops/block-height-refresher.ts
+++ b/indexer/packages/postgres/src/loops/block-height-refresher.ts
@@ -27,12 +27,14 @@ export async function start(): Promise<void> {
  */
 export async function updateBlockHeight(options?: Options): Promise<void> {
   const startTime: number = Date.now();
-  const latestBlock: BlockFromDatabase = await BlockTable.getLatest(
-    options || { readReplica: true },
-  );
-
-  latestBlockHeight = latestBlock.blockHeight;
-  stats.timing(`${config.SERVICE_NAME}.loops.update_block_height`, Date.now() - startTime);
+  try {
+    const latestBlock: BlockFromDatabase = await BlockTable.getLatest(
+      options || { readReplica: true },
+    );
+    latestBlockHeight = latestBlock.blockHeight;
+    stats.timing(`${config.SERVICE_NAME}.loops.update_block_height`, Date.now() - startTime);
+    // eslint-disable-next-line no-empty
+  } catch (error) { }
 }
 
 /**

--- a/indexer/packages/postgres/src/loops/block-height-refresher.ts
+++ b/indexer/packages/postgres/src/loops/block-height-refresher.ts
@@ -1,0 +1,59 @@
+import {
+  stats,
+  logger,
+  NodeEnv,
+} from '@dydxprotocol-indexer/base';
+
+import config from '../config';
+import * as BlockTable from '../stores/block-table';
+import { BlockFromDatabase, Options } from '../types';
+import { startUpdateLoop } from './loopHelper';
+
+let latestBlockHeight: string = '';
+
+/**
+ * Refresh loop to cache the latest block height from the database in-memory.
+ */
+export async function start(): Promise<void> {
+  await startUpdateLoop(
+    updateBlockHeight,
+    config.BLOCK_HEIGHT_REFRESHER_INTERVAL_MS,
+    'updateBlockHeight',
+  );
+}
+
+/**
+ * Updates in-memory latest block height.
+ */
+export async function updateBlockHeight(options?: Options): Promise<void> {
+  const startTime: number = Date.now();
+  const latestBlock: BlockFromDatabase = await BlockTable.getLatest(
+    options || { readReplica: true },
+  );
+
+  latestBlockHeight = latestBlock.blockHeight;
+  stats.timing(`${config.SERVICE_NAME}.loops.update_block_height`, Date.now() - startTime);
+}
+
+/**
+ * Gets the latest block height.
+ */
+export function getLatestBlockHeight(): string {
+  if (!latestBlockHeight) {
+    const message: string = 'Unable to find latest block height';
+    logger.error({
+      at: 'block-height-refresher#getLatestBlockHeight',
+      message,
+    });
+    throw new Error(message);
+  }
+  return latestBlockHeight;
+}
+
+export function clear(): void {
+  if (config.NODE_ENV !== NodeEnv.TEST) {
+    throw new Error('clear cannot be used in non-test env');
+  }
+
+  latestBlockHeight = '';
+}

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -37,6 +37,7 @@ export interface SubaccountMessageContents {
   fills?: FillSubaccountMessageContents[],
   transfers?: TransferSubaccountMessageContents,
   tradingReward?: TradingRewardSubaccountMessageContents,
+  blockHeight?: string,
 }
 
 export interface PerpetualPositionSubaccountMessageContents {

--- a/indexer/services/comlink/public/websocket-documentation.md
+++ b/indexer/services/comlink/public/websocket-documentation.md
@@ -57,7 +57,7 @@ This channel provides realtime information about orders, fills, transfers, perpe
 
 ### Initial Response
 
-Returns everything from the `/v4/addresses/:address/subaccountNumber/:subaccountNumber`, and `/v4/orders?addresses=${address}&subaccountNumber=${subaccountNumber}&status=OPEN`.
+Returns everything from the `/v4/addresses/:address/subaccountNumber/:subaccountNumber`, and `/v4/orders?addresses=${address}&subaccountNumber=${subaccountNumber}&status=OPEN` and the latest block height.
 
 ### Example
 ```tsx
@@ -84,7 +84,8 @@ Returns everything from the `/v4/addresses/:address/subaccountNumber/:subaccount
       },
       "marginEnabled": true
     },
-    "orders": []
+    "orders": [],
+    "blockHeight": "5"
   }
 }
 ```
@@ -117,6 +118,8 @@ export interface SubaccountMessageContents {
   fills?: FillSubaccountMessageContents[],
 	// Transfers that occur on the subaccount
   transfers?: TransferSubaccountMessageContents,
+    // Latest block processed by Indexer
+  blockHeight?: string,
 }
 
 export interface PerpetualPositionSubaccountMessageContents {

--- a/indexer/services/comlink/public/websocket-documentation.md
+++ b/indexer/services/comlink/public/websocket-documentation.md
@@ -118,7 +118,7 @@ export interface SubaccountMessageContents {
   fills?: FillSubaccountMessageContents[],
 	// Transfers that occur on the subaccount
   transfers?: TransferSubaccountMessageContents,
-    // Latest block processed by Indexer
+	// Latest block processed by Indexer
   blockHeight?: string,
 }
 

--- a/indexer/services/ender/__tests__/handlers/subaccount-update-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/subaccount-update-handler.test.ts
@@ -740,6 +740,7 @@ async function expectUpdatedPositionsSubaccountKafkaMessage(
     _.keyBy(perpMarkets, PerpetualMarketColumns.id),
     assetPositions,
     _.keyBy(assets, AssetColumns.id),
+    blockHeight,
   );
 
   expectSubaccountKafkaMessage({

--- a/indexer/services/ender/__tests__/handlers/transfer-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/transfer-handler.test.ts
@@ -651,6 +651,7 @@ function expectTransfersSubaccountKafkaMessage(
       event.sender!.subaccountId!,
       event.sender!.subaccountId!,
       event.recipient!.subaccountId,
+      blockHeight,
     );
   }
 
@@ -661,6 +662,7 @@ function expectTransfersSubaccountKafkaMessage(
       event.recipient!.subaccountId!,
       event.sender!.subaccountId,
       event.recipient!.subaccountId!,
+      blockHeight,
     );
   }
 

--- a/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
@@ -685,6 +685,7 @@ export async function expectFillSubaccountKafkaMessageFromLiquidationEvent(
       [convertPerpetualPosition(position!)],
       perpetualMarketRefresher.getPerpetualMarketsMap(),
     ),
+    blockHeight,
   };
 
   expectSubaccountKafkaMessage({
@@ -739,6 +740,7 @@ export function expectOrderSubaccountKafkaMessage(
     orders: [
       orderObject,
     ],
+    blockHeight,
   };
 
   expectSubaccountKafkaMessage({
@@ -798,6 +800,7 @@ export async function expectOrderFillAndPositionSubaccountKafkaMessageFromIds(
     fills: [
       generateFillSubaccountMessage(fill!, perpetualMarket!.ticker),
     ],
+    blockHeight,
   };
 
   if (position !== undefined) {

--- a/indexer/services/ender/__tests__/helpers/kafka-helper.test.ts
+++ b/indexer/services/ender/__tests__/helpers/kafka-helper.test.ts
@@ -36,6 +36,8 @@ import { updateBlockCache } from '../../src/caches/block-cache';
 import { defaultPreviousHeight, defaultWalletAddress } from './constants';
 
 describe('kafka-helper', () => {
+  const blockHeight: string = '5';
+
   describe('addPositionsToContents', () => {
     const defaultPerpetualPosition: PerpetualPositionFromDatabase = {
       id: '',
@@ -81,10 +83,12 @@ describe('kafka-helper', () => {
         {},
         [],
         {},
+        blockHeight,
       );
 
       expect(contents.perpetualPositions).toEqual(undefined);
       expect(contents.assetPositions).toEqual(undefined);
+      expect(contents.blockHeight).toEqual(blockHeight);
     });
 
     it('successfully adds one asset position and one perp position', () => {
@@ -100,6 +104,7 @@ describe('kafka-helper', () => {
         { [defaultPerpetualMarket.id]: defaultPerpetualMarket },
         [defaultAssetPosition],
         { [defaultAsset.id]: defaultAsset },
+        blockHeight,
       );
 
       expect(contents.perpetualPositions!.length).toEqual(1);
@@ -129,6 +134,7 @@ describe('kafka-helper', () => {
         side: 'LONG',
         size: defaultAssetPosition.size,
       });
+      expect(contents.blockHeight).toEqual(blockHeight);
     });
 
     it('successfully adds one asset position', () => {
@@ -144,6 +150,7 @@ describe('kafka-helper', () => {
         {},
         [defaultAssetPosition],
         { [defaultAsset.id]: defaultAsset },
+        blockHeight,
       );
 
       expect(contents.perpetualPositions).toBeUndefined();
@@ -158,6 +165,7 @@ describe('kafka-helper', () => {
         side: 'LONG',
         size: defaultAssetPosition.size,
       });
+      expect(contents.blockHeight).toEqual(blockHeight);
     });
 
     it('successfully adds one perp position', () => {
@@ -173,6 +181,7 @@ describe('kafka-helper', () => {
         { [defaultPerpetualMarket.id]: defaultPerpetualMarket },
         [],
         {},
+        blockHeight,
       );
 
       expect(contents.perpetualPositions!.length).toEqual(1);
@@ -193,6 +202,7 @@ describe('kafka-helper', () => {
       });
 
       expect(contents.assetPositions).toBeUndefined();
+      expect(contents.blockHeight).toEqual(blockHeight);
     });
 
     it('successfully adds multiple positions', () => {
@@ -222,6 +232,7 @@ describe('kafka-helper', () => {
           },
         ],
         { [defaultAsset.id]: defaultAsset },
+        blockHeight,
       );
 
       // check perpetual positions
@@ -277,6 +288,7 @@ describe('kafka-helper', () => {
         side: 'LONG',
         size: assetSize,
       });
+      expect(contents.blockHeight).toEqual(blockHeight);
     });
   });
 
@@ -343,6 +355,7 @@ describe('kafka-helper', () => {
         senderSubaccountId,
         senderSubaccountId,
         recipientSubaccountId,
+        transfer.createdAtHeight,
       );
 
       expect(contents.transfers).toEqual({
@@ -361,6 +374,7 @@ describe('kafka-helper', () => {
         createdAtHeight: transfer.createdAtHeight,
         transactionHash: transfer.transactionHash,
       });
+      expect(contents.blockHeight).toEqual(transfer.createdAtHeight);
     });
 
     it('successfully adds a transfer_in', () => {

--- a/indexer/services/ender/src/handlers/order-fills/abstract-order-fill-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/abstract-order-fill-handler.ts
@@ -72,6 +72,7 @@ export abstract class AbstractOrderFillHandler<T> extends Handler<T> {
         [position],
         perpetualMarketRefresher.getPerpetualMarketsMap(),
       ),
+      blockHeight: this.block.height.toString(),
     };
     if (order !== undefined) {
       message.orders = [

--- a/indexer/services/ender/src/handlers/stateful-order/conditional-order-placement-handler.ts
+++ b/indexer/services/ender/src/handlers/stateful-order/conditional-order-placement-handler.ts
@@ -47,6 +47,7 @@ export class ConditionalOrderPlacementHandler extends
       orders: [
         generateOrderSubaccountMessage(conditionalOrder, perpetualMarket.ticker),
       ],
+      blockHeight: this.block.height.toString(),
     };
 
     return [

--- a/indexer/services/ender/src/handlers/stateful-order/stateful-order-placement-handler.ts
+++ b/indexer/services/ender/src/handlers/stateful-order/stateful-order-placement-handler.ts
@@ -1,6 +1,7 @@
 import { generateSubaccountMessageContents } from '@dydxprotocol-indexer/kafka';
 import {
-  OrderFromDatabase, OrderModel,
+  OrderFromDatabase,
+  OrderModel,
   OrderTable,
   PerpetualMarketFromDatabase,
   perpetualMarketRefresher,
@@ -98,6 +99,7 @@ export class StatefulOrderPlacementHandler
         dbOrder,
         perpetualMarket,
         OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_OPENED,
+        this.block.height.toString(),
       );
 
       const subaccountIdProto: SubaccountId = {

--- a/indexer/services/ender/src/handlers/subaccount-update-handler.ts
+++ b/indexer/services/ender/src/handlers/subaccount-update-handler.ts
@@ -91,6 +91,7 @@ export class SubaccountUpdateHandler extends Handler<SubaccountUpdate> {
       perpetualMarketsMapping,
       updatedAssetPositions,
       assetsMap,
+      this.block.height.toString(),
     );
 
     return this.generateConsolidatedSubaccountKafkaEvent(

--- a/indexer/services/ender/src/handlers/trading-rewards-handler.ts
+++ b/indexer/services/ender/src/handlers/trading-rewards-handler.ts
@@ -51,6 +51,7 @@ export class TradingRewardsHandler extends Handler<TradingRewardsEventV1> {
 
       const subaccountMessageContents: SubaccountMessageContents = {
         tradingReward: tradingRewardSubaccountMessageContents,
+        blockHeight: this.block.height.toString(),
       };
 
       kafkaEvents.push(

--- a/indexer/services/ender/src/handlers/transfer-handler.ts
+++ b/indexer/services/ender/src/handlers/transfer-handler.ts
@@ -57,6 +57,7 @@ export class TransferHandler extends Handler<TransferEventV1> {
         this.event.sender!.subaccountId!,
         this.event.sender!.subaccountId,
         this.event.recipient!.subaccountId,
+        this.block.height.toString(),
       );
 
       kafkaEvents.push(
@@ -74,6 +75,7 @@ export class TransferHandler extends Handler<TransferEventV1> {
         this.event.recipient!.subaccountId!,
         this.event.sender!.subaccountId,
         this.event.recipient!.subaccountId,
+        this.block.height.toString(),
       );
 
       kafkaEvents.push(

--- a/indexer/services/ender/src/helpers/kafka-helper.ts
+++ b/indexer/services/ender/src/helpers/kafka-helper.ts
@@ -226,6 +226,7 @@ export function convertPerpetualPosition(
  * @param subaccountId to generate the websocket message for
  * @param senderSubaccountId
  * @param recipientSubaccountId
+ * @param blockHeight: latest block height processed by Indexer
  */
 export function generateTransferContents(
   transfer: TransferFromDatabase,

--- a/indexer/services/ender/src/helpers/kafka-helper.ts
+++ b/indexer/services/ender/src/helpers/kafka-helper.ts
@@ -50,6 +50,7 @@ export function addPositionsToContents(
   perpetualMarketsMapping: PerpetualMarketsMap,
   assetPositions: AssetPositionFromDatabase[],
   assetsMap: AssetsMap,
+  blockHeight: string,
 ): SubaccountMessageContents {
   return {
     ...contents,
@@ -63,6 +64,7 @@ export function addPositionsToContents(
       assetPositions,
       assetsMap,
     ),
+    blockHeight,
   };
 }
 
@@ -231,6 +233,7 @@ export function generateTransferContents(
   subaccountId: SubaccountId,
   senderSubaccountId?: SubaccountId,
   recipientSubaccountId?: SubaccountId,
+  blockHeight?: string,
 ): SubaccountMessageContents {
   return {
     transfers: {
@@ -254,6 +257,7 @@ export function generateTransferContents(
       createdAtHeight: transfer.createdAtHeight,
       transactionHash: transfer.transactionHash,
     },
+    blockHeight,
   };
 }
 

--- a/indexer/services/socks/__tests__/lib/message-forwarder.test.ts
+++ b/indexer/services/socks/__tests__/lib/message-forwarder.test.ts
@@ -28,7 +28,12 @@ import {
 } from '../../src/types';
 import { Admin } from 'kafkajs';
 import { SubaccountMessage, TradeMessage } from '@dydxprotocol-indexer/v4-protos';
-import { dbHelpers, testMocks, perpetualMarketRefresher } from '@dydxprotocol-indexer/postgres';
+import {
+  dbHelpers,
+  testMocks,
+  perpetualMarketRefresher,
+  blockHeightRefresher,
+} from '@dydxprotocol-indexer/postgres';
 import {
   btcClobPairId,
   btcTicker,
@@ -171,12 +176,16 @@ describe('message-forwarder', () => {
   const subaccountInitialMessage: Object = {
     ...mockAxiosResponse,
     orders: mockAxiosResponse,
+    blockHeight: '2',
   };
 
   beforeAll(async () => {
     await dbHelpers.migrate();
     await testMocks.seedData();
-    await perpetualMarketRefresher.updatePerpetualMarkets();
+    await Promise.all([
+      perpetualMarketRefresher.updatePerpetualMarkets(),
+      blockHeightRefresher.updateBlockHeight(),
+    ]);
     admin = kafka.admin();
     await Promise.all([
       connectToKafka(),

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -4,7 +4,12 @@ import { Subscriptions } from '../../src/lib/subscription';
 import { sendMessage, sendMessageString } from '../../src/helpers/wss';
 import { RateLimiter } from '../../src/lib/rate-limit';
 import {
-  dbHelpers, testMocks, perpetualMarketRefresher, CandleResolution, MAX_PARENT_SUBACCOUNTS,
+  dbHelpers,
+  testMocks,
+  perpetualMarketRefresher,
+  CandleResolution,
+  MAX_PARENT_SUBACCOUNTS,
+  blockHeightRefresher,
 } from '@dydxprotocol-indexer/postgres';
 import { btcTicker, invalidChannel, invalidTicker } from '../constants';
 import { axiosRequest } from '../../src/lib/axios';
@@ -68,7 +73,10 @@ describe('Subscriptions', () => {
   beforeAll(async () => {
     await dbHelpers.migrate();
     await testMocks.seedData();
-    await perpetualMarketRefresher.updatePerpetualMarkets();
+    await Promise.all([
+      perpetualMarketRefresher.updatePerpetualMarkets(),
+      blockHeightRefresher.updateBlockHeight(),
+    ]);
   });
 
   afterAll(async () => {

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -6,6 +6,7 @@ import {
 import {
   APIOrderStatus,
   BestEffortOpenedStatus,
+  blockHeightRefresher,
   CHILD_SUBACCOUNT_MULTIPLIER,
   CandleResolution,
   MAX_PARENT_SUBACCOUNTS,
@@ -534,7 +535,9 @@ export class Subscriptions {
       const [
         subaccountsResponse,
         ordersResponse,
+        blockHeight,
       ]: [
+        string,
         string,
         string,
       ] = await Promise.all([
@@ -557,11 +560,13 @@ export class Subscriptions {
           },
           transformResponse: (res) => res,
         }),
+        blockHeightRefresher.getLatestBlockHeight(),
       ]);
 
       return JSON.stringify({
         ...JSON.parse(subaccountsResponse),
         orders: JSON.parse(ordersResponse),
+        blockHeight,
       });
     } catch (error) {
       // The subaccounts API endpoint returns a 404 for subaccounts that are not indexed, however

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -604,7 +604,9 @@ export class Subscriptions {
       const [
         subaccountsResponse,
         ordersResponse,
+        blockHeight,
       ]: [
+        string,
         string,
         string,
       ] = await Promise.all([
@@ -627,11 +629,13 @@ export class Subscriptions {
           },
           transformResponse: (res) => res,
         }),
+        blockHeightRefresher.getLatestBlockHeight(),
       ]);
 
       return JSON.stringify({
         ...JSON.parse(subaccountsResponse),
         orders: JSON.parse(ordersResponse),
+        blockHeight,
       });
     } catch (error) {
       // The subaccounts API endpoint returns a 404 for subaccounts that are not indexed, however

--- a/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
@@ -241,7 +241,7 @@ describe('order-place-handler', () => {
       await testMocks.seedData();
       await Promise.all([
         perpetualMarketRefresher.updatePerpetualMarkets(),
-        blockHeightRefresher.getLatestBlockHeight(),
+        blockHeightRefresher.updateBlockHeight(),
       ]);
       await Promise.all([
         OrderTable.create(dbDefaultOrder),

--- a/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
@@ -30,7 +30,7 @@ import {
   testConstants,
   testMocks,
   apiTranslations,
-  TimeInForce,
+  TimeInForce, blockHeightRefresher,
 } from '@dydxprotocol-indexer/postgres';
 import {
   OpenOrdersCache,
@@ -89,7 +89,10 @@ describe('OrderRemoveHandler', () => {
 
   beforeEach(async () => {
     await testMocks.seedData();
-    await perpetualMarketRefresher.updatePerpetualMarkets();
+    await Promise.all([
+      perpetualMarketRefresher.updatePerpetualMarkets(),
+      blockHeightRefresher.updateBlockHeight(),
+    ]);
     jest.spyOn(stats, 'timing');
     jest.spyOn(stats, 'increment');
     jest.spyOn(logger, 'info');
@@ -253,6 +256,7 @@ describe('OrderRemoveHandler', () => {
             removalReason: OrderRemovalReason[defaultOrderRemove.reason],
           },
         ],
+        blockHeight: blockHeightRefresher.getLatestBlockHeight(),
       };
       expectWebsocketMessagesSent(
         producerSendSpy,
@@ -310,6 +314,7 @@ describe('OrderRemoveHandler', () => {
               type: testConstants.defaultOrder.type,
             },
           ],
+          blockHeight: blockHeightRefresher.getLatestBlockHeight(),
         };
         expectWebsocketMessagesSent(
           producerSendSpy,
@@ -505,6 +510,7 @@ describe('OrderRemoveHandler', () => {
             triggerPrice,
           },
         ],
+        blockHeight: blockHeightRefresher.getLatestBlockHeight(),
       };
       const orderbookContents: OrderbookMessageContents = {
         [OrderbookSide.BIDS]: [[
@@ -646,6 +652,7 @@ describe('OrderRemoveHandler', () => {
             triggerPrice,
           },
         ],
+        blockHeight: blockHeightRefresher.getLatestBlockHeight(),
       };
 
       const orderbookContents: OrderbookMessageContents = {
@@ -786,6 +793,7 @@ describe('OrderRemoveHandler', () => {
             clientMetadata: removedRedisOrder.order!.clientMetadata.toString(),
             triggerPrice,
           }],
+          blockHeight: blockHeightRefresher.getLatestBlockHeight(),
         };
         expectWebsocketMessagesSent(
           producerSendSpy,
@@ -928,6 +936,7 @@ describe('OrderRemoveHandler', () => {
             clientMetadata: removedRedisOrder.order!.clientMetadata.toString(),
             triggerPrice,
           }],
+          blockHeight: blockHeightRefresher.getLatestBlockHeight(),
         };
         expectWebsocketMessagesSent(
           producerSendSpy,
@@ -1238,6 +1247,7 @@ describe('OrderRemoveHandler', () => {
           clientMetadata: removedOrder.clientMetadata.toString(),
           triggerPrice,
         }],
+        blockHeight: blockHeightRefresher.getLatestBlockHeight(),
       };
       expectWebsocketMessagesSent(
         producerSendSpy,
@@ -1355,6 +1365,7 @@ describe('OrderRemoveHandler', () => {
           clientMetadata: removedOrder.clientMetadata.toString(),
           triggerPrice,
         }],
+        blockHeight: blockHeightRefresher.getLatestBlockHeight(),
       };
       expectWebsocketMessagesSent(
         producerSendSpy,
@@ -1480,6 +1491,7 @@ describe('OrderRemoveHandler', () => {
           clientMetadata: removedOrder.clientMetadata.toString(),
           triggerPrice,
         }],
+        blockHeight: blockHeightRefresher.getLatestBlockHeight(),
       };
 
       const orderbookContents: OrderbookMessageContents = {
@@ -1621,6 +1633,7 @@ describe('OrderRemoveHandler', () => {
           clientMetadata: removedOrder.clientMetadata.toString(),
           triggerPrice,
         }],
+        blockHeight: blockHeightRefresher.getLatestBlockHeight(),
       };
 
       const orderbookContents: OrderbookMessageContents = {
@@ -1758,6 +1771,7 @@ describe('OrderRemoveHandler', () => {
             clientMetadata: testConstants.defaultOrderGoodTilBlockTime.clientMetadata.toString(),
           },
         ],
+        blockHeight: blockHeightRefresher.getLatestBlockHeight(),
       };
       const orderbookContents: OrderbookMessageContents = {
         [OrderbookSide.BIDS]: [[

--- a/indexer/services/vulcan/__tests__/handlers/order-update-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-update-handler.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../helpers/helpers';
 import { redisClient as client } from '../../src/helpers/redis/redis-controller';
 import {
+  blockHeightRefresher,
   dbHelpers,
   OrderbookMessageContents,
   perpetualMarketRefresher,
@@ -60,7 +61,10 @@ describe('OrderUpdateHandler', () => {
 
     beforeEach(async () => {
       await testMocks.seedData();
-      await perpetualMarketRefresher.updatePerpetualMarkets();
+      await Promise.all([
+        perpetualMarketRefresher.updatePerpetualMarkets(),
+        blockHeightRefresher.updateBlockHeight(),
+      ]);
       jest.spyOn(stats, 'timing');
       jest.spyOn(stats, 'increment');
       jest.spyOn(OrderbookLevelsCache, 'updatePriceLevel');

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -1,6 +1,7 @@
 import { logger, runFuncWithTimingStat, stats } from '@dydxprotocol-indexer/base';
 import { createSubaccountWebsocketMessage, KafkaTopics } from '@dydxprotocol-indexer/kafka';
 import {
+  blockHeightRefresher,
   OrderFromDatabase,
   OrderTable,
   PerpetualMarketFromDatabase,
@@ -150,6 +151,7 @@ export class OrderPlaceHandler extends Handler {
           dbOrder,
           perpetualMarket,
           placementStatus,
+          blockHeightRefresher.getLatestBlockHeight(),
         ),
         headers,
       };

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -1,6 +1,7 @@
 import { logger, runFuncWithTimingStat, stats } from '@dydxprotocol-indexer/base';
 import { KafkaTopics, SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION, getTriggerPrice } from '@dydxprotocol-indexer/kafka';
 import {
+  blockHeightRefresher,
   BlockTable,
   BlockFromDatabase,
   OrderFromDatabase,
@@ -233,6 +234,7 @@ export class OrderRemoveHandler extends Handler {
         order,
         orderRemove,
         perpetualMarket.ticker,
+        blockHeightRefresher.getLatestBlockHeight(),
       ),
       headers,
     };
@@ -294,6 +296,7 @@ export class OrderRemoveHandler extends Handler {
             canceledOrder,
             orderRemove,
             perpetualMarket.ticker,
+            blockHeightRefresher.getLatestBlockHeight(),
           ),
           headers,
         };
@@ -333,6 +336,7 @@ export class OrderRemoveHandler extends Handler {
         canceledOrder,
         orderRemove,
         perpetualMarket,
+        blockHeightRefresher.getLatestBlockHeight(),
       ),
       headers,
     };
@@ -570,6 +574,7 @@ export class OrderRemoveHandler extends Handler {
     canceledOrder: OrderFromDatabase | undefined,
     orderRemove: OrderRemoveV1,
     ticker: string,
+    blockHeight: string | undefined,
   ): Buffer {
     const createdAtHeight: string | undefined = canceledOrder?.createdAtHeight;
     const updatedAt: IsoString | undefined = canceledOrder?.updatedAt;
@@ -616,6 +621,7 @@ export class OrderRemoveHandler extends Handler {
           ...(type && { type }),
         },
       ],
+      ...(blockHeight && { blockHeight }),
     };
 
     const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({
@@ -632,6 +638,7 @@ export class OrderRemoveHandler extends Handler {
     canceledOrder: OrderFromDatabase | undefined,
     orderRemove: OrderRemoveV1,
     perpetualMarket: PerpetualMarketFromDatabase,
+    blockHeight: string | undefined,
   ): Buffer {
     const redisOrder: RedisOrder = removeOrderResult.removedOrder!;
     const orderTIF: TimeInForce = protocolTranslations.protocolOrderTIFToTIF(
@@ -676,6 +683,7 @@ export class OrderRemoveHandler extends Handler {
           triggerPrice: getTriggerPrice(redisOrder.order!, perpetualMarket),
         },
       ],
+      ...(blockHeight && { blockHeight }),
     };
 
     const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({
@@ -691,6 +699,7 @@ export class OrderRemoveHandler extends Handler {
     order: OrderFromDatabase,
     orderRemove: OrderRemoveV1,
     orderTicker: string,
+    blockHeight: string | undefined,
   ): Buffer {
     const contents: SubaccountMessageContents = {
       orders: [
@@ -722,6 +731,7 @@ export class OrderRemoveHandler extends Handler {
           triggerPrice: order.triggerPrice ?? undefined,
         },
       ],
+      ...(blockHeight && { blockHeight }),
     };
 
     const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -568,13 +568,14 @@ export class OrderRemoveHandler extends Handler {
    * @param canceledOrder
    * @param orderRemove
    * @param perpetualMarket
+   * @param blockHeight: latest block height processed by Indexer
    * @protected
    */
   protected createSubaccountWebsocketMessageFromOrderRemoveMessage(
     canceledOrder: OrderFromDatabase | undefined,
     orderRemove: OrderRemoveV1,
     ticker: string,
-    blockHeight: string | undefined,
+    blockHeight: string,
   ): Buffer {
     const createdAtHeight: string | undefined = canceledOrder?.createdAtHeight;
     const updatedAt: IsoString | undefined = canceledOrder?.updatedAt;
@@ -621,7 +622,7 @@ export class OrderRemoveHandler extends Handler {
           ...(type && { type }),
         },
       ],
-      ...(blockHeight && { blockHeight }),
+      blockHeight,
     };
 
     const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({


### PR DESCRIPTION
### Changelist
Add blockHeight to subaccount websocket message

### Test Plan
Unit tested

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented caching and updating of the latest block height from the database for better performance and accuracy.
  - Included block height information in various functionalities to enhance data integrity.

- **Enhancements**
  - Improved order handling by incorporating the latest block height data in the order removal process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->