### PR TITLE
MsgBatchCancel Skip sequence number validation

### DIFF
--- a/protocol/app/ante/util.go
+++ b/protocol/app/ante/util.go
@@ -34,6 +34,10 @@ func ShouldSkipSequenceValidation(msgs []sdk.Msg) (shouldSkipValidation bool) {
 			}
 			// This is a `GoodTilBlock` message, continue to check the next message.
 			continue
+		case
+			*clobtypes.MsgBatchCancel:
+			// MsgBatchCancel only supports short term orders.
+			continue
 		default:
 			// Early return for messages that require sequence number validation.
 			return false

--- a/protocol/app/ante/util_test.go
+++ b/protocol/app/ante/util_test.go
@@ -28,6 +28,12 @@ func TestSkipSequenceValidation(t *testing.T) {
 			},
 			shouldSkipValidation: true,
 		},
+		"single batch cancel message": {
+			msgs: []sdk.Msg{
+				constants.Msg_BatchCancel,
+			},
+			shouldSkipValidation: true,
+		},
 		"single transfer message": {
 			msgs: []sdk.Msg{
 				constants.Msg_Transfer,
@@ -82,6 +88,13 @@ func TestSkipSequenceValidation(t *testing.T) {
 		"mix of conditional orders and short term orders": {
 			msgs: []sdk.Msg{
 				constants.Msg_PlaceOrder,
+				constants.Msg_PlaceOrder_Conditional,
+			},
+			shouldSkipValidation: false,
+		},
+		"mix of conditional orders and short term batch cancel orders": {
+			msgs: []sdk.Msg{
+				constants.Msg_BatchCancel,
 				constants.Msg_PlaceOrder_Conditional,
 			},
 			shouldSkipValidation: false,


### PR DESCRIPTION
Msg Batch Cancel only supports short term orders. We don't want to increase the sequence number to be incremented and verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for `MsgBatchCancel` in message validation, specifically for short-term orders.
  
- **Tests**
	- Introduced new test cases for validating message skipping logic, including scenarios for single batch cancel messages and a mix of conditional orders and short-term batch cancel orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->