### PR TITLE
increase setup go version to v1.22 in protocol-release

### DIFF
--- a/.github/workflows/protocol-release.yml
+++ b/.github/workflows/protocol-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
       - name: Create Directory
         run: mkdir ./build


### PR DESCRIPTION
### Changelist
Increase the installed go version from v1.21 to v1.22 in the `protocol-release` workflow.
This doesn't seem to currently affect anything as it just downloads v1.22 right afterwards when it realizes it needs it. Just saves a step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Go version in the workflow from 1.21 to 1.22 for better compatibility and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->