### PR TITLE
[CT-885] Deprecate and remove OpenOrdersCache

### DIFF
--- a/indexer/packages/redis/src/index.ts
+++ b/indexer/packages/redis/src/index.ts
@@ -1,7 +1,6 @@
 export * as redis from './helpers/redis';
 
 export * as AggregateTradingRewardsProcessedCache from './caches/aggregate-trading-rewards-processed-cache';
-export * as OpenOrdersCache from './caches/open-orders-cache';
 export * as OrdersCache from './caches/orders-cache';
 export * as OrdersDataCache from './caches/orders-data-cache';
 export * as OrderExpiryCache from './caches/order-expiry-cache';

--- a/indexer/services/roundtable/__tests__/tasks/orderbook-instrumentation.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/orderbook-instrumentation.test.ts
@@ -39,12 +39,6 @@ describe('orderbook-instrumentation', () => {
   });
 
   it('succeeds with empty orderbook', async () => {
-    const perpetualMarkets: PerpetualMarketFromDatabase[] = await PerpetualMarketTable.findAll(
-      {},
-      [],
-      {},
-    );
-
     await orderbookInstrumentationTask();
     expect(stats.gauge).toHaveBeenCalledTimes(0);
   });

--- a/indexer/services/roundtable/__tests__/tasks/orderbook-instrumentation.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/orderbook-instrumentation.test.ts
@@ -7,7 +7,6 @@ import {
   testMocks,
 } from '@dydxprotocol-indexer/postgres';
 import {
-  OpenOrdersCache,
   OrderbookLevelsCache,
   redis,
 } from '@dydxprotocol-indexer/redis';
@@ -113,7 +112,6 @@ describe('orderbook-instrumentation', () => {
             sizeDeltaInQuantums: '3500',
             client: redisClient,
           }),
-          OpenOrdersCache.addOpenOrder('orderUuid', perpetualMarket.clobPairId, redisClient),
         ]);
       },
       ));

--- a/indexer/services/roundtable/__tests__/tasks/orderbook-instrumentation.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/orderbook-instrumentation.test.ts
@@ -46,18 +46,7 @@ describe('orderbook-instrumentation', () => {
     );
 
     await orderbookInstrumentationTask();
-
-    perpetualMarkets.forEach((perpetualMarket: PerpetualMarketFromDatabase) => {
-      const tags: Object = { clob_pair_id: perpetualMarket.clobPairId };
-      expect(stats.gauge).toHaveBeenCalledWith(
-        'roundtable.open_orders_count',
-        0,
-        tags,
-      );
-    });
-
-    // Only open orders stat should have been sent
-    expect(stats.gauge).toHaveBeenCalledTimes(perpetualMarkets.length);
+    expect(stats.gauge).toHaveBeenCalledTimes(0);
   });
 
   it('succeeds with stats', async () => {
@@ -162,13 +151,6 @@ describe('orderbook-instrumentation', () => {
       expect(stats.gauge).toHaveBeenCalledWith(
         'roundtable.crossed_orderbook.best_ask_subticks',
         priceToSubticks('45000', perpetualMarket),
-        tags,
-      );
-
-      // Check for open order count being gauged
-      expect(stats.gauge).toHaveBeenCalledWith(
-        'roundtable.open_orders_count',
-        1,
         tags,
       );
     });

--- a/indexer/services/roundtable/src/tasks/orderbook-instrumentation.ts
+++ b/indexer/services/roundtable/src/tasks/orderbook-instrumentation.ts
@@ -8,7 +8,6 @@ import {
   QUOTE_CURRENCY_ATOMIC_RESOLUTION,
 } from '@dydxprotocol-indexer/postgres';
 import {
-  OpenOrdersCache,
   OrderbookLevels,
   OrderbookLevelsCache,
 } from '@dydxprotocol-indexer/redis';
@@ -47,15 +46,6 @@ export default async function runTask(): Promise<void> {
       },
     );
     statOrderbook(crossedOrderbookLevels, market, 'crossed_orderbook');
-    const openOrders: string[] = await OpenOrdersCache.getOpenOrderIds(
-      market.clobPairId,
-      redisClient,
-    );
-    stats.gauge(
-      `${config.SERVICE_NAME}.open_orders_count`,
-      openOrders.length,
-      { clob_pair_id: market.clobPairId },
-    );
   }
 }
 

--- a/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
@@ -33,7 +33,6 @@ import {
 } from '@dydxprotocol-indexer/postgres';
 import * as redisPackage from '@dydxprotocol-indexer/redis';
 import {
-  OpenOrdersCache,
   PriceLevel,
   OrdersCache,
   OrderbookLevels,
@@ -60,7 +59,7 @@ import { KafkaMessage } from 'kafkajs';
 import Long from 'long';
 import { redisClient, redisClient as client } from '../../src/helpers/redis/redis-controller';
 import { onMessage } from '../../src/lib/on-message';
-import { expectCanceledOrderStatus, expectOpenOrderIds, handleInitialOrderPlace } from '../helpers/helpers';
+import { expectCanceledOrderStatus, handleInitialOrderPlace } from '../helpers/helpers';
 import { expectOffchainUpdateMessage, expectWebsocketOrderbookMessage, expectWebsocketSubaccountMessage } from '../helpers/websocket-helpers';
 import { OrderbookSide } from '../../src/lib/types';
 import { getOrderIdHash, isLongTermOrder, isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
@@ -593,16 +592,6 @@ describe('order-place-handler', () => {
         sizeDeltaInQuantums: oldPriceLevelInitialQuantums.toString(),
         client,
       });
-      // Add the order to the open orders cache to check if it is removed after replacement
-      await OpenOrdersCache.addOpenOrder(
-        expectedRedisOrder.id,
-        testConstants.defaultPerpetualMarket.clobPairId.toString(),
-        client,
-      );
-      await expectOpenOrderIds(
-        testConstants.defaultPerpetualMarket.clobPairId,
-        [expectedRedisOrder.id],
-      );
 
       // Handle the order place off-chain update with the replacement order
       await onMessage(orderReplacementMessage);
@@ -623,9 +612,6 @@ describe('order-place-handler', () => {
         expect(orderbook.asks).toHaveLength(0);
         expect(orderbook.bids).toContainEqual(expectedPriceLevel);
       }
-
-      // Check the order was removed from the open orders cache
-      await expectOpenOrderIds(testConstants.defaultPerpetualMarket.clobPairId, []);
 
       expect(logger.error).not.toHaveBeenCalled();
       const orderbookContents: OrderbookMessageContents = {

--- a/indexer/services/vulcan/__tests__/handlers/order-update-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-update-handler.test.ts
@@ -7,7 +7,6 @@ import {
   StatefulOrderUpdatesCache,
 } from '@dydxprotocol-indexer/redis';
 import {
-  expectOpenOrderIds,
   expectOrderbookLevelCache,
   handleInitialOrderPlace,
   handleOrderUpdate,
@@ -181,12 +180,6 @@ describe('OrderUpdateHandler', () => {
           ]),
         );
 
-        // Check order is added to open orders cache
-        await expectOpenOrderIds(
-          testConstants.defaultPerpetualMarket.clobPairId,
-          [redisTestConstants.defaultRedisOrder.id],
-        );
-
         jest.clearAllMocks();
         const secondTotalFilledQuantums: Long = Long.fromValue(500_350, true);
         const secondUpdate: redisTestConstants.OffChainUpdateOrderUpdateUpdateMessage = {
@@ -229,9 +222,6 @@ describe('OrderUpdateHandler', () => {
           },
         };
         await handleOrderUpdate(thirdUpdate);
-
-        // Order total filled == size, order should be removed from open orders cache
-        await expectOpenOrderIds(testConstants.defaultPerpetualMarket.clobPairId, []);
       },
     );
 

--- a/indexer/services/vulcan/__tests__/helpers/helpers.ts
+++ b/indexer/services/vulcan/__tests__/helpers/helpers.ts
@@ -1,7 +1,6 @@
 import { createKafkaMessage } from '@dydxprotocol-indexer/kafka';
 import { OrderSide } from '@dydxprotocol-indexer/postgres';
 import {
-  OpenOrdersCache,
   redisTestConstants,
   OrderbookLevelsCache,
   CanceledOrdersCache,
@@ -56,17 +55,6 @@ export async function expectOrderbookLevelCache(
     redisClient,
   );
   expect(level).toEqual(size);
-}
-
-export async function expectOpenOrderIds(
-  clobPairId: string,
-  openOrderIds: string[],
-): Promise<void> {
-  const openOrders: string[] = await OpenOrdersCache.getOpenOrderIds(clobPairId, redisClient);
-  expect(openOrders).toHaveLength(openOrderIds.length);
-  openOrderIds.forEach((orderId: string) => {
-    expect(openOrders).toContain(orderId);
-  });
 }
 
 export function setTransactionHash(

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -10,7 +10,6 @@ import {
 } from '@dydxprotocol-indexer/postgres';
 import {
   CanceledOrdersCache,
-  OpenOrdersCache,
   OrderbookLevelsCache,
   placeOrder,
   PlaceOrderResult,
@@ -105,18 +104,7 @@ export class OrderPlaceHandler extends Handler {
       update,
     );
 
-    // TODO(IND-68): Error on this case once replacements are done by first removing the order, then
-    // placing a new order.
     if (placeOrderResult.replaced) {
-      // Replaced orders are no longer counted as resting on the book until an order update message
-      // is received, so remove the order from the set of open orders when replaced.
-      const clobPairId: string = order.orderId!.clobPairId.toString();
-      await OpenOrdersCache.removeOpenOrder(
-        redisOrder.id,
-        clobPairId,
-        redisClient,
-      );
-      // TODO(IND-172): Replace this with a logger.error call
       stats.increment(`${config.SERVICE_NAME}.place_order_handler.replaced_order`, 1);
     }
 

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -20,7 +20,6 @@ import {
   OrderType,
 } from '@dydxprotocol-indexer/postgres';
 import {
-  OpenOrdersCache,
   OrderbookLevelsCache,
   OrdersCache,
   RemoveOrderResult,
@@ -112,15 +111,6 @@ export class OrderRemoveHandler extends Handler {
       orderRemove,
       removeOrderResult,
     });
-
-    if (removeOrderResult.removed) {
-      const clobPairId: string = orderRemove.removedOrderId!.clobPairId.toString();
-      await OpenOrdersCache.removeOpenOrder(
-        removeOrderResult.removedOrder!.id,
-        clobPairId,
-        redisClient,
-      );
-    }
 
     if (
       orderRemove.reason === OrderRemovalReason.ORDER_REMOVAL_REASON_INDEXER_EXPIRED

--- a/indexer/services/vulcan/src/handlers/order-update-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-update-handler.ts
@@ -14,7 +14,6 @@ import {
   updateOrder,
   UpdateOrderResult,
   OrderbookLevelsCache,
-  OpenOrdersCache,
   StatefulOrderUpdatesCache,
 } from '@dydxprotocol-indexer/redis';
 import { isStatefulOrder, requiresImmediateExecution } from '@dydxprotocol-indexer/v4-proto-parser';
@@ -106,25 +105,6 @@ export class OrderUpdateHandler extends Handler {
         },
       );
       return;
-    }
-
-    const clobPairId: string = orderUpdate.orderId!.clobPairId.toString();
-    if (orderUpdate.totalFilledQuantums.gte(updateResult.order!.order!.quantums)) {
-      // TODO(IND-147): Remove once fully-filled orders are removed.
-      // If total filled >= quantums of the order, the order is fully-filled and no longer
-      // considered an open order
-      await OpenOrdersCache.removeOpenOrder(
-        updateResult.order!.id,
-        clobPairId,
-        redisClient,
-      );
-    } else {
-      // If the order is not fully filled, consider it an open order.
-      await OpenOrdersCache.addOpenOrder(
-        updateResult.order!.id,
-        clobPairId,
-        redisClient,
-      );
     }
 
     const sizeDeltaInQuantums: Big = this.getSizeDeltaInQuantums(updateResult, orderUpdate);


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed `OpenOrdersCache` usage across multiple services and handlers, simplifying the logic for managing open orders.

- **Tests**
  - Updated test cases to remove references to `OpenOrdersCache` and related functions, ensuring tests align with the new logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->