### PR TITLE
remove no-sampling setting from metric in message forwarder

### DIFF
--- a/indexer/services/socks/src/lib/message-forwarder.ts
+++ b/indexer/services/socks/src/lib/message-forwarder.ts
@@ -3,7 +3,6 @@ import {
   logger,
   InfoObject,
   safeJsonStringify,
-  STATS_NO_SAMPLING,
 } from '@dydxprotocol-indexer/base';
 import { updateOnMessageFunction } from '@dydxprotocol-indexer/kafka';
 import { KafkaMessage } from 'kafkajs';
@@ -147,7 +146,7 @@ export class MessageForwarder {
         stats.timing(
           `${config.SERVICE_NAME}.message_time_since_received`,
           startForwardMessage - Number(originalMessageTimestamp),
-          STATS_NO_SAMPLING,
+          config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
           {
             topic,
             event_type: String(message.headers?.event_type),


### PR DESCRIPTION
### Changelist
This seems to be an accidental inclusion originally. Message forwarder should sample all metrics for performance reasons.

### Test Plan
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the sampling rate configuration for statistics tracking in message forwarding to use a configurable parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->