### PR TITLE
[OTE-415] Add test for getting perpetual clob details

### DIFF
--- a/protocol/x/clob/keeper/clob_pair_test.go
+++ b/protocol/x/clob/keeper/clob_pair_test.go
@@ -1139,3 +1139,28 @@ func TestClobPairValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPerpetualClobPair(t *testing.T) {
+	memClob := memclob.NewMemClobPriceTimePriority(false)
+	mockIndexerEventManager := &mocks.IndexerEventManager{}
+	ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, mockIndexerEventManager)
+	items := keepertest.CreateNClobPair(t,
+		ks.ClobKeeper,
+		ks.PerpetualsKeeper,
+		ks.PricesKeeper,
+		ks.Ctx,
+		2,
+		mockIndexerEventManager,
+	)
+
+	for _, item := range items {
+		perpetualClobItem, err := ks.ClobKeeper.GetPerpetualClobDetails(ks.Ctx,
+			item.GetClobPairId(),
+		)
+		require.NoError(t, err)
+		perpetual, err := ks.PerpetualsKeeper.GetPerpetual(ks.Ctx, clobtest.MustPerpetualId(item))
+		require.NoError(t, err)
+		require.Equal(t, perpetualClobItem.ClobPair, item)
+		require.Equal(t, perpetualClobItem.Perpetual, perpetual)
+	}
+}


### PR DESCRIPTION
### Changelist
Adds a simple test to get perpetual clob details

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
