### PR TITLE
[CT-874] Add realizedPnl/unrealizedPnl to consolidated subaccount websocket msg sent from fills/liquidations/deleveraging Ender handlers

### DIFF
--- a/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
@@ -681,9 +681,6 @@ export async function expectFillSubaccountKafkaMessageFromLiquidationEvent(
   expect(fill).toBeDefined();
   expect(position).toBeDefined();
 
-  let perpUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = convertPerpetualPosition(
-    position!,
-  );
   const markets: MarketFromDatabase[] = await MarketTable.findAll(
     {},
     [],
@@ -692,8 +689,8 @@ export async function expectFillSubaccountKafkaMessageFromLiquidationEvent(
     markets,
     MarketColumns.id,
   );
-  perpUpdate = annotateWithPnl(
-    perpUpdate,
+  const positionUpdate = annotateWithPnl(
+    convertPerpetualPosition(position!),
     perpetualMarketRefresher.getPerpetualMarketsMap(),
     marketIdToMarket,
   );
@@ -704,7 +701,7 @@ export async function expectFillSubaccountKafkaMessageFromLiquidationEvent(
     ],
     perpetualPositions: generatePerpetualPositionsContents(
       subaccountIdProto,
-      [perpUpdate],
+      [positionUpdate],
       perpetualMarketRefresher.getPerpetualMarketsMap(),
     ),
     blockHeight,
@@ -834,17 +831,14 @@ export async function expectOrderFillAndPositionSubaccountKafkaMessageFromIds(
       markets,
       MarketColumns.id,
     );
-    let perpUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = convertPerpetualPosition(
-      position,
-    );
-    perpUpdate = annotateWithPnl(
-      perpUpdate,
+    const positionUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = annotateWithPnl(
+      convertPerpetualPosition(position),
       perpetualMarketRefresher.getPerpetualMarketsMap(),
       marketIdToMarket,
     );
     contents.perpetualPositions = generatePerpetualPositionsContents(
       subaccountIdProto,
-      [perpUpdate],
+      [positionUpdate],
       perpetualMarketRefresher.getPerpetualMarketsMap(),
     );
   }

--- a/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/indexer-proto-helpers.ts
@@ -681,13 +681,30 @@ export async function expectFillSubaccountKafkaMessageFromLiquidationEvent(
   expect(fill).toBeDefined();
   expect(position).toBeDefined();
 
+  let perpUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = convertPerpetualPosition(
+    position!,
+  );
+  const markets: MarketFromDatabase[] = await MarketTable.findAll(
+    {},
+    [],
+  );
+  const marketIdToMarket: MarketsMap = _.keyBy(
+    markets,
+    MarketColumns.id,
+  );
+  perpUpdate = annotateWithPnl(
+    perpUpdate,
+    perpetualMarketRefresher.getPerpetualMarketsMap(),
+    marketIdToMarket,
+  );
+
   const contents: SubaccountMessageContents = {
     fills: [
       generateFillSubaccountMessage(fill!, ticker),
     ],
     perpetualPositions: generatePerpetualPositionsContents(
       subaccountIdProto,
-      [convertPerpetualPosition(position!)],
+      [perpUpdate],
       perpetualMarketRefresher.getPerpetualMarketsMap(),
     ),
     blockHeight,

--- a/indexer/services/ender/src/handlers/order-fills/liquidation-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/liquidation-handler.ts
@@ -15,7 +15,8 @@ import {
   MarketTable,
   MarketsMap,
   MarketColumns,
-  UpdatedPerpetualPositionSubaccountKafkaObject, perpetualMarketRefresher,
+  UpdatedPerpetualPositionSubaccountKafkaObject,
+  perpetualMarketRefresher,
 } from '@dydxprotocol-indexer/postgres';
 import { StateFilledQuantumsCache } from '@dydxprotocol-indexer/redis';
 import { isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';

--- a/indexer/services/ender/src/handlers/order-fills/liquidation-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/liquidation-handler.ts
@@ -112,11 +112,8 @@ export class LiquidationHandler extends AbstractOrderFillHandler<OrderFillWithLi
       MarketColumns.id,
     );
 
-    let perpUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = convertPerpetualPosition(
-      position,
-    );
-    perpUpdate = annotateWithPnl(
-      perpUpdate,
+    const positionUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = annotateWithPnl(
+      convertPerpetualPosition(position),
       perpetualMarketRefresher.getPerpetualMarketsMap(),
       marketIdToMarket,
     );
@@ -137,7 +134,7 @@ export class LiquidationHandler extends AbstractOrderFillHandler<OrderFillWithLi
         this.generateConsolidatedKafkaEvent(
           castedLiquidationFillEventMessage.makerOrder.orderId!.subaccountId!,
           makerOrder,
-          perpUpdate,
+          positionUpdate,
           fill,
           perpetualMarket,
         ),
@@ -162,7 +159,7 @@ export class LiquidationHandler extends AbstractOrderFillHandler<OrderFillWithLi
         this.generateConsolidatedKafkaEvent(
           castedLiquidationFillEventMessage.liquidationOrder.liquidated!,
           undefined,
-          perpUpdate,
+          positionUpdate,
           fill,
           perpetualMarket,
         ),

--- a/indexer/services/ender/src/handlers/order-fills/order-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/order-handler.ts
@@ -95,11 +95,8 @@ export class OrderHandler extends AbstractOrderFillHandler<OrderFillWithLiquidit
       markets,
       MarketColumns.id,
     );
-    let perpUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = convertPerpetualPosition(
-      position,
-    );
-    perpUpdate = annotateWithPnl(
-      perpUpdate,
+    const positionUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = annotateWithPnl(
+      convertPerpetualPosition(position),
       perpetualMarketRefresher.getPerpetualMarketsMap(),
       marketIdToMarket,
     );
@@ -107,7 +104,7 @@ export class OrderHandler extends AbstractOrderFillHandler<OrderFillWithLiquidit
       this.generateConsolidatedKafkaEvent(
         subaccountId,
         order,
-        perpUpdate,
+        positionUpdate,
         fill,
         perpetualMarket,
       ),

--- a/indexer/services/ender/src/handlers/order-fills/order-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/order-handler.ts
@@ -11,17 +11,24 @@ import {
   PerpetualPositionModel,
   SubaccountTable,
   OrderStatus,
+  MarketFromDatabase,
+  MarketTable,
+  MarketsMap,
+  MarketColumns,
+  perpetualMarketRefresher,
+  UpdatedPerpetualPositionSubaccountKafkaObject,
 } from '@dydxprotocol-indexer/postgres';
 import { StateFilledQuantumsCache } from '@dydxprotocol-indexer/redis';
 import { isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   IndexerOrderId, IndexerSubaccountId, IndexerOrder,
 } from '@dydxprotocol-indexer/v4-protos';
+import _ from 'lodash';
 import Long from 'long';
 import * as pg from 'pg';
 
 import { STATEFUL_ORDER_ORDER_FILL_EVENT_TYPE, SUBACCOUNT_ORDER_FILL_EVENT_TYPE } from '../../constants';
-import { convertPerpetualPosition } from '../../helpers/kafka-helper';
+import { annotateWithPnl, convertPerpetualPosition } from '../../helpers/kafka-helper';
 import { redisClient } from '../../helpers/redis/redis-controller';
 import { orderFillWithLiquidityToOrderFillEventWithOrder } from '../../helpers/translation-helper';
 import { OrderFillWithLiquidity } from '../../lib/translated-types';
@@ -79,11 +86,28 @@ export class OrderHandler extends AbstractOrderFillHandler<OrderFillWithLiquidit
     } else {
       subaccountId = castedOrderFillEventMessage.order.orderId!.subaccountId!;
     }
+    const markets: MarketFromDatabase[] = await MarketTable.findAll(
+      {},
+      [],
+      { txId: this.txId },
+    );
+    const marketIdToMarket: MarketsMap = _.keyBy(
+      markets,
+      MarketColumns.id,
+    );
+    let perpUpdate: UpdatedPerpetualPositionSubaccountKafkaObject = convertPerpetualPosition(
+      position,
+    );
+    perpUpdate = annotateWithPnl(
+      perpUpdate,
+      perpetualMarketRefresher.getPerpetualMarketsMap(),
+      marketIdToMarket,
+    );
     kafkaEvents.push(
       this.generateConsolidatedKafkaEvent(
         subaccountId,
         order,
-        convertPerpetualPosition(position),
+        perpUpdate,
         fill,
         perpetualMarket,
       ),


### PR DESCRIPTION
### Changelist
Add realizedPnl/unrealizedPnl to consolidated subaccount websocket msg sent from fills/liquidations/deleveraging Ender handlers.

### Test Plan
Unit tested.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced market data handling, including updates to perpetual positions.

- **Improvements**
  - Improved PnL (Profit and Loss) calculations for perpetual positions.

- **Bug Fixes**
  - Addressed issues related to market data updates and perpetual position handling.

These changes aim to provide more accurate market data and better performance in updating perpetual positions, enhancing overall user experience in market-related functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->