### PR TITLE
[OTE-378] Remove offchain updates from `ProcessSingleMatch`

### DIFF
--- a/protocol/mocks/ClobKeeper.go
+++ b/protocol/mocks/ClobKeeper.go
@@ -1019,7 +1019,7 @@ func (_m *ClobKeeper) ProcessProposerOperations(ctx types.Context, operations []
 }
 
 // ProcessSingleMatch provides a mock function with given fields: ctx, matchWithOrders
-func (_m *ClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, *clobtypes.OffchainUpdates, error) {
+func (_m *ClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, error) {
 	ret := _m.Called(ctx, matchWithOrders)
 
 	if len(ret) == 0 {
@@ -1029,9 +1029,8 @@ func (_m *ClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *clo
 	var r0 bool
 	var r1 subaccountstypes.UpdateResult
 	var r2 subaccountstypes.UpdateResult
-	var r3 *clobtypes.OffchainUpdates
-	var r4 error
-	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, *clobtypes.OffchainUpdates, error)); ok {
+	var r3 error
+	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, error)); ok {
 		return rf(ctx, matchWithOrders)
 	}
 	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MatchWithOrders) bool); ok {
@@ -1052,21 +1051,13 @@ func (_m *ClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *clo
 		r2 = ret.Get(2).(subaccountstypes.UpdateResult)
 	}
 
-	if rf, ok := ret.Get(3).(func(types.Context, *clobtypes.MatchWithOrders) *clobtypes.OffchainUpdates); ok {
+	if rf, ok := ret.Get(3).(func(types.Context, *clobtypes.MatchWithOrders) error); ok {
 		r3 = rf(ctx, matchWithOrders)
 	} else {
-		if ret.Get(3) != nil {
-			r3 = ret.Get(3).(*clobtypes.OffchainUpdates)
-		}
+		r3 = ret.Error(3)
 	}
 
-	if rf, ok := ret.Get(4).(func(types.Context, *clobtypes.MatchWithOrders) error); ok {
-		r4 = rf(ctx, matchWithOrders)
-	} else {
-		r4 = ret.Error(4)
-	}
-
-	return r0, r1, r2, r3, r4
+	return r0, r1, r2, r3
 }
 
 // PruneStateFillAmountsForShortTermOrders provides a mock function with given fields: ctx

--- a/protocol/mocks/MemClobKeeper.go
+++ b/protocol/mocks/MemClobKeeper.go
@@ -310,7 +310,7 @@ func (_m *MemClobKeeper) OffsetSubaccountPerpetualPosition(ctx types.Context, li
 }
 
 // ProcessSingleMatch provides a mock function with given fields: ctx, matchWithOrders
-func (_m *MemClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, *clobtypes.OffchainUpdates, error) {
+func (_m *MemClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, error) {
 	ret := _m.Called(ctx, matchWithOrders)
 
 	if len(ret) == 0 {
@@ -320,9 +320,8 @@ func (_m *MemClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *
 	var r0 bool
 	var r1 subaccountstypes.UpdateResult
 	var r2 subaccountstypes.UpdateResult
-	var r3 *clobtypes.OffchainUpdates
-	var r4 error
-	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, *clobtypes.OffchainUpdates, error)); ok {
+	var r3 error
+	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MatchWithOrders) (bool, subaccountstypes.UpdateResult, subaccountstypes.UpdateResult, error)); ok {
 		return rf(ctx, matchWithOrders)
 	}
 	if rf, ok := ret.Get(0).(func(types.Context, *clobtypes.MatchWithOrders) bool); ok {
@@ -343,21 +342,13 @@ func (_m *MemClobKeeper) ProcessSingleMatch(ctx types.Context, matchWithOrders *
 		r2 = ret.Get(2).(subaccountstypes.UpdateResult)
 	}
 
-	if rf, ok := ret.Get(3).(func(types.Context, *clobtypes.MatchWithOrders) *clobtypes.OffchainUpdates); ok {
+	if rf, ok := ret.Get(3).(func(types.Context, *clobtypes.MatchWithOrders) error); ok {
 		r3 = rf(ctx, matchWithOrders)
 	} else {
-		if ret.Get(3) != nil {
-			r3 = ret.Get(3).(*clobtypes.OffchainUpdates)
-		}
+		r3 = ret.Error(3)
 	}
 
-	if rf, ok := ret.Get(4).(func(types.Context, *clobtypes.MatchWithOrders) error); ok {
-		r4 = rf(ctx, matchWithOrders)
-	} else {
-		r4 = ret.Error(4)
-	}
-
-	return r0, r1, r2, r3, r4
+	return r0, r1, r2, r3
 }
 
 // ReplayPlaceOrder provides a mock function with given fields: ctx, msg

--- a/protocol/testutil/memclob/keeper.go
+++ b/protocol/testutil/memclob/keeper.go
@@ -331,7 +331,6 @@ func (f *FakeMemClobKeeper) ProcessSingleMatch(
 	success bool,
 	takerUpdateResult satypes.UpdateResult,
 	makerUpdateResult satypes.UpdateResult,
-	offchainUpdates *types.OffchainUpdates,
 	err error,
 ) {
 	makerOrder := matchWithOrders.MakerOrder
@@ -364,7 +363,7 @@ func (f *FakeMemClobKeeper) ProcessSingleMatch(
 			)
 		}
 
-		return true, satypes.Success, satypes.Success, types.NewOffchainUpdates(), nil
+		return true, satypes.Success, satypes.Success, nil
 	}
 
 	subaccountMatchedOrders := make(map[satypes.SubaccountId][]types.PendingOpenOrder)
@@ -411,7 +410,7 @@ func (f *FakeMemClobKeeper) ProcessSingleMatch(
 		}
 	}
 
-	return success, takerUpdateResult, makerUpdateResult, types.NewOffchainUpdates(), nil
+	return success, takerUpdateResult, makerUpdateResult, nil
 }
 
 func (f *FakeMemClobKeeper) GetStatePosition(

--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -506,7 +506,7 @@ func (k Keeper) PersistMatchOrdersToState(
 		}
 		makerOrders = append(makerOrders, makerOrder)
 
-		_, _, _, _, err = k.ProcessSingleMatch(ctx, &matchWithOrders)
+		_, _, _, err = k.ProcessSingleMatch(ctx, &matchWithOrders)
 		if err != nil {
 			return err
 		}
@@ -614,7 +614,7 @@ func (k Keeper) PersistMatchLiquidationToState(
 
 		// Write the position updates and state fill amounts for this match.
 		// Note stateless validation on the constructed `matchWithOrders` is performed within this function.
-		_, _, _, _, err = k.ProcessSingleMatch(
+		_, _, _, err = k.ProcessSingleMatch(
 			ctx,
 			&matchWithOrders,
 		)

--- a/protocol/x/clob/keeper/process_operations_test.go
+++ b/protocol/x/clob/keeper/process_operations_test.go
@@ -2349,7 +2349,6 @@ func setupProcessProposerOperationsTestCase(
 			tc.rawOperations,
 		)
 	} else {
-		mockIndexerEventManager.On("Enabled").Return(false).Maybe()
 		mockIndexerEventManager.On("AddTxnEvent",
 			mock.Anything,
 			mock.Anything,
@@ -2584,10 +2583,6 @@ func setupNewMockEventManager(
 	matches []*MatchWithOrdersForTesting,
 	rawOperations []types.OperationRaw,
 ) {
-	if len(matches) > 0 {
-		mockIndexerEventManager.On("Enabled").Return(true)
-	}
-
 	// Add an expectation to the mock for each expected message.
 	var matchOrderCallMap = make(map[types.OrderId]*mock.Call)
 	for _, match := range matches {

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -9,7 +9,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/log"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
@@ -46,7 +45,6 @@ func (k Keeper) ProcessSingleMatch(
 	success bool,
 	takerUpdateResult satypes.UpdateResult,
 	makerUpdateResult satypes.UpdateResult,
-	offchainUpdates *types.OffchainUpdates,
 	err error,
 ) {
 	if matchWithOrders.TakerOrder.IsLiquidation() {
@@ -74,14 +72,13 @@ func (k Keeper) ProcessSingleMatch(
 
 	// Perform stateless validation on the match.
 	if err := matchWithOrders.Validate(); err != nil {
-		return false, takerUpdateResult, makerUpdateResult, nil, errorsmod.Wrapf(
+		return false, takerUpdateResult, makerUpdateResult, errorsmod.Wrapf(
 			err,
 			"ProcessSingleMatch: Invalid MatchWithOrders: %+v",
 			matchWithOrders,
 		)
 	}
 
-	offchainUpdates = types.NewOffchainUpdates()
 	makerMatchableOrder := matchWithOrders.MakerOrder
 	takerMatchableOrder := matchWithOrders.TakerOrder
 	fillAmount := matchWithOrders.FillAmount
@@ -90,7 +87,7 @@ func (k Keeper) ProcessSingleMatch(
 	clobPairId := makerMatchableOrder.GetClobPairId()
 	clobPair, found := k.GetClobPair(ctx, clobPairId)
 	if !found {
-		return false, takerUpdateResult, makerUpdateResult, nil, types.ErrInvalidClob
+		return false, takerUpdateResult, makerUpdateResult, types.ErrInvalidClob
 	}
 
 	// Verify that the `fillAmount` is divisible by the `StepBaseQuantums` of the `clobPair`.
@@ -98,7 +95,6 @@ func (k Keeper) ProcessSingleMatch(
 		return false,
 			takerUpdateResult,
 			makerUpdateResult,
-			nil,
 			types.ErrFillAmountNotDivisibleByStepSize
 	}
 
@@ -108,7 +104,7 @@ func (k Keeper) ProcessSingleMatch(
 	// Calculate the number of quote quantums for the match based on the maker order subticks.
 	bigFillQuoteQuantums, err := getFillQuoteQuantums(clobPair, makerSubticks, fillAmount)
 	if err != nil {
-		return false, takerUpdateResult, makerUpdateResult, nil, err
+		return false, takerUpdateResult, makerUpdateResult, err
 	}
 
 	if bigFillQuoteQuantums.Sign() == 0 {
@@ -131,7 +127,7 @@ func (k Keeper) ProcessSingleMatch(
 	// Retrieve the associated perpetual id for the `ClobPair`.
 	perpetualId, err := clobPair.GetPerpetualId()
 	if err != nil {
-		return false, takerUpdateResult, makerUpdateResult, nil, err
+		return false, takerUpdateResult, makerUpdateResult, err
 	}
 
 	// Calculate taker and maker fee ppms.
@@ -157,7 +153,7 @@ func (k Keeper) ProcessSingleMatch(
 		)
 
 		if err != nil {
-			return false, takerUpdateResult, makerUpdateResult, nil, err
+			return false, takerUpdateResult, makerUpdateResult, err
 		}
 	}
 
@@ -190,7 +186,7 @@ func (k Keeper) ProcessSingleMatch(
 		)
 
 		if err != nil {
-			return false, takerUpdateResult, makerUpdateResult, nil, err
+			return false, takerUpdateResult, makerUpdateResult, err
 		}
 	}
 
@@ -212,7 +208,7 @@ func (k Keeper) ProcessSingleMatch(
 	)
 
 	if err != nil {
-		return false, takerUpdateResult, makerUpdateResult, nil, err
+		return false, takerUpdateResult, makerUpdateResult, err
 	}
 
 	// Update both subaccounts in the matched order atomically.
@@ -227,7 +223,7 @@ func (k Keeper) ProcessSingleMatch(
 	)
 
 	if err != nil {
-		return false, takerUpdateResult, makerUpdateResult, nil, err
+		return false, takerUpdateResult, makerUpdateResult, err
 	}
 
 	// Update subaccount total quantums liquidated and total insurance fund lost for liquidation orders.
@@ -238,7 +234,7 @@ func (k Keeper) ProcessSingleMatch(
 			fillAmount.ToBigInt(),
 		)
 		if err != nil {
-			return false, takerUpdateResult, makerUpdateResult, nil, err
+			return false, takerUpdateResult, makerUpdateResult, err
 		}
 
 		k.UpdateSubaccountLiquidationInfo(
@@ -275,24 +271,22 @@ func (k Keeper) ProcessSingleMatch(
 	// Liquidation orders can only be placed when a subaccount is liquidatable
 	// and cannot be replayed, therefore we don't need to track their filled amount in state.
 	if !matchWithOrders.TakerOrder.IsLiquidation() {
-		takerOffchainUpdates := k.setOrderFillAmountsAndPruning(
+		k.setOrderFillAmountsAndPruning(
 			ctx,
 			matchWithOrders.TakerOrder.MustGetOrder(),
 			newTakerTotalFillAmount,
 			curTakerPruneableBlockHeight,
 		)
-		offchainUpdates.Append(takerOffchainUpdates)
 	}
 
-	makerOffchainUpdates := k.setOrderFillAmountsAndPruning(
+	k.setOrderFillAmountsAndPruning(
 		ctx,
 		matchWithOrders.MakerOrder.MustGetOrder(),
 		newMakerTotalFillAmount,
 		curMakerPruneableBlockHeight,
 	)
-	offchainUpdates.Append(makerOffchainUpdates)
 
-	return true, takerUpdateResult, makerUpdateResult, offchainUpdates, nil
+	return true, takerUpdateResult, makerUpdateResult, nil
 }
 
 // persistMatchedOrders persists a matched order to the subaccount state,
@@ -501,10 +495,9 @@ func (k Keeper) setOrderFillAmountsAndPruning(
 	order types.Order,
 	newTotalFillAmount satypes.BaseQuantums,
 	curPruneableBlockHeight uint32,
-) *types.OffchainUpdates {
+) {
 	// Note that stateful orders are never pruned by `BlockHeight`, so we set the value to `math.MaxUint32` here.
 	pruneableBlockHeight := uint32(math.MaxUint32)
-	offchainUpdates := types.NewOffchainUpdates()
 
 	if !order.IsStatefulOrder() {
 		// Compute the block at which this state fill amount can be pruned. This is the greater of
@@ -540,21 +533,6 @@ func (k Keeper) setOrderFillAmountsAndPruning(
 		newTotalFillAmount,
 		pruneableBlockHeight,
 	)
-
-	if k.GetIndexerEventManager().Enabled() {
-		if _, exists := k.MemClob.GetOrder(order.OrderId); exists {
-			// Generate an off-chain update message updating the total filled amount of order.
-			if message, success := off_chain_updates.CreateOrderUpdateMessage(
-				ctx,
-				order.OrderId,
-				newTotalFillAmount,
-			); success {
-				offchainUpdates.AddUpdateMessage(order.OrderId, message)
-			}
-		}
-	}
-
-	return offchainUpdates
 }
 
 // getUpdatedOrderFillAmount accepts an order's current total fill amount, total base quantums, and a new fill amount,

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -1680,7 +1680,7 @@ func (m *MemClobPriceTimePriority) mustPerformTakerOrderMatching(
 			FillAmount: matchedAmount,
 		}
 
-		success, takerUpdateResult, makerUpdateResult, _, err := m.clobKeeper.ProcessSingleMatch(ctx, &matchWithOrders)
+		success, takerUpdateResult, makerUpdateResult, err := m.clobKeeper.ProcessSingleMatch(ctx, &matchWithOrders)
 		if err != nil && !errors.Is(err, satypes.ErrFailedToUpdateSubaccounts) {
 			if errors.Is(err, types.ErrLiquidationExceedsSubaccountMaxInsuranceLost) {
 				// Subaccount has reached max insurance lost block limit. Stop matching.

--- a/protocol/x/clob/types/clob_keeper.go
+++ b/protocol/x/clob/types/clob_keeper.go
@@ -89,7 +89,6 @@ type ClobKeeper interface {
 		success bool,
 		takerUpdateResult satypes.UpdateResult,
 		makerUpdateResult satypes.UpdateResult,
-		offchainUpdates *OffchainUpdates,
 		err error,
 	)
 	SetLongTermOrderPlacement(

--- a/protocol/x/clob/types/mem_clob_keeper.go
+++ b/protocol/x/clob/types/mem_clob_keeper.go
@@ -26,7 +26,6 @@ type MemClobKeeper interface {
 		success bool,
 		takerUpdateResult satypes.UpdateResult,
 		makerUpdateResult satypes.UpdateResult,
-		offchainUpdates *OffchainUpdates,
 		err error,
 	)
 	CanDeleverageSubaccount(


### PR DESCRIPTION
### Changelist
Remove `OffchainUpdates` as a return value from `ProcessSingleMatch`. This field is not currently used anywhere. Populating this field requires read access to MemClob, which would result in unsafe concurrent map read during `DeliverTx` if OE is enabled on indexer full node.

### Test Plan
Existing tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the `ProcessSingleMatch` function across multiple modules by removing the `offchainUpdates` parameter and return type.

- **Bug Fixes**
  - Improved error handling in the `ProcessSingleMatch` function, enhancing stability and reliability.

- **Performance Improvements**
  - Streamlined order processing logic, reducing unnecessary off-chain update message generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->