### PR TITLE
chore: move SettledUpdate type to the types package

### DIFF
--- a/protocol/x/subaccounts/keeper/isolated_subaccount.go
+++ b/protocol/x/subaccounts/keeper/isolated_subaccount.go
@@ -23,7 +23,7 @@ import (
 // caused a failure, if any.
 func (k Keeper) checkIsolatedSubaccountConstraints(
 	ctx sdk.Context,
-	settledUpdates []SettledUpdate,
+	settledUpdates []types.SettledUpdate,
 	perpInfos map[uint32]perptypes.PerpInfo,
 ) (
 	success bool,
@@ -59,7 +59,7 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 //   - a subaccount with no positions cannot be updated to have positions in multiple isolated
 //     perpetuals or a combination of isolated and non-isolated perpetuals
 func isValidIsolatedPerpetualUpdates(
-	settledUpdate SettledUpdate,
+	settledUpdate types.SettledUpdate,
 	perpInfos map[uint32]perptypes.PerpInfo,
 ) (types.UpdateResult, error) {
 	// If there are no perpetual updates, then this update does not violate constraints for isolated
@@ -141,7 +141,7 @@ func isValidIsolatedPerpetualUpdates(
 // The input `settledUpdate` must have an updated subaccount (`settledUpdate.SettledSubaccount`),
 // so all the updates must have been applied already to the subaccount.
 func GetIsolatedPerpetualStateTransition(
-	settledUpdateWithUpdatedSubaccount SettledUpdate,
+	settledUpdateWithUpdatedSubaccount types.SettledUpdate,
 	perpInfos map[uint32]perptypes.PerpInfo,
 ) (*types.IsolatedPerpetualPositionStateTransition, error) {
 	// This subaccount needs to have had the updates in the `settledUpdate` already applied to it.
@@ -317,7 +317,7 @@ func (k *Keeper) transferCollateralForIsolatedPerpetual(
 // Note: This uses the `x/bank` keeper and modifies `x/bank` state.
 func (k *Keeper) computeAndExecuteCollateralTransfer(
 	ctx sdk.Context,
-	settledUpdateWithUpdatedSubaccount SettledUpdate,
+	settledUpdateWithUpdatedSubaccount types.SettledUpdate,
 	perpInfos map[uint32]perptypes.PerpInfo,
 ) error {
 	// The subaccount in `settledUpdateWithUpdatedSubaccount` already has the perpetual updates

--- a/protocol/x/subaccounts/keeper/isolated_subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/isolated_subaccount_test.go
@@ -16,7 +16,7 @@ import (
 func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 	tests := map[string]struct {
 		// parameters
-		settledUpdateWithUpdatedSubaccount keeper.SettledUpdate
+		settledUpdateWithUpdatedSubaccount types.SettledUpdate
 		perpetuals                         []perptypes.Perpetual
 
 		// expectation
@@ -24,7 +24,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 		expectedErr             error
 	}{
 		`If no perpetual updates, nil state transition is returned`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id:                 &constants.Alice_Num0,
 					PerpetualPositions: nil,
@@ -37,7 +37,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 			expectedStateTransition: nil,
 		},
 		`If single non-isolated perpetual updates, nil state transition is returned`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id:                 &constants.Alice_Num0,
 					PerpetualPositions: nil,
@@ -57,7 +57,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 			expectedStateTransition: nil,
 		},
 		`If multiple non-isolated perpetual updates, nil state transition is returned`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id:                 &constants.Alice_Num0,
 					PerpetualPositions: nil,
@@ -82,7 +82,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 			expectedStateTransition: nil,
 		},
 		`If multiple non-isolated perpetual positions, nil state transition is returned`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id: &constants.Alice_Num0,
 					PerpetualPositions: []*types.PerpetualPosition{
@@ -106,7 +106,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 			expectedStateTransition: nil,
 		},
 		`If single isolated perpetual update, no perpetual position, state transition is returned for closed position`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id:                 &constants.Alice_Num0,
 					PerpetualPositions: nil,
@@ -139,7 +139,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 		},
 		`If single isolated perpetual update, existing perpetual position with same size, state transition is returned for
 		opened position`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id: &constants.Alice_Num0,
 					PerpetualPositions: []*types.PerpetualPosition{
@@ -177,7 +177,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 		},
 		`If single isolated perpetual update, existing perpetual position with different size, nil state transition
 		returned`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id: &constants.Alice_Num0,
 					PerpetualPositions: []*types.PerpetualPosition{
@@ -209,7 +209,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 			expectedStateTransition: nil,
 		},
 		`Returns error if perpetual position was opened with no asset updates`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id: &constants.Alice_Num0,
 					PerpetualPositions: []*types.PerpetualPosition{
@@ -237,7 +237,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 			expectedErr:             types.ErrFailedToUpdateSubaccounts,
 		},
 		`Returns error if perpetual position was opened with multiple asset updates`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id: &constants.Alice_Num0,
 					PerpetualPositions: []*types.PerpetualPosition{
@@ -278,7 +278,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 			expectedErr:             types.ErrFailedToUpdateSubaccounts,
 		},
 		`Returns error if perpetual position was opened with non-usdc asset update`: {
-			settledUpdateWithUpdatedSubaccount: keeper.SettledUpdate{
+			settledUpdateWithUpdatedSubaccount: types.SettledUpdate{
 				SettledSubaccount: types.Subaccount{
 					Id: &constants.Alice_Num0,
 					PerpetualPositions: []*types.PerpetualPosition{

--- a/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
+++ b/protocol/x/subaccounts/keeper/negative_tnc_subaccount.go
@@ -123,7 +123,7 @@ func (k Keeper) getNegativeTncSubaccountStoreSuffix(
 // The slice will be de-duplicated and will contain unique store suffixes.
 func (k Keeper) getNegativeTncSubaccountStoresuffixes(
 	ctx sdk.Context,
-	settledUpdates []SettledUpdate,
+	settledUpdates []types.SettledUpdate,
 ) (
 	suffixes []string,
 	err error,
@@ -152,7 +152,7 @@ func (k Keeper) getNegativeTncSubaccountStoresuffixes(
 // collateral was seen for subaccounts in a slice of settled updates.
 func (k Keeper) getLastBlockNegativeSubaccountSeen(
 	ctx sdk.Context,
-	settledUpdates []SettledUpdate,
+	settledUpdates []types.SettledUpdate,
 ) (
 	lastBlockNegativeSubaccountSeen uint32,
 	negativeSubaccountExists bool,

--- a/protocol/x/subaccounts/keeper/oimf.go
+++ b/protocol/x/subaccounts/keeper/oimf.go
@@ -10,7 +10,7 @@ import (
 
 // Helper function to compute the delta long for a single settled update on a perpetual.
 func getDeltaLongFromSettledUpdate(
-	u SettledUpdate,
+	u types.SettledUpdate,
 	updatedPerpId uint32,
 ) (
 	deltaLong *big.Int,
@@ -51,7 +51,7 @@ func getDeltaLongFromSettledUpdate(
 //
 // For other update types, returns nil.
 func GetDeltaOpenInterestFromUpdates(
-	settledUpdates []SettledUpdate,
+	settledUpdates []types.SettledUpdate,
 	updateType types.UpdateType,
 ) (ret *perptypes.OpenInterestDelta) {
 	if updateType != types.Match {

--- a/protocol/x/subaccounts/keeper/oimf_test.go
+++ b/protocol/x/subaccounts/keeper/oimf_test.go
@@ -23,14 +23,14 @@ var (
 
 func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 	tests := map[string]struct {
-		settledUpdates []keeper.SettledUpdate
+		settledUpdates []types.SettledUpdate
 		updateType     types.UpdateType
 		expectedVal    *perptypes.OpenInterestDelta
 		panicErr       string
 	}{
 		"Invalid: 1 update": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{},
 					PerpetualUpdates: []types.PerpetualUpdate{
@@ -45,7 +45,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Invalid: one of the updates contains no perp update": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id: aliceSubaccountId,
@@ -67,7 +67,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Invalid: updates are on different perpetuals": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id: aliceSubaccountId,
@@ -95,7 +95,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Invalid: updates don't have opposite signs": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id: aliceSubaccountId,
@@ -123,7 +123,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Invalid: updates don't have equal absolute base quantums": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id: aliceSubaccountId,
@@ -151,7 +151,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Valid: 0 -> -500, 0 -> 500, delta = 500": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id: aliceSubaccountId,
@@ -182,7 +182,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Valid: 500 -> 0, 0 -> 500, delta = 0": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id:                 aliceSubaccountId,
@@ -217,7 +217,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Not Match update, return nil": {
 			updateType: types.CollatCheck,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id:                 aliceSubaccountId,
@@ -235,7 +235,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Valid: 500 -> 350, 0 -> 150, delta = 0": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id: aliceSubaccountId,
@@ -270,7 +270,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Valid: -100 -> 200, 250 -> -50, delta = -50": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id: aliceSubaccountId,
@@ -313,7 +313,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 		},
 		"Valid: -3100 -> -5000, 1000 -> 2900, delta = 1900": {
 			updateType: types.Match,
-			settledUpdates: []keeper.SettledUpdate{
+			settledUpdates: []types.SettledUpdate{
 				{
 					SettledSubaccount: types.Subaccount{
 						Id: aliceSubaccountId,

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -214,12 +214,12 @@ func (k Keeper) getSettledUpdates(
 	perpInfos map[uint32]perptypes.PerpInfo,
 	requireUniqueSubaccount bool,
 ) (
-	settledUpdates []SettledUpdate,
+	settledUpdates []types.SettledUpdate,
 	subaccountIdToFundingPayments map[types.SubaccountId]map[uint32]dtypes.SerializableInt,
 	err error,
 ) {
 	var idToSettledSubaccount = make(map[types.SubaccountId]types.Subaccount)
-	settledUpdates = make([]SettledUpdate, len(updates))
+	settledUpdates = make([]types.SettledUpdate, len(updates))
 	subaccountIdToFundingPayments = make(map[types.SubaccountId]map[uint32]dtypes.SerializableInt)
 
 	// Iterate over all updates and query the relevant `Subaccounts`.
@@ -244,7 +244,7 @@ func (k Keeper) getSettledUpdates(
 			subaccountIdToFundingPayments[u.SubaccountId] = fundingPayments
 		}
 
-		settledUpdate := SettledUpdate{
+		settledUpdate := types.SettledUpdate{
 			SettledSubaccount: settledSubaccount,
 			AssetUpdates:      u.AssetUpdates,
 			PerpetualUpdates:  u.PerpetualUpdates,
@@ -548,7 +548,7 @@ func checkPositionUpdatable(
 // caused a failure, if any.
 func (k Keeper) internalCanUpdateSubaccounts(
 	ctx sdk.Context,
-	settledUpdates []SettledUpdate,
+	settledUpdates []types.SettledUpdate,
 	updateType types.UpdateType,
 	perpInfos map[uint32]perptypes.PerpInfo,
 ) (
@@ -706,7 +706,7 @@ func (k Keeper) internalCanUpdateSubaccounts(
 		// We must now check if the state transition is valid.
 		if bigNewInitialMargin.Cmp(bigNewNetCollateral) > 0 {
 			// Get the current collateralization and margin requirements without the update applied.
-			emptyUpdate := SettledUpdate{
+			emptyUpdate := types.SettledUpdate{
 				SettledSubaccount: u.SettledSubaccount,
 			}
 
@@ -850,7 +850,7 @@ func (k Keeper) GetNetCollateralAndMarginRequirements(
 		return nil, nil, nil, err
 	}
 
-	settledUpdate := SettledUpdate{
+	settledUpdate := types.SettledUpdate{
 		SettledSubaccount: settledSubaccount,
 		AssetUpdates:      update.AssetUpdates,
 		PerpetualUpdates:  update.PerpetualUpdates,
@@ -876,7 +876,7 @@ func (k Keeper) GetNetCollateralAndMarginRequirements(
 // If two position updates reference the same position, an error is returned.
 func (k Keeper) internalGetNetCollateralAndMarginRequirements(
 	ctx sdk.Context,
-	settledUpdate SettledUpdate,
+	settledUpdate types.SettledUpdate,
 	perpInfos map[uint32]perptypes.PerpInfo,
 ) (
 	bigNetCollateral *big.Int,

--- a/protocol/x/subaccounts/keeper/subaccount_helper.go
+++ b/protocol/x/subaccounts/keeper/subaccount_helper.go
@@ -14,7 +14,7 @@ import (
 // been updated. This will include any asset postions that were closed due to an update.
 // TODO(DEC-1295): look into reducing code duplication here using Generics+Reflect.
 func getUpdatedAssetPositions(
-	update SettledUpdate,
+	update types.SettledUpdate,
 ) []*types.AssetPosition {
 	assetIdToPositionMap := make(map[uint32]*types.AssetPosition)
 	for _, assetPosition := range update.SettledSubaccount.AssetPositions {
@@ -55,7 +55,7 @@ func getUpdatedAssetPositions(
 // been updated. This will include any perpetual postions that were closed due to an update or that
 // received / paid out funding payments..
 func getUpdatedPerpetualPositions(
-	update SettledUpdate,
+	update types.SettledUpdate,
 	fundingPayments map[uint32]dtypes.SerializableInt,
 ) []*types.PerpetualPosition {
 	perpetualIdToPositionMap := make(map[uint32]*types.PerpetualPosition)
@@ -104,7 +104,7 @@ func getUpdatedPerpetualPositions(
 // to reflect settledUpdate.PerpetualUpdates.
 // For newly created positions, use `perpIdToFundingIndex` map to populate the `FundingIndex` field.
 func UpdatePerpetualPositions(
-	settledUpdates []SettledUpdate,
+	settledUpdates []types.SettledUpdate,
 	perpInfos map[uint32]perptypes.PerpInfo,
 ) {
 	// Apply the updates.
@@ -168,7 +168,7 @@ func UpdatePerpetualPositions(
 // For each settledUpdate in settledUpdates, updates its SettledSubaccount.AssetPositions
 // to reflect settledUpdate.AssetUpdates.
 func UpdateAssetPositions(
-	settledUpdates []SettledUpdate,
+	settledUpdates []types.SettledUpdate,
 ) {
 	// Apply the updates.
 	for i, u := range settledUpdates {

--- a/protocol/x/subaccounts/types/settled_update.go
+++ b/protocol/x/subaccounts/types/settled_update.go
@@ -1,8 +1,4 @@
-package keeper
-
-import (
-	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
-)
+package types
 
 // SettledUpdate is used internally in the subaccounts keeper to
 // to specify changes to one or more `Subaccounts` (for example the
@@ -10,9 +6,9 @@ import (
 // The subaccount is always in its settled state.
 type SettledUpdate struct {
 	// The `Subaccount` for which this update applies to, in its settled form.
-	SettledSubaccount types.Subaccount
+	SettledSubaccount Subaccount
 	// A list of changes to make to any `AssetPositions` in the `Subaccount`.
-	AssetUpdates []types.AssetUpdate
+	AssetUpdates []AssetUpdate
 	// A list of changes to make to any `PerpetualPositions` in the `Subaccount`.
-	PerpetualUpdates []types.PerpetualUpdate
+	PerpetualUpdates []PerpetualUpdate
 }


### PR DESCRIPTION
### Changelist
`keeper` package is not good for defining types, even if the type is used only in the keeper package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal type references to enhance type consistency and code maintainability. This change doesn't affect end-user functionality directly but ensures more robust internal handling of subaccounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->