### PR TITLE
add MapToSortedSlice function

### DIFF
--- a/protocol/lib/collections.go
+++ b/protocol/lib/collections.go
@@ -27,6 +27,19 @@ func ContainsDuplicates[V comparable](values []V) bool {
 	return false
 }
 
+// MapToSortedSlice returns a slice of values from a map, sorted by key.
+func MapToSortedSlice[R interface {
+	~[]K
+	sort.Interface
+}, K comparable, V any](m map[K]V) []V {
+	keys := GetSortedKeys[R](m)
+	values := make([]V, 0, len(m))
+	for _, key := range keys {
+		values = append(values, m[key])
+	}
+	return values
+}
+
 // DedupeSlice deduplicates a slice of comparable values.
 func DedupeSlice[V comparable](values []V) []V {
 	seenValues := make(map[V]struct{})

--- a/protocol/lib/collections_test.go
+++ b/protocol/lib/collections_test.go
@@ -118,6 +118,59 @@ func TestContainsDuplicates(t *testing.T) {
 	}
 }
 
+func BenchmarkMapToSortedSlice(b *testing.B) {
+	input := map[string]string{
+		"d": "4",
+		"b": "2",
+		"a": "1",
+		"c": "3",
+		"e": "5",
+		"f": "6",
+		"g": "7",
+		"h": "8",
+		"i": "9",
+		"j": "10",
+	}
+	for i := 0; i < b.N; i++ {
+		_ = lib.MapToSortedSlice[sort.StringSlice, string, string](input)
+	}
+}
+
+func TestMapToSortedSlice(t *testing.T) {
+	tests := map[string]struct {
+		inputMap       map[string]string
+		expectedResult []string
+	}{
+		"Nil input": {
+			inputMap:       nil,
+			expectedResult: []string{},
+		},
+		"Empty map": {
+			inputMap:       map[string]string{},
+			expectedResult: []string{},
+		},
+		"Single item": {
+			inputMap:       map[string]string{"a": "1"},
+			expectedResult: []string{"1"},
+		},
+		"Multiple items": {
+			inputMap: map[string]string{
+				"d": "4",
+				"b": "2",
+				"a": "1",
+				"c": "3",
+			},
+			expectedResult: []string{"1", "2", "3", "4"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualResult := lib.MapToSortedSlice[sort.StringSlice](tc.inputMap)
+			require.Equal(t, tc.expectedResult, actualResult)
+		})
+	}
+}
+
 func TestGetSortedKeys(t *testing.T) {
 	tests := map[string]struct {
 		inputMap       map[string]string


### PR DESCRIPTION
### Changelist
Add `MapToSortedSlice()` function with tests and benchmarks

### Test Plan
Added new tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to convert a map into a sorted slice based on keys.

- **Tests**
  - Added benchmark tests for the new map-to-sorted-slice feature.
  - Added unit tests for the new map-to-sorted-slice feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->