### PR TITLE
chore: make struct comments match struct names

### DIFF
--- a/protocol/app/prepare/prepare_proposal.go
+++ b/protocol/app/prepare/prepare_proposal.go
@@ -33,7 +33,7 @@ type FundingTxResponse struct {
 	NumVotes int
 }
 
-// OperationTxResponse represents a response for creating 'ProposedOperations' tx
+// OperationsTxResponse represents a response for creating 'ProposedOperations' tx
 type OperationsTxResponse struct {
 	Tx            []byte
 	NumOperations int

--- a/protocol/app/process/market_price_decoder.go
+++ b/protocol/app/process/market_price_decoder.go
@@ -5,7 +5,7 @@ import (
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
-// MarketPriceDecoder is an interface for decoding market price transactions, This interface is responsible
+// UpdateMarketPriceTxDecoder is an interface for decoding market price transactions, This interface is responsible
 // for distinguishing between logic for unmarshalling MarketPriceUpdates, between MarketPriceUpdates
 // determined by the proposer's price-cache, and from VoteExtensions.
 type UpdateMarketPriceTxDecoder interface {


### PR DESCRIPTION
### Changelist

make struct comments match struct names

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed `OperationTxResponse` to `OperationsTxResponse` for consistency in naming conventions.
  - Renamed `MarketPriceDecoder` interface to `UpdateMarketPriceTxDecoder` for better clarity and understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->