### PR TITLE
[OTE-419] Add GB_GEO to compliance reasons

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240613174832_add_gb_to_compliance_reasons.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240613174832_add_gb_to_compliance_reasons.ts
@@ -1,0 +1,19 @@
+import * as Knex from 'knex';
+
+import { formatAlterTableEnumSql } from '../helpers';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.raw(formatAlterTableEnumSql(
+    'compliance_status',
+    'reason',
+    ['MANUAL', 'US_GEO', 'CA_GEO', 'GB_GEO', 'SANCTIONED_GEO', 'COMPLIANCE_PROVIDER'],
+  ));
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.raw(formatAlterTableEnumSql(
+    'compliance_status',
+    'reason',
+    ['MANUAL', 'US_GEO', 'CA_GEO', 'SANCTIONED_GEO', 'COMPLIANCE_PROVIDER'],
+  ));
+}

--- a/indexer/packages/postgres/src/types/compliance-status-types.ts
+++ b/indexer/packages/postgres/src/types/compliance-status-types.ts
@@ -6,6 +6,7 @@ export enum ComplianceReason {
   MANUAL = 'MANUAL',
   US_GEO = 'US_GEO',
   CA_GEO = 'CA_GEO',
+  GB_GEO = 'GB_GEO',
   SANCTIONED_GEO = 'SANCTIONED_GEO',
   COMPLIANCE_PROVIDER = 'COMPLIANCE_PROVIDER',
 }

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -3575,6 +3575,7 @@ This operation does not require authentication
 |*anonymous*|MANUAL|
 |*anonymous*|US_GEO|
 |*anonymous*|CA_GEO|
+|*anonymous*|GB_GEO|
 |*anonymous*|SANCTIONED_GEO|
 |*anonymous*|COMPLIANCE_PROVIDER|
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -350,6 +350,7 @@
           "MANUAL",
           "US_GEO",
           "CA_GEO",
+          "GB_GEO",
           "SANCTIONED_GEO",
           "COMPLIANCE_PROVIDER"
         ],

--- a/indexer/services/comlink/src/helpers/compliance/compliance-utils.ts
+++ b/indexer/services/comlink/src/helpers/compliance/compliance-utils.ts
@@ -10,6 +10,8 @@ export function getGeoComplianceReason(
       return ComplianceReason.US_GEO;
     } else if (country === 'CA') {
       return ComplianceReason.CA_GEO;
+    } else if (country === 'GB') {
+      return ComplianceReason.GB_GEO;
     } else {
       return ComplianceReason.SANCTIONED_GEO;
     }


### PR DESCRIPTION
### Changelist
Add GB_GEO to compliance reasons

### Test Plan
None

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new geographic compliance reason, `GB_GEO`, across various parts of the application.

- **Documentation**
  - Updated API documentation to include the new `GB_GEO` geographic location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->