### PR TITLE
Remove unnecessary redact

### DIFF
--- a/indexer/packages/base/src/logger.ts
+++ b/indexer/packages/base/src/logger.ts
@@ -5,7 +5,6 @@
 import winston from 'winston';
 
 import config from './config';
-import { redact } from './sanitization';
 import { InfoObject } from './types';
 
 // Fix types. The methods available depend on the levels used. We're using syslog levels, so these
@@ -38,8 +37,7 @@ const logger: LoggerExport = winston.createLogger({
     winston.format((info) => {
       return {
         ...info,           // info contains some symbols that are lost when the object is cloned.
-        ...redact(info),
-        error: info.error, // cloning with redact() may break the error object
+        error: info.error,
       };
     })(),
     winston.format.json(),

--- a/indexer/packages/base/src/sanitization.ts
+++ b/indexer/packages/base/src/sanitization.ts
@@ -1,31 +1,6 @@
 import traverse from 'traverse';
 
-// Common request headers which should be redacted. Normalized to all-lowercase.
-export const DEFAULT_SECRET_KEYS = [
-  'Authorization',
-  'X-Routing-Key', // Used by PagerDuty.
-];
-
-const DEFAULT_REDACTED_PLACEHOLDER = '[REDACTED]';
 const JSON_CIRCULAR_PLACEHOLDER = '[CIRCULAR]';
-
-/**
- * Creates a deep copy of an object with values redacted where the key matches `secretKeys`.
- */
-export function redact<T>(
-  obj: T,
-  secretKeys: string[] = DEFAULT_SECRET_KEYS,
-  placeholder: string = DEFAULT_REDACTED_PLACEHOLDER,
-): T {
-  const normalizedSecretKeys = secretKeys.map((s) => s.toLowerCase());
-
-  // eslint-disable-next-line array-callback-return
-  return traverse(obj).map(function traverseFunction(this: traverse.TraverseContext, value: {}) {
-    if (normalizedSecretKeys.includes(this.key?.toLowerCase() as string) && value !== null) {
-      this.update(placeholder);
-    }
-  });
-}
 
 /**
  * Creates a deep copy of an object with circular references removed or replaced.


### PR DESCRIPTION
### Changelist
This function was copied from v3 but it's not actually useful.
From the profiling it also takes the majority of the logging time for all logs in-aggregate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved logging by removing unnecessary redaction of specific keys.
  - Enhanced sanitization by refocusing on removing circular references instead of specific key redactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->