### PR TITLE
[OTE-438] Allow users to read data if they are in FIRST_STRIKE_CLOSE_ONLY

### DIFF
--- a/indexer/services/comlink/__tests__/lib/compliance-and-geo-check.test.ts
+++ b/indexer/services/comlink/__tests__/lib/compliance-and-geo-check.test.ts
@@ -192,6 +192,26 @@ describe('compliance-check', () => {
   it.each([
     ['query', `/v4/check-compliance-query?address=${testConstants.defaultAddress}`],
     ['param', `/v4/check-compliance-param/${testConstants.defaultAddress}`],
+  ])('does not return 403 if address in request is in FIRST_STRIKE_CLOSE_ONLY and from restricted country (%s)', async (
+    _name: string,
+    path: string,
+  ) => {
+    isRestrictedCountrySpy.mockReturnValueOnce(true);
+    await ComplianceStatusTable.create({
+      ...testConstants.compliantStatusData,
+      status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
+    });
+    await sendRequestToApp({
+      type: RequestMethod.GET,
+      path,
+      expressApp: complianceCheckApp,
+      expectedStatus: 200,
+    });
+  });
+
+  it.each([
+    ['query', `/v4/check-compliance-query?address=${testConstants.defaultAddress}`],
+    ['param', `/v4/check-compliance-param/${testConstants.defaultAddress}`],
   ])('does return 403 if request is from restricted country (%s)', async (
     _name: string,
     path: string,

--- a/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
+++ b/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
@@ -47,7 +47,9 @@ export async function complianceAndGeoCheck(
       { readReplica: true },
     );
     if (updatedStatus.length > 0) {
-      if (updatedStatus[0].status === ComplianceStatus.CLOSE_ONLY) {
+      if (updatedStatus[0].status === ComplianceStatus.CLOSE_ONLY ||
+        updatedStatus[0].status === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY
+      ) {
         return next();
       } else if (updatedStatus[0].status === ComplianceStatus.BLOCKED) {
         return create4xxResponse(


### PR DESCRIPTION
### Changelist
Allow users to read data if they are in FIRST_STRIKE_CLOSE_ONLY

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Great Britain (GB_GEO) in compliance checks and API documentation.

- **Bug Fixes**
  - Enhanced compliance check to ensure appropriate handling of addresses in `FIRST_STRIKE_CLOSE_ONLY` compliance status from restricted countries, preventing incorrect `403` status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->