### PR TITLE
Set all ints in documentation to ints rather than numbers

### DIFF
--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -77,7 +77,7 @@ fetch(`${baseURL}/addresses/{address}`,
   "subaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0.1,
+      "subaccountNumber": 0,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -97,7 +97,7 @@ fetch(`${baseURL}/addresses/{address}`,
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -115,7 +115,7 @@ fetch(`${baseURL}/addresses/{address}`,
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -124,14 +124,14 @@ fetch(`${baseURL}/addresses/{address}`,
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "marginEnabled": true,
@@ -215,7 +215,7 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
 ```json
 {
   "address": "string",
-  "subaccountNumber": 0.1,
+  "subaccountNumber": 0,
   "equity": "string",
   "freeCollateral": "string",
   "openPerpetualPositions": {
@@ -235,7 +235,7 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     },
     "property2": {
       "market": "string",
@@ -253,7 +253,7 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   },
   "assetPositions": {
@@ -262,14 +262,14 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     },
     "property2": {
       "symbol": "string",
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   },
   "marginEnabled": true,
@@ -350,13 +350,13 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
 ```json
 {
   "address": "string",
-  "parentSubaccountNumber": 0.1,
+  "parentSubaccountNumber": 0,
   "equity": "string",
   "freeCollateral": "string",
   "childSubaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0.1,
+      "subaccountNumber": 0,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -376,7 +376,7 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -394,7 +394,7 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -403,14 +403,14 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "marginEnabled": true,
@@ -500,7 +500,7 @@ fetch(`${baseURL}/assetPositions?address=string&subaccountNumber=0.1`,
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -585,7 +585,7 @@ fetch(`${baseURL}/assetPositions/parentSubaccountNumber?address=string&parentSub
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -860,9 +860,9 @@ fetch(`${baseURL}/fills?address=string&subaccountNumber=0.1`,
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "fills": [
     {
       "id": "string",
@@ -878,7 +878,7 @@ fetch(`${baseURL}/fills?address=string&subaccountNumber=0.1`,
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -970,9 +970,9 @@ fetch(`${baseURL}/fills/parentSubaccount?address=string&parentSubaccountNumber=0
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "fills": [
     {
       "id": "string",
@@ -988,7 +988,7 @@ fetch(`${baseURL}/fills/parentSubaccount?address=string&parentSubaccountNumber=0
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -1310,9 +1310,9 @@ fetch(`${baseURL}/historical-pnl?address=string&subaccountNumber=0.1`,
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "historicalPnl": [
     {
       "id": "string",
@@ -1407,9 +1407,9 @@ fetch(`${baseURL}/historical-pnl/parentSubaccountNumber?address=string&parentSub
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "historicalPnl": [
     {
       "id": "string",
@@ -1695,6 +1695,9 @@ fetch(`${baseURL}/orders?address=string&subaccountNumber=0.1`,
 |type|TRAILING_STOP|
 |type|TAKE_PROFIT|
 |type|TAKE_PROFIT_MARKET|
+|type|HARD_TRADE|
+|type|FAILED_HARD_TRADE|
+|type|TRANSFER_PLACEHOLDER|
 
 > Example responses
 
@@ -1725,7 +1728,7 @@ fetch(`${baseURL}/orders?address=string&subaccountNumber=0.1`,
     "ticker": "string",
     "updatedAt": "string",
     "updatedAtHeight": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   }
 ]
 ```
@@ -1782,7 +1785,7 @@ Status Code **200**
 |» ticker|string|true|none|none|
 |» updatedAt|[IsoString](#schemaisostring)|false|none|none|
 |» updatedAtHeight|string|false|none|none|
-|» subaccountNumber|number(double)|true|none|none|
+|» subaccountNumber|integer(int32)|true|none|none|
 
 #### Enumerated Values
 
@@ -1797,6 +1800,9 @@ Status Code **200**
 |type|TRAILING_STOP|
 |type|TAKE_PROFIT|
 |type|TAKE_PROFIT_MARKET|
+|type|HARD_TRADE|
+|type|FAILED_HARD_TRADE|
+|type|TRANSFER_PLACEHOLDER|
 |timeInForce|GTT|
 |timeInForce|FOK|
 |timeInForce|IOC|
@@ -1889,6 +1895,9 @@ fetch(`${baseURL}/orders/parentSubaccountNumber?address=string&parentSubaccountN
 |type|TRAILING_STOP|
 |type|TAKE_PROFIT|
 |type|TAKE_PROFIT_MARKET|
+|type|HARD_TRADE|
+|type|FAILED_HARD_TRADE|
+|type|TRANSFER_PLACEHOLDER|
 
 > Example responses
 
@@ -1919,7 +1928,7 @@ fetch(`${baseURL}/orders/parentSubaccountNumber?address=string&parentSubaccountN
     "ticker": "string",
     "updatedAt": "string",
     "updatedAtHeight": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   }
 ]
 ```
@@ -1976,7 +1985,7 @@ Status Code **200**
 |» ticker|string|true|none|none|
 |» updatedAt|[IsoString](#schemaisostring)|false|none|none|
 |» updatedAtHeight|string|false|none|none|
-|» subaccountNumber|number(double)|true|none|none|
+|» subaccountNumber|integer(int32)|true|none|none|
 
 #### Enumerated Values
 
@@ -1991,6 +2000,9 @@ Status Code **200**
 |type|TRAILING_STOP|
 |type|TAKE_PROFIT|
 |type|TAKE_PROFIT_MARKET|
+|type|HARD_TRADE|
+|type|FAILED_HARD_TRADE|
+|type|TRANSFER_PLACEHOLDER|
 |timeInForce|GTT|
 |timeInForce|FOK|
 |timeInForce|IOC|
@@ -2087,7 +2099,7 @@ fetch(`${baseURL}/orders/{orderId}`,
   "ticker": "string",
   "updatedAt": "string",
   "updatedAtHeight": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 ```
 
@@ -2170,17 +2182,17 @@ fetch(`${baseURL}/perpetualMarkets`,
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0.1,
+      "trades24H": 0,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0.1,
-      "quantumConversionExponent": 0.1,
+      "atomicResolution": 0,
+      "quantumConversionExponent": 0,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0.1,
-      "subticksPerTick": 0.1,
+      "stepBaseQuantums": 0,
+      "subticksPerTick": 0,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -2193,17 +2205,17 @@ fetch(`${baseURL}/perpetualMarkets`,
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0.1,
+      "trades24H": 0,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0.1,
-      "quantumConversionExponent": 0.1,
+      "atomicResolution": 0,
+      "quantumConversionExponent": 0,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0.1,
-      "subticksPerTick": 0.1,
+      "stepBaseQuantums": 0,
+      "subticksPerTick": 0,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -2315,7 +2327,7 @@ fetch(`${baseURL}/perpetualPositions?address=string&subaccountNumber=0.1`,
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -2423,7 +2435,7 @@ fetch(`${baseURL}/perpetualPositions/parentSubaccountNumber?address=string&paren
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -2660,9 +2672,9 @@ fetch(`${baseURL}/trades/perpetualMarket/{ticker}`,
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "trades": [
     {
       "id": "string",
@@ -2754,18 +2766,18 @@ fetch(`${baseURL}/transfers?address=string&subaccountNumber=0.1`,
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -2856,18 +2868,18 @@ fetch(`${baseURL}/transfers/parentSubaccountNumber?address=string&parentSubaccou
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -3089,7 +3101,7 @@ This operation does not require authentication
   "unrealizedPnl": "string",
   "closedAt": "string",
   "exitPrice": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 
 ```
@@ -3113,7 +3125,7 @@ This operation does not require authentication
 |unrealizedPnl|string|true|none|none|
 |closedAt|[IsoString](#schemaisostring)¦null|false|none|none|
 |exitPrice|string¦null|false|none|none|
-|subaccountNumber|number(double)|true|none|none|
+|subaccountNumber|integer(int32)|true|none|none|
 
 ## PerpetualPositionsMap
 
@@ -3140,7 +3152,7 @@ This operation does not require authentication
     "unrealizedPnl": "string",
     "closedAt": "string",
     "exitPrice": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   },
   "property2": {
     "market": "string",
@@ -3158,7 +3170,7 @@ This operation does not require authentication
     "unrealizedPnl": "string",
     "closedAt": "string",
     "exitPrice": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   }
 }
 
@@ -3183,7 +3195,7 @@ This operation does not require authentication
   "side": "LONG",
   "size": "string",
   "assetId": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 
 ```
@@ -3196,7 +3208,7 @@ This operation does not require authentication
 |side|[PositionSide](#schemapositionside)|true|none|none|
 |size|string|true|none|none|
 |assetId|string|true|none|none|
-|subaccountNumber|number(double)|true|none|none|
+|subaccountNumber|integer(int32)|true|none|none|
 
 ## AssetPositionsMap
 
@@ -3212,14 +3224,14 @@ This operation does not require authentication
     "side": "LONG",
     "size": "string",
     "assetId": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   },
   "property2": {
     "symbol": "string",
     "side": "LONG",
     "size": "string",
     "assetId": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   }
 }
 
@@ -3241,7 +3253,7 @@ This operation does not require authentication
 ```json
 {
   "address": "string",
-  "subaccountNumber": 0.1,
+  "subaccountNumber": 0,
   "equity": "string",
   "freeCollateral": "string",
   "openPerpetualPositions": {
@@ -3261,7 +3273,7 @@ This operation does not require authentication
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     },
     "property2": {
       "market": "string",
@@ -3279,7 +3291,7 @@ This operation does not require authentication
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   },
   "assetPositions": {
@@ -3288,14 +3300,14 @@ This operation does not require authentication
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     },
     "property2": {
       "symbol": "string",
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   },
   "marginEnabled": true,
@@ -3310,7 +3322,7 @@ This operation does not require authentication
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |address|string|true|none|none|
-|subaccountNumber|number(double)|true|none|none|
+|subaccountNumber|integer(int32)|true|none|none|
 |equity|string|true|none|none|
 |freeCollateral|string|true|none|none|
 |openPerpetualPositions|[PerpetualPositionsMap](#schemaperpetualpositionsmap)|true|none|none|
@@ -3331,7 +3343,7 @@ This operation does not require authentication
   "subaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0.1,
+      "subaccountNumber": 0,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -3351,7 +3363,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -3369,7 +3381,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -3378,14 +3390,14 @@ This operation does not require authentication
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "marginEnabled": true,
@@ -3415,13 +3427,13 @@ This operation does not require authentication
 ```json
 {
   "address": "string",
-  "parentSubaccountNumber": 0.1,
+  "parentSubaccountNumber": 0,
   "equity": "string",
   "freeCollateral": "string",
   "childSubaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0.1,
+      "subaccountNumber": 0,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -3441,7 +3453,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -3459,7 +3471,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -3468,14 +3480,14 @@ This operation does not require authentication
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "marginEnabled": true,
@@ -3492,7 +3504,7 @@ This operation does not require authentication
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |address|string|true|none|none|
-|parentSubaccountNumber|number(double)|true|none|none|
+|parentSubaccountNumber|integer(int32)|true|none|none|
 |equity|string|true|none|none|
 |freeCollateral|string|true|none|none|
 |childSubaccounts|[[SubaccountResponseObject](#schemasubaccountresponseobject)]|true|none|none|
@@ -3512,7 +3524,7 @@ This operation does not require authentication
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -3860,7 +3872,7 @@ This operation does not require authentication
   "createdAtHeight": "string",
   "orderId": "string",
   "clientMetadata": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 
 ```
@@ -3882,7 +3894,7 @@ This operation does not require authentication
 |createdAtHeight|string|true|none|none|
 |orderId|string|false|none|none|
 |clientMetadata|string|false|none|none|
-|subaccountNumber|number(double)|true|none|none|
+|subaccountNumber|integer(int32)|true|none|none|
 
 ## FillResponse
 
@@ -3893,9 +3905,9 @@ This operation does not require authentication
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "fills": [
     {
       "id": "string",
@@ -3911,7 +3923,7 @@ This operation does not require authentication
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -3922,9 +3934,9 @@ This operation does not require authentication
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|pageSize|number(double)|false|none|none|
-|totalResults|number(double)|false|none|none|
-|offset|number(double)|false|none|none|
+|pageSize|integer(int32)|false|none|none|
+|totalResults|integer(int32)|false|none|none|
+|offset|integer(int32)|false|none|none|
 |fills|[[FillResponseObject](#schemafillresponseobject)]|true|none|none|
 
 ## HeightResponse
@@ -4098,9 +4110,9 @@ This operation does not require authentication
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "historicalPnl": [
     {
       "id": "string",
@@ -4121,9 +4133,9 @@ This operation does not require authentication
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|pageSize|number(double)|false|none|none|
-|totalResults|number(double)|false|none|none|
-|offset|number(double)|false|none|none|
+|pageSize|integer(int32)|false|none|none|
+|totalResults|integer(int32)|false|none|none|
+|offset|integer(int32)|false|none|none|
 |historicalPnl|[[PnlTicksResponseObject](#schemapnlticksresponseobject)]|true|none|none|
 
 ## TradingRewardAggregationPeriod
@@ -4398,6 +4410,9 @@ or
 |*anonymous*|TRAILING_STOP|
 |*anonymous*|TAKE_PROFIT|
 |*anonymous*|TAKE_PROFIT_MARKET|
+|*anonymous*|HARD_TRADE|
+|*anonymous*|FAILED_HARD_TRADE|
+|*anonymous*|TRANSFER_PLACEHOLDER|
 
 ## OrderResponseObject
 
@@ -4430,7 +4445,7 @@ or
   "ticker": "string",
   "updatedAt": "string",
   "updatedAtHeight": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 
 ```
@@ -4461,7 +4476,7 @@ or
 |ticker|string|true|none|none|
 |updatedAt|[IsoString](#schemaisostring)|false|none|none|
 |updatedAtHeight|string|false|none|none|
-|subaccountNumber|number(double)|true|none|none|
+|subaccountNumber|integer(int32)|true|none|none|
 
 ## PerpetualMarketStatus
 
@@ -4532,17 +4547,17 @@ or
   "oraclePrice": "string",
   "priceChange24H": "string",
   "volume24H": "string",
-  "trades24H": 0.1,
+  "trades24H": 0,
   "nextFundingRate": "string",
   "initialMarginFraction": "string",
   "maintenanceMarginFraction": "string",
   "openInterest": "string",
-  "atomicResolution": 0.1,
-  "quantumConversionExponent": 0.1,
+  "atomicResolution": 0,
+  "quantumConversionExponent": 0,
   "tickSize": "string",
   "stepSize": "string",
-  "stepBaseQuantums": 0.1,
-  "subticksPerTick": 0.1,
+  "stepBaseQuantums": 0,
+  "subticksPerTick": 0,
   "marketType": "CROSS",
   "openInterestLowerCap": "string",
   "openInterestUpperCap": "string",
@@ -4561,17 +4576,17 @@ or
 |oraclePrice|string|true|none|none|
 |priceChange24H|string|true|none|none|
 |volume24H|string|true|none|none|
-|trades24H|number(double)|true|none|none|
+|trades24H|integer(int32)|true|none|none|
 |nextFundingRate|string|true|none|none|
 |initialMarginFraction|string|true|none|none|
 |maintenanceMarginFraction|string|true|none|none|
 |openInterest|string|true|none|none|
-|atomicResolution|number(double)|true|none|none|
-|quantumConversionExponent|number(double)|true|none|none|
+|atomicResolution|integer(int32)|true|none|none|
+|quantumConversionExponent|integer(int32)|true|none|none|
 |tickSize|string|true|none|none|
 |stepSize|string|true|none|none|
-|stepBaseQuantums|number(double)|true|none|none|
-|subticksPerTick|number(double)|true|none|none|
+|stepBaseQuantums|integer(int32)|true|none|none|
+|subticksPerTick|integer(int32)|true|none|none|
 |marketType|[PerpetualMarketType](#schemaperpetualmarkettype)|true|none|none|
 |openInterestLowerCap|string|false|none|none|
 |openInterestUpperCap|string|false|none|none|
@@ -4594,17 +4609,17 @@ or
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0.1,
+      "trades24H": 0,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0.1,
-      "quantumConversionExponent": 0.1,
+      "atomicResolution": 0,
+      "quantumConversionExponent": 0,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0.1,
-      "subticksPerTick": 0.1,
+      "stepBaseQuantums": 0,
+      "subticksPerTick": 0,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -4617,17 +4632,17 @@ or
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0.1,
+      "trades24H": 0,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0.1,
-      "quantumConversionExponent": 0.1,
+      "atomicResolution": 0,
+      "quantumConversionExponent": 0,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0.1,
-      "subticksPerTick": 0.1,
+      "stepBaseQuantums": 0,
+      "subticksPerTick": 0,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -4671,7 +4686,7 @@ or
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -4823,9 +4838,9 @@ or
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "trades": [
     {
       "id": "string",
@@ -4845,9 +4860,9 @@ or
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|pageSize|number(double)|false|none|none|
-|totalResults|number(double)|false|none|none|
-|offset|number(double)|false|none|none|
+|pageSize|integer(int32)|false|none|none|
+|totalResults|integer(int32)|false|none|none|
+|offset|integer(int32)|false|none|none|
 |trades|[[TradeResponseObject](#schematraderesponseobject)]|true|none|none|
 
 ## TransferType
@@ -4888,11 +4903,11 @@ or
 {
   "id": "string",
   "sender": {
-    "subaccountNumber": 0.1,
+    "subaccountNumber": 0,
     "address": "string"
   },
   "recipient": {
-    "subaccountNumber": 0.1,
+    "subaccountNumber": 0,
     "address": "string"
   },
   "size": "string",
@@ -4911,10 +4926,10 @@ or
 |---|---|---|---|---|
 |id|string|true|none|none|
 |sender|object|true|none|none|
-|» subaccountNumber|number(double)|false|none|none|
+|» subaccountNumber|integer(int32)|false|none|none|
 |» address|string|true|none|none|
 |recipient|object|true|none|none|
-|» subaccountNumber|number(double)|false|none|none|
+|» subaccountNumber|integer(int32)|false|none|none|
 |» address|string|true|none|none|
 |size|string|true|none|none|
 |createdAt|string|true|none|none|
@@ -4932,18 +4947,18 @@ or
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -4962,9 +4977,9 @@ or
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|pageSize|number(double)|false|none|none|
-|totalResults|number(double)|false|none|none|
-|offset|number(double)|false|none|none|
+|pageSize|integer(int32)|false|none|none|
+|totalResults|integer(int32)|false|none|none|
+|offset|integer(int32)|false|none|none|
 |transfers|[[TransferResponseObject](#schematransferresponseobject)]|true|none|none|
 
 ## ParentSubaccountTransferResponse
@@ -4976,18 +4991,18 @@ or
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -5006,9 +5021,9 @@ or
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|pageSize|number(double)|false|none|none|
-|totalResults|number(double)|false|none|none|
-|offset|number(double)|false|none|none|
+|pageSize|integer(int32)|false|none|none|
+|totalResults|integer(int32)|false|none|none|
+|offset|integer(int32)|false|none|none|
 |transfers|[[TransferResponseObject](#schematransferresponseobject)]|true|none|none|
 
 ## TransferBetweenResponse

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1695,9 +1695,6 @@ fetch(`${baseURL}/orders?address=string&subaccountNumber=0.1`,
 |type|TRAILING_STOP|
 |type|TAKE_PROFIT|
 |type|TAKE_PROFIT_MARKET|
-|type|HARD_TRADE|
-|type|FAILED_HARD_TRADE|
-|type|TRANSFER_PLACEHOLDER|
 
 > Example responses
 
@@ -1800,9 +1797,6 @@ Status Code **200**
 |type|TRAILING_STOP|
 |type|TAKE_PROFIT|
 |type|TAKE_PROFIT_MARKET|
-|type|HARD_TRADE|
-|type|FAILED_HARD_TRADE|
-|type|TRANSFER_PLACEHOLDER|
 |timeInForce|GTT|
 |timeInForce|FOK|
 |timeInForce|IOC|
@@ -1895,9 +1889,6 @@ fetch(`${baseURL}/orders/parentSubaccountNumber?address=string&parentSubaccountN
 |type|TRAILING_STOP|
 |type|TAKE_PROFIT|
 |type|TAKE_PROFIT_MARKET|
-|type|HARD_TRADE|
-|type|FAILED_HARD_TRADE|
-|type|TRANSFER_PLACEHOLDER|
 
 > Example responses
 
@@ -2000,9 +1991,6 @@ Status Code **200**
 |type|TRAILING_STOP|
 |type|TAKE_PROFIT|
 |type|TAKE_PROFIT_MARKET|
-|type|HARD_TRADE|
-|type|FAILED_HARD_TRADE|
-|type|TRANSFER_PLACEHOLDER|
 |timeInForce|GTT|
 |timeInForce|FOK|
 |timeInForce|IOC|
@@ -2970,18 +2958,18 @@ fetch(`${baseURL}/transfers/between?sourceAddress=string&sourceSubaccountNumber=
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfersSubset": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -4410,9 +4398,6 @@ or
 |*anonymous*|TRAILING_STOP|
 |*anonymous*|TAKE_PROFIT|
 |*anonymous*|TAKE_PROFIT_MARKET|
-|*anonymous*|HARD_TRADE|
-|*anonymous*|FAILED_HARD_TRADE|
-|*anonymous*|TRANSFER_PLACEHOLDER|
 
 ## OrderResponseObject
 
@@ -5035,18 +5020,18 @@ or
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfersSubset": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -5066,9 +5051,9 @@ or
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|pageSize|number(double)|false|none|none|
-|totalResults|number(double)|false|none|none|
-|offset|number(double)|false|none|none|
+|pageSize|integer(int32)|false|none|none|
+|totalResults|integer(int32)|false|none|none|
+|offset|integer(int32)|false|none|none|
 |transfersSubset|[[TransferResponseObject](#schematransferresponseobject)]|true|none|none|
 |totalNetTransfers|string|true|none|none|
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -808,10 +808,7 @@
           "STOP_MARKET",
           "TRAILING_STOP",
           "TAKE_PROFIT",
-          "TAKE_PROFIT_MARKET",
-          "HARD_TRADE",
-          "FAILED_HARD_TRADE",
-          "TRANSFER_PLACEHOLDER"
+          "TAKE_PROFIT_MARKET"
         ],
         "type": "string"
       },
@@ -1293,16 +1290,16 @@
       "TransferBetweenResponse": {
         "properties": {
           "pageSize": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "totalResults": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "offset": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "transfersSubset": {
             "items": {

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -78,8 +78,8 @@
             "nullable": true
           },
           "subaccountNumber": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           }
         },
         "required": [
@@ -123,8 +123,8 @@
             "type": "string"
           },
           "subaccountNumber": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           }
         },
         "required": [
@@ -150,8 +150,8 @@
             "type": "string"
           },
           "subaccountNumber": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "equity": {
             "type": "string"
@@ -214,8 +214,8 @@
             "type": "string"
           },
           "parentSubaccountNumber": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "equity": {
             "type": "string"
@@ -466,8 +466,8 @@
             "type": "string"
           },
           "subaccountNumber": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           }
         },
         "required": [
@@ -490,16 +490,16 @@
       "FillResponse": {
         "properties": {
           "pageSize": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "totalResults": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "offset": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "fills": {
             "items": {
@@ -651,16 +651,16 @@
       "HistoricalPnlResponse": {
         "properties": {
           "pageSize": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "totalResults": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "offset": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "historicalPnl": {
             "items": {
@@ -808,7 +808,10 @@
           "STOP_MARKET",
           "TRAILING_STOP",
           "TAKE_PROFIT",
-          "TAKE_PROFIT_MARKET"
+          "TAKE_PROFIT_MARKET",
+          "HARD_TRADE",
+          "FAILED_HARD_TRADE",
+          "TRANSFER_PLACEHOLDER"
         ],
         "type": "string"
       },
@@ -881,8 +884,8 @@
             "type": "string"
           },
           "subaccountNumber": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           }
         },
         "required": [
@@ -946,8 +949,8 @@
             "type": "string"
           },
           "trades24H": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "nextFundingRate": {
             "type": "string"
@@ -962,12 +965,12 @@
             "type": "string"
           },
           "atomicResolution": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "quantumConversionExponent": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "tickSize": {
             "type": "string"
@@ -976,12 +979,12 @@
             "type": "string"
           },
           "stepBaseQuantums": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "subticksPerTick": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "marketType": {
             "$ref": "#/components/schemas/PerpetualMarketType"
@@ -1132,16 +1135,16 @@
       "TradeResponse": {
         "properties": {
           "pageSize": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "totalResults": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "offset": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "trades": {
             "items": {
@@ -1173,8 +1176,8 @@
           "sender": {
             "properties": {
               "subaccountNumber": {
-                "type": "number",
-                "format": "double"
+                "type": "integer",
+                "format": "int32"
               },
               "address": {
                 "type": "string"
@@ -1188,8 +1191,8 @@
           "recipient": {
             "properties": {
               "subaccountNumber": {
-                "type": "number",
-                "format": "double"
+                "type": "integer",
+                "format": "int32"
               },
               "address": {
                 "type": "string"
@@ -1236,16 +1239,16 @@
       "TransferResponse": {
         "properties": {
           "pageSize": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "totalResults": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "offset": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "transfers": {
             "items": {
@@ -1263,16 +1266,16 @@
       "ParentSubaccountTransferResponse": {
         "properties": {
           "pageSize": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "totalResults": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "offset": {
-            "type": "number",
-            "format": "double"
+            "type": "integer",
+            "format": "int32"
           },
           "transfers": {
             "items": {

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -43,8 +43,17 @@ export enum RequestMethod {
 
 /* ------- Pagination ------- */
 export interface PaginationResponse {
+  /**
+   * @isInt
+   */
   pageSize?: number,
+  /**
+   * @isInt
+   */
   totalResults?: number,
+  /**
+   * @isInt
+   */
   offset?: number,
 }
 
@@ -57,6 +66,9 @@ export interface AddressResponse {
 
 export interface SubaccountResponseObject {
   address: string,
+  /**
+   * @isInt
+   */
   subaccountNumber: number,
   equity: string,
   freeCollateral: string,
@@ -69,6 +81,9 @@ export interface SubaccountResponseObject {
 
 export interface ParentSubaccountResponse {
   address: string;
+  /**
+   * @isInt
+   */
   parentSubaccountNumber: number;
   equity: string; // aggregated over all child subaccounts
   freeCollateral: string; // aggregated over all child subaccounts
@@ -110,6 +125,9 @@ export interface PerpetualPositionResponseObject {
   unrealizedPnl: string;
   closedAt?: IsoString | null;
   exitPrice?: string | null;
+  /**
+   * @isInt
+   */
   subaccountNumber: number;
 }
 
@@ -124,6 +142,9 @@ export interface AssetPositionResponseObject {
   side: PositionSide;
   size: string;
   assetId: string;
+  /**
+   * @isInt
+   */
   subaccountNumber: number;
 }
 
@@ -149,6 +170,9 @@ export interface FillResponseObject {
   createdAtHeight: string,
   orderId?: string,
   clientMetadata?: string,
+  /**
+   * @isInt
+   */
   subaccountNumber: number,
 }
 
@@ -162,10 +186,16 @@ export interface TransferResponseObject {
   id: string,
   sender: {
     address: string,
+    /**
+     * @isInt
+     */
     subaccountNumber?: number,
   },
   recipient: {
     address: string,
+    /**
+     * @isInt
+     */
     subaccountNumber?: number,
   },
   size: string,
@@ -184,10 +214,16 @@ export interface ParentSubaccountTransferResponseObject {
   id: string,
   sender: {
     address: string,
+    /**
+     * @isInt
+     */
     parentSubaccountNumber?: number,
   },
   recipient: {
     address: string,
+    /**
+     * @isInt
+     */
     parentSubaccountNumber?: number,
   },
   size: string,
@@ -278,16 +314,31 @@ export interface PerpetualMarketResponseObject {
   oraclePrice: string;
   priceChange24H: string;
   volume24H: string;
+  /**
+   * @isInt
+   */
   trades24H: number;
   nextFundingRate: string;
   initialMarginFraction: string;
   maintenanceMarginFraction: string;
   openInterest: string;
+  /**
+   * @isInt
+   */
   atomicResolution: number;
+  /**
+   * @isInt
+   */
   quantumConversionExponent: number;
   tickSize: string;
   stepSize: string;
+  /**
+   * @isInt
+   */
   stepBaseQuantums: number;
+  /**
+   * @isInt
+   */
   subticksPerTick: number;
   marketType: PerpetualMarketType;
   openInterestLowerCap?: string;
@@ -317,6 +368,9 @@ export interface OrderResponseObject extends Omit<OrderFromDatabase, 'timeInForc
   ticker: string;
   updatedAt?: IsoString;
   updatedAtHeight?: string
+  /**
+   * @isInt
+   */
   subaccountNumber: number;
 }
 


### PR DESCRIPTION
### Changelist
Set all ints in documentation to ints rather than numbers

### Test Plan
Look at documentation

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to standardize the representation of `subaccountNumber` as an integer instead of a floating-point number.
  
- **New Features**
  - Added validation for several fields including `pageSize`, `totalResults`, `offset`, and `subaccountNumber` in various response objects.

- **Bug Fixes**
  - Updated Swagger JSON schema to ensure `subaccountNumber` is correctly typed as an integer (`int32`) instead of a floating-point number (`double`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->