### PR TITLE
[TRA-355] add script to derive vault

### DIFF
--- a/protocol/scripts/vault/get_vault.go
+++ b/protocol/scripts/vault/get_vault.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	appconfig "github.com/dydxprotocol/v4-chain/protocol/app/config"
+	vaultcli "github.com/dydxprotocol/v4-chain/protocol/x/vault/client/cli"
+	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+)
+
+/*
+main derives a vault (in essence a subaccount) given its type and number.
+This output can be used in a transaction to deposit into a vault.
+
+Usage:
+
+	go run scripts/vault/get_vault.go -type <vault_type> -number <vault_number>
+*/
+func main() {
+	// ------------ FLAGS ------------
+	// Get flags.
+	var vaultTypeStr string
+	var vaultNumberStr string
+	flag.StringVar(&vaultTypeStr, "type", "clob", "vault type")
+	flag.StringVar(&vaultNumberStr, "number", "0", "vault number")
+	flag.Parse()
+
+	// Convert vault type string to VaultType.
+	vaultType, err := vaultcli.GetVaultTypeFromString(vaultTypeStr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Convert vault number string to uint32.
+	vaultNumberParsed, err := strconv.ParseUint(vaultNumberStr, 10, 32)
+	if err != nil {
+		log.Fatal(err)
+	}
+	vaultNumber := uint32(vaultNumberParsed)
+
+	// Print the flags used.
+	fmt.Println("Using the following configuration (modifiable via flags):")
+	fmt.Println("type:", vaultType)
+	fmt.Println("number:", vaultNumber)
+	fmt.Println()
+
+	// ------------ LOGIC ------------
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(appconfig.Bech32PrefixAccAddr, appconfig.Bech32PrefixAccPub)
+
+	vaultId := vaulttypes.VaultId{
+		Type:   vaultType,
+		Number: vaultNumber,
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	vault := vaultId.ToSubaccountId()
+
+	// ------------ OUTPUT ------------
+	fmt.Printf("Vault:\n  Owner: %s\n  Number: %d\n", vault.Owner, vault.Number)
+}


### PR DESCRIPTION
### Changelist
add a script to derive a vault (its subaccount) given its type and number.

e.g.
```
tianqin@Tians-MacBook-Pro protocol % go run scripts/vault/get_vault.go -type clob -number 0
Using the following configuration (modifiable via flags):
type: VAULT_TYPE_CLOB
number: 0

Vault:
  Owner: dydx1c0m5x87llaunl5sgv3q5vd7j5uha26d2q2r2q0
  Number: 0

```

### Test Plan
manual testing

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a script to derive and display vault (subaccount) information based on type and number.
  - Added command-line flags for specifying vault type and number.

- **Improvements**
  - Enhanced configuration handling for vaults.

- **Output**
  - Displays derived vault information in a user-friendly format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->