### PR TITLE
Cherry-pick "Handle invalid price level updates gracefully. (#1747)"

### DIFF
--- a/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
+++ b/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
@@ -189,8 +189,6 @@ describe('orderbookLevelsCache', () => {
         client,
       });
 
-      // Test that an error is thrown if the update results in a negative quantums for the price
-      // level
       await updatePriceLevel({
         ticker,
         side: OrderSide.BUY,
@@ -200,7 +198,7 @@ describe('orderbookLevelsCache', () => {
       });
       expect(logger.crit).toHaveBeenCalledTimes(1);
 
-      // Expect that the value in the orderbook is unchanged
+      // Expect that the value in the orderbook is set to 0
       const orderbookLevels: OrderbookLevels = await getOrderBookLevels(
         ticker,
         client,

--- a/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
+++ b/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../src/caches/orderbook-levels-cache';
 import { OrderSide } from '@dydxprotocol-indexer/postgres';
 import { OrderbookLevels, PriceLevel } from '../../src/types';
-import { InvalidOptionsError, InvalidPriceLevelUpdateError } from '../../src/errors';
+import { InvalidOptionsError } from '../../src/errors';
 import { logger } from '@dydxprotocol-indexer/base';
 
 describe('orderbookLevelsCache', () => {
@@ -176,11 +176,10 @@ describe('orderbookLevelsCache', () => {
       expect(orderbookLevels.bids).toEqual([]);
     });
 
-    it('throws error if update will cause quantums to be negative', async () => {
+    it('sets price level to 0 if update will cause quantums to be negative', async () => {
       const humanPrice: string = '50000';
       const quantums: string = '1000';
       const invalidDelta: string = '-2000';
-      const resultingQuantums: string = '-1000';
       // Set existing quantums for the level
       await updatePriceLevel({
         ticker,
@@ -192,30 +191,24 @@ describe('orderbookLevelsCache', () => {
 
       // Test that an error is thrown if the update results in a negative quantums for the price
       // level
-      await expect(updatePriceLevel({
+      await updatePriceLevel({
         ticker,
         side: OrderSide.BUY,
         humanPrice,
         sizeDeltaInQuantums: invalidDelta,
         client,
-      })).rejects.toBeInstanceOf(InvalidPriceLevelUpdateError);
+      });
       expect(logger.crit).toHaveBeenCalledTimes(1);
-      await expect(updatePriceLevel({
-        ticker,
-        side: OrderSide.BUY,
-        humanPrice,
-        sizeDeltaInQuantums: invalidDelta,
-        client,
-      })).rejects.toEqual(expect.objectContaining({
-        message: expect.stringContaining(resultingQuantums),
-      }));
 
       // Expect that the value in the orderbook is unchanged
-      const orderbookLevels: OrderbookLevels = await getOrderBookLevels(ticker, client);
-      expect(orderbookLevels.bids).toMatchObject([{
-        humanPrice,
-        quantums,
-      }]);
+      const orderbookLevels: OrderbookLevels = await getOrderBookLevels(
+        ticker,
+        client,
+        {
+          removeZeros: false,
+        },
+      );
+      expect(orderbookLevels.bids).toMatchObject([{}]);
     });
   });
 

--- a/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
+++ b/indexer/packages/redis/__tests__/caches/orderbook-levels-cache.test.ts
@@ -208,7 +208,10 @@ describe('orderbookLevelsCache', () => {
           removeZeros: false,
         },
       );
-      expect(orderbookLevels.bids).toMatchObject([{}]);
+      expect(orderbookLevels.bids).toMatchObject([{
+        humanPrice,
+        quantums: '0',
+      }]);
     });
   });
 

--- a/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
+++ b/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
@@ -73,7 +73,7 @@ export async function updatePriceLevel({
     );
     logger.crit({
       at: 'orderbookLevelsCache#updatePriceLevel',
-      message: 'Price level updated to negative quantums',
+      message: 'Price level updated to negative quantums, set to zero',
       ticker,
       side,
       humanPrice,

--- a/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
+++ b/indexer/packages/redis/src/caches/orderbook-levels-cache.ts
@@ -4,7 +4,7 @@ import Big from 'big.js';
 import _ from 'lodash';
 import { Callback, RedisClient } from 'redis';
 
-import { InvalidOptionsError, InvalidPriceLevelUpdateError } from '../errors';
+import { InvalidOptionsError } from '../errors';
 import { hGetAsync } from '../helpers/redis';
 import { OrderbookLevels, PriceLevel } from '../types';
 import {
@@ -58,17 +58,17 @@ export async function updatePriceLevel({
   // NOTE: If this happens from a single price level update, it's possible for multiple subsequent
   // price level updates to fail with the same error due to interleaved price level updates.
   if (updatedQuantums < 0) {
-    // Undo the update. This can't be done in a Lua script as Redis runs Lua 5.1, which only
-    // uses doubles which support up to 53-bit integers. Race-condition where it's possible for a
-    // price-level to have negative quantums handled in `getOrderbookLevels` where price-levels with
-    // negative quantums are filtered out. Note: even though we are reverting this information, each
-    // call to incrementOrderbookLevel updates the lastUpdated key in the cache.
+    // Set the price level to 0.
+    // Race-condition where it's possible for a price-level to have negative quantums handled in
+    // `getOrderbookLevels` where price-levels with negative quantums are filtered out. Note: even
+    // though we are reverting this information, each call to incrementOrderbookLevel updates the
+    // lastUpdated key in the cache.
     await incrementOrderbookLevel(
       ticker,
       side,
       humanPrice,
       // Needs to be an integer
-      Big(sizeDeltaInQuantums).mul(-1).toFixed(0),
+      Big(updatedQuantums).mul(-1).toFixed(0),
       client,
     );
     logger.crit({
@@ -80,10 +80,7 @@ export async function updatePriceLevel({
       updatedQuantums,
       sizeDeltaInQuantums,
     });
-    throw new InvalidPriceLevelUpdateError(
-      '#updatePriceLevel: Resulting price level has negative quantums, quantums = ' +
-      `${updatedQuantums}`,
-    );
+    return 0;
   }
 
   return updatedQuantums;

--- a/indexer/packages/redis/src/errors.ts
+++ b/indexer/packages/redis/src/errors.ts
@@ -21,11 +21,3 @@ export class InvalidOptionsError extends Error {
     Error.captureStackTrace(this, this.constructor);
   }
 }
-
-export class InvalidPriceLevelUpdateError extends Error {
-  constructor(message: string) {
-    super(`Invalid price level update: ${message}`);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}


### PR DESCRIPTION
### Changelist
Cherry-pick in patch to handle invalid price levels gracefully.
Updated tests to check for 0 level.

### Test Plan
Unit tests, patch was tested in prod.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted logic to handle negative quantums by setting the price level to 0 instead of throwing an error, ensuring more robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->