### PR TITLE
Handle order replacement in vulcan

### DIFF
--- a/indexer/packages/redis/__tests__/helpers/constants.ts
+++ b/indexer/packages/redis/__tests__/helpers/constants.ts
@@ -68,6 +68,18 @@ export const defaultOrderIdConditional: IndexerOrderId = {
   clobPairId: parseInt(testConstants.defaultPerpetualMarket.clobPairId, 10),
   orderFlags: ORDER_FLAG_CONDITIONAL,
 };
+export const defaultReplacementOrderId: IndexerOrderId = {
+  subaccountId: defaultSubaccountId,
+  clientId: 4,
+  clobPairId: parseInt(testConstants.defaultPerpetualMarket.clobPairId, 10),
+  orderFlags: ORDER_FLAG_SHORT_TERM,
+};
+export const defaultReplacementOrderIdGTBT: IndexerOrderId = {
+  subaccountId: defaultSubaccountId,
+  clientId: 5,
+  clobPairId: parseInt(testConstants.defaultPerpetualMarket.clobPairId, 10),
+  orderFlags: ORDER_FLAG_LONG_TERM,
+};
 
 export const defaultSubaccountUuid: string = SubaccountTable.uuid(
   defaultSubaccountId.owner,
@@ -89,10 +101,22 @@ export const defaultOrder: IndexerOrder = {
   conditionType: IndexerOrder_ConditionType.CONDITION_TYPE_UNSPECIFIED,
   conditionalOrderTriggerSubticks: Long.fromValue(0, true),
 };
+export const defaultReplacementOrder: IndexerOrder = {
+  ...defaultOrder,
+  orderId: defaultReplacementOrderId,
+  quantums: Long.fromValue(1_500_000, true),
+  goodTilBlock: 1160,
+};
 export const defaultOrderGoodTilBlockTime: IndexerOrder = {
   ...defaultOrder,
   orderId: defaultOrderIdGoodTilBlockTime,
   goodTilBlockTime: 1_200_000_000,
+  goodTilBlock: undefined,
+};
+export const defaultReplacementOrderGTBT: IndexerOrder = {
+  ...defaultOrder,
+  orderId: defaultReplacementOrderIdGTBT,
+  goodTilBlockTime: 1_300_000_000,
   goodTilBlock: undefined,
 };
 export const defaultConditionalOrder: IndexerOrder = {
@@ -116,6 +140,12 @@ export const defaultOrderUuidGoodTilBlockTime: string = OrderTable.orderIdToUuid
 );
 export const defaultOrderUuidConditional: string = OrderTable.orderIdToUuid(
   defaultOrderIdConditional,
+);
+export const defaultReplacementOrderUuid: string = OrderTable.orderIdToUuid(
+  defaultReplacementOrderId,
+);
+export const defaultReplacementOrderUuidGTBT: string = OrderTable.orderIdToUuid(
+  defaultReplacementOrderIdGTBT,
 );
 
 export const defaultPrice = protocolTranslations.subticksToPrice(

--- a/indexer/packages/redis/__tests__/helpers/constants.ts
+++ b/indexer/packages/redis/__tests__/helpers/constants.ts
@@ -17,6 +17,7 @@ import {
   IndexerSubaccountId,
   IndexerOrder_ConditionType,
   OrderRemovalReason,
+  OrderReplaceV1,
 } from '@dydxprotocol-indexer/v4-protos';
 import Long from 'long';
 
@@ -24,16 +25,25 @@ export type OffChainUpdateOrderPlaceUpdateMessage = {
   orderUpdate: undefined,
   orderRemove: undefined,
   orderPlace: OrderPlaceV1,
+  orderReplace: undefined
 };
 export type OffChainUpdateOrderRemoveUpdateMessage = {
   orderUpdate: undefined,
   orderRemove: OrderRemoveV1,
   orderPlace: undefined,
+  orderReplace: undefined
 };
 export type OffChainUpdateOrderUpdateUpdateMessage = {
   orderUpdate: OrderUpdateV1,
   orderRemove: undefined,
   orderPlace: undefined,
+  orderReplace: undefined
+};
+export type OffChainUpdateOrderReplaceUpdateMessage = {
+  orderUpdate: undefined,
+  orderRemove: undefined,
+  orderPlace: undefined,
+  orderReplace: OrderReplaceV1,
 };
 
 export const defaultSubaccountId: IndexerSubaccountId = {
@@ -150,6 +160,7 @@ export const orderPlace: OffChainUpdateOrderPlaceUpdateMessage = {
     order: defaultOrder,
     placementStatus: OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
   },
+  orderReplace: undefined,
 };
 export const orderRemove: OffChainUpdateOrderRemoveUpdateMessage = {
   orderPlace: undefined,
@@ -159,6 +170,7 @@ export const orderRemove: OffChainUpdateOrderRemoveUpdateMessage = {
     reason: OrderRemovalReason.ORDER_REMOVAL_REASON_INTERNAL_ERROR,
     removalStatus: OrderRemoveV1_OrderRemovalStatus.ORDER_REMOVAL_STATUS_BEST_EFFORT_CANCELED,
   },
+  orderReplace: undefined,
 };
 export const orderUpdate: OffChainUpdateOrderUpdateUpdateMessage = {
   orderPlace: undefined,
@@ -166,6 +178,17 @@ export const orderUpdate: OffChainUpdateOrderUpdateUpdateMessage = {
   orderUpdate: {
     orderId: defaultOrderId,
     totalFilledQuantums: Long.fromValue(250_500, true),
+  },
+  orderReplace: undefined,
+};
+export const orderReplace: OffChainUpdateOrderReplaceUpdateMessage = {
+  orderPlace: undefined,
+  orderRemove: undefined,
+  orderUpdate: undefined,
+  orderReplace: {
+    oldOrderId: defaultOrderId,
+    order: defaultOrder,
+    placementStatus: OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
   },
 };
 

--- a/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
@@ -853,6 +853,7 @@ describe('OrderRemoveHandler', () => {
             orderId: removedRedisOrder.order!.orderId!,
             totalFilledQuantums: removedRedisOrder.order!.quantums.add(Long.fromValue(100, true)),
           },
+          orderReplace: undefined,
         };
         await handleOrderUpdate(exceedsFilledUpdate);
 
@@ -1006,6 +1007,7 @@ describe('OrderRemoveHandler', () => {
         const fullyFilledUpdate: redisTestConstants.OffChainUpdateOrderUpdateUpdateMessage = {
           orderPlace: undefined,
           orderRemove: undefined,
+          orderReplace: undefined,
           orderUpdate: {
             orderId: removedRedisOrder.order!.orderId!,
             totalFilledQuantums: removedRedisOrder.order!.quantums,
@@ -1555,6 +1557,7 @@ describe('OrderRemoveHandler', () => {
       const exceedsFilledUpdate: redisTestConstants.OffChainUpdateOrderUpdateUpdateMessage = {
         orderPlace: undefined,
         orderRemove: undefined,
+        orderReplace: undefined,
         orderUpdate: {
           orderId: removedRedisOrder.order!.orderId!,
           totalFilledQuantums: defaultQuantums.add(Long.fromValue(100, true)),

--- a/indexer/services/vulcan/__tests__/handlers/order-replace-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-replace-handler.test.ts
@@ -219,7 +219,7 @@ describe('order-replace-handler', () => {
         false,
         true,
       ],
-    ])('handles order place for replacing order (with %s), not resting on book', async (
+    ])('handles replacement (with %s), not resting on book', async (
       _name: string,
       initialOrderToPlace: IndexerOrder,
       orderReplacementMessage: KafkaMessage,
@@ -240,7 +240,7 @@ describe('order-replace-handler', () => {
       }
       synchronizeWrapBackgroundTask(wrapBackgroundTask);
       const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
-      // Handle the order place off-chain update for the initial order
+      // Handle the order place event for the initial order that will get replaced
       await handleInitialOrderPlace({
         ...redisTestConstants.orderPlace,
         orderPlace: {
@@ -261,7 +261,7 @@ describe('order-replace-handler', () => {
       // clear mocks
       jest.clearAllMocks();
 
-      // Handle the order place off-chain update with the replacement order
+      // Handle the order replacement off-chain update with the replacement order
       await onMessage(orderReplacementMessage);
 
       await checkOrderReplace(
@@ -288,8 +288,6 @@ describe('order-replace-handler', () => {
       expectStats(true);
     });
 
-    // TODO(IND-68): Remove this test once order replacement logic does not change price levels as
-    // orders are removed before being re-placed.
     it.each([
       [
         'goodTilBlock',
@@ -315,7 +313,7 @@ describe('order-replace-handler', () => {
         false,
         true,
       ],
-    ])('handles order place for replacing order (with %s), resting on book', async (
+    ])('handles order replace (with %s), resting on book', async (
       _name: string,
       initialOrderToPlace: IndexerOrder,
       orderReplacementMessage: KafkaMessage,
@@ -342,7 +340,7 @@ describe('order-replace-handler', () => {
 
       synchronizeWrapBackgroundTask(wrapBackgroundTask);
       const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
-      // Handle the order place event for the initial order
+      // Handle the order place event for the initial order that will get replaced
       await handleInitialOrderPlace({
         ...redisTestConstants.orderPlace,
         orderPlace: {
@@ -380,7 +378,7 @@ describe('order-replace-handler', () => {
         client,
       });
 
-      // Handle the order place off-chain update with the replacement order
+      // Handle the order replacement off-chain update with the replacement order
       await onMessage(orderReplacementMessage);
 
       await checkOrderReplace(
@@ -413,8 +411,6 @@ describe('order-replace-handler', () => {
       expectStats(true);
     });
 
-    // TODO(IND-68): Remove this test once order replacement logic does not change price levels as
-    // orders are removed before being re-placed.
     it.each([
       [
         'goodTilBlock',
@@ -438,7 +434,7 @@ describe('order-replace-handler', () => {
         replacedOrderGoodTilBlockTime,
         false,
       ],
-    ])('handles order place for replacing order (with %s), resting on book, 0 remaining quantums',
+    ])('handles order replacement (with %s), resting on book, 0 remaining quantums',
       async (
         _name: string,
         initialOrderToPlace: IndexerOrder,
@@ -452,7 +448,7 @@ describe('order-replace-handler', () => {
       ) => {
         synchronizeWrapBackgroundTask(wrapBackgroundTask);
         const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
-        // Handle the order place event for the initial order
+        // Handle the order place event for the initial order that will get replaced
         await handleInitialOrderPlace({
           ...redisTestConstants.orderPlace,
           orderPlace: {
@@ -479,7 +475,7 @@ describe('order-replace-handler', () => {
           newTotalFilledQuantums: Number(initialOrderToPlace.quantums),
           client,
         });
-        // Handle the order place off-chain update with the replacement order
+        // Handle the order replacement off-chain update with the replacement order
         await onMessage(orderReplacementMessage);
 
         await checkOrderReplace(
@@ -552,7 +548,7 @@ describe('order-replace-handler', () => {
         },
         'Invalid OrderReplace, placement status is UNSPECIFIED',
       ],
-    ])('logs error and does not update caches on invalid order place off-chain update: %s', async (
+    ])('logs error and does not update caches on invalid order replacement off-chain update: %s', async (
       _name: string,
       updateMessage: any,
       errorMsg: string,

--- a/indexer/services/vulcan/__tests__/handlers/order-replace-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-replace-handler.test.ts
@@ -1,0 +1,899 @@
+import {
+  logger,
+  stats,
+  STATS_FUNCTION_NAME,
+  wrapBackgroundTask,
+} from '@dydxprotocol-indexer/base';
+import { synchronizeWrapBackgroundTask } from '@dydxprotocol-indexer/dev';
+import {
+  createKafkaMessage,
+  producer,
+  SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
+  getTriggerPrice,
+} from '@dydxprotocol-indexer/kafka';
+import {
+  APIOrderStatus,
+  APIOrderStatusEnum,
+  apiTranslations,
+  blockHeightRefresher,
+  BlockTable,
+  dbHelpers,
+  OrderFromDatabase,
+  OrderTable,
+  PerpetualMarketFromDatabase,
+  perpetualMarketRefresher,
+  protocolTranslations,
+  SubaccountMessageContents,
+  SubaccountTable,
+  testConstants,
+  testMocks,
+  TimeInForce,
+} from '@dydxprotocol-indexer/postgres';
+import * as redisPackage from '@dydxprotocol-indexer/redis';
+import {
+  PriceLevel,
+  OrdersCache,
+  OrderbookLevels,
+  OrderbookLevelsCache,
+  redis,
+  redisTestConstants,
+  SubaccountOrderIdsCache,
+  CanceledOrdersCache,
+  updateOrder,
+  CanceledOrderStatus,
+} from '@dydxprotocol-indexer/redis';
+import {
+  OffChainUpdateV1,
+  IndexerOrder,
+  OrderbookMessage,
+  OrderPlaceV1_OrderPlacementStatus,
+  RedisOrder,
+  SubaccountId,
+  SubaccountMessage,
+} from '@dydxprotocol-indexer/v4-protos';
+import { KafkaMessage } from 'kafkajs';
+import Long from 'long';
+import { redisClient, redisClient as client } from '../../src/helpers/redis/redis-controller';
+import { onMessage } from '../../src/lib/on-message';
+import { expectCanceledOrderStatus, handleInitialOrderPlace } from '../helpers/helpers';
+import { expectOffchainUpdateMessage, expectWebsocketOrderbookMessage, expectWebsocketSubaccountMessage } from '../helpers/websocket-helpers';
+import { isStatefulOrder } from '@dydxprotocol-indexer/v4-proto-parser';
+import { defaultKafkaHeaders } from '../helpers/constants';
+import config from '../../src/config';
+import { defaultOrderId, defaultOrderIdConditional, defaultOrderIdGoodTilBlockTime } from '@dydxprotocol-indexer/redis/build/__tests__/helpers/constants';
+
+jest.mock('@dydxprotocol-indexer/base', () => ({
+  ...jest.requireActual('@dydxprotocol-indexer/base'),
+  wrapBackgroundTask: jest.fn(),
+}));
+
+interface OffchainUpdateRecord {
+  key: Buffer,
+  offchainUpdate: OffChainUpdateV1
+}
+
+describe('order-replace-handler', () => {
+  beforeAll(async () => {
+    await BlockTable.create(testConstants.defaultBlock);
+    await blockHeightRefresher.updateBlockHeight();
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS = true;
+  });
+
+  describe('handle', () => {
+    const replacementOrder: IndexerOrder = {
+      ...redisTestConstants.defaultOrder,
+      goodTilBlock: 1160,
+      goodTilBlockTime: undefined,
+      quantums: Long.fromValue(500_000, true),
+      subticks: Long.fromValue(1_000_000, true),
+    };
+    const replacementOrderGoodTilBlockTime: IndexerOrder = {
+      ...replacementOrder,
+      orderId: redisTestConstants.defaultOrderIdGoodTilBlockTime,
+      goodTilBlock: undefined,
+      goodTilBlockTime: 1_300_000_000,
+    };
+    const replacementOrderConditional: IndexerOrder = {
+      ...redisTestConstants.defaultConditionalOrder,
+      quantums: Long.fromValue(500_000, true),
+      subticks: Long.fromValue(1_000_000, true),
+      goodTilBlock: undefined,
+      goodTilBlockTime: 1_300_000_000,
+    };
+    const replacementOrderFok: IndexerOrder = {
+      ...redisTestConstants.defaultOrderFok,
+      goodTilBlock: 1160,
+      goodTilBlockTime: undefined,
+      quantums: Long.fromValue(500_000, true),
+      subticks: Long.fromValue(1_000_000, true),
+    };
+    const replacementOrderIoc: IndexerOrder = {
+      ...redisTestConstants.defaultOrderIoc,
+      goodTilBlock: 1160,
+      goodTilBlockTime: undefined,
+      quantums: Long.fromValue(500_000, true),
+      subticks: Long.fromValue(1_000_000, true),
+    };
+    const replacedOrder: RedisOrder = redisPackage.convertToRedisOrder(
+      replacementOrder,
+      testConstants.defaultPerpetualMarket,
+    );
+    const replacedOrderGoodTilBlockTime: RedisOrder = redisPackage.convertToRedisOrder(
+      replacementOrderGoodTilBlockTime,
+      testConstants.defaultPerpetualMarket,
+    );
+    const replacedOrderConditional: RedisOrder = redisPackage.convertToRedisOrder(
+      replacementOrderConditional,
+      testConstants.defaultPerpetualMarket,
+    );
+    const replacedOrderFok: RedisOrder = redisPackage.convertToRedisOrder(
+      replacementOrderFok,
+      testConstants.defaultPerpetualMarket,
+    );
+    const replacedOrderIoc: RedisOrder = redisPackage.convertToRedisOrder(
+      replacementOrderIoc,
+      testConstants.defaultPerpetualMarket,
+    );
+    const replacementUpdate: OffChainUpdateV1 = {
+      orderReplace: {
+        oldOrderId: defaultOrderId,
+        order: replacementOrder,
+        placementStatus:
+            OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+      },
+    };
+    const replacementUpdateGoodTilBlockTime: OffChainUpdateV1 = {
+      orderReplace: {
+        oldOrderId: defaultOrderIdGoodTilBlockTime,
+        order: replacementOrderGoodTilBlockTime,
+        placementStatus:
+            OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+      },
+    };
+    const replacementUpdateConditional: OffChainUpdateV1 = {
+      orderReplace: {
+        oldOrderId: defaultOrderIdConditional,
+        order: replacementOrderConditional,
+        placementStatus:
+            OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+      },
+    };
+    const replacementUpdateFok: OffChainUpdateV1 = {
+      orderReplace: {
+        oldOrderId: defaultOrderId,
+        order: replacementOrderFok,
+        placementStatus:
+            OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+      },
+    };
+    const replacementUpdateIoc: OffChainUpdateV1 = {
+      orderReplace: {
+        oldOrderId: defaultOrderId,
+        order: replacementOrderIoc,
+        placementStatus:
+            OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+      },
+    };
+    const replacementMessage: KafkaMessage = createKafkaMessage(
+      Buffer.from(Uint8Array.from(OffChainUpdateV1.encode(replacementUpdate).finish())),
+    );
+    const replacementMessageGoodTilBlockTime: KafkaMessage = createKafkaMessage(
+      Buffer.from(Uint8Array.from(
+        OffChainUpdateV1.encode(replacementUpdateGoodTilBlockTime).finish(),
+      )),
+    );
+    const replacementMessageConditional: KafkaMessage = createKafkaMessage(
+      Buffer.from(Uint8Array.from(
+        OffChainUpdateV1.encode(replacementUpdateConditional).finish(),
+      )),
+    );
+    const replacementMessageFok: KafkaMessage = createKafkaMessage(
+      Buffer.from(Uint8Array.from(OffChainUpdateV1.encode(replacementUpdateFok).finish())),
+    );
+    const replacementMessageIoc: KafkaMessage = createKafkaMessage(
+      Buffer.from(Uint8Array.from(OffChainUpdateV1.encode(replacementUpdateIoc).finish())),
+    );
+    [replacementMessage, replacementMessageGoodTilBlockTime, replacementMessageConditional,
+      replacementMessageFok, replacementMessageIoc].forEach((message) => {
+      // eslint-disable-next-line no-param-reassign
+      message.headers = defaultKafkaHeaders;
+    });
+
+    const dbDefaultOrder: OrderFromDatabase = {
+      ...testConstants.defaultOrder,
+      id: testConstants.defaultOrderId,
+    };
+    const dbOrderGoodTilBlockTime: OrderFromDatabase = {
+      ...testConstants.defaultOrderGoodTilBlockTime,
+      id: testConstants.defaultOrderGoodTilBlockTimeId,
+      createdAtHeight: '2',
+    };
+    const dbConditionalOrder: OrderFromDatabase = {
+      ...testConstants.defaultConditionalOrder,
+      id: testConstants.defaultConditionalOrderId,
+      createdAtHeight: '3',
+    };
+    const dbDefaultOrderFok: OrderFromDatabase = {
+      ...testConstants.defaultOrder,
+      id: testConstants.defaultOrderId,
+      timeInForce: TimeInForce.FOK,
+    };
+    const dbDefaultOrderIoc: OrderFromDatabase = {
+      ...testConstants.defaultOrder,
+      id: testConstants.defaultOrderId,
+      timeInForce: TimeInForce.IOC,
+    };
+
+    beforeAll(async () => {
+      await dbHelpers.migrate();
+    });
+
+    beforeEach(async () => {
+      await dbHelpers.clearData();
+      await testMocks.seedData();
+      await Promise.all([
+        perpetualMarketRefresher.updatePerpetualMarkets(),
+        blockHeightRefresher.updateBlockHeight(),
+      ]);
+      await Promise.all([
+        OrderTable.create(dbDefaultOrder),
+        OrderTable.create(dbOrderGoodTilBlockTime),
+        OrderTable.create(dbConditionalOrder),
+      ]);
+      jest.spyOn(stats, 'timing');
+      jest.spyOn(OrderbookLevelsCache, 'updatePriceLevel');
+      jest.spyOn(CanceledOrdersCache, 'removeOrderFromCaches');
+      jest.spyOn(stats, 'increment');
+      jest.spyOn(redisPackage, 'placeOrder');
+      jest.spyOn(logger, 'error');
+      jest.spyOn(logger, 'info');
+    });
+
+    afterEach(async () => {
+      await redis.deleteAllAsync(client);
+      await dbHelpers.clearData();
+      jest.restoreAllMocks();
+    });
+
+    afterAll(async () => {
+      await dbHelpers.teardown();
+    });
+    // TODO(IND-68): Remove this test once order replacement logic does not change price levels as
+    // orders are removed before being re-placed.
+    it.each([
+      [
+        'goodTilBlock',
+        redisTestConstants.defaultOrder,
+        replacementMessage,
+        redisTestConstants.defaultRedisOrder,
+        dbDefaultOrder,
+        redisTestConstants.defaultOrderUuid,
+        replacedOrder,
+        true,
+        false,
+      ],
+      [
+        'goodTilBlockTime',
+        redisTestConstants.defaultOrderGoodTilBlockTime,
+        replacementMessageGoodTilBlockTime,
+        redisTestConstants.defaultRedisOrderGoodTilBlockTime,
+        dbOrderGoodTilBlockTime,
+        redisTestConstants.defaultOrderUuidGoodTilBlockTime,
+        replacedOrderGoodTilBlockTime,
+        false,
+        false,
+      ],
+      [
+        'conditional',
+        redisTestConstants.defaultConditionalOrder,
+        replacementMessageConditional,
+        redisTestConstants.defaultRedisOrderConditional,
+        dbConditionalOrder,
+        redisTestConstants.defaultOrderUuidConditional,
+        replacedOrderConditional,
+        false,
+        false,
+      ],
+      [
+        'goodTilBlock and canceled order',
+        redisTestConstants.defaultOrder,
+        replacementMessage,
+        redisTestConstants.defaultRedisOrder,
+        dbDefaultOrder,
+        redisTestConstants.defaultOrderUuid,
+        replacedOrder,
+        true,
+        true,
+      ],
+      [
+        'goodTilBlockTime and canceled order',
+        redisTestConstants.defaultOrderGoodTilBlockTime,
+        replacementMessageGoodTilBlockTime,
+        redisTestConstants.defaultRedisOrderGoodTilBlockTime,
+        dbOrderGoodTilBlockTime,
+        redisTestConstants.defaultOrderUuidGoodTilBlockTime,
+        replacedOrderGoodTilBlockTime,
+        false,
+        true,
+      ],
+      [
+        'conditional and canceled order',
+        redisTestConstants.defaultConditionalOrder,
+        replacementMessageConditional,
+        redisTestConstants.defaultRedisOrderConditional,
+        dbConditionalOrder,
+        redisTestConstants.defaultOrderUuidConditional,
+        replacedOrderConditional,
+        false,
+        true,
+      ],
+    ])('handles order place for replacing order (with %s), not resting on book', async (
+      _name: string,
+      initialOrderToPlace: IndexerOrder,
+      orderReplacementMessage: KafkaMessage,
+      expectedRedisOrder: RedisOrder,
+      dbOrder: OrderFromDatabase,
+      expectedOrderUuid: string,
+      expectedReplacedOrder: RedisOrder,
+      expectSubaccountMessage: boolean,
+      hasCanceledOrderId: boolean,
+    ) => {
+      if (hasCanceledOrderId) {
+        await redisPackage.CanceledOrdersCache.addCanceledOrderId(
+          expectedOrderUuid,
+          Date.now(),
+          redisClient,
+        );
+      }
+      synchronizeWrapBackgroundTask(wrapBackgroundTask);
+      const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
+      // Handle the order place off-chain update for the initial order
+      await handleInitialOrderPlace({
+        ...redisTestConstants.orderPlace,
+        orderPlace: {
+          order: initialOrderToPlace,
+          placementStatus:
+              OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+        },
+      });
+      expectWebsocketMessagesSent(
+        producerSendSpy,
+        expectedRedisOrder,
+        dbOrder,
+        testConstants.defaultPerpetualMarket,
+        APIOrderStatusEnum.BEST_EFFORT_OPENED,
+        expectSubaccountMessage,
+      );
+      expectStats();
+      // clear mocks
+      jest.clearAllMocks();
+
+      // Handle the order place off-chain update with the replacement order
+      await onMessage(orderReplacementMessage);
+
+      await checkOrderPlace(
+        expectedOrderUuid,
+        redisTestConstants.defaultSubaccountUuid,
+        expectedReplacedOrder,
+      );
+      expect(OrderbookLevelsCache.updatePriceLevel).not.toHaveBeenCalled();
+      if (hasCanceledOrderId) {
+        expect(CanceledOrdersCache.removeOrderFromCaches).toHaveBeenCalled();
+      }
+      await expectCanceledOrderStatus(expectedOrderUuid, CanceledOrderStatus.NOT_CANCELED);
+
+      expect(logger.error).not.toHaveBeenCalled();
+      expectWebsocketMessagesSent(
+        producerSendSpy,
+        expectedReplacedOrder,
+        dbOrder,
+        testConstants.defaultPerpetualMarket,
+        APIOrderStatusEnum.BEST_EFFORT_OPENED,
+        expectSubaccountMessage,
+      );
+      expectStats(true);
+    });
+
+    // TODO(IND-68): Remove this test once order replacement logic does not change price levels as
+    // orders are removed before being re-placed.
+    it.each([
+      [
+        'goodTilBlock',
+        redisTestConstants.defaultOrder,
+        replacementMessage,
+        redisTestConstants.defaultRedisOrder,
+        dbDefaultOrder,
+        redisTestConstants.defaultOrderUuid,
+        replacedOrder,
+        true,
+        true,
+      ],
+      [
+        'goodTilBlockTime',
+        redisTestConstants.defaultOrderGoodTilBlockTime,
+        replacementMessageGoodTilBlockTime,
+        redisTestConstants.defaultRedisOrderGoodTilBlockTime,
+        dbOrderGoodTilBlockTime,
+        redisTestConstants.defaultOrderUuidGoodTilBlockTime,
+        replacedOrderGoodTilBlockTime,
+        false,
+        true,
+      ],
+      [
+        'conditional',
+        redisTestConstants.defaultConditionalOrder,
+        replacementMessageConditional,
+        redisTestConstants.defaultRedisOrderConditional,
+        dbConditionalOrder,
+        redisTestConstants.defaultOrderUuidConditional,
+        replacedOrderConditional,
+        false,
+        true,
+      ],
+      [
+        'Fill-or-Kill',
+        redisTestConstants.defaultOrderFok,
+        replacementMessageFok,
+        redisTestConstants.defaultRedisOrderFok,
+        dbDefaultOrderFok,
+        redisTestConstants.defaultOrderUuid,
+        replacedOrderFok,
+        true,
+        false,
+      ],
+      [
+        'Immediate-or-Cancel',
+        redisTestConstants.defaultOrderIoc,
+        replacementMessageIoc,
+        redisTestConstants.defaultRedisOrderIoc,
+        dbDefaultOrderIoc,
+        redisTestConstants.defaultOrderUuid,
+        replacedOrderIoc,
+        true,
+        false,
+      ],
+    ])('handles order place for replacing order (with %s), resting on book', async (
+      _name: string,
+      initialOrderToPlace: IndexerOrder,
+      orderReplacementMessage: KafkaMessage,
+      expectedRedisOrder: RedisOrder,
+      dbOrder: OrderFromDatabase,
+      expectedOrderUuid: string,
+      expectedReplacedOrder: RedisOrder,
+      expectSubaccountMessage: boolean,
+      expectOrderBookUpdate: boolean,
+    ) => {
+      const oldOrderTotalFilled: number = 10;
+      const oldPriceLevelInitialQuantums: number = Number(initialOrderToPlace.quantums) * 2;
+      // After replacing the order the quantums at the price level of the old order should be:
+      // initial quantums - (old order quantums - old order total filled)
+      const expectedPriceLevelQuantums: number = (
+        oldPriceLevelInitialQuantums - (Number(initialOrderToPlace.quantums) - oldOrderTotalFilled)
+      );
+      const expectedPriceLevel: PriceLevel = {
+        humanPrice: expectedRedisOrder.price,
+        quantums: expectedPriceLevelQuantums.toString(),
+        lastUpdated: expect.stringMatching(/^[0-9]{10}$/),
+      };
+
+      synchronizeWrapBackgroundTask(wrapBackgroundTask);
+      const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
+      // Handle the order place event for the initial order
+      await handleInitialOrderPlace({
+        ...redisTestConstants.orderPlace,
+        orderPlace: {
+          order: initialOrderToPlace,
+          placementStatus:
+              OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+        },
+      });
+      expectWebsocketMessagesSent(
+        producerSendSpy,
+        expectedRedisOrder,
+        dbOrder,
+        testConstants.defaultPerpetualMarket,
+        APIOrderStatusEnum.BEST_EFFORT_OPENED,
+        expectSubaccountMessage,
+      );
+      // clear mocks
+      jest.clearAllMocks();
+
+      // Update the order to set it to be resting on the book
+      await updateOrder({
+        updatedOrderId: initialOrderToPlace.orderId!,
+        newTotalFilledQuantums: oldOrderTotalFilled,
+        client,
+      });
+
+      // Update the price level in the order book to a value larger than the quantums of the order
+      await OrderbookLevelsCache.updatePriceLevel({
+        ticker: testConstants.defaultPerpetualMarket.ticker,
+        side: protocolTranslations.protocolOrderSideToOrderSide(
+          initialOrderToPlace.side,
+        ),
+        humanPrice: expectedRedisOrder.price,
+        sizeDeltaInQuantums: oldPriceLevelInitialQuantums.toString(),
+        client,
+      });
+
+      // Handle the order place off-chain update with the replacement order
+      await onMessage(orderReplacementMessage);
+
+      await checkOrderPlace(
+        expectedOrderUuid,
+        redisTestConstants.defaultSubaccountUuid,
+        expectedReplacedOrder,
+      );
+      const orderbook: OrderbookLevels = await OrderbookLevelsCache.getOrderBookLevels(
+        testConstants.defaultPerpetualMarket.ticker,
+        client,
+      );
+
+      // Check the order book levels were updated
+      if (expectOrderBookUpdate) {
+        expect(orderbook.bids).toHaveLength(1);
+        expect(orderbook.asks).toHaveLength(0);
+        expect(orderbook.bids).toContainEqual(expectedPriceLevel);
+      }
+
+      expect(logger.error).not.toHaveBeenCalled();
+      expectWebsocketMessagesSent(
+        producerSendSpy,
+        expectedReplacedOrder,
+        dbOrder,
+        testConstants.defaultPerpetualMarket,
+        APIOrderStatusEnum.BEST_EFFORT_OPENED,
+        expectSubaccountMessage,
+      );
+      expectStats(true);
+    });
+
+    // TODO(IND-68): Remove this test once order replacement logic does not change price levels as
+    // orders are removed before being re-placed.
+    it.each([
+      [
+        'goodTilBlock',
+        redisTestConstants.defaultOrder,
+        replacementMessage,
+        redisTestConstants.defaultRedisOrder,
+        dbDefaultOrder,
+        redisTestConstants.defaultOrderUuid,
+        replacedOrder,
+        true,
+      ],
+      [
+        'goodTilBlockTime',
+        redisTestConstants.defaultOrderGoodTilBlockTime,
+        replacementMessageGoodTilBlockTime,
+        redisTestConstants.defaultRedisOrderGoodTilBlockTime,
+        dbOrderGoodTilBlockTime,
+        redisTestConstants.defaultOrderUuidGoodTilBlockTime,
+        replacedOrderGoodTilBlockTime,
+        false,
+      ],
+      [
+        'conditional',
+        redisTestConstants.defaultConditionalOrder,
+        replacementMessageConditional,
+        redisTestConstants.defaultRedisOrderConditional,
+        dbConditionalOrder,
+        redisTestConstants.defaultOrderUuidConditional,
+        replacedOrderConditional,
+        false,
+      ],
+    ])('handles order place for replacing order (with %s), resting on book, 0 remaining quantums',
+      async (
+        _name: string,
+        initialOrderToPlace: IndexerOrder,
+        orderReplacementMessage: KafkaMessage,
+        expectedRedisOrder: RedisOrder,
+        dbOrder: OrderFromDatabase,
+        expectedOrderUuid: string,
+        expectedReplacedOrder: RedisOrder,
+        expectSubaccountMessage: boolean,
+      ) => {
+        synchronizeWrapBackgroundTask(wrapBackgroundTask);
+        const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
+        // Handle the order place event for the initial order
+        await handleInitialOrderPlace({
+          ...redisTestConstants.orderPlace,
+          orderPlace: {
+            order: initialOrderToPlace,
+            placementStatus:
+                OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+          },
+        });
+        expectWebsocketMessagesSent(
+          producerSendSpy,
+          expectedRedisOrder,
+          dbOrder,
+          testConstants.defaultPerpetualMarket,
+          APIOrderStatusEnum.BEST_EFFORT_OPENED,
+          expectSubaccountMessage,
+        );
+        expectStats();
+        // clear mocks
+        jest.clearAllMocks();
+
+        // Update the order to set it to be resting on the book
+        await updateOrder({
+          updatedOrderId: initialOrderToPlace.orderId!,
+          newTotalFilledQuantums: Number(initialOrderToPlace.quantums),
+          client,
+        });
+        // Handle the order place off-chain update with the replacement order
+        await onMessage(orderReplacementMessage);
+
+        await checkOrderPlace(
+          expectedOrderUuid,
+          redisTestConstants.defaultSubaccountUuid,
+          expectedReplacedOrder,
+        );
+        // expect(OrderbookLevelsCache.updatePriceLevel).not.toHaveBeenCalled();
+
+        expect(logger.error).not.toHaveBeenCalled();
+        expectWebsocketMessagesSent(
+          producerSendSpy,
+          expectedReplacedOrder,
+          dbOrder,
+          testConstants.defaultPerpetualMarket,
+          APIOrderStatusEnum.BEST_EFFORT_OPENED,
+          expectSubaccountMessage,
+        );
+        expectStats(true);
+      },
+    );
+
+    it.each([
+      [
+        'missing order',
+        {
+          ...redisTestConstants.orderReplace,
+          orderReplace: { ...redisTestConstants.orderReplace.orderReplace, order: undefined },
+        },
+        'Invalid OrderReplace, order is undefined',
+      ],
+      [
+        'missing order id',
+        {
+          orderReplace: {
+            ...redisTestConstants.orderReplace.orderReplace,
+            order: {
+              ...redisTestConstants.defaultOrder,
+              orderId: undefined,
+            },
+          },
+        },
+        'Invalid OrderReplace, order id is undefined',
+      ],
+      [
+        'missing order id',
+        {
+          orderReplace: {
+            ...redisTestConstants.orderReplace.orderReplace,
+            order: {
+              ...redisTestConstants.defaultOrder,
+              orderId: {
+                ...redisTestConstants.defaultOrderId,
+                subaccountId: undefined,
+              },
+            },
+          },
+        },
+        'Invalid OrderReplace, subaccount id is undefined',
+      ],
+      [
+        'unspecified placement status',
+        {
+          ...redisTestConstants.orderReplace,
+          orderReplace: {
+            ...redisTestConstants.orderReplace.orderReplace,
+            placementStatus: OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_UNSPECIFIED,
+          },
+        },
+        'Invalid OrderReplace, placement status is UNSPECIFIED',
+      ],
+    ])('logs error and does not update caches on invalid order place off-chain update: %s', async (
+      _name: string,
+      updateMessage: any,
+      errorMsg: string,
+    ) => {
+      const update: OffChainUpdateV1 = {
+        ...updateMessage,
+      };
+      const message: KafkaMessage = createKafkaMessage(
+        Buffer.from(Uint8Array.from(OffChainUpdateV1.encode(update).finish())),
+      );
+
+      synchronizeWrapBackgroundTask(wrapBackgroundTask);
+      const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
+      await onMessage(message);
+
+      expect(redisPackage.placeOrder).not.toHaveBeenCalled();
+      expect(OrderbookLevelsCache.updatePriceLevel).not.toHaveBeenCalled();
+      expectWebsocketMessagesNotSent(producerSendSpy);
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({
+        at: 'OrderReplaceHandler#logAndThrowParseMessageError',
+        message: errorMsg,
+      }));
+    });
+
+    it('logs error and does not update caches if order has invalid clobPairId', async () => {
+      const update: OffChainUpdateV1 = {
+        orderReplace: {
+          ...redisTestConstants.orderReplace.orderReplace,
+          order: {
+            ...redisTestConstants.defaultOrder,
+            orderId: {
+              ...redisTestConstants.defaultOrderId,
+              clobPairId: 34,
+            },
+          },
+          placementStatus:
+              OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED,
+        },
+      };
+      const message: KafkaMessage = createKafkaMessage(
+        Buffer.from(Uint8Array.from(OffChainUpdateV1.encode(update).finish())),
+      );
+
+      synchronizeWrapBackgroundTask(wrapBackgroundTask);
+      const producerSendSpy: jest.SpyInstance = jest.spyOn(producer, 'send').mockReturnThis();
+      await onMessage(message);
+
+      expect(redisPackage.placeOrder).not.toHaveBeenCalled();
+      expect(OrderbookLevelsCache.updatePriceLevel).not.toHaveBeenCalled();
+      expectWebsocketMessagesNotSent(producerSendSpy);
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({
+        at: 'OrderReplaceHandler#logAndThrowParseMessageError',
+        message: 'Order in OrderReplace has invalid clobPairId',
+      }));
+    });
+  });
+});
+
+async function checkOrderPlace(
+  placedOrderId: string,
+  placedSubaccountId: string,
+  expectedOrder: RedisOrder,
+): Promise<void> {
+  const redisOrder: RedisOrder | null = await OrdersCache.getOrder(placedOrderId, client);
+  const orderIdsForSubaccount: string[] = await SubaccountOrderIdsCache.getOrderIdsForSubaccount(
+    placedSubaccountId,
+    client,
+  );
+
+  expect(redisOrder).toEqual(expectedOrder);
+  expect(orderIdsForSubaccount).toEqual([placedOrderId]);
+}
+
+function expectStats(orderWasReplaced: boolean = false): void {
+  let className: string = 'OrderPlaceHandler';
+
+  if (orderWasReplaced) {
+    className = 'OrderReplaceHandler';
+  }
+  expect(stats.timing).toHaveBeenCalledWith(
+    `vulcan.${STATS_FUNCTION_NAME}.timing`,
+    expect.any(Number),
+    { className, fnName: 'place_order_cache_update' },
+  );
+
+  expect(stats.increment).not.toHaveBeenCalledWith(
+    'vulcan.place_order_handler.replaced_order',
+    expect.any(Number),
+  );
+}
+
+function expectWebsocketMessagesSent(
+  producerSendSpy: jest.SpyInstance,
+  redisOrder: RedisOrder,
+  dbOrder: OrderFromDatabase,
+  perpetualMarket: PerpetualMarketFromDatabase,
+  placementStatus: APIOrderStatus,
+  expectSubaccountMessage: boolean,
+  expectedOrderbookMessage?: OrderbookMessage,
+  expectedOffchainUpdate?: OffchainUpdateRecord,
+): void {
+  jest.runOnlyPendingTimers();
+  // expect one subaccount update message being sent
+  let numMessages: number = 0;
+  if (expectSubaccountMessage) {
+    numMessages += 1;
+  }
+  if (expectedOrderbookMessage !== undefined) {
+    numMessages += 1;
+  }
+  if (expectedOffchainUpdate !== undefined) {
+    numMessages += 1;
+  }
+  expect(producerSendSpy).toHaveBeenCalledTimes(numMessages);
+
+  let callIndex: number = 0;
+
+  if (expectedOffchainUpdate) {
+    expectOffchainUpdateMessage(
+      producerSendSpy.mock.calls[callIndex][0],
+      expectedOffchainUpdate.key,
+      expectedOffchainUpdate.offchainUpdate,
+    );
+    callIndex += 1;
+  }
+
+  if (expectSubaccountMessage) {
+    const orderTIF: TimeInForce = protocolTranslations.protocolOrderTIFToTIF(
+      redisOrder.order!.timeInForce,
+    );
+    const isStateful: boolean = isStatefulOrder(redisOrder.order!.orderId!.orderFlags);
+    const contents: SubaccountMessageContents = {
+      orders: [
+        {
+          id: OrderTable.orderIdToUuid(
+            redisOrder.order!.orderId!,
+          ),
+          subaccountId: SubaccountTable.subaccountIdToUuid(
+            redisOrder.order!.orderId!.subaccountId!,
+          ),
+          clientId: redisOrder.order!.orderId!.clientId.toString(),
+          clobPairId: perpetualMarket.clobPairId,
+          side: protocolTranslations.protocolOrderSideToOrderSide(redisOrder.order!.side),
+          size: redisOrder.size,
+          price: redisOrder.price,
+          status: placementStatus,
+          type: protocolTranslations.protocolConditionTypeToOrderType(
+            redisOrder.order!.conditionType,
+          ),
+          timeInForce: apiTranslations.orderTIFToAPITIF(orderTIF),
+          postOnly: apiTranslations.isOrderTIFPostOnly(orderTIF),
+          reduceOnly: redisOrder.order!.reduceOnly,
+          orderFlags: redisOrder.order!.orderId!.orderFlags.toString(),
+          goodTilBlock: protocolTranslations.getGoodTilBlock(redisOrder.order!)
+            ?.toString(),
+          goodTilBlockTime: protocolTranslations.getGoodTilBlockTime(redisOrder.order!),
+          ticker: redisOrder.ticker,
+          ...(isStateful && { createdAtHeight: dbOrder.createdAtHeight }),
+          ...(isStateful && { updatedAt: dbOrder.updatedAt }),
+          ...(isStateful && { updatedAtHeight: dbOrder.updatedAtHeight }),
+          clientMetadata: redisOrder.order!.clientMetadata.toString(),
+          triggerPrice: getTriggerPrice(redisOrder.order!, perpetualMarket),
+        },
+      ],
+      blockHeight: blockHeightRefresher.getLatestBlockHeight(),
+    };
+    const subaccountMessage: SubaccountMessage = SubaccountMessage.fromPartial({
+      contents: JSON.stringify(contents),
+      subaccountId: SubaccountId.fromPartial(redisOrder.order!.orderId!.subaccountId!),
+      version: SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
+    });
+
+    expectWebsocketSubaccountMessage(
+      producerSendSpy.mock.calls[callIndex][0],
+      subaccountMessage,
+      defaultKafkaHeaders,
+    );
+    callIndex += 1;
+  }
+
+  if (expectedOrderbookMessage !== undefined) {
+    expectWebsocketOrderbookMessage(
+      producerSendSpy.mock.calls[callIndex][0],
+      expectedOrderbookMessage,
+    );
+  }
+}
+
+function expectWebsocketMessagesNotSent(
+  producerSendSpy: jest.SpyInstance,
+): void {
+  expect(producerSendSpy).not.toBeCalled();
+}

--- a/indexer/services/vulcan/__tests__/lib/on-message.test.ts
+++ b/indexer/services/vulcan/__tests__/lib/on-message.test.ts
@@ -5,6 +5,7 @@ import { KafkaMessage } from 'kafkajs';
 import { onMessage } from '../../src/lib/on-message';
 import { OrderPlaceHandler } from '../../src/handlers/order-place-handler';
 import { OrderRemoveHandler } from '../../src/handlers/order-remove-handler';
+import { OrderReplaceHandler } from '../../src/handlers/order-replace-handler';
 import { OrderUpdateHandler } from '../../src/handlers/order-update-handler';
 import { redisTestConstants } from '@dydxprotocol-indexer/redis';
 import { setTransactionHash } from '../helpers/helpers';
@@ -12,12 +13,14 @@ import { setTransactionHash } from '../helpers/helpers';
 jest.mock('../../src/handlers/order-place-handler');
 jest.mock('../../src/handlers/order-remove-handler');
 jest.mock('../../src/handlers/order-update-handler');
+jest.mock('../../src/handlers/order-replace-handler');
 
 describe('onMessage', () => {
   const handlerMocks: jest.Mock[] = [
     (OrderPlaceHandler as jest.Mock),
     (OrderRemoveHandler as jest.Mock),
     (OrderUpdateHandler as jest.Mock),
+    (OrderReplaceHandler as jest.Mock),
   ];
   const testTxhash: Buffer = Buffer.from('testTxhash');
   let handleUpdateMock: jest.Mock;
@@ -44,6 +47,7 @@ describe('onMessage', () => {
     ['orderPlace', redisTestConstants.orderPlace, (OrderPlaceHandler as jest.Mock)],
     ['orderRemove', redisTestConstants.orderRemove, (OrderRemoveHandler as jest.Mock)],
     ['orderUpdate', redisTestConstants.orderUpdate, (OrderUpdateHandler as jest.Mock)],
+    ['orderReplace', redisTestConstants.orderReplace, (OrderReplaceHandler as jest.Mock)],
   ])('processes updates with the correct handler: %s', async (
     messageType: string,
     updateMessage: any,

--- a/indexer/services/vulcan/src/handlers/order-replace-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-replace-handler.ts
@@ -111,7 +111,7 @@ export class OrderReplaceHandler extends Handler {
       if (sendOrderbookMessage) {
         logger.info({
           at: 'OrderReplaceHandler#handle',
-          message: 'Sending orderbook message because price is the same',
+          message: 'Sending orderbook message because price is different',
           redisOrder,
           removedOrder: removeOrderResult.removedOrder!.order,
         });

--- a/indexer/services/vulcan/src/handlers/order-replace-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-replace-handler.ts
@@ -50,7 +50,7 @@ import { Handler } from './handler';
  * - Add the new order to the OrdersCache, OrdersDataCache, and SubaccountOrderIdsCache
  *  - this is done using the `placeOrder` function from the `redis` package
  *  - Remove the order from the CanceledOrdersCache if it exists
- * - Because the order is a stateful order, attempt to remove any cached order update from the
+ * - If the order is a stateful order, attempt to remove any cached order update from the
  *   StatefulOrderUpdatesCache, and then queue the order update to be re-sent and re-processed
  * - If the order doesn't already exist in the caches, return
  * - If the order exists in the caches, but was not replaced due to the expiry of the existing order

--- a/indexer/services/vulcan/src/handlers/order-replace-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-replace-handler.ts
@@ -43,7 +43,7 @@ import { sendMessageWrapper } from '../lib/send-message-helper';
 import { Handler } from './handler';
 
 /**
- * Handler for OrderReplace messages.
+ * Handler for OrderReplace messages. This is currently only expected for stateful vault orders.
  * The behavior is as follows:
  * - Remove the old order
  *  - this is done using the `removeOrder` function from the `redis` package
@@ -54,7 +54,7 @@ import { Handler } from './handler';
  *   StatefulOrderUpdatesCache, and then queue the order update to be re-sent and re-processed
  * - If the order doesn't already exist in the caches, return
  * - If the order exists in the caches, but was not replaced due to the expiry of the existing order
- *   being greater than or equal to the expiry of the order in the OrderPlace message, return
+ *   being greater than or equal to the expiry of the order in the OrderReplace message, return
  */
 export class OrderReplaceHandler extends Handler {
   protected async handle(update: OffChainUpdateV1, headers: IHeaders): Promise<void> {
@@ -225,7 +225,7 @@ export class OrderReplaceHandler extends Handler {
 
   /**
    * Determine whether to send a subaccount websocket message given the order place.
-   * @param orderPlace
+   * @param orderReplace
    * @returns TODO(CLOB-597): Remove once best-effort-opened messages are not sent for stateful
    * orders.
    */
@@ -252,7 +252,7 @@ export class OrderReplaceHandler extends Handler {
       return false;
     }
 
-    // In the case where a stateful orderPlace is opened with a more recent expiry than an
+    // In the case where a stateful orderReplace is opened with a more recent expiry than an
     // existing order on the indexer, then the order will not have been placed or replaced and
     // no subaccount message should be sent.
     if (placeOrderResult.placed === false &&

--- a/indexer/services/vulcan/src/handlers/order-replace-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-replace-handler.ts
@@ -1,0 +1,393 @@
+import { logger, runFuncWithTimingStat, stats } from '@dydxprotocol-indexer/base';
+import { createSubaccountWebsocketMessage, KafkaTopics } from '@dydxprotocol-indexer/kafka';
+import {
+  OrderFromDatabase,
+  OrderTable,
+  PerpetualMarketFromDatabase,
+  blockHeightRefresher,
+  perpetualMarketRefresher,
+  protocolTranslations,
+} from '@dydxprotocol-indexer/postgres';
+import {
+  CanceledOrdersCache,
+  OrderbookLevelsCache,
+  placeOrder,
+  PlaceOrderResult,
+  StatefulOrderUpdatesCache,
+  convertToRedisOrder,
+  removeOrder,
+  RemoveOrderResult,
+} from '@dydxprotocol-indexer/redis';
+import {
+  getOrderIdHash,
+  isLongTermOrder,
+  isStatefulOrder,
+  ORDER_FLAG_SHORT_TERM,
+  requiresImmediateExecution,
+} from '@dydxprotocol-indexer/v4-proto-parser';
+import {
+  IndexerOrder,
+  IndexerOrderId,
+  OffChainUpdateV1,
+  OrderPlaceV1_OrderPlacementStatus,
+  OrderReplaceV1,
+  OrderUpdateV1,
+  RedisOrder,
+} from '@dydxprotocol-indexer/v4-protos';
+import Big from 'big.js';
+import { IHeaders, Message } from 'kafkajs';
+
+import config from '../config';
+import { redisClient } from '../helpers/redis/redis-controller';
+import { sendMessageWrapper } from '../lib/send-message-helper';
+import { Handler } from './handler';
+
+/**
+ * Handler for OrderReplace messages.
+ * The behavior is as follows:
+ * - Remove the old order
+ *  - this is done using the `removeOrder` function from the `redis` package
+ * - Add the new order to the OrdersCache, OrdersDataCache, and SubaccountOrderIdsCache
+ *  - this is done using the `placeOrder` function from the `redis` package
+ *  - Remove the order from the CanceledOrdersCache if it exists
+ * - Because the order is a stateful order, attempt to remove any cached order update from the
+ *   StatefulOrderUpdatesCache, and then queue the order update to be re-sent and re-processed
+ * - If the order doesn't already exist in the caches, return
+ * - If the order exists in the caches, but was not replaced due to the expiry of the existing order
+ *   being greater than or equal to the expiry of the order in the OrderPlace message, return
+ */
+export class OrderReplaceHandler extends Handler {
+  protected async handle(update: OffChainUpdateV1, headers: IHeaders): Promise<void> {
+    logger.info({
+      at: 'OrderReplaceHandler#handle',
+      message: 'Received OffChainUpdate with OrderReplace.',
+      update,
+      txHash: this.txHash,
+    });
+    const orderReplace: OrderReplaceV1 = update.orderReplace!;
+    this.validateOrderReplace(orderReplace);
+    const oldOrderId: IndexerOrderId = orderReplace.oldOrderId!;
+
+    /* Remove old order */
+    const removeOrderResult: RemoveOrderResult = await this.removeOldOrder(oldOrderId);
+
+    /* Place new order */
+    const order: IndexerOrder = orderReplace.order!;
+    const placementStatus: OrderPlaceV1_OrderPlacementStatus = orderReplace.placementStatus;
+    const perpetualMarket: PerpetualMarketFromDatabase | undefined = perpetualMarketRefresher
+      .getPerpetualMarketFromClobPairId(order.orderId!.clobPairId.toString());
+    if (perpetualMarket === undefined) {
+      this.logAndThrowParseMessageError(
+        'Order in OrderReplace has invalid clobPairId',
+        {
+          order,
+        },
+      );
+      // Needed so TS compiler knows `perpetualMarket` is defined
+      return;
+    }
+    const redisOrder: RedisOrder = convertToRedisOrder(order, perpetualMarket);
+    const placeOrderResult: PlaceOrderResult = await this.placeNewOrder(redisOrder);
+    if (placeOrderResult.replaced) {
+      // This is not expected because the replaced orders either have different order IDs or
+      // should have been removed before being placed again
+      stats.increment(`${config.SERVICE_NAME}.replace_order_handler.place_order_result_replaced_order`, 1);
+    }
+
+    // If an order was removed from the Orders cache and was resting on the book, update the
+    // orderbook levels cache
+    // Orders that require immediate execution do not rest on the book, and also should not lead
+    // to an update to the orderbook levels cache
+    if (
+      removeOrderResult.removed &&
+      removeOrderResult.restingOnBook === true &&
+      !requiresImmediateExecution(removeOrderResult.removedOrder!.order!.timeInForce)
+    ) {
+      // Don't send orderbook message if price is the same to prevent flickering because
+      // the order update will send the correct size update
+      const sendOrderbookMessage: boolean = (
+        redisOrder.order!.subticks.neq(removeOrderResult.removedOrder!.order!.subticks)
+      );
+      if (sendOrderbookMessage) {
+        logger.info({
+          at: 'OrderReplaceHandler#handle',
+          message: 'Sending orderbook message because price is the same',
+          redisOrder,
+          removedOrder: removeOrderResult.removedOrder!.order,
+        });
+      }
+      await this.removeOldOrderFromOrderbook(
+        removeOrderResult,
+        perpetualMarket,
+        headers,
+        sendOrderbookMessage,
+      );
+    }
+
+    // TODO(CLOB-597): Remove this logic and log erorrs once best-effort-open is not sent for
+    // stateful orders in the protocol
+    if (this.shouldSendSubaccountMessage(
+      orderReplace,
+      placeOrderResult,
+      placementStatus,
+      redisOrder,
+    )) {
+      // TODO(IND-171): Determine whether we should always be sending a message, even when the cache
+      // isn't updated.
+      // For stateful and conditional orders, look the order up in the db for the createdAtHeight
+      // and send any cached order updates for the stateful or conditional order
+      let dbOrder: OrderFromDatabase | undefined;
+      if (isStatefulOrder(redisOrder.order!.orderId!.orderFlags)) {
+        const orderUuid: string = OrderTable.orderIdToUuid(redisOrder.order!.orderId!);
+        dbOrder = await OrderTable.findById(orderUuid);
+        if (dbOrder === undefined) {
+          logger.crit({
+            at: 'OrderReplaceHandler#createSubaccountWebsocketMessage',
+            message: 'Stateful order not found in database',
+          });
+          throw new Error(`Stateful order not found in database: ${orderUuid}`);
+        }
+        await this.sendCachedOrderUpdate(orderUuid, headers);
+      }
+      const subaccountMessage: Message = {
+        value: createSubaccountWebsocketMessage(
+          redisOrder,
+          dbOrder,
+          perpetualMarket,
+          placementStatus,
+          blockHeightRefresher.getLatestBlockHeight(),
+        ),
+        headers,
+      };
+      sendMessageWrapper(subaccountMessage, KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS);
+    }
+  }
+
+  protected validateOrderReplace(orderReplace: OrderReplaceV1): void {
+    if (orderReplace.order === undefined) {
+      this.logAndThrowParseMessageError('Invalid OrderReplace, order is undefined');
+      return;
+    }
+
+    if (orderReplace.order.orderId === undefined) {
+      this.logAndThrowParseMessageError('Invalid OrderReplace, order id is undefined');
+      return;
+    }
+
+    if (orderReplace.order.orderId.subaccountId === undefined) {
+      this.logAndThrowParseMessageError('Invalid OrderReplace, subaccount id is undefined');
+    }
+
+    if (
+      orderReplace
+        .placementStatus === OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_UNSPECIFIED
+    ) {
+      this.logAndThrowParseMessageError('Invalid OrderReplace, placement status is UNSPECIFIED');
+    }
+  }
+
+  protected async removeOldOrder(oldOrderId: IndexerOrderId): Promise<RemoveOrderResult> {
+    const removeOrderResult: RemoveOrderResult = await runFuncWithTimingStat(
+      removeOrder({
+        removedOrderId: oldOrderId,
+        client: redisClient,
+      }),
+      this.generateTimingStatsOptions('remove_order'),
+    );
+    logger.info({
+      at: 'OrderReplaceHandler#handle',
+      message: 'removeOrder processed',
+      oldOrderId,
+      removeOrderResult,
+    });
+    return removeOrderResult;
+  }
+
+  protected async placeNewOrder(redisOrder: RedisOrder): Promise<PlaceOrderResult> {
+    const placeOrderResult: PlaceOrderResult = await runFuncWithTimingStat(
+      placeOrder({
+        redisOrder,
+        client: redisClient,
+      }),
+      this.generateTimingStatsOptions('place_order_cache_update'),
+    );
+    await this.removeOrderFromCanceledOrdersCache(
+      OrderTable.orderIdToUuid(redisOrder.order?.orderId!),
+    );
+    logger.info({
+      at: 'OrderReplaceHandler#handle',
+      message: 'placeOrder processed',
+      redisOrder,
+      placeOrderResult,
+    });
+    return placeOrderResult;
+  }
+
+  /**
+   * Determine whether to send a subaccount websocket message given the order place.
+   * @param orderPlace
+   * @returns TODO(CLOB-597): Remove once best-effort-opened messages are not sent for stateful
+   * orders.
+   */
+  protected shouldSendSubaccountMessage(
+    orderReplace: OrderReplaceV1,
+    placeOrderResult: PlaceOrderResult,
+    placementStatus: OrderPlaceV1_OrderPlacementStatus,
+    redisOrder: RedisOrder,
+  ): boolean {
+    if (
+      isLongTermOrder(redisOrder.order!.orderId!.orderFlags) &&
+      !config.SEND_SUBACCOUNT_WEBSOCKET_MESSAGE_FOR_STATEFUL_ORDERS
+    ) {
+      return false;
+    }
+
+    const orderFlags: number = orderReplace.order!.orderId!.orderFlags;
+    const status: OrderPlaceV1_OrderPlacementStatus = orderReplace.placementStatus;
+    // Best-effort-opened status should only be sent for short-term orders
+    if (
+      orderFlags !== ORDER_FLAG_SHORT_TERM &&
+      status === OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED
+    ) {
+      return false;
+    }
+
+    // In the case where a stateful orderPlace is opened with a more recent expiry than an
+    // existing order on the indexer, then the order will not have been placed or replaced and
+    // no subaccount message should be sent.
+    if (placeOrderResult.placed === false &&
+      placeOrderResult.replaced === false &&
+      placementStatus ===
+      OrderPlaceV1_OrderPlacementStatus.ORDER_PLACEMENT_STATUS_BEST_EFFORT_OPENED) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Removes the order from the cancelled orders cache in Redis.
+   *
+   * @param orderId
+   * @protected
+   */
+  protected async removeOrderFromCanceledOrdersCache(
+    orderId: string,
+  ): Promise<void> {
+    await runFuncWithTimingStat(
+      CanceledOrdersCache.removeOrderFromCaches(orderId, redisClient),
+      this.generateTimingStatsOptions('remove_order_from_cancel_cache'),
+    );
+  }
+
+  /**
+   * Removes and sends the cached order update for the given order id if it exists.
+   *
+   * @param orderId
+   * @returns
+   */
+  protected async sendCachedOrderUpdate(
+    orderId: string,
+    headers: IHeaders,
+  ): Promise<void> {
+    const cachedOrderUpdate: OrderUpdateV1 | undefined = await StatefulOrderUpdatesCache
+      .removeStatefulOrderUpdate(
+        orderId,
+        Date.now(),
+        redisClient,
+      );
+
+    if (cachedOrderUpdate === undefined) {
+      return;
+    }
+
+    const orderUpdateMessage: Message = {
+      key: getOrderIdHash(cachedOrderUpdate.orderId!),
+      value: Buffer.from(
+        Uint8Array.from(OffChainUpdateV1.encode({ orderUpdate: cachedOrderUpdate }).finish()),
+      ),
+      headers,
+    };
+    sendMessageWrapper(orderUpdateMessage, KafkaTopics.TO_VULCAN);
+  }
+
+  /**
+   * Updates the orderbook and sends a message to socks for the change in the orderbook.
+   * @param removeOrderResult
+   * @param perpetualMarket
+   */
+  protected async removeOldOrderFromOrderbook(
+    removeOrderResult: RemoveOrderResult,
+    perpetualMarket: PerpetualMarketFromDatabase,
+    headers: IHeaders,
+    sendWebsocketMessage: boolean,
+  ): Promise<void> {
+    const updatedQuantums: number = await runFuncWithTimingStat(
+      this.updatePriceLevelsCache(
+        removeOrderResult,
+      ),
+      this.generateTimingStatsOptions('update_price_level_cache'),
+    );
+    if (sendWebsocketMessage) {
+      const orderbookMessage: Message = {
+        value: this.createOrderbookWebsocketMessage(
+          removeOrderResult.removedOrder!,
+          perpetualMarket,
+          updatedQuantums,
+        ),
+        headers,
+      };
+      sendMessageWrapper(orderbookMessage, KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS);
+    }
+  }
+
+  /**
+   * Update orderbookLevelsCache, and assumes that the order is resting on the book
+   * @param removeOrderResult
+   * @returns
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  protected async updatePriceLevelsCache(
+    removeOrderResult: RemoveOrderResult,
+  ): Promise<number> {
+    const redisOrder: RedisOrder = removeOrderResult.removedOrder!;
+    return OrderbookLevelsCache.updatePriceLevel({
+      ticker: redisOrder.ticker,
+      side: protocolTranslations.protocolOrderSideToOrderSide(redisOrder.order!.side),
+      humanPrice: redisOrder.price,
+      sizeDeltaInQuantums: this.getSizeDeltaInQuantums(
+        removeOrderResult,
+        redisOrder,
+      ),
+      client: redisClient,
+    });
+  }
+
+  protected getSizeDeltaInQuantums(
+    removeOrderResult: RemoveOrderResult,
+    redisOrder: RedisOrder,
+  ): string {
+    const sizeDelta: Big = Big(
+      removeOrderResult.totalFilledQuantums!.toString(),
+    ).minus(
+      redisOrder.order!.quantums.toString(),
+    );
+
+    // TODO(IND-147): This should not be happening once `ender` updates orderbook for filled orders
+    // rather than having off-chain updates sent from the protocol. Change to error once it's
+    // confirmed this case no longer happens normally.
+    if (sizeDelta.gt(0)) {
+      logger.info({
+        at: 'OrderReplaceHandler#getSizeDeltaInQuantums',
+        message: 'Total filled of order exceeds quantums of order',
+        totalFilled: removeOrderResult.totalFilledQuantums!.toString(),
+        quantums: redisOrder.order!.quantums.toString(),
+        removeOrderResult,
+        redisOrder,
+      });
+      return '0';
+    }
+
+    return sizeDelta.toFixed();
+  }
+
+}

--- a/indexer/services/vulcan/src/lib/on-message.ts
+++ b/indexer/services/vulcan/src/lib/on-message.ts
@@ -12,6 +12,7 @@ import { Handler } from 'src/handlers/handler';
 import config from '../config';
 import { OrderPlaceHandler } from '../handlers/order-place-handler';
 import { OrderRemoveHandler } from '../handlers/order-remove-handler';
+import { OrderReplaceHandler } from '../handlers/order-replace-handler';
 import { OrderUpdateHandler } from '../handlers/order-update-handler';
 import { DydxRecordHeaderKeys } from './types';
 
@@ -26,6 +27,8 @@ function getHandler(update: OffChainUpdateV1): HandlerInitializer | undefined {
     return OrderPlaceHandler;
   } else if (update.orderRemove !== undefined) {
     return OrderRemoveHandler;
+  } else if (update.orderReplace !== undefined) {
+    return OrderReplaceHandler;
   }
   return undefined;
 }
@@ -37,6 +40,8 @@ function getMessageType(update: OffChainUpdateV1): string {
     return 'orderPlace';
   } else if (update.orderRemove !== undefined) {
     return 'orderRemove';
+  } else if (update.orderReplace !== undefined) {
+    return 'orderReplace';
   }
   return 'unknown';
 }
@@ -116,6 +121,8 @@ export async function onMessage(message: KafkaMessage): Promise<void> {
         headers.event_type = 'ShortTermOrderRemoval';
       } else if (update.orderUpdate) {
         headers.event_type = 'ShortTermOrderUpdate';
+      } else if (update.orderUpdate) {
+        headers.event_type = 'ShortTermOrderReplacement';
       }
     }
 
@@ -183,8 +190,9 @@ function getOffChainUpdate(messageValue: Buffer, offset: string): OffChainUpdate
 function validateOffChainUpdate(update: OffChainUpdateV1) {
   if (update.orderUpdate === undefined &&
     update.orderPlace === undefined &&
-    update.orderRemove === undefined) {
-    throw new ParseMessageError('Message does not contain an order update, place, or remove');
+    update.orderRemove === undefined &&
+    update.orderReplace === undefined) {
+    throw new ParseMessageError('Message does not contain an order update, place, remove, or replace');
   }
 }
 


### PR DESCRIPTION
### Changelist
Handle order replacement message in vulcan by:
1. Removing old order id from Orders Cache
2. Adding new order to Orders Cache
3. Update OrderbookLevelsCache by removing the unfilled amount of the old order from that price level
4. Send an orderbook message to socks only if price of old and new order are different. If they are the same, do not send it in this handler and expect it to be sent when handling the following order update message

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented `OrderReplaceHandler` for managing OrderReplace messages, including old order removal, new order placement, and orderbook updates.

- **Tests**
  - Added comprehensive tests for order replacement logic, cache updates, and messaging to ensure robust handling of replaced orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->