### PR TITLE
[CT-941] introduce state methods for managing the safety heap

### DIFF
--- a/protocol/x/subaccounts/keeper/safety_heap_state.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_state.go
@@ -1,0 +1,172 @@
+package keeper
+
+import (
+	"cosmossdk.io/store/prefix"
+	gogotypes "github.com/cosmos/gogoproto/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+)
+
+// MustGetSubaccountAtIndex returns the subaccount at the given index.
+// Panics if the subaccount is not found.
+func (k Keeper) MustGetSubaccountAtIndex(
+	store prefix.Store,
+	heapIndex uint32,
+) (
+	subaccountId types.SubaccountId,
+) {
+	subaccountId, found := k.GetSubaccountAtIndex(store, heapIndex)
+	if !found {
+		panic(types.ErrSafetyHeapSubaccountNotFoundAtIndex)
+	}
+	return subaccountId
+}
+
+// GetSubaccountAtIndex returns the subaccount at the given index.
+func (k Keeper) GetSubaccountAtIndex(
+	store prefix.Store,
+	heapIndex uint32,
+) (
+	subaccountId types.SubaccountId,
+	found bool,
+) {
+	prefix := prefix.NewStore(
+		store,
+		[]byte(types.SafetyHeapSubaccountIdsPrefix),
+	)
+	key := lib.Uint32ToKey(heapIndex)
+
+	b := prefix.Get(key)
+
+	if b != nil {
+		k.cdc.MustUnmarshal(b, &subaccountId)
+	}
+	return subaccountId, b != nil
+}
+
+// SetSubaccountAtIndex updates the subaccount at the given index.
+func (k Keeper) SetSubaccountAtIndex(
+	store prefix.Store,
+	subaccountId types.SubaccountId,
+	heapIndex uint32,
+) {
+	prefix := prefix.NewStore(
+		store,
+		[]byte(types.SafetyHeapSubaccountIdsPrefix),
+	)
+	key := lib.Uint32ToKey(heapIndex)
+
+	prefix.Set(
+		key,
+		k.cdc.MustMarshal(&subaccountId),
+	)
+	k.SetSubaccountHeapIndex(store, subaccountId, heapIndex)
+}
+
+// DeleteSubaccountAtIndex deletes the subaccount at the given index.
+// Panics if the heap index is not found.
+func (k Keeper) DeleteSubaccountAtIndex(
+	store prefix.Store,
+	heapIndex uint32,
+) {
+	prefix := prefix.NewStore(
+		store,
+		[]byte(types.SafetyHeapSubaccountIdsPrefix),
+	)
+	subaccountId := k.MustGetSubaccountAtIndex(store, heapIndex)
+
+	key := lib.Uint32ToKey(heapIndex)
+	prefix.Delete(key)
+
+	k.DeleteSubaccountHeapIndex(store, subaccountId)
+}
+
+// MustGetSubaccountHeapIndex returns the heap index of the subaccount.
+// Panics if the heap index is not found.
+func (k Keeper) MustGetSubaccountHeapIndex(
+	store prefix.Store,
+	subaccountId types.SubaccountId,
+) (
+	heapIndex uint32,
+) {
+	heapIndex, found := k.GetSubaccountHeapIndex(store, subaccountId)
+	if !found {
+		panic(types.ErrSafetyHeapSubaccountIndexNotFound)
+	}
+	return heapIndex
+}
+
+// GetSubaccountHeapIndex returns the heap index of the subaccount.
+func (k Keeper) GetSubaccountHeapIndex(
+	store prefix.Store,
+	subaccountId types.SubaccountId,
+) (
+	heapIndex uint32,
+	found bool,
+) {
+	key := subaccountId.ToStateKey()
+
+	index := gogotypes.UInt32Value{Value: 0}
+	b := store.Get(key)
+
+	if b != nil {
+		k.cdc.MustUnmarshal(b, &index)
+	}
+	return index.Value, b != nil
+}
+
+// SetSubaccountHeapIndex sets the heap index of the subaccount.
+func (k Keeper) SetSubaccountHeapIndex(
+	store prefix.Store,
+	subaccountId types.SubaccountId,
+	heapIndex uint32,
+) {
+	key := subaccountId.ToStateKey()
+
+	index := gogotypes.UInt32Value{Value: heapIndex}
+	store.Set(
+		key,
+		k.cdc.MustMarshal(&index),
+	)
+}
+
+// DeleteSubaccountHeapIndex deletes the heap index of the subaccount.
+func (k Keeper) DeleteSubaccountHeapIndex(
+	store prefix.Store,
+	subaccountId types.SubaccountId,
+) {
+	key := subaccountId.ToStateKey()
+	store.Delete(key)
+}
+
+// GetSafetyHeapLength returns the length of heap.
+func (k Keeper) GetSafetyHeapLength(
+	store prefix.Store,
+) (
+	length uint32,
+) {
+	key := []byte(types.SafetyHeapLengthPrefix)
+
+	index := gogotypes.UInt32Value{Value: 0}
+	b := store.Get(key)
+
+	if b != nil {
+		k.cdc.MustUnmarshal(b, &index)
+	}
+
+	return index.Value
+}
+
+// SetSafetyHeapLength sets the heap length.
+func (k Keeper) SetSafetyHeapLength(
+	store prefix.Store,
+	length uint32,
+) {
+	key := []byte(types.SafetyHeapLengthPrefix)
+
+	index := gogotypes.UInt32Value{Value: length}
+	store.Set(
+		key,
+		k.cdc.MustMarshal(&index),
+	)
+}

--- a/protocol/x/subaccounts/keeper/safety_heap_state_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_state_test.go
@@ -1,0 +1,122 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSetSubaccountAtIndex(t *testing.T) {
+	// Setup keeper state and test parameters.
+	ctx, subaccountsKeeper, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
+
+	// Write a couple of subaccounts to the store.
+	store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, types.Long)
+	subaccountsKeeper.SetSubaccountAtIndex(store, constants.Alice_Num0, 0)
+	subaccountsKeeper.SetSubaccountAtIndex(store, constants.Bob_Num0, 1)
+	subaccountsKeeper.SetSubaccountAtIndex(store, constants.Carl_Num0, 2)
+
+	// Get.
+	require.Equal(t, constants.Alice_Num0, subaccountsKeeper.MustGetSubaccountAtIndex(store, 0))
+	require.Equal(t, constants.Bob_Num0, subaccountsKeeper.MustGetSubaccountAtIndex(store, 1))
+	require.Equal(t, constants.Carl_Num0, subaccountsKeeper.MustGetSubaccountAtIndex(store, 2))
+
+	// Overwrite the subaccount at index 1.
+	subaccountsKeeper.SetSubaccountAtIndex(store, constants.Alice_Num1, 0)
+	require.Equal(t, constants.Alice_Num1, subaccountsKeeper.MustGetSubaccountAtIndex(store, 0))
+	subaccountsKeeper.SetSubaccountAtIndex(store, constants.Dave_Num0, 1)
+	require.Equal(t, constants.Dave_Num0, subaccountsKeeper.MustGetSubaccountAtIndex(store, 1))
+
+	// Delete
+	subaccountsKeeper.DeleteSubaccountAtIndex(store, 2)
+	subaccountsKeeper.DeleteSubaccountAtIndex(store, 1)
+
+	// Getting non existent subaccount.
+	_, found := subaccountsKeeper.GetSubaccountAtIndex(store, 1)
+	require.False(t, found)
+
+	require.PanicsWithError(
+		t,
+		types.ErrSafetyHeapSubaccountNotFoundAtIndex.Error(),
+		func() {
+			subaccountsKeeper.MustGetSubaccountAtIndex(store, 1)
+		},
+	)
+
+	_, found = subaccountsKeeper.GetSubaccountAtIndex(store, 2)
+	require.False(t, found)
+
+	require.PanicsWithError(
+		t,
+		types.ErrSafetyHeapSubaccountNotFoundAtIndex.Error(),
+		func() {
+			subaccountsKeeper.MustGetSubaccountAtIndex(store, 2)
+		},
+	)
+}
+
+func TestGetSetSubaccountHeapIndex(t *testing.T) {
+	// Setup keeper state and test parameters.
+	ctx, subaccountsKeeper, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
+
+	// Write a couple of subaccounts to the store.
+	store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, types.Long)
+	subaccountsKeeper.SetSubaccountHeapIndex(store, constants.Alice_Num0, 0)
+	subaccountsKeeper.SetSubaccountHeapIndex(store, constants.Bob_Num0, 1)
+	subaccountsKeeper.SetSubaccountHeapIndex(store, constants.Carl_Num0, 2)
+
+	// Get.
+	require.Equal(t, uint32(0), subaccountsKeeper.MustGetSubaccountHeapIndex(store, constants.Alice_Num0))
+	require.Equal(t, uint32(1), subaccountsKeeper.MustGetSubaccountHeapIndex(store, constants.Bob_Num0))
+	require.Equal(t, uint32(2), subaccountsKeeper.MustGetSubaccountHeapIndex(store, constants.Carl_Num0))
+
+	// Overwrite the subaccount at index 1.
+	subaccountsKeeper.SetSubaccountHeapIndex(store, constants.Alice_Num0, 3)
+	require.Equal(t, uint32(3), subaccountsKeeper.MustGetSubaccountHeapIndex(store, constants.Alice_Num0))
+	subaccountsKeeper.SetSubaccountHeapIndex(store, constants.Carl_Num0, 4)
+	require.Equal(t, uint32(4), subaccountsKeeper.MustGetSubaccountHeapIndex(store, constants.Carl_Num0))
+
+	// Delete
+	subaccountsKeeper.DeleteSubaccountHeapIndex(store, constants.Alice_Num0)
+	subaccountsKeeper.DeleteSubaccountHeapIndex(store, constants.Carl_Num0)
+
+	// Getting non existent subaccount.
+	_, found := subaccountsKeeper.GetSubaccountHeapIndex(store, constants.Alice_Num0)
+	require.False(t, found)
+
+	require.PanicsWithError(
+		t,
+		types.ErrSafetyHeapSubaccountIndexNotFound.Error(),
+		func() {
+			subaccountsKeeper.MustGetSubaccountHeapIndex(store, constants.Alice_Num0)
+		},
+	)
+
+	_, found = subaccountsKeeper.GetSubaccountHeapIndex(store, constants.Carl_Num0)
+	require.False(t, found)
+
+	require.PanicsWithError(
+		t,
+		types.ErrSafetyHeapSubaccountIndexNotFound.Error(),
+		func() {
+			subaccountsKeeper.MustGetSubaccountHeapIndex(store, constants.Carl_Num0)
+		},
+	)
+}
+
+func TestGetSetSafetyHeapLength(t *testing.T) {
+	// Setup keeper state and test parameters.
+	ctx, subaccountsKeeper, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
+
+	// Write a couple of subaccounts to the store.
+	store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, types.Long)
+
+	require.Equal(t, uint32(0), subaccountsKeeper.GetSafetyHeapLength(store))
+
+	subaccountsKeeper.SetSafetyHeapLength(store, 7)
+
+	require.Equal(t, uint32(7), subaccountsKeeper.GetSafetyHeapLength(store))
+}

--- a/protocol/x/subaccounts/keeper/safety_heap_stores.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_stores.go
@@ -1,0 +1,36 @@
+package keeper
+
+import (
+	"fmt"
+
+	"cosmossdk.io/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+)
+
+// GetSafetyHeapStore returns the safety heap store.
+func (k Keeper) GetSafetyHeapStore(
+	ctx sdk.Context,
+	perpetualId uint32,
+	side types.SafetyHeapPositionSide,
+) prefix.Store {
+	return prefix.NewStore(
+		ctx.KVStore(k.storeKey),
+		k.GetSafetyHeapKeyPrefix(perpetualId, side),
+	)
+}
+
+// GetSafetyHeapKeyPrefix returns the prefix for the safety heap store.
+func (k Keeper) GetSafetyHeapKeyPrefix(
+	perpetualId uint32,
+	side types.SafetyHeapPositionSide,
+) []byte {
+	return []byte(
+		fmt.Sprintf(
+			"%s/%d/%d/",
+			types.SafetyHeapStorePrefix,
+			perpetualId,
+			side,
+		),
+	)
+}

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -71,4 +71,13 @@ var (
 		ModuleName, 500, "asset transfer quantums is not positive")
 	ErrAssetTransferThroughBankNotImplemented = errorsmod.Register(
 		ModuleName, 501, "asset transfer (other than USDC) through the bank module is not implemented")
+
+	// 600 - 699: safety heap related.
+	ErrSafetyHeapEmpty                     = errorsmod.Register(ModuleName, 600, "safety heap is empty")
+	ErrSafetyHeapSubaccountNotFoundAtIndex = errorsmod.Register(
+		ModuleName,
+		601,
+		"subaccount not found at index in safety heap",
+	)
+	ErrSafetyHeapSubaccountIndexNotFound = errorsmod.Register(ModuleName, 602, "subaccount index not found")
 )

--- a/protocol/x/subaccounts/types/keys.go
+++ b/protocol/x/subaccounts/types/keys.go
@@ -19,4 +19,10 @@ const (
 	// Suffix for the store key to the last block a negative TNC subaccount was seen in state for the
 	// cross collateral pool.
 	CrossCollateralSuffix = "cross"
+
+	// Safety Heap
+	SafetyHeapStorePrefix             = "SH"
+	SafetyHeapSubaccountIdsPrefix     = "Heap/"
+	SafetyHeapSubaccountToIndexPrefix = "Idx/"
+	SafetyHeapLengthPrefix            = "Len/"
 )

--- a/protocol/x/subaccounts/types/subaccount.go
+++ b/protocol/x/subaccounts/types/subaccount.go
@@ -17,6 +17,13 @@ const (
 // BaseQuantums is used to represent an amount in base quantums.
 type BaseQuantums uint64
 
+type SafetyHeapPositionSide uint
+
+const (
+	Long SafetyHeapPositionSide = iota
+	Short
+)
+
 // Get the BaseQuantum value in *big.Int.
 func (bq BaseQuantums) ToBigInt() *big.Int {
 	return new(big.Int).SetUint64(bq.ToUint64())


### PR DESCRIPTION
### Changelist
The safety heap will be represented using an array in state. We don't want to serialize/deserialize the entire heap every time we read/write from state (i.e. putting the entire heap under the same key). Instead, we will use their heap indices as keys and store them under the same prefix.

Essentially we need three things in state
- SH/<perpetual_id>/\<side>/Heap/\<index> --> SubaccountId
- SH/<perpetual_id>/\<side>/Idx/\<subaccount_id> -> heap index (uint32)
- SH/<perpetual_id>/\<side>/Len/  -> length of the heap

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
