### PR TITLE
Disable arm release build

### DIFF
--- a/.github/workflows/protocol-release.yml
+++ b/.github/workflows/protocol-release.yml
@@ -31,15 +31,12 @@ jobs:
       - name: Create Directory
         run: mkdir ./build
       - name: Build Reproducible Linux Binaries
-        run: make distclean build-reproducible
+        run: make distclean build-reproducible-linux-amd64
       - name: Rename Binaries
         run: |
-          mv ./build/dydxprotocold:linux-arm64 ./build/dydxprotocold-${{ env.VERSION }}-linux-arm64
           mv ./build/dydxprotocold:linux-amd64 ./build/dydxprotocold-${{ env.VERSION }}-linux-amd64
       - name: Compress binaries
         run: |
-          tar -cvzf dydxprotocold-${{ env.VERSION }}-linux-arm64.tar.gz \
-            ./build/dydxprotocold-${{ env.VERSION }}-linux-arm64
           tar -cvzf dydxprotocold-${{ env.VERSION }}-linux-amd64.tar.gz \
             ./build/dydxprotocold-${{ env.VERSION }}-linux-amd64
       - name: Create Release
@@ -62,15 +59,6 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: protocol/dydxprotocold-${{ env.VERSION }}-linux-amd64.tar.gz
           asset_name: dydxprotocold-${{ env.VERSION }}-linux-amd64.tar.gz
-          asset_content_type: application/gzip
-      - name: Upload linux-arm64 tar.gz
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: protocol/dydxprotocold-${{ env.VERSION }}-linux-arm64.tar.gz
-          asset_name: dydxprotocold-${{ env.VERSION }}-linux-arm64.tar.gz
           asset_content_type: application/gzip
           # TODO(DEC-1743): add build report and binary check sums
 


### PR DESCRIPTION
### Changelist
This build is taking too long, and I don't think anyone uses it. Disable for now.

### Test Plan
Tried running a release with new workflow.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build process to target specific Linux architectures.
	- Removed upload step for `linux-arm64` architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->