### PR TITLE
Change >=2 to >2 for stale pnl accounts

### DIFF
--- a/indexer/services/roundtable/src/tasks/pnl-instrumentation.ts
+++ b/indexer/services/roundtable/src/tasks/pnl-instrumentation.ts
@@ -74,7 +74,7 @@ export default async function runTask(): Promise<void> {
     const lastTransferTime: DateTime = DateTime.fromISO(time);
     const hoursSinceLastTransfer = startTaskTime.diff(lastTransferTime, 'hours').hours;
 
-    if (hoursSinceLastTransfer >= 2) {
+    if (hoursSinceLastTransfer > 2) {
       staleTransferSubaccounts.push(subaccountId);
     }
   });


### PR DESCRIPTION
### Changelist
Change >= to > for stale pnl accounts

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the logic for handling transfers to ensure more accurate detection of stale transfer accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->