### PR TITLE
[CT-913] Fix issue where pnl wasn't being calculated for some subaccounts

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
@@ -184,14 +184,27 @@ describe('PnlTicks store', () => {
       }),
     ]);
 
-    const latestBlocktime: string = await PnlTicksTable.findLatestProcessedBlocktime();
+    const {
+      maxBlockTime, count,
+    }: {
+      maxBlockTime: string,
+      count: number
+    } = await PnlTicksTable.findLatestProcessedBlocktimeAndCount();
 
-    expect(latestBlocktime).toEqual(blockTime);
+    expect(maxBlockTime).toEqual(blockTime);
+    expect(count).toEqual(2);
   });
 
   it('Successfully finds latest block time without any pnl ticks', async () => {
-    const latestBlocktime: string = await PnlTicksTable.findLatestProcessedBlocktime();
-    expect(latestBlocktime).toEqual(ZERO_TIME_ISO_8601);
+    const {
+      maxBlockTime, count,
+    }: {
+      maxBlockTime: string,
+      count: number
+    } = await PnlTicksTable.findLatestProcessedBlocktimeAndCount();
+
+    expect(maxBlockTime).toEqual(ZERO_TIME_ISO_8601);
+    expect(count).toEqual(0);
   });
 
   it('createMany PnlTicks, find most recent pnl ticks for each account', async () => {

--- a/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
+++ b/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
@@ -212,17 +212,24 @@ function convertPnlTicksFromDatabaseToPnlTicksCreateObject(
   return _.omit(pnlTicksFromDatabase, PnlTicksColumns.id);
 }
 
-export async function findLatestProcessedBlocktime(): Promise<string> {
+export async function findLatestProcessedBlocktimeAndCount(): Promise<{
+  maxBlockTime: string,
+  count: number,
+}> {
   const result: {
-    rows: [{ max: string }]
+    rows: [{ max: string, count: number }]
   } = await knexReadReplica.getConnection().raw(
     `
-    SELECT MAX("blockTime")
+    SELECT MAX("blockTime") as max, COUNT(*) as count
     FROM "pnl_ticks"
     `
     ,
-  ) as unknown as { rows: [{ max: string }] };
-  return result.rows[0].max || ZERO_TIME_ISO_8601;
+  ) as unknown as { rows: [{ max: string, count: number }] };
+
+  return {
+    maxBlockTime: result.rows[0].max || ZERO_TIME_ISO_8601,
+    count: Number(result.rows[0].count) || 0,
+  };
 }
 
 export async function findMostRecentPnlTickForEachAccount(

--- a/indexer/services/roundtable/__tests__/tasks/create-pnl-ticks.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/create-pnl-ticks.test.ts
@@ -277,9 +277,16 @@ describe('create-pnl-ticks', () => {
         ...testConstants.defaultPnlTick,
         blockTime: testConstants.defaultBlock.time,
       });
-      const blockTimeIsoString: string = await PnlTicksTable.findLatestProcessedBlocktime();
+      const {
+        maxBlockTime,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        count,
+      }: {
+        maxBlockTime: string,
+        count: number,
+      } = await PnlTicksTable.findLatestProcessedBlocktimeAndCount();
 
-      const date: number = Date.parse(blockTimeIsoString).valueOf();
+      const date: number = Date.parse(maxBlockTime).valueOf();
       jest.spyOn(Date, 'now').mockImplementation(() => date);
       jest.spyOn(DateTime, 'utc').mockImplementation(() => dateTime);
       jest.spyOn(logger, 'info');
@@ -305,7 +312,7 @@ describe('create-pnl-ticks', () => {
       expect(pnlTicks.length).toEqual(1);
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: 'Skipping run because update interval has not been reached',
+          message: 'Skipping run because update interval has not been reached and all subaccounts have been processed',
         }),
       );
     });

--- a/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
+++ b/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
@@ -17,26 +17,32 @@ export default async function runTask(): Promise<void> {
   const startGetNewTicks: number = Date.now();
   const [
     block,
-    pnlTickLatestBlocktime,
+    {
+      maxBlockTime,
+      count,
+    },
   ]: [
     BlockFromDatabase,
-    string,
+    {
+      maxBlockTime: string,
+      count: number,
+    },
   ] = await Promise.all([
     BlockTable.getLatest({ readReplica: true }),
-    PnlTicksTable.findLatestProcessedBlocktime(),
+    PnlTicksTable.findLatestProcessedBlocktimeAndCount(),
   ]);
   const latestBlockTime: string = block.time;
   const latestBlockHeight: string = block.blockHeight;
   // Check that the latest block time is within PNL_TICK_UPDATE_INTERVAL_MS of the last computed
   // PNL tick block time.
   if (
-    Date.parse(latestBlockTime) - normalizeStartTime(new Date(pnlTickLatestBlocktime)).getTime() <
-    config.PNL_TICK_UPDATE_INTERVAL_MS
+    Date.parse(latestBlockTime) - normalizeStartTime(new Date(maxBlockTime)).getTime() <
+    config.PNL_TICK_UPDATE_INTERVAL_MS && count < config.PNL_TICK_MAX_ACCOUNTS_PER_RUN
   ) {
     logger.info({
       at: 'create-pnl-ticks#runTask',
-      message: 'Skipping run because update interval has not been reached',
-      pnlTickLatestBlocktime,
+      message: 'Skipping run because update interval has not been reached and all subaccounts have been processed',
+      pnlTickLatestBlocktime: maxBlockTime,
       latestBlockTime,
       threshold: config.PNL_TICK_UPDATE_INTERVAL_MS,
     });


### PR DESCRIPTION
### Changelist
Fix issue where pnl wasn't being calculated for some subaccounts

### Test Plan
Tested in env

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced functionality to provide additional information about the latest processed block time and the count of records.

- **Refactor**
  - Updated methods to return both `maxBlockTime` and `count` for better data insights.
  - Improved logging to include more detailed information about subaccount processing.

- **Tests**
  - Updated test cases to reflect changes in method returns.
  - Added a new test case for subaccount limit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->