### PR TITLE
chore: update slinky version used in docker

### DIFF
--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
   slinky0:
-    image: ghcr.io/skip-mev/slinky-sidecar:v1.0.0
+    image: ghcr.io/skip-mev/slinky-sidecar:1.0.1-rc
     entrypoint: >
       sh -c "slinky --marketmap-provider dydx_api --market-map-endpoint http://dydxprotocold0:1317 --update-market-config-path /etc/market.json --log-std-out-level error"
     ports:


### PR DESCRIPTION
## In This PR
- I update the slinky version used in the dydx docker test network
