### PR TITLE
Ensure message forwarder samples all stats

### DIFF
--- a/indexer/services/socks/src/lib/message-forwarder.ts
+++ b/indexer/services/socks/src/lib/message-forwarder.ts
@@ -3,7 +3,6 @@ import {
   logger,
   InfoObject,
   safeJsonStringify,
-  STATS_NO_SAMPLING,
 } from '@dydxprotocol-indexer/base';
 import { updateOnMessageFunction } from '@dydxprotocol-indexer/kafka';
 import { KafkaMessage } from 'kafkajs';
@@ -147,7 +146,7 @@ export class MessageForwarder {
         stats.timing(
           `${config.SERVICE_NAME}.message_time_since_received`,
           startForwardMessage - Number(originalMessageTimestamp),
-          STATS_NO_SAMPLING,
+          config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
           {
             topic,
             event_type: String(message.headers?.event_type),


### PR DESCRIPTION
### Changelist
Ensure message forwarder samples all stats

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the sampling rate configuration for statistics tracking in the message forwarder to use the new `MESSAGE_FORWARDER_STATSD_SAMPLE_RATE` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->