### PR TITLE
[CT-850] feat(OE): add flag to enable optimistic block execution

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -392,6 +392,11 @@ func New(
 	interfaceRegistry := encodingConfig.InterfaceRegistry
 	txConfig := encodingConfig.TxConfig
 
+	// Enable optimistic block execution.
+	if appFlags.OptimisticExecutionEnabled {
+		baseAppOptions = append(baseAppOptions, baseapp.SetOptimisticExecution())
+	}
+
 	bApp := baseapp.NewBaseApp(appconstants.AppName, logger, db, txConfig.TxDecoder(), baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)
 	bApp.SetVersion(version.Version)

--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -381,6 +381,10 @@ func New(
 	if err := appFlags.Validate(); err != nil {
 		panic(err)
 	}
+	if appFlags.OptimisticExecutionEnabled {
+		// TODO(OTE-573): Remove warning once OE is fully supported.
+		logger.Warn("Optimistic execution is enabled. This is a test feature not intended for production use!")
+	}
 
 	initDatadogProfiler(logger, appFlags.DdAgentHost, appFlags.DdTraceAgentPort)
 

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -27,6 +27,8 @@ type Flags struct {
 	GrpcStreamingMaxChannelBufferSize uint32
 
 	VEOracleEnabled bool // Slinky Vote Extensions
+	// Optimistic block execution
+	OptimisticExecutionEnabled bool
 }
 
 // List of CLI flags.
@@ -48,6 +50,9 @@ const (
 
 	// Slinky VEs enabled
 	VEOracleEnabled = "slinky-vote-extension-oracle-enabled"
+
+	// Enable optimistic block execution.
+	OptimisticExecutionEnabled = "optimistic-execution-enabled"
 )
 
 // Default values.
@@ -62,7 +67,8 @@ const (
 	DefaultGrpcStreamingMaxBatchSize         = 10000
 	DefaultGrpcStreamingMaxChannelBufferSize = 10000
 
-	DefaultVEOracleEnabled = true
+	DefaultVEOracleEnabled            = true
+	DefaultOptimisticExecutionEnabled = false
 )
 
 // AddFlagsToCmd adds flags to app initialization.
@@ -116,6 +122,11 @@ func AddFlagsToCmd(cmd *cobra.Command) {
 		DefaultVEOracleEnabled,
 		"Whether to run on-chain oracle via slinky vote extensions",
 	)
+	cmd.Flags().Bool(
+		OptimisticExecutionEnabled,
+		DefaultOptimisticExecutionEnabled,
+		"Whether to enable optimistic block execution",
+	)
 }
 
 // Validate checks that the flags are valid.
@@ -164,7 +175,8 @@ func GetFlagValuesFromOptions(
 		GrpcStreamingMaxBatchSize:         DefaultGrpcStreamingMaxBatchSize,
 		GrpcStreamingMaxChannelBufferSize: DefaultGrpcStreamingMaxChannelBufferSize,
 
-		VEOracleEnabled: true,
+		VEOracleEnabled:            true,
+		OptimisticExecutionEnabled: DefaultOptimisticExecutionEnabled,
 	}
 
 	// Populate the flags if they exist.
@@ -234,5 +246,10 @@ func GetFlagValuesFromOptions(
 		}
 	}
 
+	if option := appOpts.Get(OptimisticExecutionEnabled); option != nil {
+		if v, err := cast.ToBoolE(option); err == nil {
+			result.OptimisticExecutionEnabled = v
+		}
+	}
 	return result
 }

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -138,6 +138,10 @@ func (f *Flags) Validate() error {
 
 	// Grpc streaming
 	if f.GrpcStreamingEnabled {
+		if f.OptimisticExecutionEnabled {
+			// TODO(OTE-456): Finish gRPC streaming x OE integration.
+			return fmt.Errorf("grpc streaming cannot be enabled together with optimistic execution")
+		}
 		if !f.GrpcEnable {
 			return fmt.Errorf("grpc.enable must be set to true - grpc streaming requires gRPC server")
 		}

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -91,6 +91,15 @@ func TestValidate(t *testing.T) {
 				OptimisticExecutionEnabled: true,
 			},
 		},
+		"failure - optimistic execution cannot be enabled with gRPC streaming": {
+			flags: flags.Flags{
+				NonValidatingFullNode:      false,
+				GrpcEnable:                 true,
+				GrpcStreamingEnabled:       true,
+				OptimisticExecutionEnabled: true,
+			},
+			expectedErr: fmt.Errorf("grpc streaming cannot be enabled together with optimistic execution"),
+		},
 		"failure - gRPC disabled": {
 			flags: flags.Flags{
 				GrpcEnable: false,

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -41,6 +41,9 @@ func TestAddFlagsToCommand(t *testing.T) {
 		fmt.Sprintf("Has %s flag", flags.GrpcStreamingMaxChannelBufferSize): {
 			flagName: flags.GrpcStreamingMaxChannelBufferSize,
 		},
+		fmt.Sprintf("Has %s flag", flags.OptimisticExecutionEnabled): {
+			flagName: flags.OptimisticExecutionEnabled,
+		},
 	}
 
 	for name, tc := range tests {
@@ -57,11 +60,12 @@ func TestValidate(t *testing.T) {
 	}{
 		"success (default values)": {
 			flags: flags.Flags{
-				NonValidatingFullNode: flags.DefaultNonValidatingFullNode,
-				DdAgentHost:           flags.DefaultDdAgentHost,
-				DdTraceAgentPort:      flags.DefaultDdTraceAgentPort,
-				GrpcAddress:           config.DefaultGRPCAddress,
-				GrpcEnable:            true,
+				NonValidatingFullNode:      flags.DefaultNonValidatingFullNode,
+				DdAgentHost:                flags.DefaultDdAgentHost,
+				DdTraceAgentPort:           flags.DefaultDdTraceAgentPort,
+				GrpcAddress:                config.DefaultGRPCAddress,
+				GrpcEnable:                 true,
+				OptimisticExecutionEnabled: false,
 			},
 		},
 		"success - full node & gRPC disabled": {
@@ -78,6 +82,13 @@ func TestValidate(t *testing.T) {
 				GrpcStreamingFlushIntervalMs:      100,
 				GrpcStreamingMaxBatchSize:         10000,
 				GrpcStreamingMaxChannelBufferSize: 10000,
+			},
+		},
+		"success - optimistic execution": {
+			flags: flags.Flags{
+				NonValidatingFullNode:      false,
+				GrpcEnable:                 true,
+				OptimisticExecutionEnabled: true,
 			},
 		},
 		"failure - gRPC disabled": {
@@ -153,6 +164,7 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 		expectedGrpcStreamingFlushMs              uint32
 		expectedGrpcStreamingBatchSize            uint32
 		expectedGrpcStreamingMaxChannelBufferSize uint32
+		expectedOptimisticExecutionEnabled        bool
 	}{
 		"Sets to default if unset": {
 			expectedNonValidatingFullNodeFlag:         false,
@@ -164,6 +176,7 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 			expectedGrpcStreamingFlushMs:              50,
 			expectedGrpcStreamingBatchSize:            10000,
 			expectedGrpcStreamingMaxChannelBufferSize: 10000,
+			expectedOptimisticExecutionEnabled:        false,
 		},
 		"Sets values from options": {
 			optsMap: map[string]any{
@@ -176,6 +189,7 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 				flags.GrpcStreamingFlushIntervalMs:      uint32(408),
 				flags.GrpcStreamingMaxBatchSize:         uint32(650),
 				flags.GrpcStreamingMaxChannelBufferSize: uint32(972),
+				flags.OptimisticExecutionEnabled:        "true",
 			},
 			expectedNonValidatingFullNodeFlag:         true,
 			expectedDdAgentHost:                       "agentHostTest",
@@ -186,6 +200,7 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 			expectedGrpcStreamingFlushMs:              408,
 			expectedGrpcStreamingBatchSize:            650,
 			expectedGrpcStreamingMaxChannelBufferSize: 972,
+			expectedOptimisticExecutionEnabled:        true,
 		},
 	}
 


### PR DESCRIPTION
### Changelist

Add flag to enable optimistic block execution. Default is false this this is no-op.

### Test Plan

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
