### PR TITLE
Move off-chain-updates tests to its own package

### DIFF
--- a/protocol/indexer/off_chain_updates/off_chain_updates.go
+++ b/protocol/indexer/off_chain_updates/off_chain_updates.go
@@ -48,7 +48,7 @@ func CreateOrderPlaceMessage(
 		return msgsender.Message{}, false
 	}
 
-	update, err := newOrderPlaceMessage(order)
+	update, err := NewOrderPlaceMessage(order)
 	if err != nil {
 		log.ErrorLogWithError(
 			ctx,
@@ -92,7 +92,7 @@ func CreateOrderReplaceMessage(
 		return msgsender.Message{}, false
 	}
 
-	update, err := newOrderReplaceMessage(order)
+	update, err := NewOrderReplaceMessage(order)
 	if err != nil {
 		log.ErrorLogWithError(
 			ctx,
@@ -139,7 +139,7 @@ func CreateOrderUpdateMessage(
 		return msgsender.Message{}, false
 	}
 
-	update, err := newOrderUpdateMessage(orderId, totalFilled)
+	update, err := NewOrderUpdateMessage(orderId, totalFilled)
 	if err != nil {
 		log.ErrorLogWithError(
 			ctx,
@@ -192,7 +192,7 @@ func CreateOrderRemoveMessageWithReason(
 		return msgsender.Message{}, false
 	}
 
-	update, err := newOrderRemoveMessage(orderId, reason, removalStatus)
+	update, err := NewOrderRemoveMessage(orderId, reason, removalStatus)
 	if err != nil {
 		log.ErrorLogWithError(
 			ctx,
@@ -284,9 +284,9 @@ func CreateOrderRemoveMessageWithDefaultReason(
 	return CreateOrderRemoveMessageWithReason(ctx, orderId, reason, removalStatus)
 }
 
-// newOrderPlaceMessage returns an `OffChainUpdate` struct populated with an `OrderPlace` struct
+// NewOrderPlaceMessage returns an `OffChainUpdate` struct populated with an `OrderPlace` struct
 // as the `UpdateMessage` parameter, encoded as a byte slice.
-func newOrderPlaceMessage(
+func NewOrderPlaceMessage(
 	order clobtypes.Order,
 ) ([]byte, error) {
 	indexerOrder := v1.OrderToIndexerOrder(order)
@@ -302,10 +302,10 @@ func newOrderPlaceMessage(
 	return proto.Marshal(&update)
 }
 
-// newOrderPlaceMessage returns an `OffChainUpdate` struct populated with an `OrderRemove`
+// NewOrderRemoveMessage returns an `OffChainUpdate` struct populated with an `OrderRemove`
 // struct as the `UpdateMessage` parameter, encoded as a byte slice.
 // The `OrderRemove` struct is instantiated with the given orderId, reason and status parameters.
-func newOrderRemoveMessage(
+func NewOrderRemoveMessage(
 	orderId clobtypes.OrderId,
 	reason sharedtypes.OrderRemovalReason,
 	status ocutypes.OrderRemoveV1_OrderRemovalStatus,
@@ -326,7 +326,7 @@ func newOrderRemoveMessage(
 // NewOrderUpdateMessage returns an `OffChainUpdate` struct populated with an `OrderUpdate`
 // struct as the `UpdateMessage` parameter, encoded as a byte slice.
 // The `OrderUpdate` struct is instantiated with the given orderId and totalFilled parameters.
-func newOrderUpdateMessage(
+func NewOrderUpdateMessage(
 	orderId clobtypes.OrderId,
 	totalFilled satypes.BaseQuantums,
 ) ([]byte, error) {
@@ -342,9 +342,9 @@ func newOrderUpdateMessage(
 	return proto.Marshal(&update)
 }
 
-// newOrderReplaceMessage returns an `OffChainUpdate` struct populated with an `OrderReplace` struct
+// NewOrderReplaceMessage returns an `OffChainUpdate` struct populated with an `OrderReplace` struct
 // as the `UpdateMessage` parameter, encoded as a byte slice.
-func newOrderReplaceMessage(
+func NewOrderReplaceMessage(
 	order clobtypes.Order,
 ) ([]byte, error) {
 	indexerOrder := v1.OrderToIndexerOrder(order)

--- a/protocol/indexer/off_chain_updates/off_chain_updates_test.go
+++ b/protocol/indexer/off_chain_updates/off_chain_updates_test.go
@@ -1,4 +1,4 @@
-package off_chain_updates
+package off_chain_updates_test
 
 import (
 	"testing"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/msgsender"
+	ocu "github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates"
 	ocutypes "github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates/types"
 	v1 "github.com/dydxprotocol/v4-chain/protocol/indexer/protocol/v1"
 	sharedtypes "github.com/dydxprotocol/v4-chain/protocol/indexer/shared/types"
@@ -73,7 +74,7 @@ var (
 
 func TestCreateOrderPlaceMessage(t *testing.T) {
 	ctx, _, _ := sdk.NewSdkContextWithMultistore()
-	actualMessage, success := CreateOrderPlaceMessage(
+	actualMessage, success := ocu.CreateOrderPlaceMessage(
 		ctx,
 		order,
 	)
@@ -90,7 +91,7 @@ func TestCreateOrderPlaceMessage(t *testing.T) {
 
 func TestCreateOrderReplaceMessage(t *testing.T) {
 	ctx, _, _ := sdk.NewSdkContextWithMultistore()
-	actualMessage, success := CreateOrderReplaceMessage(
+	actualMessage, success := ocu.CreateOrderReplaceMessage(
 		ctx,
 		order,
 	)
@@ -108,7 +109,7 @@ func TestCreateOrderReplaceMessage(t *testing.T) {
 func TestCreateOrderUpdateMessage(t *testing.T) {
 	ctx, _, _ := sdk.NewSdkContextWithMultistore()
 
-	actualMessage, success := CreateOrderUpdateMessage(ctx, order.OrderId, totalFilledAmount)
+	actualMessage, success := ocu.CreateOrderUpdateMessage(ctx, order.OrderId, totalFilledAmount)
 	require.True(t, success)
 
 	updateBytes, err := proto.Marshal(&offchainUpdateOrderUpdate)
@@ -123,7 +124,7 @@ func TestCreateOrderUpdateMessage(t *testing.T) {
 func TestCreateOrderRemoveWithReason(t *testing.T) {
 	ctx, _, _ := sdk.NewSdkContextWithMultistore()
 
-	actualMessage, success := CreateOrderRemoveMessage(
+	actualMessage, success := ocu.CreateOrderRemoveMessage(
 		ctx,
 		order.OrderId,
 		orderStatus,
@@ -150,7 +151,7 @@ func TestCreateOrderRemoveMessageWithDefaultReason_HappyPath(t *testing.T) {
 		defaultRemovalReason,
 		"defaultRemovalReason must be different than expectedMessage's removal reason for test to "+
 			"be valid & useful.")
-	actualMessage, success := CreateOrderRemoveMessageWithDefaultReason(
+	actualMessage, success := ocu.CreateOrderRemoveMessageWithDefaultReason(
 		ctx,
 		order.OrderId,
 		orderStatus,
@@ -171,7 +172,7 @@ func TestCreateOrderRemoveMessageWithDefaultReason_HappyPath(t *testing.T) {
 
 func TestCreateOrderRemoveMessageWithDefaultReason_DefaultReasonReturned(t *testing.T) {
 	ctx, _, _ := sdk.NewSdkContextWithMultistore()
-	actualMessage, success := CreateOrderRemoveMessageWithDefaultReason(
+	actualMessage, success := ocu.CreateOrderRemoveMessageWithDefaultReason(
 		ctx,
 		order.OrderId,
 		clobtypes.Success,
@@ -197,7 +198,7 @@ func TestCreateOrderRemoveMessageWithDefaultReason_InvalidDefault(t *testing.T) 
 		t,
 		"Invalid parameter: defaultRemovalReason cannot be OrderRemove_ORDER_REMOVAL_REASON_UNSPECIFIED",
 		func() {
-			CreateOrderRemoveMessageWithDefaultReason(
+			ocu.CreateOrderRemoveMessageWithDefaultReason(
 				ctx,
 				order.OrderId,
 				clobtypes.Success,
@@ -212,7 +213,7 @@ func TestCreateOrderRemoveMessageWithDefaultReason_InvalidDefault(t *testing.T) 
 func TestCreateOrderRemoveWithReasonMessage(t *testing.T) {
 	ctx, _, _ := sdk.NewSdkContextWithMultistore()
 
-	actualMessage, success := CreateOrderRemoveMessageWithReason(
+	actualMessage, success := ocu.CreateOrderRemoveMessageWithReason(
 		ctx,
 		order.OrderId,
 		reason,
@@ -230,7 +231,7 @@ func TestCreateOrderRemoveWithReasonMessage(t *testing.T) {
 }
 
 func TestNewOrderPlaceMessage(t *testing.T) {
-	actualUpdateBytes, err := newOrderPlaceMessage(
+	actualUpdateBytes, err := ocu.NewOrderPlaceMessage(
 		order,
 	)
 	require.NoError(
@@ -254,7 +255,7 @@ func TestNewOrderPlaceMessage(t *testing.T) {
 }
 
 func TestNewOrderUpdateMessage(t *testing.T) {
-	actualUpdateBytes, err := newOrderUpdateMessage(order.OrderId, totalFilledAmount)
+	actualUpdateBytes, err := ocu.NewOrderUpdateMessage(order.OrderId, totalFilledAmount)
 	require.NoError(
 		t,
 		err,
@@ -276,7 +277,7 @@ func TestNewOrderUpdateMessage(t *testing.T) {
 }
 
 func TestNewOrderRemoveMessage(t *testing.T) {
-	actualUpdateBytes, err := newOrderRemoveMessage(order.OrderId, reason, status)
+	actualUpdateBytes, err := ocu.NewOrderRemoveMessage(order.OrderId, reason, status)
 	require.NoError(
 		t,
 		err,
@@ -313,7 +314,7 @@ func TestGetOrderIdHash(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			hash, err := GetOrderIdHash(tc.orderId)
+			hash, err := ocu.GetOrderIdHash(tc.orderId)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedHash, hash)
 		})
@@ -395,7 +396,7 @@ func TestShouldSendOrderRemovalOnReplay(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			shouldSend := ShouldSendOrderRemovalOnReplay(tc.orderError)
+			shouldSend := ocu.ShouldSendOrderRemovalOnReplay(tc.orderError)
 			require.Equal(t, tc.expected, shouldSend)
 		})
 	}


### PR DESCRIPTION
### Changelist
- Was getting error `indexer/off_chain_updates/off_chain_updates.go:1: : import cycle not allowed in test` while working on another pr. Moved test into a new package to fix the issue.
- Make some off-chain-updates functions public to allow for testing
- Fix a typo in the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed functions to follow a consistent naming convention for creating order update messages.
  - Updated test package and references to align with new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->