### PR TITLE
Revert "Add a channel buffer to decouple abci and grpc streaming (#15…

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"math/big"
 	"net/http"
@@ -458,9 +457,6 @@ func New(
 			}
 			if app.SlinkyClient != nil {
 				app.SlinkyClient.Stop()
-			}
-			if app.GrpcStreamingManager != nil {
-				app.GrpcStreamingManager.Stop()
 			}
 			return nil
 		},
@@ -1674,7 +1670,6 @@ func (app *App) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
 	}
 	block := app.IndexerEventManager.ProduceBlock(ctx)
 	app.IndexerEventManager.SendOnchainData(block)
-	app.GrpcStreamingManager.EmitMetrics()
 	return response, err
 }
 
@@ -1692,7 +1687,6 @@ func (app *App) PrepareCheckStater(ctx sdk.Context) {
 	if err := app.ModuleManager.PrepareCheckState(ctx); err != nil {
 		panic(err)
 	}
-	app.GrpcStreamingManager.EmitMetrics()
 }
 
 // InitChainer application update at chain initialization.
@@ -1936,9 +1930,8 @@ func getGrpcStreamingManagerFromOptions(
 	logger log.Logger,
 ) (manager streamingtypes.GrpcStreamingManager) {
 	if appFlags.GrpcStreamingEnabled {
-		grpcStreamingBufferSize := uint32(appFlags.GrpcStreamingBufferSize)
-		logger.Info(fmt.Sprintf("GRPC streaming is enabled with buffer size %d", grpcStreamingBufferSize))
-		return streaming.NewGrpcStreamingManager(logger, grpcStreamingBufferSize)
+		logger.Info("GRPC streaming is enabled")
+		return streaming.NewGrpcStreamingManager()
 	}
 	return streaming.NewNoopGrpcStreamingManager()
 }

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -21,9 +21,8 @@ type Flags struct {
 	GrpcEnable  bool
 
 	// Grpc Streaming
-	GrpcStreamingEnabled    bool
-	GrpcStreamingBufferSize uint16
-	VEOracleEnabled         bool // Slinky Vote Extensions
+	GrpcStreamingEnabled bool
+	VEOracleEnabled      bool // Slinky Vote Extensions
 }
 
 // List of CLI flags.
@@ -38,8 +37,7 @@ const (
 	GrpcEnable  = "grpc.enable"
 
 	// Grpc Streaming
-	GrpcStreamingEnabled    = "grpc-streaming-enabled"
-	GrpcStreamingBufferSize = "grpc-streaming-buffer-size"
+	GrpcStreamingEnabled = "grpc-streaming-enabled"
 
 	// Slinky VEs enabled
 	VEOracleEnabled = "slinky-vote-extension-oracle-enabled"
@@ -53,9 +51,7 @@ const (
 	DefaultDdErrorTrackingFormat = false
 
 	DefaultGrpcStreamingEnabled = false
-	// TODO(jonfung) better value after stress testing
-	DefaultGrpcStreamingBufferSize = 1000
-	DefaultVEOracleEnabled         = true
+	DefaultVEOracleEnabled      = true
 )
 
 // AddFlagsToCmd adds flags to app initialization.
@@ -88,11 +84,6 @@ func AddFlagsToCmd(cmd *cobra.Command) {
 		GrpcStreamingEnabled,
 		DefaultGrpcStreamingEnabled,
 		"Whether to enable grpc streaming for full nodes",
-	)
-	cmd.Flags().Uint16(
-		GrpcStreamingBufferSize,
-		DefaultGrpcStreamingBufferSize,
-		"Protocol-side buffer channel size to store grpc stream updates before dropping messages",
 	)
 	cmd.Flags().Bool(
 		VEOracleEnabled,
@@ -133,9 +124,8 @@ func GetFlagValuesFromOptions(
 		GrpcAddress: config.DefaultGRPCAddress,
 		GrpcEnable:  true,
 
-		GrpcStreamingEnabled:    DefaultGrpcStreamingEnabled,
-		GrpcStreamingBufferSize: DefaultGrpcStreamingBufferSize,
-		VEOracleEnabled:         true,
+		GrpcStreamingEnabled: DefaultGrpcStreamingEnabled,
+		VEOracleEnabled:      true,
 	}
 
 	// Populate the flags if they exist.
@@ -178,12 +168,6 @@ func GetFlagValuesFromOptions(
 	if option := appOpts.Get(GrpcStreamingEnabled); option != nil {
 		if v, err := cast.ToBoolE(option); err == nil {
 			result.GrpcStreamingEnabled = v
-		}
-	}
-
-	if option := appOpts.Get(GrpcStreamingBufferSize); option != nil {
-		if v, err := cast.ToUint16E(option); err == nil {
-			result.GrpcStreamingBufferSize = v
 		}
 	}
 

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -32,9 +32,6 @@ func TestAddFlagsToCommand(t *testing.T) {
 		fmt.Sprintf("Has %s flag", flags.GrpcStreamingEnabled): {
 			flagName: flags.GrpcStreamingEnabled,
 		},
-		fmt.Sprintf("Has %s flag", flags.GrpcStreamingBufferSize): {
-			flagName: flags.GrpcStreamingBufferSize,
-		},
 	}
 
 	for name, tc := range tests {
@@ -66,10 +63,9 @@ func TestValidate(t *testing.T) {
 		},
 		"success - gRPC streaming enabled for validating nodes": {
 			flags: flags.Flags{
-				NonValidatingFullNode:   false,
-				GrpcEnable:              true,
-				GrpcStreamingEnabled:    true,
-				GrpcStreamingBufferSize: 15,
+				NonValidatingFullNode: false,
+				GrpcEnable:            true,
+				GrpcStreamingEnabled:  true,
 			},
 		},
 		"failure - gRPC disabled": {
@@ -111,7 +107,6 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 		expectedGrpcAddress               string
 		expectedGrpcEnable                bool
 		expectedGrpcStreamingEnable       bool
-		expectedGrpcStreamingBufferSize   uint16
 	}{
 		"Sets to default if unset": {
 			expectedNonValidatingFullNodeFlag: false,
@@ -120,7 +115,6 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 			expectedGrpcAddress:               "localhost:9090",
 			expectedGrpcEnable:                true,
 			expectedGrpcStreamingEnable:       false,
-			expectedGrpcStreamingBufferSize:   1000,
 		},
 		"Sets values from options": {
 			optsMap: map[string]any{
@@ -130,7 +124,6 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 				flags.GrpcEnable:                false,
 				flags.GrpcAddress:               "localhost:9091",
 				flags.GrpcStreamingEnabled:      "true",
-				flags.GrpcStreamingBufferSize:   "15",
 			},
 			expectedNonValidatingFullNodeFlag: true,
 			expectedDdAgentHost:               "agentHostTest",
@@ -138,7 +131,6 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 			expectedGrpcEnable:                false,
 			expectedGrpcAddress:               "localhost:9091",
 			expectedGrpcStreamingEnable:       true,
-			expectedGrpcStreamingBufferSize:   15,
 		},
 	}
 
@@ -175,21 +167,6 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 				t,
 				tc.expectedGrpcAddress,
 				flags.GrpcAddress,
-			)
-			require.Equal(
-				t,
-				tc.expectedGrpcAddress,
-				flags.GrpcAddress,
-			)
-			require.Equal(
-				t,
-				tc.expectedGrpcStreamingEnable,
-				flags.GrpcStreamingEnabled,
-			)
-			require.Equal(
-				t,
-				tc.expectedGrpcStreamingBufferSize,
-				flags.GrpcStreamingBufferSize,
 			)
 		})
 	}

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -68,8 +68,6 @@ const (
 	FullNodeGrpc                    = "full_node_grpc"
 	GrpcSendOrderbookUpdatesLatency = "grpc_send_orderbook_updates_latency"
 	GrpcSendOrderbookFillsLatency   = "grpc_send_orderbook_fills_latency"
-	GrpcStreamingBufferSize         = "grpc_streaming_buffer_size"
-	GrpcStreamingNumConnections     = "grpc_streaming_num_connections"
 	EndBlocker                      = "end_blocker"
 	EndBlockerLag                   = "end_blocker_lag"
 )

--- a/protocol/streaming/grpc/grpc_streaming_manager.go
+++ b/protocol/streaming/grpc/grpc_streaming_manager.go
@@ -1,11 +1,9 @@
 package grpc
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
-	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
 	ocutypes "github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates/types"
@@ -19,26 +17,11 @@ var _ types.GrpcStreamingManager = (*GrpcStreamingManagerImpl)(nil)
 
 // GrpcStreamingManagerImpl is an implementation for managing gRPC streaming subscriptions.
 type GrpcStreamingManagerImpl struct {
-	logger log.Logger
 	sync.Mutex
 
 	// orderbookSubscriptions maps subscription IDs to their respective orderbook subscriptions.
 	orderbookSubscriptions map[uint32]*OrderbookSubscription
 	nextSubscriptionId     uint32
-
-	// Readonly buffer to enqueue orderbook updates before pushing them through grpc streams.
-	// Decouples the execution of abci logic with full node streaming.
-	updateBuffer           chan bufferInternalResponse
-	updateBufferWindowSize uint32
-}
-
-// bufferInternalResponse is enqueued into the readonly buffer.
-// It contains an update respnose and the clob pair id to send this information to.
-type bufferInternalResponse struct {
-	response clobtypes.StreamOrderbookUpdatesResponse
-
-	// Information relevant to which Orderbook Subscription to send out to
-	clobPairId uint32
 }
 
 // OrderbookSubscription represents a active subscription to the orderbook updates stream.
@@ -53,76 +36,14 @@ type OrderbookSubscription struct {
 	srv clobtypes.Query_StreamOrderbookUpdatesServer
 }
 
-func NewGrpcStreamingManager(
-	logger log.Logger,
-	bufferWindow uint32,
-) *GrpcStreamingManagerImpl {
-	grpcStreamingManager := &GrpcStreamingManagerImpl{
-		logger:                 logger.With("module", "grpc-streaming"),
+func NewGrpcStreamingManager() *GrpcStreamingManagerImpl {
+	return &GrpcStreamingManagerImpl{
 		orderbookSubscriptions: make(map[uint32]*OrderbookSubscription),
-		nextSubscriptionId:     0,
-
-		updateBuffer:           make(chan bufferInternalResponse, bufferWindow),
-		updateBufferWindowSize: bufferWindow,
 	}
-
-	// Worker goroutine to consistently read from channel and send out updates
-	go func() {
-		for internalResponse := range grpcStreamingManager.updateBuffer {
-			grpcStreamingManager.sendUpdateResponse(internalResponse)
-		}
-	}()
-
-	return grpcStreamingManager
 }
 
 func (sm *GrpcStreamingManagerImpl) Enabled() bool {
 	return true
-}
-
-func (sm *GrpcStreamingManagerImpl) Stop() {
-	close(sm.updateBuffer)
-}
-
-func (sm *GrpcStreamingManagerImpl) EmitMetrics() {
-	metrics.SetGauge(metrics.GrpcStreamingBufferSize, float32(len(sm.updateBuffer)))
-	metrics.SetGauge(metrics.GrpcStreamingNumConnections, float32(len(sm.orderbookSubscriptions)))
-}
-
-func (sm *GrpcStreamingManagerImpl) removeSubscription(id uint32) {
-	sm.logger.Info(
-		fmt.Sprintf(
-			"Removing orderbook subscriptions for subscription id %+v",
-			id,
-		),
-	)
-	delete(sm.orderbookSubscriptions, id)
-}
-
-func (sm *GrpcStreamingManagerImpl) sendUpdateResponse(
-	internalResponse bufferInternalResponse,
-) {
-	// Send update to subscribers.
-	subscriptionIdsToRemove := make([]uint32, 0)
-
-	for id, subscription := range sm.orderbookSubscriptions {
-		for _, clobPairId := range subscription.clobPairIds {
-			if clobPairId == internalResponse.clobPairId {
-				if err := subscription.srv.Send(
-					&internalResponse.response,
-				); err != nil {
-					sm.logger.Error("Error sending out update", "err", err)
-					subscriptionIdsToRemove = append(subscriptionIdsToRemove, id)
-				}
-			}
-		}
-	}
-	// Clean up subscriptions that have been closed.
-	// If a Send update has failed for any clob pair id, the whole subscription will be removed.
-	for _, id := range subscriptionIdsToRemove {
-		sm.removeSubscription(id)
-	}
-	sm.EmitMetrics()
 }
 
 // Subscribe subscribes to the orderbook updates stream.
@@ -149,13 +70,89 @@ func (sm *GrpcStreamingManagerImpl) Subscribe(
 
 	sm.orderbookSubscriptions[sm.nextSubscriptionId] = subscription
 	sm.nextSubscriptionId++
-	sm.logger.Info(fmt.Sprintf("New GRPC Stream Connection established, %+v", clobPairIds))
+
 	return nil
 }
 
+// SendOrderbookUpdates groups updates by their clob pair ids and
+// sends messages to the subscribers.
+func (sm *GrpcStreamingManagerImpl) SendOrderbookUpdates(
+	offchainUpdates *clobtypes.OffchainUpdates,
+	snapshot bool,
+	blockHeight uint32,
+	execMode sdk.ExecMode,
+) {
+	defer metrics.ModuleMeasureSince(
+		metrics.FullNodeGrpc,
+		metrics.GrpcSendOrderbookUpdatesLatency,
+		time.Now(),
+	)
+
+	// Group updates by clob pair id.
+	updates := make(map[uint32]*clobtypes.OffchainUpdates)
+	for _, message := range offchainUpdates.Messages {
+		clobPairId := message.OrderId.ClobPairId
+		if _, ok := updates[clobPairId]; !ok {
+			updates[clobPairId] = clobtypes.NewOffchainUpdates()
+		}
+		updates[clobPairId].Messages = append(updates[clobPairId].Messages, message)
+	}
+
+	// Unmarshal messages to v1 updates.
+	v1updates := make(map[uint32][]ocutypes.OffChainUpdateV1)
+	for clobPairId, update := range updates {
+		v1update, err := GetOffchainUpdatesV1(update)
+		if err != nil {
+			panic(err)
+		}
+		v1updates[clobPairId] = v1update
+	}
+
+	sm.Lock()
+	defer sm.Unlock()
+
+	// Send updates to subscribers.
+	idsToRemove := make([]uint32, 0)
+	for id, subscription := range sm.orderbookSubscriptions {
+		updatesToSend := make([]ocutypes.OffChainUpdateV1, 0)
+		for _, clobPairId := range subscription.clobPairIds {
+			if updates, ok := v1updates[clobPairId]; ok {
+				updatesToSend = append(updatesToSend, updates...)
+			}
+		}
+
+		if len(updatesToSend) > 0 {
+			streamUpdates := clobtypes.StreamUpdate{
+				UpdateMessage: &clobtypes.StreamUpdate_OrderbookUpdate{
+					OrderbookUpdate: &clobtypes.StreamOrderbookUpdate{
+						Updates:  updatesToSend,
+						Snapshot: snapshot,
+					},
+				},
+			}
+			if err := subscription.srv.Send(
+				&clobtypes.StreamOrderbookUpdatesResponse{
+					Updates:     []clobtypes.StreamUpdate{streamUpdates},
+					BlockHeight: blockHeight,
+					ExecMode:    uint32(execMode),
+				},
+			); err != nil {
+				idsToRemove = append(idsToRemove, id)
+			}
+		}
+	}
+
+	// Clean up subscriptions that have been closed.
+	// If a Send update has failed for any clob pair id, the whole subscription will be removed.
+	for _, id := range idsToRemove {
+		delete(sm.orderbookSubscriptions, id)
+	}
+}
+
 // SendOrderbookFillUpdates groups fills by their clob pair ids and
-// enqueues messages to be sent to the subscribers.
+// sends messages to the subscribers.
 func (sm *GrpcStreamingManagerImpl) SendOrderbookFillUpdates(
+	ctx sdk.Context,
 	orderbookFills []clobtypes.StreamOrderbookFill,
 	blockHeight uint32,
 	execMode sdk.ExecMode,
@@ -165,8 +162,6 @@ func (sm *GrpcStreamingManagerImpl) SendOrderbookFillUpdates(
 		metrics.GrpcSendOrderbookFillsLatency,
 		time.Now(),
 	)
-	sm.Lock()
-	defer sm.Unlock()
 
 	// Group fills by clob pair id.
 	updatesByClobPairId := make(map[uint32][]clobtypes.StreamUpdate)
@@ -186,89 +181,37 @@ func (sm *GrpcStreamingManagerImpl) SendOrderbookFillUpdates(
 		updatesByClobPairId[clobPairId] = append(updatesByClobPairId[clobPairId], streamUpdate)
 	}
 
-	// Send response updates into the stream buffer
-	for clobPairId, streamUpdates := range updatesByClobPairId {
-		streamResponse := clobtypes.StreamOrderbookUpdatesResponse{
-			Updates:     streamUpdates,
-			BlockHeight: blockHeight,
-			ExecMode:    uint32(execMode),
-		}
-
-		sm.mustEnqueueOrderbookUpdate(bufferInternalResponse{
-			response:   streamResponse,
-			clobPairId: clobPairId,
-		})
-	}
-}
-
-// SendOrderbookUpdates groups updates by their clob pair ids and
-// enqueues messages to be sent to the subscribers.
-func (sm *GrpcStreamingManagerImpl) SendOrderbookUpdates(
-	offchainUpdates *clobtypes.OffchainUpdates,
-	snapshot bool,
-	blockHeight uint32,
-	execMode sdk.ExecMode,
-) {
-	defer metrics.ModuleMeasureSince(
-		metrics.FullNodeGrpc,
-		metrics.GrpcSendOrderbookUpdatesLatency,
-		time.Now(),
-	)
 	sm.Lock()
 	defer sm.Unlock()
 
-	// Group updates by clob pair id.
-	updatesByClobPairId := make(map[uint32]*clobtypes.OffchainUpdates)
-	for _, message := range offchainUpdates.Messages {
-		clobPairId := message.OrderId.ClobPairId
-		if _, ok := updatesByClobPairId[clobPairId]; !ok {
-			updatesByClobPairId[clobPairId] = clobtypes.NewOffchainUpdates()
+	// Send updates to subscribers.
+	idsToRemove := make([]uint32, 0)
+	for id, subscription := range sm.orderbookSubscriptions {
+		streamUpdatesForSubscription := make([]clobtypes.StreamUpdate, 0)
+		for _, clobPairId := range subscription.clobPairIds {
+			if update, ok := updatesByClobPairId[clobPairId]; ok {
+				streamUpdatesForSubscription = append(streamUpdatesForSubscription, update...)
+			}
 		}
-		updatesByClobPairId[clobPairId].Messages = append(updatesByClobPairId[clobPairId].Messages, message)
-	}
 
-	// Unmarshal messages to v1 updates and enqueue in buffer to be sent.
-	for clobPairId, update := range updatesByClobPairId {
-		v1updates, err := GetOffchainUpdatesV1(update)
-		if err != nil {
-			panic(err)
-		}
-		streamUpdate := clobtypes.StreamUpdate{
-			UpdateMessage: &clobtypes.StreamUpdate_OrderbookUpdate{
-				OrderbookUpdate: &clobtypes.StreamOrderbookUpdate{
-					Updates:  v1updates,
-					Snapshot: snapshot,
+		if len(streamUpdatesForSubscription) > 0 {
+			if err := subscription.srv.Send(
+				&clobtypes.StreamOrderbookUpdatesResponse{
+					Updates:     streamUpdatesForSubscription,
+					BlockHeight: blockHeight,
+					ExecMode:    uint32(execMode),
 				},
-			},
+			); err != nil {
+				idsToRemove = append(idsToRemove, id)
+			}
 		}
-		sm.mustEnqueueOrderbookUpdate(bufferInternalResponse{
-			response: clobtypes.StreamOrderbookUpdatesResponse{
-				Updates:     []clobtypes.StreamUpdate{streamUpdate},
-				BlockHeight: blockHeight,
-				ExecMode:    uint32(execMode),
-			},
-			clobPairId: clobPairId,
-		})
 	}
-}
 
-// mustEnqueueOrderbookUpdate tries to enqueue an orderbook update to the buffer via non-blocking send.
-// If the buffer is full, *all* streaming subscriptions will be shut down.
-func (sm *GrpcStreamingManagerImpl) mustEnqueueOrderbookUpdate(internalResponse bufferInternalResponse) {
-	select {
-	case sm.updateBuffer <- internalResponse:
-	default:
-		sm.logger.Error("GRPC Streaming buffer full capacity. Dropping messages and all subscriptions. " +
-			"Disconnect all clients and increase buffer size via the `grpc-streaming-buffer-size flag.")
-		for k := range sm.orderbookSubscriptions {
-			sm.removeSubscription(k)
-		}
-		// Clear out the buffer
-		for len(sm.updateBuffer) > 0 {
-			<-sm.updateBuffer
-		}
+	// Clean up subscriptions that have been closed.
+	// If a Send update has failed for any clob pair id, the whole subscription will be removed.
+	for _, id := range idsToRemove {
+		delete(sm.orderbookSubscriptions, id)
 	}
-	sm.EmitMetrics()
 }
 
 // GetUninitializedClobPairIds returns the clob pair ids that have not been initialized.

--- a/protocol/streaming/grpc/noop_streaming_manager.go
+++ b/protocol/streaming/grpc/noop_streaming_manager.go
@@ -36,6 +36,7 @@ func (sm *NoopGrpcStreamingManager) SendOrderbookUpdates(
 }
 
 func (sm *NoopGrpcStreamingManager) SendOrderbookFillUpdates(
+	ctx sdk.Context,
 	orderbookFills []clobtypes.StreamOrderbookFill,
 	blockHeight uint32,
 	execMode sdk.ExecMode,
@@ -44,10 +45,4 @@ func (sm *NoopGrpcStreamingManager) SendOrderbookFillUpdates(
 
 func (sm *NoopGrpcStreamingManager) GetUninitializedClobPairIds() []uint32 {
 	return []uint32{}
-}
-
-func (sm *NoopGrpcStreamingManager) Stop() {
-}
-
-func (sm *NoopGrpcStreamingManager) EmitMetrics() {
 }

--- a/protocol/streaming/grpc/types/manager.go
+++ b/protocol/streaming/grpc/types/manager.go
@@ -22,9 +22,8 @@ type GrpcStreamingManager interface {
 		blockHeight uint32,
 		execMode sdk.ExecMode,
 	)
-	Stop()
-	EmitMetrics()
 	SendOrderbookFillUpdates(
+		ctx sdk.Context,
 		orderbookFills []clobtypes.StreamOrderbookFill,
 		blockHeight uint32,
 		execMode sdk.ExecMode,

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -302,6 +302,7 @@ func (k Keeper) SendOrderbookFillUpdates(
 		return
 	}
 	k.GetGrpcStreamingManager().SendOrderbookFillUpdates(
+		ctx,
 		orderbookFills,
 		lib.MustConvertIntegerToUint32(ctx.BlockHeight()),
 		ctx.ExecMode(),


### PR DESCRIPTION
…30)"

This reverts commit bd91a7379f3512b61c1b437c34eb1579b5be1f72.

Reverts channel-based design, going to try batching


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed GRPC streaming management functionality to simplify the codebase.
  - Updated flag handling by removing `GrpcStreamingBufferSize` and modifying related flags.
  - Streamlined metric keys by removing unused constants.
  - Enhanced `GrpcStreamingManager` to efficiently handle updates without logging dependencies.
  - Updated methods to include context parameters for better consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->