### PR TITLE
Revert "Disable arm release build"

### DIFF
--- a/.github/workflows/protocol-release.yml
+++ b/.github/workflows/protocol-release.yml
@@ -31,12 +31,15 @@ jobs:
       - name: Create Directory
         run: mkdir ./build
       - name: Build Reproducible Linux Binaries
-        run: make distclean build-reproducible-linux-amd64
+        run: make distclean build-reproducible
       - name: Rename Binaries
         run: |
+          mv ./build/dydxprotocold:linux-arm64 ./build/dydxprotocold-${{ env.VERSION }}-linux-arm64
           mv ./build/dydxprotocold:linux-amd64 ./build/dydxprotocold-${{ env.VERSION }}-linux-amd64
       - name: Compress binaries
         run: |
+          tar -cvzf dydxprotocold-${{ env.VERSION }}-linux-arm64.tar.gz \
+            ./build/dydxprotocold-${{ env.VERSION }}-linux-arm64
           tar -cvzf dydxprotocold-${{ env.VERSION }}-linux-amd64.tar.gz \
             ./build/dydxprotocold-${{ env.VERSION }}-linux-amd64
       - name: Create Release
@@ -59,6 +62,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: protocol/dydxprotocold-${{ env.VERSION }}-linux-amd64.tar.gz
           asset_name: dydxprotocold-${{ env.VERSION }}-linux-amd64.tar.gz
+          asset_content_type: application/gzip
+      - name: Upload linux-arm64 tar.gz
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: protocol/dydxprotocold-${{ env.VERSION }}-linux-arm64.tar.gz
+          asset_name: dydxprotocold-${{ env.VERSION }}-linux-arm64.tar.gz
           asset_content_type: application/gzip
           # TODO(DEC-1743): add build report and binary check sums
 


### PR DESCRIPTION
Reverts dydxprotocol/v4-chain#1641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build process to create reproducible binaries for Linux-amd64 and Linux-arm64 architectures.
  - Compressed binaries into tar.gz files with version-specific naming.
  - Implemented steps to upload compressed binaries to GitHub release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->