### PR TITLE
Geoblocking should be based on ComplianceStatusTable

### DIFF
--- a/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
+++ b/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
@@ -1,7 +1,4 @@
 import {
-  CountryHeaders,
-  isRestrictedCountryHeaders,
-  INDEXER_GEOBLOCKED_PAYLOAD,
   INDEXER_COMPLIANCE_BLOCKED_PAYLOAD,
 } from '@dydxprotocol-indexer/compliance';
 import {
@@ -58,15 +55,6 @@ export async function complianceAndGeoCheck(
         );
       }
     }
-  }
-
-  if (isRestrictedCountryHeaders(req.headers as CountryHeaders)) {
-    return create4xxResponse(
-      res,
-      INDEXER_GEOBLOCKED_PAYLOAD,
-      403,
-      { code: BlockedCode.GEOBLOCKED },
-    );
   }
 
   return next();


### PR DESCRIPTION
### Changelist
Geoblocking should be based on ComplianceStatusTable rather than country code from cloudflare

### Test Plan
Removing unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compliance-check functionality by removing outdated checks for restricted countries, resulting in more streamlined and accurate compliance validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->