### PR TITLE
optimize perpInfos

### DIFF
--- a/protocol/daemons/liquidation/client/sub_task_runner.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner.go
@@ -305,13 +305,10 @@ func (c *Client) CheckSubaccountCollateralization(
 
 	// Funding payments are lazily settled, so get the settled subaccount
 	// to ensure that the funding payments are included in the net collateral calculation.
-	settledSubaccount, _, err := salib.GetSettledSubaccountWithPerpetuals(
+	settledSubaccount, _ := salib.GetSettledSubaccountWithPerpetuals(
 		unsettledSubaccount,
 		perpInfos,
 	)
-	if err != nil {
-		return false, false, err
-	}
 
 	bigTotalNetCollateral := big.NewInt(0)
 	bigTotalMaintenanceMargin := big.NewInt(0)

--- a/protocol/x/perpetuals/types/errors.go
+++ b/protocol/x/perpetuals/types/errors.go
@@ -122,6 +122,11 @@ var (
 		25,
 		"open interest would become negative after update",
 	)
+	ErrPerpetualInfoDoesNotExist = errorsmod.Register(
+		ModuleName,
+		26,
+		"PerpetualInfo does not exist",
+	)
 
 	// Errors for Not Implemented
 	ErrNotImplementedFunding = errorsmod.Register(ModuleName, 1001, "Not Implemented: Perpetuals Funding")

--- a/protocol/x/perpetuals/types/perpinfo.go
+++ b/protocol/x/perpetuals/types/perpinfo.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
@@ -9,4 +10,22 @@ type PerpInfo struct {
 	Perpetual     Perpetual
 	Price         pricestypes.MarketPrice
 	LiquidityTier LiquidityTier
+}
+
+// PerpInfos is a map of PerpInfo objects, keyed by perpetualId.
+type PerpInfos map[uint32]PerpInfo
+
+// MustGet returns the PerpInfo for the given perpetualId, or panics if it does not exist.
+func (pi PerpInfos) MustGet(perpetualId uint32) PerpInfo {
+	p, ok := pi[perpetualId]
+
+	if !ok {
+		panic(errorsmod.Wrapf(
+			ErrPerpetualInfoDoesNotExist,
+			"perpetualId: %d",
+			perpetualId,
+		))
+	}
+
+	return p
 }

--- a/protocol/x/subaccounts/keeper/isolated_subaccount.go
+++ b/protocol/x/subaccounts/keeper/isolated_subaccount.go
@@ -28,16 +28,12 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 ) (
 	success bool,
 	successPerUpdate []types.UpdateResult,
-	err error,
 ) {
 	success = true
 	successPerUpdate = make([]types.UpdateResult, len(settledUpdates))
 
 	for i, u := range settledUpdates {
-		result, err := isValidIsolatedPerpetualUpdates(u, perpInfos)
-		if err != nil {
-			return false, nil, err
-		}
+		result := isValidIsolatedPerpetualUpdates(u, perpInfos)
 		if result != types.Success {
 			success = false
 		}
@@ -45,7 +41,7 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 		successPerUpdate[i] = result
 	}
 
-	return success, successPerUpdate, nil
+	return success, successPerUpdate
 }
 
 // Checks whether the perpetual updates to a settled subaccount violates constraints for isolated
@@ -61,11 +57,11 @@ func (k Keeper) checkIsolatedSubaccountConstraints(
 func isValidIsolatedPerpetualUpdates(
 	settledUpdate types.SettledUpdate,
 	perpInfos perptypes.PerpInfos,
-) (types.UpdateResult, error) {
+) types.UpdateResult {
 	// If there are no perpetual updates, then this update does not violate constraints for isolated
 	// markets.
 	if len(settledUpdate.PerpetualUpdates) == 0 {
-		return types.Success, nil
+		return types.Success
 	}
 
 	// Check if the updates contain an update to an isolated perpetual.
@@ -99,19 +95,19 @@ func isValidIsolatedPerpetualUpdates(
 	// A subaccount with a perpetual position in an isolated perpetual cannot have updates to other
 	// non-isolated perpetuals.
 	if isIsolatedSubaccount && !hasIsolatedUpdate {
-		return types.ViolatesIsolatedSubaccountConstraints, nil
+		return types.ViolatesIsolatedSubaccountConstraints
 	}
 
 	// A subaccount with perpetual positions in non-isolated perpetuals cannot have an update
 	// to an isolated perpetual.
 	if !isIsolatedSubaccount && hasPerpetualPositions && hasIsolatedUpdate {
-		return types.ViolatesIsolatedSubaccountConstraints, nil
+		return types.ViolatesIsolatedSubaccountConstraints
 	}
 
 	// There cannot be more than a single perpetual update if an update to an isolated perpetual
 	// exists in the slice of perpetual updates.
 	if hasIsolatedUpdate && len(settledUpdate.PerpetualUpdates) > 1 {
-		return types.ViolatesIsolatedSubaccountConstraints, nil
+		return types.ViolatesIsolatedSubaccountConstraints
 	}
 
 	// Note we can assume that if `hasIsolatedUpdate` is true, there is only a single perpetual
@@ -121,10 +117,10 @@ func isValidIsolatedPerpetualUpdates(
 	if isIsolatedSubaccount &&
 		hasIsolatedUpdate &&
 		isolatedPositionPerpetualId != isolatedUpdatePerpetualId {
-		return types.ViolatesIsolatedSubaccountConstraints, nil
+		return types.ViolatesIsolatedSubaccountConstraints
 	}
 
-	return types.Success, nil
+	return types.Success
 }
 
 // GetIsolatedPerpetualStateTransition computes whether an isolated perpetual position will be

--- a/protocol/x/subaccounts/keeper/isolated_subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/isolated_subaccount_test.go
@@ -319,7 +319,7 @@ func TestGetIsolatedPerpetualStateTransition(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(
 			name, func(t *testing.T) {
-				perpInfos := make(map[uint32]perptypes.PerpInfo, len(tc.perpetuals))
+				perpInfos := make(perptypes.PerpInfos, len(tc.perpetuals))
 				for _, perp := range tc.perpetuals {
 					perpInfos[perp.Params.Id] = perptypes.PerpInfo{
 						Perpetual: perp,

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -236,10 +236,7 @@ func (k Keeper) getSettledUpdates(
 		// idToSettledSubaccount map.
 		if !exists {
 			subaccount := k.GetSubaccount(ctx, u.SubaccountId)
-			settledSubaccount, fundingPayments, err = salib.GetSettledSubaccountWithPerpetuals(subaccount, perpInfos)
-			if err != nil {
-				return nil, nil, err
-			}
+			settledSubaccount, fundingPayments = salib.GetSettledSubaccountWithPerpetuals(subaccount, perpInfos)
 
 			idToSettledSubaccount[u.SubaccountId] = settledSubaccount
 			subaccountIdToFundingPayments[u.SubaccountId] = fundingPayments
@@ -487,14 +484,11 @@ func (k Keeper) internalCanUpdateSubaccounts(
 	// TODO(TRA-99): Add integration / E2E tests on order placement / matching with this new
 	// constraint.
 	// Check if the updates satisfy the isolated perpetual constraints.
-	success, successPerUpdate, err = k.checkIsolatedSubaccountConstraints(
+	success, successPerUpdate = k.checkIsolatedSubaccountConstraints(
 		ctx,
 		settledUpdates,
 		perpInfos,
 	)
-	if err != nil {
-		return false, nil, err
-	}
 	if !success {
 		return success, successPerUpdate, nil
 	}
@@ -702,10 +696,7 @@ func (k Keeper) GetNetCollateralAndMarginRequirements(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	settledSubaccount, _, err := salib.GetSettledSubaccountWithPerpetuals(subaccount, perpInfos)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	settledSubaccount, _ := salib.GetSettledSubaccountWithPerpetuals(subaccount, perpInfos)
 
 	settledUpdate := types.SettledUpdate{
 		SettledSubaccount: settledSubaccount,

--- a/protocol/x/subaccounts/lib/updates.go
+++ b/protocol/x/subaccounts/lib/updates.go
@@ -19,7 +19,7 @@ import (
 // payment as value (for emitting funding payments to indexer).
 func GetSettledSubaccountWithPerpetuals(
 	subaccount types.Subaccount,
-	perpInfos map[uint32]perptypes.PerpInfo,
+	perpInfos perptypes.PerpInfos,
 ) (
 	settledSubaccount types.Subaccount,
 	fundingPayments map[uint32]dtypes.SerializableInt,
@@ -32,10 +32,7 @@ func GetSettledSubaccountWithPerpetuals(
 
 	// Iterate through and settle all perpetual positions.
 	for _, p := range subaccount.PerpetualPositions {
-		perpInfo, found := perpInfos[p.PerpetualId]
-		if !found {
-			return types.Subaccount{}, nil, errorsmod.Wrapf(types.ErrPerpetualInfoDoesNotExist, "%d", p.PerpetualId)
-		}
+		perpInfo := perpInfos.MustGet(p.PerpetualId)
 
 		// Call the stateless utility function to get the net settlement and new funding index.
 		bigNetSettlementPpm, newFundingIndex := perplib.GetSettlementPpmWithPerpetual(
@@ -306,7 +303,7 @@ func GetUpdatedPerpetualPositions(
 // For newly created positions, use `perpIdToFundingIndex` map to populate the `FundingIndex` field.
 func UpdatePerpetualPositions(
 	settledUpdates []types.SettledUpdate,
-	perpInfos map[uint32]perptypes.PerpInfo,
+	perpInfos perptypes.PerpInfos,
 ) {
 	// Apply the updates.
 	for i, u := range settledUpdates {
@@ -334,12 +331,7 @@ func UpdatePerpetualPositions(
 			} else {
 				// This subaccount does not have a matching position for this update.
 				// Create the new position.
-				perpInfo, exists := perpInfos[pu.PerpetualId]
-				if !exists {
-					// Invariant: `perpInfos` should all relevant perpetuals, which includes all
-					// perpetuals that are updated.
-					panic(errorsmod.Wrapf(types.ErrPerpetualInfoDoesNotExist, "%d", pu.PerpetualId))
-				}
+				perpInfo := perpInfos.MustGet(pu.PerpetualId)
 				perpetualPosition := &types.PerpetualPosition{
 					PerpetualId:  pu.PerpetualId,
 					Quantums:     dtypes.NewIntFromBigInt(pu.GetBigQuantums()),

--- a/protocol/x/subaccounts/lib/updates.go
+++ b/protocol/x/subaccounts/lib/updates.go
@@ -23,7 +23,6 @@ func GetSettledSubaccountWithPerpetuals(
 ) (
 	settledSubaccount types.Subaccount,
 	fundingPayments map[uint32]dtypes.SerializableInt,
-	err error,
 ) {
 	totalNetSettlementPpm := big.NewInt(0)
 
@@ -78,7 +77,7 @@ func GetSettledSubaccountWithPerpetuals(
 	)
 	// TODO(CLOB-993): Remove this function and use `UpdateAssetPositions` instead.
 	newSubaccount.SetUsdcAssetPosition(newUsdcPosition)
-	return newSubaccount, fundingPayments, nil
+	return newSubaccount, fundingPayments
 }
 
 // IsValidStateTransitionForUndercollateralizedSubaccount returns an `UpdateResult`

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -65,11 +65,6 @@ var (
 		403,
 		"cannot revert perpetual open interest for OIMF calculation",
 	)
-	ErrPerpetualInfoDoesNotExist = errorsmod.Register(
-		ModuleName,
-		404,
-		"PerpetualInfo does not exist in map",
-	)
 
 	// 500 - 599: transfer related.
 	ErrAssetTransferQuantumsNotPositive = errorsmod.Register(

--- a/protocol/x/subaccounts/types/expected_keepers.go
+++ b/protocol/x/subaccounts/types/expected_keepers.go
@@ -62,12 +62,27 @@ type PerpetualsKeeper interface {
 		perpetual perptypes.Perpetual,
 		err error,
 	)
+	GetPerpetualAndMarketPrice(
+		ctx sdk.Context,
+		perpetualId uint32,
+	) (
+		perptypes.Perpetual,
+		pricestypes.MarketPrice,
+		error,
+	)
 	GetPerpetualAndMarketPriceAndLiquidityTier(
 		ctx sdk.Context,
 		perpetualId uint32,
 	) (
 		perptypes.Perpetual,
 		pricestypes.MarketPrice,
+		perptypes.LiquidityTier,
+		error,
+	)
+	GetLiquidityTier(
+		ctx sdk.Context,
+		id uint32,
+	) (
 		perptypes.LiquidityTier,
 		error,
 	)


### PR DESCRIPTION
### Changelist
- Add type `PerpInfos` which is a map from perpetual ID to `PerpInfo`
- Add helper function to `PerpInfos` to get a perpetual by ID or panic
- When constructing `PerpInfos`, optimize the number of state-reads when getting the Liquidity Tier information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added error handling for non-existent `PerpInfo` with `ErrPerpetualInfoDoesNotExist`.

- **Refactor**
  - Unified type usage for `PerpInfos` across various functions and components for consistent and efficient data handling.

- **Bug Fixes**
  - Improved error messaging and handling in scenarios where `PerpInfo` does not exist, enhancing debugging and stability.

- **Tests**
  - Updated tests to reflect changes in type usage for `PerpInfos`.

- **Documentation**
  - Updated method signatures and relevant documentation to reflect the new `PerpInfos` type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->