### PR TITLE
[CT-756] add roundtable task that uncrosses orderbook

### DIFF
--- a/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
+++ b/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
@@ -646,6 +646,7 @@ describe('orderbookLevelsCache', () => {
         ticker,
         side: OrderSide.BUY,
         humanPrice,
+        timeThreshold: 10,
         client,
       });
 
@@ -674,6 +675,7 @@ describe('orderbookLevelsCache', () => {
         ticker,
         side: OrderSide.BUY,
         humanPrice,
+        timeThreshold: 10,
         client,
       });
 

--- a/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
+++ b/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
@@ -10,6 +10,8 @@ import {
   getOrderBookLevels,
   getKey,
   deleteZeroPriceLevel,
+  getLastUpdatedKey,
+  deleteStalePriceLevel,
 } from '../../src/caches/orderbook-levels-cache';
 import { OrderSide } from '@dydxprotocol-indexer/postgres';
 import { OrderbookLevels, PriceLevel } from '../../src/types';
@@ -604,6 +606,78 @@ describe('orderbookLevelsCache', () => {
       });
 
       size = await hGetAsync(
+        {
+          hash: getKey(ticker, OrderSide.BUY),
+          key: humanPrice,
+        },
+        client,
+      );
+
+      expect(deleted).toEqual(false);
+      expect(size).toEqual('10');
+    });
+  });
+
+  describe('deleteStalePriceLevel', () => {
+    const humanPrice: string = '45100';
+
+    it('deletes stale price level', async () => {
+      await updatePriceLevel({
+        ticker,
+        side: OrderSide.BUY,
+        humanPrice,
+        sizeDeltaInQuantums: '100',
+        client,
+      });
+
+      client.hset(getLastUpdatedKey(ticker, OrderSide.BUY), humanPrice, (Date.now() / 1000) - 20);
+
+      let size: string | null = await hGetAsync(
+        {
+          hash: getKey(ticker, OrderSide.BUY),
+          key: humanPrice,
+        },
+        client,
+      );
+
+      expect(size).toEqual('100');
+
+      const deleted: boolean = await deleteStalePriceLevel({
+        ticker,
+        side: OrderSide.BUY,
+        humanPrice,
+        client,
+      });
+
+      size = await hGetAsync(
+        {
+          hash: getKey(ticker, OrderSide.BUY),
+          key: humanPrice,
+        },
+        client,
+      );
+
+      expect(deleted).toEqual(true);
+      expect(size).toBeNull();
+    });
+
+    it('does not delete recent price level', async () => {
+      await updatePriceLevel({
+        ticker,
+        side: OrderSide.BUY,
+        humanPrice,
+        sizeDeltaInQuantums: '10',
+        client,
+      });
+
+      const deleted: boolean = await deleteStalePriceLevel({
+        ticker,
+        side: OrderSide.BUY,
+        humanPrice,
+        client,
+      });
+
+      const size: string | null = await hGetAsync(
         {
           hash: getKey(ticker, OrderSide.BUY),
           key: humanPrice,

--- a/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
+++ b/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
@@ -7,7 +7,12 @@ import { Callback, RedisClient } from 'redis';
 import { InvalidOptionsError, InvalidPriceLevelUpdateError } from '../errors';
 import { hGetAsync } from '../helpers/redis';
 import { OrderbookLevels, PriceLevel } from '../types';
-import { deleteZeroPriceLevelScript, getOrderbookSideScript, incrementOrderbookLevelScript } from './scripts';
+import {
+  deleteZeroPriceLevelScript,
+  deleteStalePriceLevelScript,
+  getOrderbookSideScript,
+  incrementOrderbookLevelScript,
+} from './scripts';
 
 // Cache of orderbook levels for each clob pair
 // Each side of each exchange pair is an HSET with the hash = price, and value = total size of
@@ -334,6 +339,64 @@ export async function deleteZeroPriceLevel({
 }
 
 /**
+ * Deletes a stale price level from the orderbook levels cache idempotently using a Lua script.
+ * @param param0 Ticker of the exchange pair, side, human readable price level to delete.
+ * @returns `boolean`, true/false for whether the level was deleted.
+ */
+export async function deleteStalePriceLevel({
+  ticker,
+  side,
+  humanPrice,
+  client,
+}: {
+  ticker: string,
+  side: OrderSide,
+  humanPrice: string,
+  client: RedisClient,
+}): Promise<boolean> {
+  // Number of keys for the lua script.
+  const numKeys: number = 2;
+
+  let evalAsync: (
+    orderbookKey: string,
+    lastUpdatedKey: string,
+    priceLevel: string,
+  ) => Promise<boolean> = (
+    orderbookKey,
+    lastUpdatedKey,
+    priceLevel,
+  ) => {
+    return new Promise((resolve, reject) => {
+      const callback: Callback<number> = (
+        err: Error | null,
+        results: number,
+      ) => {
+        if (err) {
+          return reject(err);
+        }
+        const deleted: number = results;
+        return resolve(deleted === 1);
+      };
+      client.evalsha(
+        deleteStalePriceLevelScript.hash,
+        numKeys,
+        orderbookKey,
+        lastUpdatedKey,
+        priceLevel,
+        callback,
+      );
+    });
+  };
+  evalAsync = evalAsync.bind(client);
+
+  return evalAsync(
+    getKey(ticker, side),
+    getLastUpdatedKey(ticker, side),
+    humanPrice,
+  );
+}
+
+/**
  * Gets the quantums and lastUpdated data from the cache for the given orderbook side.
  * @param param0 Ticker of the exchange pair, side, Redis client.
  * @returns An mapping from human-readable price to objects containing data for the price point.
@@ -396,8 +459,10 @@ export async function getOrderbookSideData({
   // The 1st list is a flat array of alternating key-value pairs representing prices and quantums.
   // The 2nd is a flat array of alternating key-value pairs representing prices and lastUpdated
   // values.
-  const quantumsMapping: {[field: string]: string} = _.fromPairs(_.chunk(rawRedisResults[0], 2));
-  const lastUpdatedMapping: {[field: string]: string} = _.fromPairs(_.chunk(rawRedisResults[1], 2));
+  const quantumsMapping: { [field: string]: string } = _.fromPairs(_.chunk(rawRedisResults[0], 2));
+  const lastUpdatedMapping: { [field: string]: string } = _.fromPairs(
+    _.chunk(rawRedisResults[1], 2),
+  );
 
   return convertToPriceLevels(ticker, side, quantumsMapping, lastUpdatedMapping);
 
@@ -432,8 +497,8 @@ async function getOrderbookSide(
 function convertToPriceLevels(
   ticker: string,
   side: OrderSide,
-  price2QuantumsMapping: {[field: string]: string},
-  price2LastUpdatedMapping: {[field: string]: string},
+  price2QuantumsMapping: { [field: string]: string },
+  price2LastUpdatedMapping: { [field: string]: string },
 ): PriceLevel[] {
   const quantumsKeys: string[] = _.keys(price2QuantumsMapping);
   const lastUpdatedKeys: string[] = _.keys(price2LastUpdatedMapping);

--- a/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
+++ b/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
@@ -340,18 +340,20 @@ export async function deleteZeroPriceLevel({
 
 /**
  * Deletes a stale price level from the orderbook levels cache idempotently using a Lua script.
- * @param param0 Ticker of the exchange pair, side, human readable price level to delete.
+ * @param param0 Ticker of the exchange pair, side, human readable price level, time threshold to delete.
  * @returns `boolean`, true/false for whether the level was deleted.
  */
 export async function deleteStalePriceLevel({
   ticker,
   side,
   humanPrice,
+  timeThreshold,
   client,
 }: {
   ticker: string,
   side: OrderSide,
   humanPrice: string,
+  timeThreshold: number,
   client: RedisClient,
 }): Promise<boolean> {
   // Number of keys for the lua script.
@@ -361,10 +363,12 @@ export async function deleteStalePriceLevel({
     orderbookKey: string,
     lastUpdatedKey: string,
     priceLevel: string,
+    timeInterval: number,
   ) => Promise<boolean> = (
     orderbookKey,
     lastUpdatedKey,
     priceLevel,
+    timeInterval,
   ) => {
     return new Promise((resolve, reject) => {
       const callback: Callback<number> = (
@@ -383,6 +387,7 @@ export async function deleteStalePriceLevel({
         orderbookKey,
         lastUpdatedKey,
         priceLevel,
+        timeInterval,
         callback,
       );
     });
@@ -393,6 +398,7 @@ export async function deleteStalePriceLevel({
     getKey(ticker, side),
     getLastUpdatedKey(ticker, side),
     humanPrice,
+    timeThreshold,
   );
 }
 

--- a/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
+++ b/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
@@ -340,7 +340,8 @@ export async function deleteZeroPriceLevel({
 
 /**
  * Deletes a stale price level from the orderbook levels cache idempotently using a Lua script.
- * @param param0 Ticker of the exchange pair, side, human readable price level, time threshold to delete.
+ * @param param0 Ticker of the exchange pair, side, human readable price level,
+ * time threshold to delete.
  * @returns `boolean`, true/false for whether the level was deleted.
  */
 export async function deleteStalePriceLevel({

--- a/indexer/packages/redis/src/caches/scripts.ts
+++ b/indexer/packages/redis/src/caches/scripts.ts
@@ -53,6 +53,7 @@ function newLuaScript(name: string, scriptPath: string): LuaScript {
 
 // Lua Scripts for deleting zero price levels
 export const deleteZeroPriceLevelScript: LuaScript = newLuaScript('deleteZeroPriceLevel', '../scripts/delete_zero_level.lua');
+export const deleteStalePriceLevelScript: LuaScript = newLuaScript('deleteStalePriceLevel', '../scripts/delete_stale_price_level.lua');
 // Lua Scripts for updating/retrieving the orderbook levels, keeping the lastUpdated cache in sync
 export const incrementOrderbookLevelScript: LuaScript = newLuaScript('incrementOrderbookLevel', '../scripts/increment_orderbook_level.lua');
 export const getOrderbookSideScript: LuaScript = newLuaScript('getOrderbookSide', '../scripts/get_orderbook_side.lua');
@@ -65,6 +66,7 @@ export const removeStatefulOrderUpdateScript: LuaScript = newLuaScript('removeSt
 
 export const allLuaScripts: LuaScript[] = [
   deleteZeroPriceLevelScript,
+  deleteStalePriceLevelScript,
   incrementOrderbookLevelScript,
   getOrderbookSideScript,
   updateOrderScript,

--- a/indexer/packages/redis/src/scripts/delete_stale_price_level.lua
+++ b/indexer/packages/redis/src/scripts/delete_stale_price_level.lua
@@ -4,8 +4,10 @@ local hash = KEYS[1]
 local lastUpdatedHash = KEYS[2]
 -- Price level
 local level = ARGV[1]
+-- Time threshold in seconds
+local timeThreshold = tonumber(ARGV[2])
 
--- This script deletes a price level in the orderbook levels cache if the last updated time is more than 10 seconds in the past.
+-- This script deletes a price level in the orderbook levels cache if the last updated time is more than timeThreshold seconds in the past.
 -- The return value is 1 if a price level was deleted and 0 if a price level was not deleted.
 
 -- Get the current time
@@ -17,8 +19,8 @@ if not lastUpdatedTime then
     return 0
 end
 
--- Check if the last updated time is more than 10 seconds in the past
-if currentTime - lastUpdatedTime <= 10 then
+-- Check if the last updated time is more than timeThreshold seconds in the past
+if currentTime - lastUpdatedTime <= timeThreshold then
     return 0
 end
 

--- a/indexer/packages/redis/src/scripts/delete_stale_price_level.lua
+++ b/indexer/packages/redis/src/scripts/delete_stale_price_level.lua
@@ -1,0 +1,28 @@
+-- Key for the hset of price levels
+local hash = KEYS[1]
+-- Key for the hset of price levels 'last updated' data
+local lastUpdatedHash = KEYS[2]
+-- Price level
+local level = ARGV[1]
+
+-- This script deletes a price level in the orderbook levels cache if the last updated time is more than 10 seconds in the past.
+-- The return value is 1 if a price level was deleted and 0 if a price level was not deleted.
+
+-- Get the current time
+local currentTime = tonumber(redis.call("time")[1])
+
+-- Get the last updated time for the level
+local lastUpdatedTime = tonumber(redis.call("hget", lastUpdatedHash, level))
+if not lastUpdatedTime then
+    return 0
+end
+
+-- Check if the last updated time is more than 10 seconds in the past
+if currentTime - lastUpdatedTime <= 10 then
+    return 0
+end
+
+-- Delete the level from both hashes
+redis.call("hdel", hash, level)
+redis.call("hdel", lastUpdatedHash, level)
+return 1

--- a/indexer/services/roundtable/__tests__/tasks/uncross-orderbook.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/uncross-orderbook.test.ts
@@ -155,6 +155,10 @@ describe('uncross-orderbook', () => {
 
     await runTask();
 
+    // the bids are sorted in descending order
+    // the asks are sorted in ascending order
+    // the highest bid at price level 45200 was updated after the ask at price level 45000,
+    // so the ask at price level 45000 should be removed.
     expect(require('@dydxprotocol-indexer/redis/build/src/caches/orderbook-levels-cache').deleteStalePriceLevel).toHaveBeenCalledWith(
       expect.objectContaining({
         side: OrderSide.SELL,

--- a/indexer/services/roundtable/__tests__/tasks/uncross-orderbook.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/uncross-orderbook.test.ts
@@ -1,0 +1,132 @@
+import { logger, stats } from '@dydxprotocol-indexer/base';
+import {
+  dbHelpers,
+  OrderSide,
+  PerpetualMarketFromDatabase,
+  PerpetualMarketTable,
+  testMocks,
+} from '@dydxprotocol-indexer/postgres';
+import { OrderbookLevelsCache, redis } from '@dydxprotocol-indexer/redis';
+import runTask from '../../src/tasks/uncross-orderbook';
+import { redisClient } from '../../src/helpers/redis';
+
+jest.mock('@dydxprotocol-indexer/redis/build/src/caches/orderbook-levels-cache', () => ({
+  ...jest.requireActual('@dydxprotocol-indexer/redis/build/src/caches/orderbook-levels-cache'),
+  deleteStalePriceLevel: jest.fn(),
+}));
+
+describe('uncross-orderbook', () => {
+  beforeAll(async () => {
+    await dbHelpers.migrate();
+    await dbHelpers.clearData();
+    jest.spyOn(logger, 'info');
+    jest.spyOn(stats, 'gauge');
+  });
+
+  beforeEach(async () => {
+    await testMocks.seedData();
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await dbHelpers.teardown();
+    jest.resetAllMocks();
+  });
+
+  afterEach(async () => {
+    await dbHelpers.clearData();
+    await redis.deleteAllAsync(redisClient);
+    jest.clearAllMocks();
+  });
+
+  it('succeeds without any crossed levels', async () => {
+    const perpetualMarkets: PerpetualMarketFromDatabase[] = await PerpetualMarketTable.findAll(
+      {},
+      [],
+    );
+    const market = perpetualMarkets[0];
+    await OrderbookLevelsCache.updatePriceLevel({
+      ticker: market.ticker,
+      side: OrderSide.BUY,
+      humanPrice: '30100',
+      sizeDeltaInQuantums: '2000',
+      client: redisClient,
+    });
+    await OrderbookLevelsCache.updatePriceLevel({
+      ticker: market.ticker,
+      side: OrderSide.SELL,
+      humanPrice: '45000',
+      sizeDeltaInQuantums: '1000',
+      client: redisClient,
+    });
+
+    await runTask();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('removes crossed bid and ask levels', async () => {
+    const perpetualMarkets: PerpetualMarketFromDatabase[] = await PerpetualMarketTable.findAll(
+      {},
+      [],
+    );
+    const market = perpetualMarkets[0];
+    await OrderbookLevelsCache.updatePriceLevel({
+      ticker: market.ticker,
+      side: OrderSide.BUY,
+      humanPrice: '45100',
+      sizeDeltaInQuantums: '2000',
+      client: redisClient,
+    });
+    await OrderbookLevelsCache.updatePriceLevel({
+      ticker: market.ticker,
+      side: OrderSide.SELL,
+      humanPrice: '45000',
+      sizeDeltaInQuantums: '1000',
+      client: redisClient,
+    });
+
+    await runTask();
+
+    expect(require('@dydxprotocol-indexer/redis/build/src/caches/orderbook-levels-cache').deleteStalePriceLevel).toHaveBeenCalledWith(expect.objectContaining({
+      side: OrderSide.BUY,
+      humanPrice: '45100',
+    }));
+    expect(require('@dydxprotocol-indexer/redis/build/src/caches/orderbook-levels-cache').deleteStalePriceLevel).not.toHaveBeenCalledWith(expect.objectContaining({
+      side: OrderSide.SELL,
+      humanPrice: '45000',
+    }));
+  });
+
+  it('logs a failure to delete stale bid or ask level', async () => {
+    const { deleteStalePriceLevel } = require('@dydxprotocol-indexer/redis/build/src/caches/orderbook-levels-cache');
+    deleteStalePriceLevel.mockImplementationOnce(() => false);
+
+    const perpetualMarkets: PerpetualMarketFromDatabase[] = await PerpetualMarketTable.findAll(
+      {},
+      [],
+    );
+    const market = perpetualMarkets[0];
+    await OrderbookLevelsCache.updatePriceLevel({
+      ticker: market.ticker,
+      side: OrderSide.BUY,
+      humanPrice: '45100',
+      sizeDeltaInQuantums: '2000',
+      client: redisClient,
+    });
+    await OrderbookLevelsCache.updatePriceLevel({
+      ticker: market.ticker,
+      side: OrderSide.SELL,
+      humanPrice: '45000',
+      sizeDeltaInQuantums: '1000',
+      client: redisClient,
+    });
+
+    await runTask();
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('Failed to delete stale bid level for'),
+      side: OrderSide.BUY,
+      humanPrice: '45100',
+    }));
+  });
+});

--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -37,6 +37,7 @@ export const configSchema = {
   // Loop Enablement
   LOOPS_ENABLED_MARKET_UPDATER: parseBoolean({ default: true }),
   LOOPS_ENABLED_DELETE_ZERO_PRICE_LEVELS: parseBoolean({ default: true }),
+  LOOPS_ENABLED_UNCROSS_ORDERBOOK: parseBoolean({ default: false }),
   LOOPS_ENABLED_PNL_TICKS: parseBoolean({ default: true }),
   LOOPS_ENABLED_REMOVE_EXPIRED_ORDERS: parseBoolean({ default: true }),
   LOOPS_ORDERBOOK_INSTRUMENTATION: parseBoolean({ default: true }),
@@ -56,6 +57,9 @@ export const configSchema = {
   }),
   LOOPS_INTERVAL_MS_DELETE_ZERO_PRICE_LEVELS: parseInteger({
     default: 2 * ONE_MINUTE_IN_MILLISECONDS,
+  }),
+  LOOPS_INTERVAL_MS_UNCROSS_ORDERBOOK: parseInteger({
+    default: THIRTY_SECONDS_IN_MILLISECONDS,
   }),
   LOOPS_INTERVAL_MS_PNL_TICKS: parseInteger({
     default: THIRTY_SECONDS_IN_MILLISECONDS,
@@ -103,6 +107,7 @@ export const configSchema = {
   // Lock multipliers
   MARKET_UPDATER_LOCK_MULTIPLIER: parseInteger({ default: 10 }),
   DELETE_ZERO_PRICE_LEVELS_LOCK_MULTIPLIER: parseInteger({ default: 1 }),
+  UNCROSS_ORDERBOOK_LOCK_MULTIPLIER: parseInteger({ default: 1 }),
   PNL_TICK_UPDATE_LOCK_MULTIPLIER: parseInteger({ default: 20 }),
 
   // Maximum number of running tasks - set this equal to PG_POOL_MIN in .env, default is 2

--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -160,6 +160,9 @@ export const configSchema = {
     default: ONE_HOUR_IN_MILLISECONDS,
   }),
   AGGREGATE_TRADING_REWARDS_CHUNK_SIZE: parseInteger({ default: 50 }),
+
+  // Uncross orderbook
+  STALE_ORDERBOOK_LEVEL_THRESHOLD_SECONDS: parseInteger({ default: 10 }),
 };
 
 export default parseSchema(configSchema);

--- a/indexer/services/roundtable/src/index.ts
+++ b/indexer/services/roundtable/src/index.ts
@@ -21,6 +21,7 @@ import removeExpiredOrdersTask from './tasks/remove-expired-orders';
 import removeOldOrderUpdatesTask from './tasks/remove-old-order-updates';
 import takeFastSyncSnapshotTask from './tasks/take-fast-sync-snapshot';
 import trackLag from './tasks/track-lag';
+import uncrossOrderbookTask from './tasks/uncross-orderbook';
 import updateComplianceDataTask from './tasks/update-compliance-data';
 import updateResearchEnvironmentTask from './tasks/update-research-environment';
 
@@ -61,6 +62,15 @@ async function start(): Promise<void> {
       'delete_zero_price_levels',
       config.LOOPS_INTERVAL_MS_DELETE_ZERO_PRICE_LEVELS,
       config.DELETE_ZERO_PRICE_LEVELS_LOCK_MULTIPLIER,
+    );
+  }
+
+  if (config.LOOPS_ENABLED_UNCROSS_ORDERBOOK) {
+    startLoop(
+      uncrossOrderbookTask,
+      'uncross_orderbook',
+      config.LOOPS_INTERVAL_MS_UNCROSS_ORDERBOOK,
+      config.UNCROSS_ORDERBOOK_LOCK_MULTIPLIER,
     );
   }
 

--- a/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
+++ b/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
@@ -60,6 +60,8 @@ async function uncrossOrderbook(
   let ai = 0;
   let bi = 0;
 
+  // the bids are sorted in descending order
+  // the asks are sorted in ascending order
   while (
     ai < orderbookLevels.asks.length &&
     bi < orderbookLevels.bids.length &&

--- a/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
+++ b/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
@@ -1,7 +1,6 @@
 import { logger } from '@dydxprotocol-indexer/base';
 import { OrderSide, PerpetualMarketFromDatabase, PerpetualMarketTable } from '@dydxprotocol-indexer/postgres';
 import { OrderbookLevels, OrderbookLevelsCache } from '@dydxprotocol-indexer/redis';
-import { deleteStalePriceLevel } from '@dydxprotocol-indexer/redis/build/src/caches/orderbook-levels-cache';
 import Big from 'big.js';
 
 import { redisClient } from '../helpers/redis';
@@ -85,7 +84,7 @@ async function uncrossOrderbook(
   });
 
   for (const bid of removeBidLevels) {
-    const deleted: boolean = await deleteStalePriceLevel({
+    const deleted: boolean = await OrderbookLevelsCache.deleteStalePriceLevel({
       ticker,
       side: OrderSide.BUY,
       humanPrice: bid.humanPrice,
@@ -102,7 +101,7 @@ async function uncrossOrderbook(
   }
 
   for (const ask of removeAskLevels) {
-    const deleted: boolean = await deleteStalePriceLevel({
+    const deleted: boolean = await OrderbookLevelsCache.deleteStalePriceLevel({
       ticker,
       side: OrderSide.SELL,
       humanPrice: ask.humanPrice,

--- a/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
+++ b/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
@@ -63,7 +63,7 @@ async function uncrossOrderbook(
     bi < orderbookLevels.bids.length &&
     Big(orderbookLevels.bids[bi].humanPrice).gte(Big(orderbookLevels.asks[ai].humanPrice))
   ) {
-    // Compare the recency and size of the bid and ask to decide which to remove
+    // Remove the older side
     if (
       Number(orderbookLevels.bids[bi].lastUpdated) > Number(orderbookLevels.asks[ai].lastUpdated)
     ) {
@@ -76,6 +76,13 @@ async function uncrossOrderbook(
   // Remove crossed levels from Redis
   const removeBidLevels = orderbookLevels.bids.slice(0, bi);
   const removeAskLevels = orderbookLevels.asks.slice(0, ai);
+
+  logger.info({
+    at: 'uncrossOrderbook#uncrossOrderbook',
+    message: `Uncrossing orderbook for ${ticker}`,
+    removedBids: JSON.stringify(removeBidLevels),
+    removedAsks: JSON.stringify(removeAskLevels),
+  });
 
   for (const bid of removeBidLevels) {
     const deleted: boolean = await deleteStalePriceLevel({
@@ -110,11 +117,4 @@ async function uncrossOrderbook(
       });
     }
   }
-
-  logger.info({
-    at: 'uncrossOrderbook#uncrossOrderbook',
-    message: `Uncrossed orderbook for ${ticker}`,
-    removedBids: JSON.stringify(removeBidLevels),
-    removedAsks: JSON.stringify(removeAskLevels),
-  });
 }

--- a/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
+++ b/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
@@ -101,12 +101,20 @@ async function uncrossOrderbook(
       client: redisClient,
     });
     if (!deleted) {
-      stats.increment(`${config.SERVICE_NAME}.uncross_orderbook_failed`, { side: OrderSide.BUY });
+      stats.increment(
+        `${config.SERVICE_NAME}.uncross_orderbook_failed`,
+        {
+          side: OrderSide.BUY,
+          clobPairId: market.clobPairId,
+          ticker,
+        },
+      );
       logger.info({
         at: 'uncrossOrderbook#deleteStalePriceLevel',
         message: `Failed to delete stale bid level for ${ticker}`,
         side: OrderSide.BUY,
         humanPrice: bid.humanPrice,
+        ticker,
       });
     } else {
       stats.increment(`${config.SERVICE_NAME}.uncross_orderbook`, { side: OrderSide.BUY });
@@ -128,12 +136,20 @@ async function uncrossOrderbook(
       client: redisClient,
     });
     if (!deleted) {
-      stats.increment(`${config.SERVICE_NAME}.uncross_orderbook_failed`, { side: OrderSide.SELL });
+      stats.increment(
+        `${config.SERVICE_NAME}.uncross_orderbook_failed`,
+        {
+          side: OrderSide.SELL,
+          clobPairId: market.clobPairId,
+          ticker,
+        },
+      );
       logger.info({
         at: 'uncrossOrderbook#deleteStalePriceLevel',
         message: `Failed to delete stale ask level for ${ticker}`,
         side: OrderSide.SELL,
         humanPrice: ask.humanPrice,
+        ticker,
       });
     } else {
       stats.increment(`${config.SERVICE_NAME}.uncross_orderbook`, { side: OrderSide.SELL });

--- a/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
+++ b/indexer/services/roundtable/src/tasks/uncross-orderbook.ts
@@ -1,0 +1,120 @@
+import { logger } from '@dydxprotocol-indexer/base';
+import { OrderSide, PerpetualMarketFromDatabase, PerpetualMarketTable } from '@dydxprotocol-indexer/postgres';
+import { OrderbookLevels, OrderbookLevelsCache } from '@dydxprotocol-indexer/redis';
+import { deleteStalePriceLevel } from '@dydxprotocol-indexer/redis/build/src/caches/orderbook-levels-cache';
+import Big from 'big.js';
+
+import { redisClient } from '../helpers/redis';
+
+/**
+ * Task to uncross the orderbook.
+ */
+export default async function runTask(): Promise<void> {
+  const markets: PerpetualMarketFromDatabase[] = await PerpetualMarketTable.findAll({}, []);
+
+  for (let i: number = 0; i < markets.length; i++) {
+    const market: PerpetualMarketFromDatabase = markets[i];
+
+    const crossedOrderbookLevels: OrderbookLevels = await OrderbookLevelsCache.getOrderBookLevels(
+      market.ticker,
+      redisClient,
+      {
+        removeZeros: true,
+        sortSides: true,
+        uncrossBook: false,
+      },
+    );
+
+    // Check if the orderbook is crossed
+    if (isOrderbookCrossed(crossedOrderbookLevels)) {
+      await uncrossOrderbook(market, crossedOrderbookLevels);
+    }
+  }
+}
+
+/**
+ * Check if the orderbook is crossed.
+ */
+function isOrderbookCrossed(orderbookLevels: OrderbookLevels): boolean {
+  if (orderbookLevels.bids.length > 0 && orderbookLevels.asks.length > 0) {
+    const bestBid = Big(orderbookLevels.bids[0].humanPrice);
+    const bestAsk = Big(orderbookLevels.asks[0].humanPrice);
+    return bestBid.gte(bestAsk);
+  }
+  return false;
+}
+
+/**
+ * Uncross the orderbook by removing overlapping bid and ask levels.
+ * Remove the price levels that are older.
+ */
+async function uncrossOrderbook(
+  market: PerpetualMarketFromDatabase,
+  orderbookLevels: OrderbookLevels,
+): Promise<void> {
+  const ticker = market.ticker;
+
+  // Remove overlapping levels
+  let ai = 0;
+  let bi = 0;
+
+  while (
+    ai < orderbookLevels.asks.length &&
+    bi < orderbookLevels.bids.length &&
+    Big(orderbookLevels.bids[bi].humanPrice).gte(Big(orderbookLevels.asks[ai].humanPrice))
+  ) {
+    // Compare the recency and size of the bid and ask to decide which to remove
+    if (
+      Number(orderbookLevels.bids[bi].lastUpdated) > Number(orderbookLevels.asks[ai].lastUpdated)
+    ) {
+      ai += 1;
+    } else {
+      bi += 1;
+    }
+  }
+
+  // Remove crossed levels from Redis
+  const removeBidLevels = orderbookLevels.bids.slice(0, bi);
+  const removeAskLevels = orderbookLevels.asks.slice(0, ai);
+
+  for (const bid of removeBidLevels) {
+    const deleted: boolean = await deleteStalePriceLevel({
+      ticker,
+      side: OrderSide.BUY,
+      humanPrice: bid.humanPrice,
+      client: redisClient,
+    });
+    if (!deleted) {
+      logger.info({
+        at: 'uncrossOrderbook#deleteStalePriceLevel',
+        message: `Failed to delete stale bid level for ${ticker}`,
+        side: OrderSide.BUY,
+        humanPrice: bid.humanPrice,
+      });
+    }
+  }
+
+  for (const ask of removeAskLevels) {
+    const deleted: boolean = await deleteStalePriceLevel({
+      ticker,
+      side: OrderSide.SELL,
+      humanPrice: ask.humanPrice,
+      client: redisClient,
+    });
+    if (!deleted) {
+      logger.info({
+        at: 'uncrossOrderbook#deleteStalePriceLevel',
+        message: `Failed to delete stale ask level for ${ticker}`,
+        side: OrderSide.SELL,
+        humanPrice: ask.humanPrice,
+      });
+    }
+  }
+
+  logger.info({
+    at: 'uncrossOrderbook#uncrossOrderbook',
+    message: `Uncrossed orderbook for ${ticker}`,
+    removedBids: JSON.stringify(removeBidLevels),
+    removedAsks: JSON.stringify(removeAskLevels),
+  });
+}


### PR DESCRIPTION
### Changelist
Add roundtable task that uncrosses orderbook every 30 seconds.
Only removes a price level if it is >10 seconds stale.

### Test Plan
Unit tested & verified in staging.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a task to uncross the orderbook, ensuring the removal of overlapping bid and ask levels for a consistent market state.
  - Added new functionality to delete stale price levels in the orderbook.

- **Tests**
  - Added comprehensive tests for the new uncross-orderbook task, covering various scenarios to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->