### PR TITLE
chore: remove `BigInt0()` & `BigFloat0()`

### DIFF
--- a/protocol/lib/big_math_test.go
+++ b/protocol/lib/big_math_test.go
@@ -790,14 +790,6 @@ func TestBigIntRoundToMultiple(t *testing.T) {
 	}
 }
 
-func TestBigInt0(t *testing.T) {
-	require.Equal(t, big.NewInt(0), lib.BigInt0())
-}
-
-func TestBigFloat0(t *testing.T) {
-	require.Equal(t, big.NewFloat(0), lib.BigFloat0())
-}
-
 func TestBigFloatMaxUint64(t *testing.T) {
 	require.Equal(t, new(big.Float).SetUint64(math.MaxUint64), lib.BigFloatMaxUint64())
 }

--- a/protocol/lib/constants.go
+++ b/protocol/lib/constants.go
@@ -28,11 +28,6 @@ var PowerReduction = sdkmath.NewIntFromBigInt(
 	new(big.Int).SetUint64(1_000_000_000_000_000_000),
 )
 
-// BigInt0 returns a `big.Int` that is set to 0.
-func BigInt0() *big.Int {
-	return big.NewInt(0)
-}
-
 // BigNegMaxUint64 returns a `big.Int` that is set to -math.MaxUint64.
 func BigNegMaxUint64() *big.Int {
 	return new(big.Int).Neg(
@@ -43,11 +38,6 @@ func BigNegMaxUint64() *big.Int {
 // BigMaxInt32 returns a `big.Int` that represents `MaxInt32`.
 func BigMaxInt32() *big.Int {
 	return big.NewInt(math.MaxInt32)
-}
-
-// BigFloat0 returns a `big.Float` that is set to 0.
-func BigFloat0() *big.Float {
-	return big.NewFloat(0)
 }
 
 // BigFloatMaxUint64 returns a `big.Float` that is set to MaxUint64.

--- a/protocol/lib/convert.go
+++ b/protocol/lib/convert.go
@@ -26,7 +26,7 @@ func ConvertBigFloatToUint64(value *big.Float) (uint64, error) {
 		return 0, errors.New("value overflows uint64")
 	}
 
-	if value.Cmp(BigFloat0()) == -1 {
+	if value.Sign() < 0 {
 		return 0, errors.New("value underflows uint64")
 	}
 

--- a/protocol/x/clob/simulation/place_order.go
+++ b/protocol/x/clob/simulation/place_order.go
@@ -122,7 +122,7 @@ func SimulateMsgPlaceOrder(
 				"Subaccount does not have enough free collateral to place minimum order",
 			), nil, nil
 		}
-		if bigMinOrderQuoteQuantums.Cmp(lib.BigInt0()) == 0 {
+		if bigMinOrderQuoteQuantums.BitLen() == 0 {
 			return simtypes.NoOpMsg(
 				types.ModuleName,
 				typeMsgPlaceOrder,
@@ -263,7 +263,7 @@ func generateValidPlaceOrder(
 	// Handle special order conditions.
 	if reduceOnly {
 		// Reduce only must be opposite of current positions in clob pair.
-		curPositionSign := currentPositionSizeQuantums.Cmp(lib.BigInt0())
+		curPositionSign := currentPositionSizeQuantums.Sign()
 		if curPositionSign < 0 {
 			// currently short, order should go long
 			orderSide = types.Order_SIDE_BUY

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -141,7 +141,7 @@ func (k Keeper) AddRewardSharesForFill(
 		bigTakerFeeQuoteQuantums,
 		makerRebateMulTakerVolume,
 	)
-	if takerWeight.Cmp(lib.BigInt0()) > 0 {
+	if takerWeight.Sign() > 0 {
 		// We aren't concerned with errors here because we've already validated the weight is positive.
 		if err := k.AddRewardShareToAddress(
 			ctx,
@@ -158,7 +158,7 @@ func (k Keeper) AddRewardSharesForFill(
 
 	// Process reward weight for maker.
 	makerWeight := new(big.Int).Set(bigMakerFeeQuoteQuantums)
-	if makerWeight.Cmp(lib.BigInt0()) > 0 {
+	if makerWeight.Sign() > 0 {
 		// We aren't concerned with errors here because we've already validated the weight is positive.
 		if err := k.AddRewardShareToAddress(
 			ctx,
@@ -182,7 +182,7 @@ func (k Keeper) AddRewardShareToAddress(
 	address string,
 	weight *big.Int,
 ) error {
-	if weight.Cmp(lib.BigInt0()) <= 0 {
+	if weight.Sign() <= 0 {
 		return errorsmod.Wrapf(
 			types.ErrNonpositiveWeight,
 			"Invalid weight %v",

--- a/protocol/x/subaccounts/lib/updates.go
+++ b/protocol/x/subaccounts/lib/updates.go
@@ -46,7 +46,7 @@ func GetSettledSubaccountWithPerpetuals(
 		// Record non-zero funding payment (to be later emitted in SubaccountUpdateEvent to indexer).
 		// Note: Funding payment is the negative of settlement, i.e. positive settlement is equivalent
 		// to a negative funding payment (position received funding payment) and vice versa.
-		if bigNetSettlementPpm.Cmp(lib.BigInt0()) != 0 {
+		if bigNetSettlementPpm.BitLen() != 0 {
 			fundingPayments[p.PerpetualId] = dtypes.NewIntFromBigInt(
 				new(big.Int).Neg(
 					new(big.Int).Div(bigNetSettlementPpm, lib.BigIntOneMillion()),


### PR DESCRIPTION
### Changelist
Removes superfluous functions that were only used to do `Cmp(0)` which can be substituted to use `Sign()` or `BitLen()` instead
