### PR TITLE
Stop serializing message to logger tags

### DIFF
--- a/protocol/x/clob/keeper/msg_server_cancel_orders.go
+++ b/protocol/x/clob/keeper/msg_server_cancel_orders.go
@@ -47,7 +47,6 @@ func (k Keeper) HandleMsgCancelOrder(
 		log.Callback, lib.TxMode(ctx),
 		log.BlockHeight, ctx.BlockHeight(),
 		log.Handler, log.CancelOrder,
-		log.Msg, msg,
 	)
 
 	defer func() {

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -51,7 +51,6 @@ func (k Keeper) HandleMsgPlaceOrder(
 		log.Callback, lib.TxMode(ctx),
 		log.BlockHeight, ctx.BlockHeight(),
 		log.Handler, log.PlaceOrder,
-		log.Msg, msg,
 	)
 
 	if !isInternalOrder {


### PR DESCRIPTION
### Changelist
- Remove this serialization. It is taking time in stateful order placement which is important due to vaults. We can consider removing all these allocs in the future.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logging behavior by removing redundant logging parameters during order placement and cancellation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->