### PR TITLE
Remove unneeded memstores

### DIFF
--- a/protocol/x/clob/abci_test.go
+++ b/protocol/x/clob/abci_test.go
@@ -807,11 +807,11 @@ func TestEndBlocker_Success(t *testing.T) {
 			for _, triggeredConditionalOrderId := range actualProcessProposerMatchesEvents.
 				ConditionalOrderIdsTriggeredInLastBlock {
 				// TODO(CLOB-746) Once R/W methods are created, substitute those methods here.
-				triggeredConditionalOrderMemstore := ks.ClobKeeper.GetTriggeredConditionalOrderPlacementMemStore(ctx)
-				untriggeredConditionalOrderMemstore := ks.ClobKeeper.GetUntriggeredConditionalOrderPlacementMemStore(ctx)
-				exists := triggeredConditionalOrderMemstore.Has(triggeredConditionalOrderId.ToStateKey())
+				triggeredConditionalOrderStore := ks.ClobKeeper.GetTriggeredConditionalOrderPlacementStore(ctx)
+				untriggeredConditionalOrderStore := ks.ClobKeeper.GetUntriggeredConditionalOrderPlacementStore(ctx)
+				exists := triggeredConditionalOrderStore.Has(triggeredConditionalOrderId.ToStateKey())
 				require.True(t, exists)
-				exists = untriggeredConditionalOrderMemstore.Has(triggeredConditionalOrderId.ToStateKey())
+				exists = untriggeredConditionalOrderStore.Has(triggeredConditionalOrderId.ToStateKey())
 				require.False(t, exists)
 			}
 

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -215,7 +215,6 @@ func (k Keeper) InitMemStore(ctx sdk.Context) {
 
 	// Initialize all the necessary memory stores.
 	for _, keyPrefix := range []string{
-		types.OrderAmountFilledKeyPrefix,
 		types.StatefulOrderKeyPrefix,
 	} {
 		// Retrieve an instance of the memstore.

--- a/protocol/x/clob/keeper/order_state_test.go
+++ b/protocol/x/clob/keeper/order_state_test.go
@@ -582,10 +582,6 @@ func TestRemoveOrderFillAmount(t *testing.T) {
 					string(constants.Order_Alice_Num1_Clob0_Id4_Buy10_Price45_GTB20.OrderId.ToStateKey()),
 				types.OrderAmountFilledKeyPrefix +
 					string(constants.Order_Alice_Num1_Clob0_Id4_Buy10_Price45_GTB20.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num1_Clob0_Id4_Buy10_Price45_GTB20.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num1_Clob0_Id4_Buy10_Price45_GTB20.OrderId.ToStateKey()),
 			},
 		},
 		"SetOrderFillAmount twice and then RemoveOrderFillAmount removes the fill amount": {
@@ -617,12 +613,6 @@ func TestRemoveOrderFillAmount(t *testing.T) {
 					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
 				types.OrderAmountFilledKeyPrefix +
 					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
 			},
 		},
 		"RemoveOrderFillAmount with non-existent order": {
@@ -632,8 +622,6 @@ func TestRemoveOrderFillAmount(t *testing.T) {
 			},
 			expectedExists: false,
 			expectedMultiStoreWrites: []string{
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
 				types.OrderAmountFilledKeyPrefix +
 					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
 			},
@@ -662,12 +650,6 @@ func TestRemoveOrderFillAmount(t *testing.T) {
 			expectedExists:     true,
 			expectedFillAmount: 50,
 			expectedMultiStoreWrites: []string{
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
 				types.OrderAmountFilledKeyPrefix +
 					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
 				types.OrderAmountFilledKeyPrefix +
@@ -704,12 +686,6 @@ func TestRemoveOrderFillAmount(t *testing.T) {
 			expectedMultiStoreWrites: []string{
 				types.OrderAmountFilledKeyPrefix +
 					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Alice_Num0_Id0_Clob0_Buy5_Price10_GTB15.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Bob_Num0_Id0_Clob1_Sell10_Price15_GTB20.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.Order_Bob_Num0_Id0_Clob1_Sell10_Price15_GTB20.OrderId.ToStateKey()),
 				types.OrderAmountFilledKeyPrefix +
 					string(constants.Order_Bob_Num0_Id0_Clob1_Sell10_Price15_GTB20.OrderId.ToStateKey()),
 				types.OrderAmountFilledKeyPrefix +

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -144,13 +144,9 @@ func TestPlaceShortTermOrder(t *testing.T) {
 				types.PrunableOrdersKeyPrefix,
 				// Update taker order fill amount
 				types.OrderAmountFilledKeyPrefix,
-				// Update taker order fill amount in memStore
-				types.OrderAmountFilledKeyPrefix,
 				// Update prunable block height for maker fill amount
 				types.PrunableOrdersKeyPrefix,
 				// Update maker order fill amount
-				types.OrderAmountFilledKeyPrefix,
-				// Update maker order fill amount in memStore
 				types.OrderAmountFilledKeyPrefix,
 			},
 			expectedOpenInterests: map[uint32]*big.Int{
@@ -396,13 +392,9 @@ func TestPlaceShortTermOrder(t *testing.T) {
 				types.PrunableOrdersKeyPrefix,
 				// Update taker order fill amount
 				types.OrderAmountFilledKeyPrefix,
-				// Update taker order fill amount in memStore
-				types.OrderAmountFilledKeyPrefix,
 				// Update prunable block height for maker fill amount
 				types.PrunableOrdersKeyPrefix,
 				// Update maker order fill amount
-				types.OrderAmountFilledKeyPrefix,
-				// Update maker order fill amount in memStore
 				types.OrderAmountFilledKeyPrefix,
 			},
 			expectedOpenInterests: map[uint32]*big.Int{
@@ -754,14 +746,10 @@ func TestAddPreexistingStatefulOrder(t *testing.T) {
 				indexer_manager.IndexerEventsCountKey,
 				// Update block stats
 				statstypes.BlockStatsKey,
-				// Update taker order fill amount to state and memStore.
+				// Update taker order fill amount to state.
 				types.OrderAmountFilledKeyPrefix +
 					string(constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10.OrderId.ToStateKey()),
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10.OrderId.ToStateKey()),
-				// Update maker order fill amount to state and memStore.
-				types.OrderAmountFilledKeyPrefix +
-					string(constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10.OrderId.ToStateKey()),
+				// Update maker order fill amount to state.
 				types.OrderAmountFilledKeyPrefix +
 					string(constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10.OrderId.ToStateKey()),
 			},
@@ -2434,11 +2422,9 @@ func TestPlaceConditionalOrdersTriggeredInLastBlock(t *testing.T) {
 				longTermOrderPlacementBytes := ks.Cdc.MustMarshal(&longTermOrderPlacement)
 
 				store := ks.ClobKeeper.GetTriggeredConditionalOrderPlacementStore(ctx)
-				memstore := ks.ClobKeeper.GetTriggeredConditionalOrderPlacementMemStore(ctx)
 
 				orderKey := order.OrderId.ToStateKey()
 				store.Set(orderKey, longTermOrderPlacementBytes)
-				memstore.Set(orderKey, longTermOrderPlacementBytes)
 			}
 
 			// Write to untriggered orders state
@@ -2449,11 +2435,9 @@ func TestPlaceConditionalOrdersTriggeredInLastBlock(t *testing.T) {
 				longTermOrderPlacementBytes := ks.Cdc.MustMarshal(&longTermOrderPlacement)
 
 				store := ks.ClobKeeper.GetUntriggeredConditionalOrderPlacementStore(ctx)
-				memstore := ks.ClobKeeper.GetUntriggeredConditionalOrderPlacementMemStore(ctx)
 
 				orderKey := order.OrderId.ToStateKey()
 				store.Set(orderKey, longTermOrderPlacementBytes)
-				memstore.Set(orderKey, longTermOrderPlacementBytes)
 			}
 
 			// Assert expected order placement memclob calls.

--- a/protocol/x/clob/keeper/stateful_order_state_test.go
+++ b/protocol/x/clob/keeper/stateful_order_state_test.go
@@ -167,18 +167,14 @@ func TestMustTriggerConditionalOrder(t *testing.T) {
 		return orderPlacement, true
 	}
 
-	triggeredConditionalOrderMemStore := ks.ClobKeeper.GetTriggeredConditionalOrderPlacementMemStore(ks.Ctx)
 	triggeredConditionalOrderStore := ks.ClobKeeper.GetTriggeredConditionalOrderPlacementStore(ks.Ctx)
-	untriggeredConditionalOrderMemStore := ks.ClobKeeper.GetUntriggeredConditionalOrderPlacementMemStore(ks.Ctx)
 	untriggeredConditionalOrderStore := ks.ClobKeeper.GetUntriggeredConditionalOrderPlacementStore(ks.Ctx)
 
-	// Verify that the triggered conditional order does not exist in untriggered memstore/store
+	// Verify that the triggered conditional order does not exist in untriggered store
 	_, found = getOrderFromStore(conditionalOrder.OrderId, untriggeredConditionalOrderStore)
 	require.False(t, found)
-	_, found = getOrderFromStore(conditionalOrder.OrderId, untriggeredConditionalOrderMemStore)
-	require.False(t, found)
 
-	// Verify that the triggered conditional order does exist in triggered memstore/store
+	// Verify that the triggered conditional order does exist in triggered store
 	longTermOrderPlacement, found = getOrderFromStore(conditionalOrder.OrderId, triggeredConditionalOrderStore)
 	require.True(t, found)
 	require.Equal(
@@ -191,8 +187,6 @@ func TestMustTriggerConditionalOrder(t *testing.T) {
 		uint32(0),
 		longTermOrderPlacement.PlacementIndex.BlockHeight,
 	)
-	_, found = getOrderFromStore(conditionalOrder.OrderId, triggeredConditionalOrderMemStore)
-	require.True(t, found)
 	require.Equal(
 		t,
 		conditionalOrder,
@@ -211,24 +205,18 @@ func TestMustTriggerConditionalOrder(t *testing.T) {
 	traceDecoder.RequireKeyPrefixWrittenInSequence(
 		t,
 		[]string{
-			// Write the order to untriggered state and memStore and increment the stateful order
+			// Write the order to untriggered state and increment the stateful order
 			// count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
-			types.UntriggeredConditionalOrderKeyPrefix +
-				orderToStringId(conditionalOrder),
 			types.UntriggeredConditionalOrderKeyPrefix +
 				orderToStringId(conditionalOrder),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(conditionalOrder),
 			types.NextStatefulOrderBlockTransactionIndexKey,
-			// Write to triggered state and memstore
+			// Write to triggered state
 			types.TriggeredConditionalOrderKeyPrefix +
 				orderToStringId(conditionalOrder),
-			types.TriggeredConditionalOrderKeyPrefix +
-				orderToStringId(conditionalOrder),
-			// Delete from state and memstore
-			types.UntriggeredConditionalOrderKeyPrefix +
-				orderToStringId(conditionalOrder),
+			// Delete from state
 			types.UntriggeredConditionalOrderKeyPrefix +
 				orderToStringId(conditionalOrder),
 		},
@@ -338,92 +326,68 @@ func TestGetSetDeleteLongTermOrderState(t *testing.T) {
 	traceDecoder.RequireKeyPrefixWrittenInSequence(
 		t,
 		[]string{
-			// Delete the order from state and memStore and decrement the stateful order count.
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-			types.StatefulOrderCountPrefix +
-				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-			// Write the order to state and memStore and increment the stateful order count.
-			types.NextStatefulOrderBlockTransactionIndexKey,
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
+			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-			// Delete the order from state and memStore and decrement the stateful order count.
+			// Write the order to state and increment the stateful order count.
+			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
+				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
+			types.StatefulOrderCountPrefix +
+				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
+			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-			// Write the order to state and memStore and increment the stateful order count.
+			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-			// Delete the order from state and memStore and decrement the stateful order count.
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
+			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
-			// Write the order to state and memStore and increment the stateful order count.
+			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
-			// Delete the order from state and memStore and decrement the stateful order count.
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
+			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-			// Delete the order from state and memStore and decrement the stateful order count.
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
+			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-			// Delete the order from state and memStore and decrement the stateful order count.
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
+			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
-			// Write the order to state and memStore and increment the stateful order count.
+			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-			// Write the order to state and memStore and increment the stateful order count.
+			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-			// Write the order to state and memStore and increment the stateful order count.
+			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
 			types.StatefulOrderCountPrefix +
@@ -490,24 +454,18 @@ func TestGetSetDeleteLongTermOrderState_Replacements(t *testing.T) {
 	traceDecoder.RequireKeyPrefixWrittenInSequence(
 		t,
 		[]string{
-			// Write the order to state and memStore and increment the stateful order count.
+			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 			types.StatefulOrderCountPrefix +
 				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-			// Write the order to state and memStore. We should not expect the stateful order
+			// Write the order to state. We should not expect the stateful order
 			// count to change since this is a replacement.
 			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-			// Delete the order from state and memStore and decrement the stateful order count.
-			types.LongTermOrderPlacementKeyPrefix +
-				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
+			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 			types.StatefulOrderCountPrefix +
@@ -630,12 +588,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set first stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
-				// Place the first stateful order in state and memStore and increment the stateful order count.
+				// Place the first stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
 				types.StatefulOrderCountPrefix +
@@ -645,12 +599,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set second stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				// Place the second stateful order in state and memStore and increment the stateful order count.
+				// Place the second stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.StatefulOrderCountPrefix +
@@ -660,12 +610,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set third stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				// Place the third stateful order in state and memStore and increment the stateful order count.
+				// Place the third stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				types.StatefulOrderCountPrefix +
@@ -715,12 +661,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set first stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
-				// Place the first stateful order in state and memStore and increment the stateful order count.
+				// Place the first stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
 				types.StatefulOrderCountPrefix +
@@ -730,12 +672,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set second stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				// Place the second stateful order in state and memStore and increment the stateful order count.
+				// Place the second stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.StatefulOrderCountPrefix +
@@ -745,37 +683,25 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set third stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				// Place the third stateful order in state and memStore and increment the stateful order count.
+				// Place the third stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				types.StatefulOrderCountPrefix +
 					orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				// Remove first order from stateful order slice, which removes the fill amount, stateful
-				// order placement from state and memStore, and decrement the stateful order count.
+				// order placement from state, and decrement the stateful order count.
 				types.StatefulOrdersTimeSlicePrefix + "1970-01-01T00:00:30.000000000",
 				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.StatefulOrderCountPrefix +
 					orderToStringSubaccountId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				// Remove second order from stateful order slice, which removes the fill amount, stateful
-				// order placement from state and memStore, and decrement the stateful order count.
+				// order placement from state, and decrement the stateful order count.
 				types.StatefulOrdersTimeSlicePrefix + "1970-01-01T00:00:15.000000000",
 				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
@@ -844,12 +770,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set first stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
-				// Place the first stateful order in state and memStore and increment the stateful order count.
+				// Place the first stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
 				types.StatefulOrderCountPrefix +
@@ -859,12 +781,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set second stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				// Place the second stateful order in state and memStore and increment the stateful order count.
+				// Place the second stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.StatefulOrderCountPrefix +
@@ -873,12 +791,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				types.StatefulOrdersTimeSlicePrefix + "2021-02-21T00:00:00.000000000",
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
-				// Place the third stateful order in state and memStore and increment the stateful order count.
+				// Place the third stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				types.StatefulOrderCountPrefix +
@@ -888,12 +802,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set fourth stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
-				// Place the fourth stateful order in state and memStore and increment the stateful order count.
+				// Place the fourth stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
 				types.StatefulOrderCountPrefix +
@@ -903,12 +813,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set fifth stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
-				// Place the fifth stateful order in state and memStore and increment the stateful order count.
+				// Place the fifth stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				types.StatefulOrderCountPrefix +
@@ -918,12 +824,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set sixth stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-				// Place the sixth stateful order in state and memStore and increment the stateful order count.
+				// Place the sixth stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 				types.StatefulOrderCountPrefix +
@@ -933,12 +835,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set seventh stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-				// Place the seventh stateful order in state and memStore and increment the stateful order count.
+				// Place the seventh stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 				types.StatefulOrderCountPrefix +
@@ -984,12 +882,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set first stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
-				// Place the first stateful order in state and memStore and increment the stateful order count.
+				// Place the first stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				types.StatefulOrderCountPrefix +
@@ -999,12 +893,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set second stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
-				// Place the second stateful order in state and memStore and increment the stateful order count.
+				// Place the second stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				types.StatefulOrderCountPrefix +
@@ -1014,50 +904,34 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set third stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				// Place the third stateful order in state and memStore and increment the stateful order count.
+				// Place the third stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				types.StatefulOrderCountPrefix +
 					orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				// Remove first order from stateful order slice, which removes the fill amount, stateful
-				// order placement from state and memStore, and decrement the stateful order count.
+				// order placement from state, and decrement the stateful order count.
 				types.StatefulOrdersTimeSlicePrefix + "1970-01-01T00:00:15.000000000",
 				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
-				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				types.StatefulOrderCountPrefix +
 					orderToStringSubaccountId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				// Remove second order from stateful order slice, which removes the fill amount, stateful
-				// order placement from state and memStore, and decrement the stateful order count.
+				// order placement from state, and decrement the stateful order count.
 				types.StatefulOrdersTimeSlicePrefix + "1970-01-01T00:00:10.000000000",
 				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
-				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				types.StatefulOrderCountPrefix +
 					orderToStringSubaccountId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				// Remove third order from stateful order slice, which removes the fill amount, stateful
-				// order placement from state and memStore, and decrement the stateful order count.
+				// order placement from state, and decrement the stateful order count.
 				types.StatefulOrdersTimeSlicePrefix + "1970-01-01T00:00:15.000000000",
 				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
-				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15),
@@ -1110,13 +984,9 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set first stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
-				// Place the first stateful order in state and memStore and increment the stateful
+				// Place the first stateful order in state and increment the stateful
 				// order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20),
 				types.StatefulOrderCountPrefix +
@@ -1126,12 +996,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set second stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-				// Place the second stateful order in state and memStore and increment the stateful order count.
+				// Place the second stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 				types.StatefulOrderCountPrefix +
@@ -1141,12 +1007,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set third stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-				// Place the third stateful order in state and memStore and increment the stateful order count.
+				// Place the third stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 				types.StatefulOrderCountPrefix +
@@ -1156,12 +1018,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set fourth stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
-				// Place the fourth stateful order in state and memStore and increment the stateful order count.
+				// Place the fourth stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id0_Clob0_Sell5_Price10_GTBT15_StopLoss15),
 				types.StatefulOrderCountPrefix +
@@ -1171,12 +1029,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set fifth stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
-				// Place the fifth stateful order in state and memStore and increment the stateful order count.
+				// Place the fifth stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.UntriggeredConditionalOrderKeyPrefix +
-					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.UntriggeredConditionalOrderKeyPrefix +
 					orderToStringId(constants.ConditionalOrder_Alice_Num1_Id1_Clob0_Sell50_Price5_GTBT30_TakeProfit10),
 				types.StatefulOrderCountPrefix +
@@ -1185,12 +1039,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				types.StatefulOrdersTimeSlicePrefix + "1970-01-01T00:00:10.000000000",
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
-				// Place the sixth stateful order in state and memStore and increment the stateful order count.
+				// Place the sixth stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num1_Id1_Clob0_Sell25_Price30_GTBT10),
 				types.StatefulOrderCountPrefix +
@@ -1200,12 +1050,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Set seventh stateful order fill amount to a non-zero value in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
-				// Place the seventh stateful order in state and memStore and increment the stateful order count.
+				// Place the seventh stateful order in state and increment the stateful order count.
 				types.NextStatefulOrderBlockTransactionIndexKey,
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
 				types.StatefulOrderCountPrefix +
@@ -1215,12 +1061,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Remove seventh stateful order fill amount in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
-				// Remove the seventh stateful order placement from state and memStore and decrement the stateful
+				// Remove the seventh stateful order placement from state and decrement the stateful
 				// order count.
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10),
 				types.StatefulOrderCountPrefix +
@@ -1230,12 +1072,8 @@ func TestGetAddAndRemoveStatefulOrderTimeSlice(t *testing.T) {
 				// Remove third stateful order fill amount in state.
 				types.OrderAmountFilledKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-				types.OrderAmountFilledKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-				// Remove the third stateful order placement from state and memStore and decrement the stateful
+				// Remove the third stateful order placement from state and decrement the stateful
 				// order count.
-				types.LongTermOrderPlacementKeyPrefix +
-					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 				types.LongTermOrderPlacementKeyPrefix +
 					orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 				types.StatefulOrderCountPrefix +

--- a/protocol/x/clob/keeper/stores.go
+++ b/protocol/x/clob/keeper/stores.go
@@ -21,29 +21,11 @@ func (k Keeper) GetLongTermOrderPlacementStore(ctx sdk.Context) prefix.Store {
 	)
 }
 
-// GetLongTermOrderPlacementMemStore fetches a state store used for creating,
-// reading, updating, and deleting a stateful order placement from state.
-func (k Keeper) GetLongTermOrderPlacementMemStore(ctx sdk.Context) prefix.Store {
-	return prefix.NewStore(
-		ctx.KVStore(k.memKey),
-		[]byte(types.LongTermOrderPlacementKeyPrefix),
-	)
-}
-
 // GetUntriggeredConditionalOrderPlacementStore fetches a state store used for creating,
 // reading, updating, and deleting untriggered conditional order placement from state.
 func (k Keeper) GetUntriggeredConditionalOrderPlacementStore(ctx sdk.Context) prefix.Store {
 	return prefix.NewStore(
 		ctx.KVStore(k.storeKey),
-		[]byte(types.UntriggeredConditionalOrderKeyPrefix),
-	)
-}
-
-// GetUntriggeredConditionalOrderPlacementMemStore fetches a state store used for creating,
-// reading, updating, and deleting a stateful order placement from state.
-func (k Keeper) GetUntriggeredConditionalOrderPlacementMemStore(ctx sdk.Context) prefix.Store {
-	return prefix.NewStore(
-		ctx.KVStore(k.memKey),
 		[]byte(types.UntriggeredConditionalOrderKeyPrefix),
 	)
 }
@@ -96,15 +78,6 @@ func (k Keeper) GetTriggeredConditionalOrderPlacementStore(ctx sdk.Context) pref
 	)
 }
 
-// GetTriggeredConditionalOrderPlacementMemStore fetches a state store used for creating,
-// reading, updating, and deleting a stateful order placement from state.
-func (k Keeper) GetTriggeredConditionalOrderPlacementMemStore(ctx sdk.Context) prefix.Store {
-	return prefix.NewStore(
-		ctx.KVStore(k.memKey),
-		[]byte(types.TriggeredConditionalOrderKeyPrefix),
-	)
-}
-
 // getStatefulOrdersTimeSliceStore fetches a state store used for creating,
 // reading, updating, and deleting a stateful order time slice from state.
 func (k Keeper) getStatefulOrdersTimeSliceStore(ctx sdk.Context) prefix.Store {
@@ -129,21 +102,17 @@ func (k Keeper) getTransientStore(ctx sdk.Context) storetypes.KVStore {
 func (k Keeper) fetchStateStoresForOrder(
 	ctx sdk.Context,
 	orderId types.OrderId,
-) (store prefix.Store, memstore prefix.Store) {
+) prefix.Store {
 	orderId.MustBeStatefulOrder()
 
 	if orderId.IsConditionalOrder() {
 		triggered := k.IsConditionalOrderTriggered(ctx, orderId)
 		if triggered {
-			store = k.GetTriggeredConditionalOrderPlacementStore(ctx)
-			memstore = k.GetTriggeredConditionalOrderPlacementMemStore(ctx)
-			return store, memstore
+			return k.GetTriggeredConditionalOrderPlacementStore(ctx)
 		}
-		store = k.GetUntriggeredConditionalOrderPlacementStore(ctx)
-		memstore = k.GetUntriggeredConditionalOrderPlacementMemStore(ctx)
-		return store, memstore
+		return k.GetUntriggeredConditionalOrderPlacementStore(ctx)
 	} else if orderId.IsLongTermOrder() {
-		return k.GetLongTermOrderPlacementStore(ctx), k.GetLongTermOrderPlacementMemStore(ctx)
+		return k.GetLongTermOrderPlacementStore(ctx)
 	}
 	panic(
 		fmt.Sprintf(

--- a/protocol/x/clob/types/keys.go
+++ b/protocol/x/clob/types/keys.go
@@ -56,10 +56,7 @@ const (
 	// StatefulOrdersTimeSlicePrefix is the key to retrieve a unique list of the stateful orders that
 	// expire at a given timestamp, sorted by order ID.
 	StatefulOrdersTimeSlicePrefix = "ExpTm:"
-)
 
-// Store / Memstore
-const (
 	// TriggeredConditionalOrderKeyPrefix is the key to retrieve an triggered conditional order and
 	// information about when it was triggered.
 	TriggeredConditionalOrderKeyPrefix = PlacedStatefulOrderKeyPrefix + "T:"


### PR DESCRIPTION
### Changelist
- These memstores just result in extra complexity and unneeded writes.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated variable names and refactored storage handling logic for conditional orders to enhance consistency and clarity.
  - Removed redundant lines and unnecessary initializations in test cases and functions.

- **Bug Fixes**
  - Ensured all order placements and state updates consistently use the correct store, improving data integrity.

- **Tests**
  - Enhanced test functions by removing redundant code and improving clarity and efficiency in test setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->