### PR TITLE
Add helper methods to compare risks

### DIFF
--- a/protocol/lib/margin/risk.go
+++ b/protocol/lib/margin/risk.go
@@ -53,6 +53,19 @@ func (a *Risk) IsLiquidatable() bool {
 	return a.MMR.Sign() > 0 && a.MMR.Cmp(a.NC) > 0
 }
 
+// Cmp compares the risks of two accounts.
+// Returns -1 if a is less risky than b, 0 if they are equally risky, and 1 if a is more risky than b.
+
+// Note that here we are effectively checking that
+// `a.NetCollateral / a.MaintenanceMargin >= b.NetCollateral / b.MaintenanceMargin`.
+// However, to avoid rounding errors, we factor this as
+// `a.NetCollateral * b.MaintenanceMargin >= b.NetCollateral * a.MaintenanceMargin`.
+func (a *Risk) Cmp(b Risk) int {
+	ANcMultBMmr := new(big.Int).Mul(a.NC, b.MMR)
+	BNcMultAMmr := new(big.Int).Mul(b.NC, a.MMR)
+	return BNcMultAMmr.Cmp(ANcMultBMmr)
+}
+
 func mustExist(i *big.Int) *big.Int {
 	if i == nil {
 		return new(big.Int)

--- a/protocol/lib/margin/risk.go
+++ b/protocol/lib/margin/risk.go
@@ -63,7 +63,22 @@ func (a *Risk) IsLiquidatable() bool {
 func (a *Risk) Cmp(b Risk) int {
 	ANcMultBMmr := new(big.Int).Mul(a.NC, b.MMR)
 	BNcMultAMmr := new(big.Int).Mul(b.NC, a.MMR)
-	return BNcMultAMmr.Cmp(ANcMultBMmr)
+
+	result := BNcMultAMmr.Cmp(ANcMultBMmr)
+
+	// Special case: if the ratios are the same, compare the net collateral and maintenance margin
+	// for strict ordering.
+	if result == 0 {
+		if a.MMR.Sign() == 0 && b.MMR.Sign() == 0 {
+			// If both MMRs are zero, then the account with less net collateral is more
+			// risky.
+			return b.NC.Cmp(a.NC)
+		}
+
+		// otherwise, the account with the higher maintenance margin is more risky.
+		return a.MMR.Cmp(b.MMR)
+	}
+	return result
 }
 
 func mustExist(i *big.Int) *big.Int {

--- a/protocol/lib/margin/risk_test.go
+++ b/protocol/lib/margin/risk_test.go
@@ -220,3 +220,93 @@ func TestRisk_IsLiquidatable(t *testing.T) {
 		})
 	}
 }
+
+func TestRisk_Cmp(t *testing.T) {
+	tests := map[string]struct {
+		firstNC  *big.Int
+		firstMMR *big.Int
+
+		secondNC  *big.Int
+		secondMMR *big.Int
+
+		expected int
+	}{
+		"equal": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(100),
+			secondNC:  big.NewInt(100),
+			secondMMR: big.NewInt(100),
+			expected:  0,
+		},
+		"first is less risky than second": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(50),
+			secondNC:  big.NewInt(100),
+			secondMMR: big.NewInt(100),
+			expected:  -1,
+		},
+		"first is less risky than second - second has zero TNC": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(50),
+			secondNC:  big.NewInt(0),
+			secondMMR: big.NewInt(100),
+			expected:  -1,
+		},
+		"first is less risky than second - second has negative TNC": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(50),
+			secondNC:  big.NewInt(-100),
+			secondMMR: big.NewInt(100),
+			expected:  -1,
+		},
+		"first is less risky than second - both have negative TNC": {
+			firstNC:   big.NewInt(-100),
+			firstMMR:  big.NewInt(150),
+			secondNC:  big.NewInt(-100),
+			secondMMR: big.NewInt(100),
+			expected:  -1,
+		},
+		"first is more risky than second": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(150),
+			secondNC:  big.NewInt(100),
+			secondMMR: big.NewInt(100),
+			expected:  1,
+		},
+		"first is more risky than second - first has zero TNC": {
+			firstNC:   big.NewInt(0),
+			firstMMR:  big.NewInt(150),
+			secondNC:  big.NewInt(100),
+			secondMMR: big.NewInt(100),
+			expected:  1,
+		},
+		"first is more risky than second - first has negative TNC": {
+			firstNC:   big.NewInt(-100),
+			firstMMR:  big.NewInt(150),
+			secondNC:  big.NewInt(100),
+			secondMMR: big.NewInt(100),
+			expected:  1,
+		},
+		"first is more risky than second - both hahave negative TNC": {
+			firstNC:   big.NewInt(-100),
+			firstMMR:  big.NewInt(50),
+			secondNC:  big.NewInt(-100),
+			secondMMR: big.NewInt(100),
+			expected:  1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			firstRisk := margin.Risk{
+				MMR: tc.firstMMR,
+				NC:  tc.firstNC,
+			}
+			secondRisk := margin.Risk{
+				MMR: tc.secondMMR,
+				NC:  tc.secondNC,
+			}
+			require.Equal(t, tc.expected, firstRisk.Cmp(secondRisk))
+		})
+	}
+}

--- a/protocol/lib/margin/risk_test.go
+++ b/protocol/lib/margin/risk_test.go
@@ -231,13 +231,7 @@ func TestRisk_Cmp(t *testing.T) {
 
 		expected int
 	}{
-		"equal": {
-			firstNC:   big.NewInt(100),
-			firstMMR:  big.NewInt(100),
-			secondNC:  big.NewInt(100),
-			secondMMR: big.NewInt(100),
-			expected:  0,
-		},
+		// Normal cases: different ratios.
 		"first is less risky than second": {
 			firstNC:   big.NewInt(100),
 			firstMMR:  big.NewInt(50),
@@ -292,6 +286,63 @@ func TestRisk_Cmp(t *testing.T) {
 			firstMMR:  big.NewInt(50),
 			secondNC:  big.NewInt(-100),
 			secondMMR: big.NewInt(100),
+			expected:  1,
+		},
+		"first is less risky than second - first has zero MMR": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(0),
+			secondNC:  big.NewInt(100),
+			secondMMR: big.NewInt(100),
+			expected:  -1,
+		},
+		"first is more risky than second - second has zero MMR": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(100),
+			secondNC:  big.NewInt(100),
+			secondMMR: big.NewInt(0),
+			expected:  1,
+		},
+		// special cases: ratio is the same
+		"special case: equally risky": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(100),
+			secondNC:  big.NewInt(100),
+			secondMMR: big.NewInt(100),
+			expected:  0,
+		},
+		"special case: same ratio, tie break by MMR": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(50),
+			secondNC:  big.NewInt(200),
+			secondMMR: big.NewInt(100),
+			expected:  -1,
+		},
+		"special case: first with zero NC and second with zero NC, tie break by MMR": {
+			firstNC:   big.NewInt(0),
+			firstMMR:  big.NewInt(50),
+			secondNC:  big.NewInt(0),
+			secondMMR: big.NewInt(100),
+			expected:  -1,
+		},
+		"special case: first with zero NC and MMR, tie break by MMR": {
+			firstNC:   big.NewInt(0),
+			firstMMR:  big.NewInt(0),
+			secondNC:  big.NewInt(200),
+			secondMMR: big.NewInt(100),
+			expected:  -1,
+		},
+		"special case: second with zero NC and MMR, tie break by MMR": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(50),
+			secondNC:  big.NewInt(0),
+			secondMMR: big.NewInt(0),
+			expected:  1,
+		},
+		"special case: first with zero MMR and second with zero MMR, tie break by NC": {
+			firstNC:   big.NewInt(100),
+			firstMMR:  big.NewInt(0),
+			secondNC:  big.NewInt(200),
+			secondMMR: big.NewInt(0),
 			expected:  1,
 		},
 	}

--- a/protocol/x/subaccounts/lib/updates.go
+++ b/protocol/x/subaccounts/lib/updates.go
@@ -128,16 +128,9 @@ func IsValidStateTransitionForUndercollateralizedSubaccount(
 		return underCollateralizationResult
 	}
 
-	// Note that here we are effectively checking that
-	// `newNetCollateral / newMaintenanceMargin >= curNetCollateral / curMaintenanceMargin`.
-	// However, to avoid rounding errors, we factor this as
-	// `newNetCollateral * curMaintenanceMargin >= curNetCollateral * newMaintenanceMargin`.
-	newNcOldMmr := new(big.Int).Mul(riskNew.NC, riskCur.MMR)
-	oldNcNewMmr := new(big.Int).Mul(riskCur.NC, riskNew.MMR)
-
 	// The subaccount is not well-collateralized, and the state transition leaves the subaccount in a
 	// "more-risky" state (collateral relative to margin requirements is decreasing).
-	if oldNcNewMmr.Cmp(newNcOldMmr) > 0 {
+	if riskNew.Cmp(riskCur) > 0 {
 		return underCollateralizationResult
 	}
 


### PR DESCRIPTION
### Changelist
- Add helper methods to compare risks for future safety heap PRs. Note that this only compares the TNC/MR ratio of the two risk objects, and does not include other constraints (e.g. margin requirements can not increase when subaccount is already under-collateralized) that are used in state transition validations. 

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to compare risks between two accounts, improving accuracy by handling rounding errors.

- **Tests**
  - Added tests to ensure the new risk comparison method works correctly with different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->