### PR TITLE
Remove collateralization-check for unmatched orders

### DIFF
--- a/protocol/mocks/MemClobKeeper.go
+++ b/protocol/mocks/MemClobKeeper.go
@@ -24,36 +24,6 @@ type MemClobKeeper struct {
 	mock.Mock
 }
 
-// AddOrderToOrderbookSubaccountUpdatesCheck provides a mock function with given fields: ctx, clobPairId, subaccountOpenOrders
-func (_m *MemClobKeeper) AddOrderToOrderbookSubaccountUpdatesCheck(ctx types.Context, clobPairId clobtypes.ClobPairId, subaccountOpenOrders map[subaccountstypes.SubaccountId][]clobtypes.PendingOpenOrder) (bool, map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult) {
-	ret := _m.Called(ctx, clobPairId, subaccountOpenOrders)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AddOrderToOrderbookSubaccountUpdatesCheck")
-	}
-
-	var r0 bool
-	var r1 map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPairId, map[subaccountstypes.SubaccountId][]clobtypes.PendingOpenOrder) (bool, map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult)); ok {
-		return rf(ctx, clobPairId, subaccountOpenOrders)
-	}
-	if rf, ok := ret.Get(0).(func(types.Context, clobtypes.ClobPairId, map[subaccountstypes.SubaccountId][]clobtypes.PendingOpenOrder) bool); ok {
-		r0 = rf(ctx, clobPairId, subaccountOpenOrders)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	if rf, ok := ret.Get(1).(func(types.Context, clobtypes.ClobPairId, map[subaccountstypes.SubaccountId][]clobtypes.PendingOpenOrder) map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult); ok {
-		r1 = rf(ctx, clobPairId, subaccountOpenOrders)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(map[subaccountstypes.SubaccountId]subaccountstypes.UpdateResult)
-		}
-	}
-
-	return r0, r1
-}
-
 // AddPreexistingStatefulOrder provides a mock function with given fields: ctx, order, memclob
 func (_m *MemClobKeeper) AddPreexistingStatefulOrder(ctx types.Context, order *clobtypes.Order, memclob clobtypes.MemClob) (subaccountstypes.BaseQuantums, clobtypes.OrderStatus, *clobtypes.OffchainUpdates, error) {
 	ret := _m.Called(ctx, order, memclob)

--- a/protocol/testutil/memclob/keeper.go
+++ b/protocol/testutil/memclob/keeper.go
@@ -284,17 +284,6 @@ func (f *FakeMemClobKeeper) GetStatefulOrdersTimeSlice(
 	return orderIds
 }
 
-func (f *FakeMemClobKeeper) AddOrderToOrderbookSubaccountUpdatesCheck(
-	ctx sdk.Context,
-	clobPairId types.ClobPairId,
-	subaccountOpenOrders map[satypes.SubaccountId][]types.PendingOpenOrder,
-) (
-	success bool,
-	successPerUpdate map[satypes.SubaccountId]satypes.UpdateResult,
-) {
-	return f.collatCheckFn(subaccountOpenOrders)
-}
-
 func (f *FakeMemClobKeeper) addFakePositionSize(
 	ctx sdk.Context,
 	clobPairId types.ClobPairId,

--- a/protocol/x/clob/e2e/order_removal_test.go
+++ b/protocol/x/clob/e2e/order_removal_test.go
@@ -183,35 +183,6 @@ func TestConditionalOrderRemoval(t *testing.T) {
 			// TODO(CORE-858): Re-enable determinism checks once non-determinism issue is found and resolved.
 			disableNonDeterminismChecks: true,
 		},
-		"under-collateralized conditional taker when adding to book is removed": {
-			subaccounts: []satypes.Subaccount{
-				constants.Carl_Num0_100000USD,
-				constants.Dave_Num0_10000USD,
-			},
-			orders: []clobtypes.Order{
-				constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price49500_GTBT10,
-				// Does not cross with best bid.
-				constants.ConditionalOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_50003,
-			},
-			withdrawal: &sendingtypes.MsgWithdrawFromSubaccount{
-				Sender:    constants.Dave_Num0,
-				Recipient: constants.DaveAccAddress.String(),
-				AssetId:   constants.Usdc.Id,
-				Quantums:  10_000_000_000,
-			},
-			priceUpdate: &prices.MsgUpdateMarketPrices{
-				MarketPriceUpdates: []*prices.MsgUpdateMarketPrices_MarketPrice{
-					prices.NewMarketPriceUpdate(0, 5_000_250_000),
-				},
-			},
-
-			expectedOrderRemovals: []bool{
-				false,
-				true, // taker order fails add-to-orderbook collateralization check
-			},
-			// TODO(CORE-858): Re-enable determinism checks once non-determinism issue is found and resolved.
-			disableNonDeterminismChecks: true,
-		},
 		"under-collateralized conditional maker is removed": {
 			subaccounts: []satypes.Subaccount{
 				constants.Carl_Num0_10000USD,
@@ -805,27 +776,6 @@ func TestOrderRemoval(t *testing.T) {
 
 			expectedFirstOrderRemoved:  false,
 			expectedSecondOrderRemoved: true, // taker order fails collateralization check during matching
-			// TODO(CORE-858): Re-enable determinism checks once non-determinism issue is found and resolved.
-			disableNonDeterminismChecks: true,
-		},
-		"under-collateralized taker when adding to book is removed": {
-			subaccounts: []satypes.Subaccount{
-				constants.Carl_Num0_10000USD,
-				constants.Dave_Num0_10000USD,
-			},
-			firstOrder: constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price49500_GTBT10,
-			// Does not cross with best bid.
-			secondOrder: constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
-
-			withdrawal: &sendingtypes.MsgWithdrawFromSubaccount{
-				Sender:    constants.Dave_Num0,
-				Recipient: constants.DaveAccAddress.String(),
-				AssetId:   constants.Usdc.Id,
-				Quantums:  10_000_000_000,
-			},
-
-			expectedFirstOrderRemoved:  false,
-			expectedSecondOrderRemoved: true, // taker order fails add-to-orderbook collateralization check
 			// TODO(CORE-858): Re-enable determinism checks once non-determinism issue is found and resolved.
 			disableNonDeterminismChecks: true,
 		},

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -158,29 +158,6 @@ func TestPlaceShortTermOrder(t *testing.T) {
 				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(0),
 			},
 		},
-		"Cannot place an order on the orderbook if the account would be undercollateralized": {
-			perpetuals: []perptypes.Perpetual{
-				constants.BtcUsd_SmallMarginRequirement,
-				constants.EthUsd_20PercentInitial_10PercentMaintenance,
-			},
-			subaccounts: []satypes.Subaccount{
-				constants.Carl_Num0_599USD,
-			},
-			clobs: []types.ClobPair{
-				constants.ClobPair_Btc,
-				constants.ClobPair_Eth,
-			},
-			feeParams: constants.PerpetualFeeParams,
-
-			order: constants.Order_Carl_Num0_Id3_Clob1_Buy1ETH_Price3000,
-
-			expectedOrderStatus: types.Undercollateralized,
-			expectedFilledSize:  0,
-			expectedOpenInterests: map[uint32]*big.Int{
-				// unchanged, no match happened
-				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
-			},
-		},
 		"Can place an order on the orderbook if the subaccount is right at the initial margin ratio": {
 			perpetuals: []perptypes.Perpetual{
 				constants.BtcUsd_100PercentMarginRequirement,
@@ -196,28 +173,6 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			order: constants.Order_Carl_Num0_Id0_Clob0_Buy10QtBTC_Price100000QuoteQt,
 
 			expectedOrderStatus: types.Success,
-			expectedFilledSize:  0,
-			expectedOpenInterests: map[uint32]*big.Int{
-				// unchanged, no match happened
-				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
-			},
-		},
-		"Cannot place an order on the orderbook if the account would be undercollateralized due to fees paid": {
-			perpetuals: []perptypes.Perpetual{
-				constants.BtcUsd_100PercentMarginRequirement,
-			},
-			subaccounts: []satypes.Subaccount{
-				constants.Carl_Num0_1BTC_Short,
-			},
-			clobs: []types.ClobPair{
-				// Exact same set-up as the previous test, except the clob pair has fees.
-				constants.ClobPair_Btc,
-			},
-			feeParams: constants.PerpetualFeeParams,
-
-			order: constants.Order_Carl_Num0_Id0_Clob0_Buy10QtBTC_Price100000QuoteQt,
-
-			expectedOrderStatus: types.Undercollateralized,
 			expectedFilledSize:  0,
 			expectedOpenInterests: map[uint32]*big.Int{
 				// unchanged, no match happened
@@ -394,73 +349,6 @@ func TestPlaceShortTermOrder(t *testing.T) {
 				constants.BtcUsd_SmallMarginRequirement.Params.Id: big.NewInt(100_000_000),
 			},
 		},
-		// This is a regression test for an issue whereby orders that had been previously matched were being checked for
-		// collateralization as if the subticks of the order were `0`. This resulted in always using `0`
-		// `bigFillQuoteQuantums` for the order when performing collateralization checks during `PlaceOrder`.
-		// This meant that previous buy orders in the match queue could only ever increase collateralization
-		// of the subaccount.
-		// Context: https://dydx-team.slack.com/archives/C03SLFHC3L7/p1668105457456389
-		`Regression: New order should be undercollateralized when adding to the orderbook when previous fills make it
-			undercollateralized`: {
-			perpetuals: []perptypes.Perpetual{
-				constants.BtcUsd_100PercentMarginRequirement,
-			},
-			subaccounts: []satypes.Subaccount{
-				constants.Carl_Num1_500USD,
-				constants.Carl_Num0_10000USD,
-			},
-			clobs: []types.ClobPair{
-				constants.ClobPair_Btc,
-			},
-			existingOrders: []types.Order{
-				// The maker subaccount places an order which is a maker order to buy $500 worth of BTC.
-				// The subaccount has a balance of $500 worth of USDC, and the perpetual has a 100% margin requirement.
-				// This order does not match, and is placed on the book as a maker order.
-				constants.Order_Carl_Num1_Id0_Clob0_Buy1kQtBTC_Price50000,
-				// The taker subaccount places an order which fully fills the previous order.
-				constants.Order_Carl_Num0_Id0_Clob0_Sell1kQtBTC_Price50000,
-			},
-			feeParams: constants.PerpetualFeeParamsNoFee,
-			// The maker subaccount places a second order identical to the first.
-			// This should fail, because the maker subaccount currently has a balance of $0 USDC, and a perpetual of size
-			// 0.01 BTC ($500), and the perpetual has a 100% margin requirement.
-			order:               constants.Order_Carl_Num1_Id1_Clob0_Buy1kQtBTC_Price50000,
-			expectedOrderStatus: types.Undercollateralized,
-		},
-		`Regression: New order should be undercollateralized when matching when previous fills make it
-				undercollateralized`: {
-			perpetuals: []perptypes.Perpetual{
-				constants.BtcUsd_100PercentMarginRequirement,
-			},
-			subaccounts: []satypes.Subaccount{
-				constants.Carl_Num1_500USD,
-				constants.Carl_Num0_10000USD,
-			},
-			clobs: []types.ClobPair{
-				constants.ClobPair_Btc,
-			},
-			existingOrders: []types.Order{
-				// The maker subaccount places an order which is a maker order to buy $500 worth of BTC.
-				// The subaccount has a balance of $500 worth of USDC, and the perpetual has a 100% margin requirement.
-				// This order does not match, and is placed on the book as a maker order.
-				constants.Order_Carl_Num1_Id0_Clob0_Buy1kQtBTC_Price50000,
-				// The taker subaccount places an order which fully fills the previous order.
-				constants.Order_Carl_Num0_Id0_Clob0_Sell1kQtBTC_Price50000,
-				// Match queue is now empty.
-				// The subaccount from the above order now places an order which is added to the book.
-				constants.Order_Carl_Num0_Id1_Clob0_Sell1kQtBTC_Price50000,
-			},
-			feeParams: constants.PerpetualFeeParamsNoFee,
-			// The maker subaccount places a second order identical to the first.
-			// This should fail, because the maker during matching, because subaccount currently has a balance of $0 USDC,
-			// and a perpetual of size 0.01 BTC ($500), and the perpetual has a 100% margin requirement.
-			order:               constants.Order_Carl_Num1_Id1_Clob0_Buy1kQtBTC_Price50000,
-			expectedOrderStatus: types.Undercollateralized,
-			expectedOpenInterests: map[uint32]*big.Int{
-				// 1 BTC + 0.01 BTC filled
-				constants.BtcUsd_100PercentMarginRequirement.Params.Id: big.NewInt(101_000_000),
-			},
-		},
 		`New order should be undercollateralized when matching when previous fills make it undercollateralized when using
 				maker orders subticks, but would be collateralized if using taker order subticks`: {
 			perpetuals: []perptypes.Perpetual{
@@ -599,22 +487,6 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			expectedFilledSize:       0,
 			expectedMultiStoreWrites: []string{},
 		},
-		`Subaccount cannot place buy order due to a failed collateralization check with its maker price but would
-				pass if using the oracle price`: {
-			perpetuals: []perptypes.Perpetual{
-				constants.BtcUsd_50PercentInitial_40PercentMaintenance,
-			},
-			subaccounts: []satypes.Subaccount{constants.Carl_Num0_100000USD},
-			clobs: []types.ClobPair{
-				constants.ClobPair_Btc,
-			},
-			existingOrders:           []types.Order{},
-			feeParams:                constants.PerpetualFeeParamsNoFee,
-			order:                    constants.Order_Carl_Num0_Id0_Clob0_Buy1BTC_Price500000_GTB10,
-			expectedOrderStatus:      types.Undercollateralized,
-			expectedFilledSize:       0,
-			expectedMultiStoreWrites: []string{},
-		},
 		`Subaccount placed buy order passes collateralization check when using the maker price`: {
 			perpetuals: []perptypes.Perpetual{
 				constants.BtcUsd_50PercentInitial_40PercentMaintenance,
@@ -649,22 +521,6 @@ func TestPlaceShortTermOrder(t *testing.T) {
 			feeParams:                constants.PerpetualFeeParamsNoFee,
 			order:                    constants.Order_Carl_Num0_Id0_Clob0_Sell1BTC_Price500000_GTB10,
 			expectedOrderStatus:      types.Success,
-			expectedFilledSize:       0,
-			expectedMultiStoreWrites: []string{},
-		},
-		`Subaccount cannot place sell order due to a failed collateralization check with its maker price but would
-				pass if using the oracle price`: {
-			perpetuals: []perptypes.Perpetual{
-				constants.BtcUsd_50PercentInitial_40PercentMaintenance,
-			},
-			subaccounts: []satypes.Subaccount{constants.Carl_Num0_50000USD},
-			clobs: []types.ClobPair{
-				constants.ClobPair_Btc,
-			},
-			existingOrders:           []types.Order{},
-			feeParams:                constants.PerpetualFeeParamsNoFee,
-			order:                    constants.Order_Carl_Num0_Id0_Clob0_Sell1BTC_Price5000_GTB10,
-			expectedOrderStatus:      types.Undercollateralized,
 			expectedFilledSize:       0,
 			expectedMultiStoreWrites: []string{},
 		},

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -637,40 +637,6 @@ func (m *MemClobPriceTimePriority) PlaceOrder(
 		return orderSizeOptimisticallyFilledFromMatchingQuantums, orderStatus, offchainUpdates, nil
 	}
 
-	// The taker order has unfilled size which will be added to the orderbook as a maker order.
-	// Verify the maker order can be added to the orderbook by performing the add-to-orderbook
-	// subaccount updates check.
-	addOrderOrderStatus := m.addOrderToOrderbookSubaccountUpdatesCheck(
-		ctx,
-		order,
-	)
-
-	// If the add order to orderbook subaccount updates check failed, we cannot add the order to the orderbook.
-	if !addOrderOrderStatus.IsSuccess() {
-		if m.generateOffchainUpdates {
-			// Send an off-chain update message indicating the order should be removed from the orderbook
-			// on the Indexer.
-			if message, success := off_chain_updates.CreateOrderRemoveMessage(
-				ctx,
-				order.OrderId,
-				addOrderOrderStatus,
-				nil,
-				ocutypes.OrderRemoveV1_ORDER_REMOVAL_STATUS_BEST_EFFORT_CANCELED,
-			); success {
-				offchainUpdates.AddRemoveMessage(order.OrderId, message)
-			}
-		}
-
-		// remove stateful orders which fail collateralization check while being added to orderbook
-		if order.IsStatefulOrder() && !m.operationsToPropose.IsOrderRemovalInOperationsQueue(order.OrderId) {
-			m.operationsToPropose.MustAddOrderRemovalToOperationsQueue(
-				order.OrderId,
-				types.OrderRemoval_REMOVAL_REASON_UNDERCOLLATERALIZED,
-			)
-		}
-		return orderSizeOptimisticallyFilledFromMatchingQuantums, addOrderOrderStatus, offchainUpdates, nil
-	}
-
 	// If this is a Short-Term order and it's not in the operations queue, add the TX bytes to the
 	// operations to propose.
 	if order.IsShortTermOrder() &&
@@ -1465,59 +1431,6 @@ func (m *MemClobPriceTimePriority) validateNewOrder(
 	}
 
 	return nil
-}
-
-// addOrderToOrderbookSubaccountUpdatesCheck will perform a check to verify that the subaccount updates
-// if the new maker order were to be fully filled are valid.
-// It returns the result of this subaccount updates check. If the check returns an error, it will return
-// the  error so that it can be surfaced to the client.
-//
-// This function will assume that all prior order validation has passed, including the pre-requisite validation of
-// `validateNewOrder` and the actual validation performed within `validateNewOrder`.
-// Note that this is a loose check, mainly for the purposes of spam mitigation. We perform an additional
-// check on the subaccount updates for orders when we attempt to match them.
-func (m *MemClobPriceTimePriority) addOrderToOrderbookSubaccountUpdatesCheck(
-	ctx sdk.Context,
-	order types.Order,
-) types.OrderStatus {
-	defer telemetry.ModuleMeasureSince(
-		types.ModuleName,
-		time.Now(),
-		metrics.PlaceOrder,
-		metrics.Memclob,
-		metrics.AddToOrderbookCollateralizationCheck,
-		metrics.Latency,
-	)
-
-	orderId := order.OrderId
-	subaccountId := orderId.SubaccountId
-
-	// For the collateralization check, use the remaining amount of the order that is resting on the book.
-	remainingAmount, hasRemainingAmount := m.GetOrderRemainingAmount(ctx, order)
-	if !hasRemainingAmount {
-		panic(fmt.Sprintf("addOrderToOrderbookSubaccountUpdatesCheck: order has no remaining amount %v", order))
-	}
-
-	pendingOpenOrder := types.PendingOpenOrder{
-		RemainingQuantums: remainingAmount,
-		IsBuy:             order.IsBuy(),
-		Subticks:          order.GetOrderSubticks(),
-		ClobPairId:        order.GetClobPairId(),
-	}
-
-	// Temporarily construct the subaccountOpenOrders with a single PendingOpenOrder.
-	subaccountOpenOrders := make(map[satypes.SubaccountId][]types.PendingOpenOrder)
-	subaccountOpenOrders[subaccountId] = []types.PendingOpenOrder{pendingOpenOrder}
-
-	// TODO(DEC-1896): AddOrderToOrderbookSubaccountUpdatesCheck should accept a single PendingOpenOrder as a
-	// parameter rather than the subaccountOpenOrders map.
-	_, successPerSubaccountUpdate := m.clobKeeper.AddOrderToOrderbookSubaccountUpdatesCheck(
-		ctx,
-		order.GetClobPairId(),
-		subaccountOpenOrders,
-	)
-
-	return updateResultToOrderStatus(successPerSubaccountUpdate[subaccountId])
 }
 
 // mustAddOrderToOrderbook will add the order to the resting orderbook.

--- a/protocol/x/clob/memclob/memclob_cancel_order_test.go
+++ b/protocol/x/clob/memclob/memclob_cancel_order_test.go
@@ -434,21 +434,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
 				0: {
 					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 30,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-				1: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
 						constants.Alice_Num0: {
 							{
 								RemainingQuantums: 5,
@@ -540,21 +525,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
 				0: {
 					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 30,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num0: satypes.Success,
-					},
-				},
-				1: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
 						constants.Alice_Num0: {
 							{
 								RemainingQuantums: 5,
@@ -642,23 +612,7 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 					),
 				),
 			},
-			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
-				0: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 30,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-			},
+			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{},
 
 			expectedOperations:         []types.Operation{},
 			expectedInternalOperations: []types.InternalOperation{},
@@ -691,21 +645,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 								ClobPairId:        0,
 							},
 						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-				1: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 30,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
 						constants.Bob_Num0: {
 							{
 								RemainingQuantums: 30,
@@ -718,21 +657,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 					Result: map[satypes.SubaccountId]satypes.UpdateResult{
 						constants.Alice_Num1: satypes.Success,
 						constants.Bob_Num0:   satypes.Success,
-					},
-				},
-				2: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Bob_Num0: {
-							{
-								RemainingQuantums: 5,
-								IsBuy:             false,
-								Subticks:          35,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Bob_Num0: satypes.Success,
 					},
 				},
 			},
@@ -816,9 +740,18 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 								ClobPairId:        0,
 							},
 						},
+						constants.Alice_Num1: {
+							{
+								RemainingQuantums: 5,
+								IsBuy:             true,
+								Subticks:          10,
+								ClobPairId:        0,
+							},
+						},
 					},
 					Result: map[satypes.SubaccountId]satypes.UpdateResult{
 						constants.Alice_Num0: satypes.Success,
+						constants.Alice_Num1: satypes.Success,
 					},
 				},
 				1: {
@@ -827,7 +760,7 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 							{
 								RemainingQuantums: 5,
 								IsBuy:             false,
-								Subticks:          10,
+								Subticks:          15,
 								ClobPairId:        0,
 							},
 						},
@@ -835,7 +768,7 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 							{
 								RemainingQuantums: 5,
 								IsBuy:             true,
-								Subticks:          10,
+								Subticks:          15,
 								ClobPairId:        0,
 							},
 						},
@@ -846,75 +779,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 					},
 				},
 				2: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 25,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-				3: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num0: {
-							{
-								RemainingQuantums: 25,
-								IsBuy:             false,
-								Subticks:          15,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Bob_Num0: satypes.Success,
-					},
-				},
-				4: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num0: {
-							{
-								RemainingQuantums: 5,
-								IsBuy:             false,
-								Subticks:          15,
-								ClobPairId:        0,
-							},
-						},
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 5,
-								IsBuy:             true,
-								Subticks:          15,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num0: satypes.Success,
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-				5: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 10,
-								IsBuy:             true,
-								Subticks:          45,
-								ClobPairId:        1,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-				6: {
 					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
 						constants.Alice_Num0: {
 							{
@@ -1080,21 +944,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
 				0: {
 					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 30,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num0: satypes.Success,
-					},
-				},
-				1: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
 						constants.Alice_Num0: {
 							{
 								RemainingQuantums: 5,
@@ -1114,21 +963,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 					},
 					Result: map[satypes.SubaccountId]satypes.UpdateResult{
 						constants.Alice_Num0: satypes.Success,
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-				2: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 45,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
 						constants.Alice_Num1: satypes.Success,
 					},
 				},
@@ -1202,24 +1036,7 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 				),
 			},
 			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
-				// Collateralization checks for first order placement.
 				0: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 30,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num0: satypes.Success,
-					},
-				},
-				// Collateralization checks for second order placement.
-				1: {
 					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
 						constants.Alice_Num0: {
 							{
@@ -1243,24 +1060,7 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 						constants.Alice_Num1: satypes.Success,
 					},
 				},
-				// Collateralization checks for third order placement.
-				2: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Bob_Num0: {
-							{
-								RemainingQuantums: 20,
-								IsBuy:             false,
-								Subticks:          10,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Bob_Num0: satypes.Success,
-					},
-				},
-				// Collateralization checks for fourth order placement.
-				3: {
+				1: {
 					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
 						constants.Alice_Num1: {
 							{
@@ -1282,21 +1082,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 					Result: map[satypes.SubaccountId]satypes.UpdateResult{
 						constants.Alice_Num1: satypes.Success,
 						constants.Bob_Num0:   satypes.Success,
-					},
-				},
-				4: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 25,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num1: satypes.Success,
 					},
 				},
 			},
@@ -1387,21 +1172,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
 				0: {
 					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 30,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-				1: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
 						constants.Alice_Num0: {
 							{
 								RemainingQuantums: 5,
@@ -1421,21 +1191,6 @@ func TestCancelOrder_OperationsQueue(t *testing.T) {
 					},
 					Result: map[satypes.SubaccountId]satypes.UpdateResult{
 						constants.Alice_Num0: satypes.Success,
-						constants.Alice_Num1: satypes.Success,
-					},
-				},
-				2: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num1: {
-							{
-								RemainingQuantums: 45,
-								IsBuy:             true,
-								Subticks:          50,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
 						constants.Alice_Num1: satypes.Success,
 					},
 				},

--- a/protocol/x/clob/memclob/memclob_get_order_filled_amount_test.go
+++ b/protocol/x/clob/memclob/memclob_get_order_filled_amount_test.go
@@ -46,9 +46,6 @@ func TestGetOrderFilledAmount(t *testing.T) {
 				ClientId:     0,
 			}
 
-			memClobKeeper.On("AddOrderToOrderbookSubaccountUpdatesCheck", mock.Anything, mock.Anything).
-				Return(true, make(map[satypes.SubaccountId]satypes.UpdateResult))
-
 			memClobKeeper.On("GetStatePosition", mock.Anything, mock.Anything, mock.Anything).
 				Return(big.NewInt(0))
 

--- a/protocol/x/clob/memclob/memclob_place_order_long_term_test.go
+++ b/protocol/x/clob/memclob/memclob_place_order_long_term_test.go
@@ -32,24 +32,8 @@ func TestPlaceOrder_LongTerm(t *testing.T) {
 		expectedErr                error
 	}{
 		"Can place a valid Long-Term buy order on an empty orderbook": {
-			placedMatchableOrders: []types.MatchableOrder{},
-			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
-				0: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num0: {
-							{
-								RemainingQuantums: constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetBaseQuantums(),
-								IsBuy:             constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.IsBuy(),
-								Subticks:          constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetOrderSubticks(),
-								ClobPairId:        constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetClobPairId(),
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num0: satypes.Success,
-					},
-				},
-			},
+			placedMatchableOrders:  []types.MatchableOrder{},
+			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{},
 
 			order: constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 
@@ -97,21 +81,6 @@ func TestPlaceOrder_LongTerm(t *testing.T) {
 					Result: map[satypes.SubaccountId]satypes.UpdateResult{
 						constants.Alice_Num0: satypes.Success,
 						constants.Bob_Num0:   satypes.Success,
-					},
-				},
-				1: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Bob_Num0: {
-							{
-								RemainingQuantums: 15,
-								IsBuy:             true,
-								Subticks:          30,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Bob_Num0: satypes.Success,
 					},
 				},
 			},
@@ -473,98 +442,6 @@ func TestPlaceOrder_LongTerm(t *testing.T) {
 			expectedRemainingBids: []OrderWithRemainingSize{},
 			expectedRemainingAsks: []OrderWithRemainingSize{},
 		},
-		`A Long-Term sell order can partially match with a Long-Term buy order, fail collateralization
-			checks when adding to orderbook, and all existing matches are considered valid`: {
-			placedMatchableOrders: []types.MatchableOrder{
-				&constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10,
-			},
-			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
-				0: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num0: {
-							{
-								RemainingQuantums: 25,
-								IsBuy:             false,
-								Subticks:          30,
-								ClobPairId:        0,
-							},
-						},
-						constants.Bob_Num0: {
-							{
-								RemainingQuantums: 25,
-								IsBuy:             true,
-								Subticks:          30,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num0: satypes.Success,
-						constants.Bob_Num0:   satypes.Success,
-					},
-				},
-				1: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num0: {
-							{
-								RemainingQuantums: 40,
-								IsBuy:             false,
-								Subticks:          10,
-								ClobPairId:        0,
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num0: satypes.NewlyUndercollateralized,
-					},
-				},
-			},
-
-			order: constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25,
-
-			expectedFilledSize:  25,
-			expectedOrderStatus: types.Undercollateralized,
-			expectedOperations: []types.Operation{
-				clobtest.NewOrderPlacementOperation(
-					constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10,
-				),
-				clobtest.NewOrderPlacementOperation(
-					constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25,
-				),
-				clobtest.NewMatchOperation(
-					&constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25,
-					[]types.MakerFill{
-						{
-							MakerOrderId: constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10.OrderId,
-							FillAmount:   25,
-						},
-					},
-				),
-			},
-			expectedInternalOperations: []types.InternalOperation{
-				types.NewPreexistingStatefulOrderPlacementInternalOperation(
-					constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10,
-				),
-				types.NewPreexistingStatefulOrderPlacementInternalOperation(
-					constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25,
-				),
-				types.NewMatchOrdersInternalOperation(
-					constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25,
-					[]types.MakerFill{
-						{
-							MakerOrderId: constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10.OrderId,
-							FillAmount:   25,
-						},
-					},
-				),
-				types.NewOrderRemovalInternalOperation(
-					constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25.OrderId,
-					types.OrderRemoval_REMOVAL_REASON_UNDERCOLLATERALIZED,
-				),
-			},
-			expectedRemainingBids: []OrderWithRemainingSize{},
-			expectedRemainingAsks: []OrderWithRemainingSize{},
-		},
 		`A Long-Term post-only sell order can partially match with a Long-Term buy order,
 				all existing matches are reverted and it's not added to pendingStatefulOrders`: {
 			placedMatchableOrders: []types.MatchableOrder{
@@ -626,23 +503,7 @@ func TestPlaceOrder_LongTerm(t *testing.T) {
 			placedMatchableOrders: []types.MatchableOrder{
 				&constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 			},
-			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{
-				0: {
-					CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-						constants.Alice_Num0: {
-							{
-								RemainingQuantums: constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25.GetBaseQuantums(),
-								IsBuy:             constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25.IsBuy(),
-								Subticks:          constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25.GetOrderSubticks(),
-								ClobPairId:        constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25.GetClobPairId(),
-							},
-						},
-					},
-					Result: map[satypes.SubaccountId]satypes.UpdateResult{
-						constants.Alice_Num0: satypes.Success,
-					},
-				},
-			},
+			collateralizationCheck: map[int]testutil_memclob.CollateralizationCheck{},
 
 			order: constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25,
 
@@ -706,23 +567,7 @@ func TestPlaceOrder_PreexistingStatefulOrder(t *testing.T) {
 	ctx, _, _ := sdktest.NewSdkContextWithMultistore()
 	ctx = ctx.WithIsCheckTx(true)
 	longTermOrder := constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15
-	collateralizationCheck := map[int]testutil_memclob.CollateralizationCheck{
-		0: {
-			CollatCheck: map[satypes.SubaccountId][]types.PendingOpenOrder{
-				constants.Alice_Num0: {
-					{
-						RemainingQuantums: 5,
-						IsBuy:             true,
-						Subticks:          10,
-						ClobPairId:        0,
-					},
-				},
-			},
-			Result: map[satypes.SubaccountId]satypes.UpdateResult{
-				constants.Alice_Num0: satypes.Success,
-			},
-		},
-	}
+	collateralizationCheck := map[int]testutil_memclob.CollateralizationCheck{}
 	memclob, fakeMemClobKeeper, expectedNumCollateralizationChecks, numCollateralChecks := simplePlaceOrderTestSetup(
 		t,
 		ctx,

--- a/protocol/x/clob/memclob/memclob_place_order_test.go
+++ b/protocol/x/clob/memclob/memclob_place_order_test.go
@@ -2822,8 +2822,6 @@ func TestAddOrderToOrderbook_ErrorPlaceNewFullyFilledOrder(t *testing.T) {
 	memclob.SetClobKeeper(&memClobKeeper)
 	memclob.CreateOrderbook(ctx, constants.ClobPair_Btc)
 
-	memClobKeeper.On("AddOrderToOrderbookSubaccountUpdatesCheck", mock.Anything, mock.Anything, mock.Anything).
-		Return(true, make(map[satypes.SubaccountId]satypes.UpdateResult))
 	memClobKeeper.On("GetStatePosition", mock.Anything, mock.Anything, mock.Anything).
 		Return(big.NewInt(0))
 	memClobKeeper.On("ValidateSubaccountEquityTierLimitForNewOrder", mock.Anything, mock.Anything).
@@ -2855,9 +2853,6 @@ func TestAddOrderToOrderbook_PanicsIfFullyFilled(t *testing.T) {
 	order := constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15
 	orderId := order.OrderId
 	quantums := order.GetBaseQuantums()
-
-	memClobKeeper.On("AddOrderToOrderbookSubaccountUpdatesCheck", mock.Anything, mock.Anything, mock.Anything).
-		Return(true, make(map[satypes.SubaccountId]satypes.UpdateResult))
 
 	memClobKeeper.On("GetStatePosition", mock.Anything, mock.Anything, mock.Anything).
 		Return(big.NewInt(0))

--- a/protocol/x/clob/memclob/memclob_place_order_test.go
+++ b/protocol/x/clob/memclob/memclob_place_order_test.go
@@ -177,24 +177,6 @@ func TestPlaceOrder_AddOrderToOrderbook(t *testing.T) {
 			expectedOrderStatus:    types.Success,
 			expectedToReplaceOrder: false,
 		},
-		"Placing an order that causes the account to be undercollateralized fails": {
-			existingOrders:         []types.MatchableOrder{},
-			collateralizationCheck: satypes.NewlyUndercollateralized,
-
-			order: constants.Order_Bob_Num0_Id1_Clob1_Sell11_Price16_GTB20,
-
-			expectedOrderStatus:    types.Undercollateralized,
-			expectedToReplaceOrder: false,
-		},
-		"Placing an order that throws an error from the collateralization check fails": {
-			existingOrders:         []types.MatchableOrder{},
-			collateralizationCheck: satypes.UpdateCausedError,
-
-			order: constants.Order_Bob_Num0_Id1_Clob1_Sell11_Price16_GTB20,
-
-			expectedOrderStatus:    types.InternalError,
-			expectedToReplaceOrder: false,
-		},
 		"Replacing an order fails if GoodTilBlock is lower than existing order": {
 			existingOrders: []types.MatchableOrder{
 				&constants.Order_Bob_Num0_Id1_Clob1_Sell11_Price16_GTB20,
@@ -274,18 +256,6 @@ func TestPlaceOrder_AddOrderToOrderbook(t *testing.T) {
 
 			collateralizationCheck: satypes.Success,
 			expectedOrderStatus:    types.Success,
-			expectedToReplaceOrder: true,
-		},
-		`Old order is removed from the book if GoodTilBlock is greater than existing order, the order
-		passes initial validation, and new replacement order fails collateralization checks`: {
-			existingOrders: []types.MatchableOrder{
-				&constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15,
-			},
-
-			order: constants.Order_Alice_Num0_Id0_Clob0_Buy6_Price10_GTB20,
-
-			collateralizationCheck: satypes.NewlyUndercollateralized,
-			expectedOrderStatus:    types.Undercollateralized,
 			expectedToReplaceOrder: true,
 		},
 		`Replacing an order succeeds and old order is skipped during matching if GoodTilBlock is greater

--- a/protocol/x/clob/memclob/memclob_purge_invalid_memclob_state_test.go
+++ b/protocol/x/clob/memclob/memclob_purge_invalid_memclob_state_test.go
@@ -260,17 +260,12 @@ func TestPurgeInvalidMemclobState(t *testing.T) {
 				case *types.Operation_ShortTermOrderPlacement:
 					order := operation.GetShortTermOrderPlacement().Order
 					orderId := order.OrderId
-					// Mock out the first 4 calls to GetOrderFillAmount, which is called during test setup.
+					// Mock out calls to GetOrderFillAmount during test setup.
 					mockMemClobKeeper.On("GetOrderFillAmount", mock.Anything, orderId).Return(
 						false,
 						satypes.BaseQuantums(0),
 						uint32(0),
-					).Times(5)
-
-					// Mock out all remaining calls to GetOrderFillAmount, which is called in
-					// `memclob.PurgeInvalidMemclobState` and during test assertions.
-					fillAmount, exists := tc.newOrderFillAmounts[orderId]
-					mockMemClobKeeper.On("GetOrderFillAmount", mock.Anything, orderId).Return(exists, fillAmount, uint32(5))
+					)
 				}
 			}
 
@@ -290,6 +285,19 @@ func TestPurgeInvalidMemclobState(t *testing.T) {
 				tc.placedOperations,
 				mockMemClobKeeper,
 			)
+
+			for _, operation := range tc.placedOperations {
+				switch operation.Operation.(type) {
+				case *types.Operation_ShortTermOrderPlacement:
+					order := operation.GetShortTermOrderPlacement().Order
+					orderId := order.OrderId
+					// Mock out all remaining calls to GetOrderFillAmount, which is called in
+					// `memclob.PurgeInvalidMemclobState` and during test assertions.
+					fillAmount, exists := tc.newOrderFillAmounts[orderId]
+					mockMemClobKeeper.On("GetOrderFillAmount", mock.Anything, orderId).Unset()
+					mockMemClobKeeper.On("GetOrderFillAmount", mock.Anything, orderId).Return(exists, fillAmount, uint32(5))
+				}
+			}
 
 			// Run the test.
 			ctx = ctx.WithBlockHeight(10)

--- a/protocol/x/clob/memclob/memclob_purge_invalid_memclob_state_test.go
+++ b/protocol/x/clob/memclob/memclob_purge_invalid_memclob_state_test.go
@@ -266,8 +266,6 @@ func TestPurgeInvalidMemclobState(t *testing.T) {
 						satypes.BaseQuantums(0),
 						uint32(0),
 					).Times(5)
-					mockMemClobKeeper.On("AddOrderToOrderbookSubaccountUpdatesCheck", mock.Anything, mock.Anything, mock.Anything).
-						Return(true, make(map[satypes.SubaccountId]satypes.UpdateResult)).Once()
 
 					// Mock out all remaining calls to GetOrderFillAmount, which is called in
 					// `memclob.PurgeInvalidMemclobState` and during test assertions.

--- a/protocol/x/clob/memclob/memclob_remove_order_test.go
+++ b/protocol/x/clob/memclob/memclob_remove_order_test.go
@@ -327,8 +327,6 @@ func TestRemoveOrderIfFilled(t *testing.T) {
 			memclob := NewMemClobPriceTimePriority(false)
 			memclob.SetClobKeeper(&memClobKeeper)
 
-			memClobKeeper.On("AddOrderToOrderbookSubaccountUpdatesCheck", mock.Anything, mock.Anything, mock.Anything).
-				Return(true, make(map[satypes.SubaccountId]satypes.UpdateResult))
 			memClobKeeper.On("ValidateSubaccountEquityTierLimitForNewOrder", mock.Anything, mock.Anything).Return(nil)
 			memClobKeeper.On("SendOrderbookUpdates", mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 

--- a/protocol/x/clob/memclob/memclob_test_util.go
+++ b/protocol/x/clob/memclob/memclob_test_util.go
@@ -102,26 +102,6 @@ func createCollatCheckExpectationsFromPendingMatches(
 		expectedCollatChecks[i] = expectedPendingMatchesForCollatCheck
 	}
 
-	expectedMatchingCollateralizationChecks := len(expectedPendingMatches)
-
-	// If this is not a liquidation and taker order size will be added to the book, populate the
-	// expected parameters of the collateralization check for adding an order to the orderbook.
-	if !order.IsLiquidation() && addToOrderbookSize > 0 {
-		orderbookPendingMatches := []types.PendingOpenOrder{
-			{
-				RemainingQuantums: addToOrderbookSize,
-				IsBuy:             order.IsBuy(),
-				Subticks:          order.GetOrderSubticks(),
-				ClobPairId:        clobPairId,
-			},
-		}
-
-		expectedCollatChecks[expectedMatchingCollateralizationChecks] =
-			map[satypes.SubaccountId][]types.PendingOpenOrder{
-				order.GetSubaccountId(): orderbookPendingMatches,
-			}
-	}
-
 	return expectedCollatChecks
 }
 

--- a/protocol/x/clob/types/mem_clob_keeper.go
+++ b/protocol/x/clob/types/mem_clob_keeper.go
@@ -29,14 +29,6 @@ type MemClobKeeper interface {
 		offchainUpdates *OffchainUpdates,
 		err error,
 	)
-	AddOrderToOrderbookSubaccountUpdatesCheck(
-		ctx sdk.Context,
-		clobPairId ClobPairId,
-		subaccountOpenOrders map[satypes.SubaccountId][]PendingOpenOrder,
-	) (
-		success bool,
-		successPerUpdate map[satypes.SubaccountId]satypes.UpdateResult,
-	)
 	CanDeleverageSubaccount(
 		ctx sdk.Context,
 		subaccountId satypes.SubaccountId,


### PR DESCRIPTION
### Changelist
Removes collateralization-check for orders placed on the orderbook in the memclob

### Test Plan
- Purely removal of code, existing tests covers other cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed outdated collateralization checks and test cases to improve order processing efficiency and accuracy.
  
- **Tests**
  - Updated and streamlined test cases by removing redundant collateralization check scenarios.
  - Refined mocking strategies in tests to ensure proper testing conditions without unnecessary checks.

- **Refactor**
  - Simplified order processing logic by eliminating specific subaccount update check steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->