### PR TITLE
Add latest block height to /addresses API endpoint

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
@@ -82,6 +82,7 @@ describe('addresses-controller#V4', () => {
           freeCollateral: getFixedRepresentation(152000),
           marginEnabled: true,
           updatedAtHeight: testConstants.defaultSubaccount.updatedAtHeight,
+          latestProcessedBlockHeight: latestHeight,
           openPerpetualPositions: {
             [testConstants.defaultPerpetualMarket.ticker]: {
               market: testConstants.defaultPerpetualMarket.ticker,
@@ -160,6 +161,7 @@ describe('addresses-controller#V4', () => {
           freeCollateral: getFixedRepresentation(10000),
           marginEnabled: true,
           updatedAtHeight: testConstants.defaultSubaccount.updatedAtHeight,
+          latestProcessedBlockHeight: latestHeight,
           openPerpetualPositions: {},
           assetPositions: {
             [testConstants.defaultAsset.symbol]: {
@@ -245,6 +247,7 @@ describe('addresses-controller#V4', () => {
             freeCollateral: getFixedRepresentation(152000),
             marginEnabled: true,
             updatedAtHeight: testConstants.defaultSubaccount.updatedAtHeight,
+            latestProcessedBlockHeight: latestHeight,
             openPerpetualPositions: {
               [testConstants.defaultPerpetualMarket.ticker]: {
                 market: testConstants.defaultPerpetualMarket.ticker,
@@ -296,6 +299,7 @@ describe('addresses-controller#V4', () => {
             freeCollateral: getFixedRepresentation(0),
             marginEnabled: true,
             updatedAtHeight: testConstants.defaultSubaccount2.updatedAtHeight,
+            latestProcessedBlockHeight: latestHeight,
             openPerpetualPositions: {},
             assetPositions: {},
           },
@@ -306,6 +310,7 @@ describe('addresses-controller#V4', () => {
             freeCollateral: getFixedRepresentation(0),
             marginEnabled: true,
             updatedAtHeight: testConstants.isolatedSubaccount.updatedAtHeight,
+            latestProcessedBlockHeight: latestHeight,
             openPerpetualPositions: {},
             assetPositions: {},
           },
@@ -316,6 +321,7 @@ describe('addresses-controller#V4', () => {
             freeCollateral: getFixedRepresentation(0),
             marginEnabled: true,
             updatedAtHeight: testConstants.isolatedSubaccount2.updatedAtHeight,
+            latestProcessedBlockHeight: latestHeight,
             openPerpetualPositions: {},
             assetPositions: {},
           },
@@ -354,6 +360,7 @@ describe('addresses-controller#V4', () => {
             freeCollateral: getFixedRepresentation(0),
             marginEnabled: true,
             updatedAtHeight: testConstants.defaultSubaccount.updatedAtHeight,
+            latestProcessedBlockHeight: latestHeight,
             assetPositions: {},
             openPerpetualPositions: {},
           },
@@ -438,6 +445,7 @@ describe('addresses-controller#V4', () => {
               freeCollateral: getFixedRepresentation(152000),
               marginEnabled: true,
               updatedAtHeight: testConstants.defaultSubaccount.updatedAtHeight,
+              latestProcessedBlockHeight: latestHeight,
               openPerpetualPositions: {
                 [testConstants.defaultPerpetualMarket.ticker]: {
                   market: testConstants.defaultPerpetualMarket.ticker,
@@ -489,6 +497,7 @@ describe('addresses-controller#V4', () => {
               freeCollateral: getFixedRepresentation(5000),
               marginEnabled: true,
               updatedAtHeight: testConstants.isolatedSubaccount.updatedAtHeight,
+              latestProcessedBlockHeight: latestHeight,
               openPerpetualPositions: {},
               assetPositions: {
                 [testConstants.defaultAsset.symbol]: {
@@ -507,6 +516,7 @@ describe('addresses-controller#V4', () => {
               freeCollateral: getFixedRepresentation(0),
               marginEnabled: true,
               updatedAtHeight: testConstants.isolatedSubaccount2.updatedAtHeight,
+              latestProcessedBlockHeight: latestHeight,
               openPerpetualPositions: {},
               assetPositions: {},
             },

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -135,7 +135,8 @@ fetch(`${baseURL}/addresses/{address}`,
         }
       },
       "marginEnabled": true,
-      "updatedAtHeight": "string"
+      "updatedAtHeight": "string",
+      "latestProcessedBlockHeight": "string"
     }
   ],
   "totalTradingRewards": "string"
@@ -272,7 +273,8 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
     }
   },
   "marginEnabled": true,
-  "updatedAtHeight": "string"
+  "updatedAtHeight": "string",
+  "latestProcessedBlockHeight": "string"
 }
 ```
 
@@ -412,7 +414,8 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
         }
       },
       "marginEnabled": true,
-      "updatedAtHeight": "string"
+      "updatedAtHeight": "string",
+      "latestProcessedBlockHeight": "string"
     }
   ]
 }
@@ -3193,7 +3196,8 @@ This operation does not require authentication
     }
   },
   "marginEnabled": true,
-  "updatedAtHeight": "string"
+  "updatedAtHeight": "string",
+  "latestProcessedBlockHeight": "string"
 }
 
 ```
@@ -3210,6 +3214,7 @@ This operation does not require authentication
 |assetPositions|[AssetPositionsMap](#schemaassetpositionsmap)|true|none|none|
 |marginEnabled|boolean|true|none|none|
 |updatedAtHeight|string|true|none|none|
+|latestProcessedBlockHeight|string|true|none|none|
 
 ## AddressResponse
 
@@ -3281,7 +3286,8 @@ This operation does not require authentication
         }
       },
       "marginEnabled": true,
-      "updatedAtHeight": "string"
+      "updatedAtHeight": "string",
+      "latestProcessedBlockHeight": "string"
     }
   ],
   "totalTradingRewards": "string"
@@ -3370,7 +3376,8 @@ This operation does not require authentication
         }
       },
       "marginEnabled": true,
-      "updatedAtHeight": "string"
+      "updatedAtHeight": "string",
+      "latestProcessedBlockHeight": "string"
     }
   ]
 }

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -170,6 +170,9 @@
           },
           "updatedAtHeight": {
             "type": "string"
+          },
+          "latestProcessedBlockHeight": {
+            "type": "string"
           }
         },
         "required": [
@@ -180,7 +183,8 @@
           "openPerpetualPositions",
           "assetPositions",
           "marginEnabled",
-          "updatedAtHeight"
+          "updatedAtHeight",
+          "latestProcessedBlockHeight"
         ],
         "type": "object",
         "additionalProperties": false

--- a/indexer/services/comlink/src/controllers/api/v4/addresses-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/addresses-controller.ts
@@ -156,6 +156,7 @@ class AddressesController extends Controller {
           assets,
           markets,
           unsettledFunding,
+          latestBlock.blockHeight,
         );
       },
     ));
@@ -241,6 +242,7 @@ class AddressesController extends Controller {
       assets,
       markets,
       unsettledFunding,
+      latestBlock.blockHeight,
     );
     return subaccountResponse;
   }
@@ -324,6 +326,7 @@ class AddressesController extends Controller {
           assets,
           markets,
           unsettledFunding,
+          latestBlock.blockHeight,
         );
       },
     ));
@@ -493,6 +496,7 @@ async function getSubaccountResponse(
   assets: AssetFromDatabase[],
   markets: MarketFromDatabase[],
   unsettledFunding: Big,
+  latestBlockHeight: string,
 ): Promise<SubaccountResponseObject> {
   const perpetualMarketsMap: PerpetualMarketsMap = perpetualMarketRefresher
     .getPerpetualMarketsMap();
@@ -569,6 +573,7 @@ async function getSubaccountResponse(
     subaccount,
     equity,
     freeCollateral,
+    latestBlockHeight,
     openPerpetualPositions: perpetualPositionsMap,
     assetPositions: adjustedAssetPositionsMap,
   });

--- a/indexer/services/comlink/src/request-helpers/request-transformer.ts
+++ b/indexer/services/comlink/src/request-helpers/request-transformer.ts
@@ -310,12 +310,14 @@ export function subaccountToResponseObject({
   subaccount,
   equity,
   freeCollateral,
+  latestBlockHeight,
   openPerpetualPositions = {},
   assetPositions = {},
 }: {
   subaccount: SubaccountFromDatabase,
   equity: string,
   freeCollateral: string,
+  latestBlockHeight: string,
   openPerpetualPositions: PerpetualPositionsMap,
   assetPositions: AssetPositionsMap,
 }): SubaccountResponseObject {
@@ -329,6 +331,7 @@ export function subaccountToResponseObject({
     // TODO(DEC-687): Track `marginEnabled` for subaccounts.
     marginEnabled: true,
     updatedAtHeight: subaccount.updatedAtHeight,
+    latestProcessedBlockHeight: latestBlockHeight,
   };
 }
 

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -64,6 +64,7 @@ export interface SubaccountResponseObject {
   assetPositions: AssetPositionsMap,
   marginEnabled: boolean,
   updatedAtHeight: string,
+  latestProcessedBlockHeight: string,
 }
 
 export interface ParentSubaccountResponse {


### PR DESCRIPTION
### Changelist
Add latest block height to /addresses API endpoint

### Test Plan
Unit tested

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `latestProcessedBlockHeight` field in various API responses to provide additional block height information.

- **Documentation**
  - Updated API documentation to include the `latestProcessedBlockHeight` field.

- **Tests**
  - Enhanced test cases to cover the new `latestProcessedBlockHeight` property.

- **Refactor**
  - Modified functions and method calls to support the new `latestProcessedBlockHeight` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->