### PR TITLE
Perf: add an software override (1.5sec) for `TimeoutPropose`

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"cosmossdk.io/client/v2/autocli"
 	"cosmossdk.io/core/appmodule"
@@ -55,6 +57,9 @@ const (
 	EnvPrefix = "DYDX"
 
 	flagIAVLCacheSize = "iavl-cache-size"
+
+	// TimeoutProposeOverride is the software override for the `timeout_propose` consensus parameter.
+	TimeoutProposeOverride = 1500 * time.Millisecond
 )
 
 // NewRootCmd creates a new root command for `dydxprotocold`. It is called once in the main function.
@@ -63,11 +68,18 @@ func NewRootCmd(
 	option *RootCmdOption,
 	homeDir string,
 ) *cobra.Command {
+	logger := log.NewLogger(os.Stdout)
 	return NewRootCmdWithInterceptors(
 		option,
 		homeDir,
 		func(serverCtxPtr *server.Context) {
-
+			// Provide an override for `timeout_propose`. This value should be consistent across the network
+			// for synchrony, and should never be tweaked by individual validators in practice.
+			logger.Info(fmt.Sprintf(
+				"Overriding [consensus.timeout_propose] from %v to software constant: %v",
+				serverCtxPtr.Config.Consensus.TimeoutPropose,
+				TimeoutProposeOverride))
+			serverCtxPtr.Config.Consensus.TimeoutPropose = TimeoutProposeOverride
 		},
 		func(s string, appConfig *DydxAppConfig) (string, *DydxAppConfig) {
 			return s, appConfig


### PR DESCRIPTION
# Problem
Network experiences a ~5sec block time when a proposer is offline/severely lagging behind. This is due to the current software default, `TimeoutPropose = 3s`, which means that when a proposer is unavailable, we spend 3s waiting for the proposal + 0.5s for round 0 prevote/precommit, so ~3.5s more than an average block.

This software default of 3s was not conscious, and could've been updated along when `timeout_commit` was reduced to 500ms.

See attached [block dump](https://dydx-team.slack.com/archives/C03FP255RRU/p1718920517021299?thread_ts=1718920455.352289&cid=C03FP255RRU) during a period when 2 small validators went offline, and 4% of the blocks have elevated >5sec blocks. As a result, average block time is much higher than median block time during this period:

Median block time: 1.1144995 seconds
Average block time: 1.35415654 seconds

# Solution

Add a software override for TimeoutPropose to 1.5s. This should be way more than enough for a [block where proposer is present](https://app.datadoghq.com/dashboard/25s-bg4-rfr?fromUser=false&fullscreen_end_ts=1718747340000&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=edit&fullscreen_start_ts=1718740140000&fullscreen_widget=7303499879955068&refresh_mode=paused&tpl_var_env%5B0%5D=mainnet&view=spans&from_ts=1718802091418&to_ts=1718809804409&live=false). More aggressive value (e.g. 1s) is also possible and can be done in future upgrades.

This should reduce p98 (by ~30%) as well as average block time.

Requires a coordinated upgrade to maintain synchrony among validators (technically, not `state-breaking` but `consensus-breaking`)

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option to override the `timeout_propose` consensus parameter, enhancing control over proposal timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->