### PR TITLE
[CT-946] only send snapshots to uninitialized streams

### DIFF
--- a/protocol/streaming/grpc/grpc_streaming_manager.go
+++ b/protocol/streaming/grpc/grpc_streaming_manager.go
@@ -204,9 +204,9 @@ func (sm *GrpcStreamingManagerImpl) Stop() {
 	sm.done <- true
 }
 
-// SendSnapshot groups updates by their clob pair ids and
-// sends messages to the subscribers. It groups out updates differently
-// and bypasses the buffer.
+// SendSnapshot sends messages to a particular subscriber without buffering.
+// Note this method requires the lock and assumes that the lock has already been
+// acquired by the caller.
 func (sm *GrpcStreamingManagerImpl) SendSnapshot(
 	offchainUpdates *clobtypes.OffchainUpdates,
 	subscriptionId uint32,
@@ -386,16 +386,21 @@ func (sm *GrpcStreamingManagerImpl) AddUpdatesToCache(
 	sm.EmitMetrics()
 }
 
-// FlushStreamUpdates takes in a map of clob pair id to stream updates and emits them to subscribers.
 func (sm *GrpcStreamingManagerImpl) FlushStreamUpdates() {
+	sm.Lock()
+	defer sm.Unlock()
+	sm.FlushStreamUpdatesWithLock()
+}
+
+// FlushStreamUpdatesWithLock takes in a map of clob pair id to stream updates and emits them to subscribers.
+// Note this method requires the lock and assumes that the lock has already been
+// acquired by the caller.
+func (sm *GrpcStreamingManagerImpl) FlushStreamUpdatesWithLock() {
 	defer metrics.ModuleMeasureSince(
 		metrics.FullNodeGrpc,
 		metrics.GrpcFlushUpdatesLatency,
 		time.Now(),
 	)
-
-	sm.Lock()
-	defer sm.Unlock()
 
 	// Non-blocking send updates through subscriber's buffered channel.
 	// If the buffer is full, drop the subscription.
@@ -444,6 +449,10 @@ func (sm *GrpcStreamingManagerImpl) InitializeNewGrpcStreams(
 ) {
 	sm.Lock()
 	defer sm.Unlock()
+
+	// Flush any pending updates before sending the snapshot to avoid
+	// race conditions with the snapshot.
+	sm.FlushStreamUpdatesWithLock()
 
 	updatesByClobPairId := make(map[uint32]*clobtypes.OffchainUpdates)
 	for subscriptionId, subscription := range sm.orderbookSubscriptions {

--- a/protocol/streaming/grpc/grpc_streaming_manager.go
+++ b/protocol/streaming/grpc/grpc_streaming_manager.go
@@ -9,7 +9,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
 	ocutypes "github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates/types"
-	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/streaming/grpc/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
@@ -210,6 +209,7 @@ func (sm *GrpcStreamingManagerImpl) Stop() {
 // and bypasses the buffer.
 func (sm *GrpcStreamingManagerImpl) SendSnapshot(
 	offchainUpdates *clobtypes.OffchainUpdates,
+	subscriptionId uint32,
 	blockHeight uint32,
 	execMode sdk.ExecMode,
 ) {
@@ -219,74 +219,56 @@ func (sm *GrpcStreamingManagerImpl) SendSnapshot(
 		time.Now(),
 	)
 
-	// Group updates by clob pair id.
-	updates := make(map[uint32]*clobtypes.OffchainUpdates)
-	for _, message := range offchainUpdates.Messages {
-		clobPairId := message.OrderId.ClobPairId
-		if _, ok := updates[clobPairId]; !ok {
-			updates[clobPairId] = clobtypes.NewOffchainUpdates()
-		}
-		updates[clobPairId].Messages = append(updates[clobPairId].Messages, message)
+	v1updates, err := GetOffchainUpdatesV1(offchainUpdates)
+	if err != nil {
+		panic(err)
 	}
 
-	// Unmarshal each per-clob pair message to v1 updates.
-	updatesByClobPairId := make(map[uint32][]ocutypes.OffChainUpdateV1)
-	for clobPairId, update := range updates {
-		v1updates, err := GetOffchainUpdatesV1(update)
-		if err != nil {
-			panic(err)
-		}
-		updatesByClobPairId[clobPairId] = v1updates
-	}
-
-	sm.Lock()
-	defer sm.Unlock()
-
-	idsToRemove := make([]uint32, 0)
-	for id, subscription := range sm.orderbookSubscriptions {
-		// Consolidate orderbook updates into a single `StreamUpdate`.
-		v1updates := make([]ocutypes.OffChainUpdateV1, 0)
-		for _, clobPairId := range subscription.clobPairIds {
-			if update, ok := updatesByClobPairId[clobPairId]; ok {
-				v1updates = append(v1updates, update...)
-			}
-		}
-
-		if len(v1updates) > 0 {
-			streamUpdates := []clobtypes.StreamUpdate{
-				{
-					UpdateMessage: &clobtypes.StreamUpdate_OrderbookUpdate{
-						OrderbookUpdate: &clobtypes.StreamOrderbookUpdate{
-							Updates:  v1updates,
-							Snapshot: true,
-						},
-					},
-					BlockHeight: blockHeight,
-					ExecMode:    uint32(execMode),
-				},
-			}
-			metrics.IncrCounter(
-				metrics.GrpcAddToSubscriptionChannelCount,
-				1,
+	removeSubscription := false
+	if len(v1updates) > 0 {
+		subscription, ok := sm.orderbookSubscriptions[subscriptionId]
+		if !ok {
+			sm.logger.Error(
+				fmt.Sprintf(
+					"GRPC Streaming subscription id %+v not found. This should not happen.",
+					subscriptionId,
+				),
 			)
-			select {
-			case subscription.updatesChannel <- streamUpdates:
-			default:
-				sm.logger.Error(
-					fmt.Sprintf(
-						"GRPC Streaming subscription id %+v channel full capacity. Dropping subscription connection.",
-						id,
-					),
-				)
-				idsToRemove = append(idsToRemove, subscription.subscriptionId)
-			}
+			return
+		}
+		streamUpdates := []clobtypes.StreamUpdate{
+			{
+				UpdateMessage: &clobtypes.StreamUpdate_OrderbookUpdate{
+					OrderbookUpdate: &clobtypes.StreamOrderbookUpdate{
+						Updates:  v1updates,
+						Snapshot: true,
+					},
+				},
+				BlockHeight: blockHeight,
+				ExecMode:    uint32(execMode),
+			},
+		}
+		metrics.IncrCounter(
+			metrics.GrpcAddToSubscriptionChannelCount,
+			1,
+		)
+		select {
+		case subscription.updatesChannel <- streamUpdates:
+		default:
+			sm.logger.Error(
+				fmt.Sprintf(
+					"GRPC Streaming subscription id %+v channel full capacity. Dropping subscription connection.",
+					subscriptionId,
+				),
+			)
+			removeSubscription = true
 		}
 	}
 
 	// Clean up subscriptions that have been closed.
 	// If a Send update has failed for any clob pair id, the whole subscription will be removed.
-	for _, id := range idsToRemove {
-		sm.removeSubscription(id)
+	if removeSubscription {
+		sm.removeSubscription(subscriptionId)
 	}
 }
 
@@ -455,23 +437,30 @@ func (sm *GrpcStreamingManagerImpl) FlushStreamUpdates() {
 	sm.EmitMetrics()
 }
 
-// GetUninitializedClobPairIds returns the clob pair ids that have not been initialized.
-func (sm *GrpcStreamingManagerImpl) GetUninitializedClobPairIds() []uint32 {
+func (sm *GrpcStreamingManagerImpl) InitializeNewGrpcStreams(
+	getOrderbookSnapshot func(clobPairId clobtypes.ClobPairId) *clobtypes.OffchainUpdates,
+	blockHeight uint32,
+	execMode sdk.ExecMode,
+) {
 	sm.Lock()
 	defer sm.Unlock()
 
-	clobPairIds := make(map[uint32]bool)
-	for _, subscription := range sm.orderbookSubscriptions {
+	updatesByClobPairId := make(map[uint32]*clobtypes.OffchainUpdates)
+	for subscriptionId, subscription := range sm.orderbookSubscriptions {
 		subscription.initialize.Do(
 			func() {
+				allUpdates := clobtypes.NewOffchainUpdates()
 				for _, clobPairId := range subscription.clobPairIds {
-					clobPairIds[clobPairId] = true
+					if _, ok := updatesByClobPairId[clobPairId]; !ok {
+						updatesByClobPairId[clobPairId] = getOrderbookSnapshot(clobtypes.ClobPairId(clobPairId))
+					}
+					allUpdates.Append(updatesByClobPairId[clobPairId])
 				}
+
+				sm.SendSnapshot(allUpdates, subscriptionId, blockHeight, execMode)
 			},
 		)
 	}
-
-	return lib.GetSortedKeys[lib.Sortable[uint32]](clobPairIds)
 }
 
 // GetOffchainUpdatesV1 unmarshals messages in offchain updates to OffchainUpdateV1.

--- a/protocol/streaming/grpc/noop_streaming_manager.go
+++ b/protocol/streaming/grpc/noop_streaming_manager.go
@@ -29,6 +29,7 @@ func (sm *NoopGrpcStreamingManager) Subscribe(
 
 func (sm *NoopGrpcStreamingManager) SendSnapshot(
 	updates *clobtypes.OffchainUpdates,
+	subscriptionId uint32,
 	blockHeight uint32,
 	execMode sdk.ExecMode,
 ) {
@@ -49,8 +50,11 @@ func (sm *NoopGrpcStreamingManager) SendOrderbookFillUpdates(
 ) {
 }
 
-func (sm *NoopGrpcStreamingManager) GetUninitializedClobPairIds() []uint32 {
-	return []uint32{}
+func (sm *NoopGrpcStreamingManager) InitializeNewGrpcStreams(
+	getOrderbookSnapshot func(clobPairId clobtypes.ClobPairId) *clobtypes.OffchainUpdates,
+	blockHeight uint32,
+	execMode sdk.ExecMode,
+) {
 }
 
 func (sm *NoopGrpcStreamingManager) Stop() {

--- a/protocol/streaming/grpc/types/manager.go
+++ b/protocol/streaming/grpc/types/manager.go
@@ -15,9 +15,14 @@ type GrpcStreamingManager interface {
 	) (
 		err error,
 	)
-	GetUninitializedClobPairIds() []uint32
+	InitializeNewGrpcStreams(
+		getOrderbookSnapshot func(clobPairId clobtypes.ClobPairId) *clobtypes.OffchainUpdates,
+		blockHeight uint32,
+		execMode sdk.ExecMode,
+	)
 	SendSnapshot(
 		offchainUpdates *clobtypes.OffchainUpdates,
+		subscriptionId uint32,
 		blockHeight uint32,
 		execMode sdk.ExecMode,
 	)

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -259,20 +259,14 @@ func (k *Keeper) SetAnteHandler(anteHandler sdk.AnteHandler) {
 // by sending the corresponding orderbook snapshots.
 func (k Keeper) InitializeNewGrpcStreams(ctx sdk.Context) {
 	streamingManager := k.GetGrpcStreamingManager()
-	allUpdates := types.NewOffchainUpdates()
 
-	uninitializedClobPairIds := streamingManager.GetUninitializedClobPairIds()
-	for _, clobPairId := range uninitializedClobPairIds {
-		update := k.MemClob.GetOffchainUpdatesForOrderbookSnapshot(
-			ctx,
-			types.ClobPairId(clobPairId),
-		)
-
-		allUpdates.Append(update)
-	}
-
-	streamingManager.SendSnapshot(
-		allUpdates,
+	streamingManager.InitializeNewGrpcStreams(
+		func(clobPairId types.ClobPairId) *types.OffchainUpdates {
+			return k.MemClob.GetOffchainUpdatesForOrderbookSnapshot(
+				ctx,
+				clobPairId,
+			)
+		},
 		lib.MustConvertIntegerToUint32(ctx.BlockHeight()),
 		ctx.ExecMode(),
 	)


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced gRPC streaming with new methods for better handling of orderbook snapshots and subscriptions.

- **Refactor**
  - Updated `SendSnapshot` method to include a `subscriptionId` parameter, improving context for streaming operations.
  - Introduced `InitializeNewGrpcStreams` method for initializing new gRPC streams more efficiently.

- **Chores**
  - Modified workflow to optimize build-and-push jobs, retaining only the job for the dev5 environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->