### PR TITLE
Update how apply positions are done

### DIFF
--- a/protocol/testutil/subaccounts/subaccounts.go
+++ b/protocol/testutil/subaccounts/subaccounts.go
@@ -1,0 +1,19 @@
+package subaccounts
+
+import (
+	"math/big"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+)
+
+func CreatePerpetualUpdate(
+	id uint32,
+	delta *big.Int,
+) []types.PerpetualUpdate {
+	return []types.PerpetualUpdate{
+		{
+			PerpetualId:      id,
+			BigQuantumsDelta: delta,
+		},
+	}
+}

--- a/protocol/x/subaccounts/types/position_size.go
+++ b/protocol/x/subaccounts/types/position_size.go
@@ -119,7 +119,7 @@ func (au AssetUpdate) GetIsLong() bool {
 }
 
 func (au AssetUpdate) GetBigQuantums() *big.Int {
-	return au.BigQuantumsDelta
+	return new(big.Int).Set(au.BigQuantumsDelta)
 }
 
 func (au AssetUpdate) GetId() uint32 {
@@ -131,7 +131,7 @@ func (au AssetUpdate) GetProductType() string {
 }
 
 func (pu PerpetualUpdate) GetBigQuantums() *big.Int {
-	return pu.BigQuantumsDelta
+	return new(big.Int).Set(pu.BigQuantumsDelta)
 }
 
 func (pu PerpetualUpdate) GetId() uint32 {
@@ -159,8 +159,9 @@ func (pu PositionUpdate) SetBigQuantums(bigQuantums *big.Int) {
 }
 
 func (pu PositionUpdate) GetBigQuantums() *big.Int {
-	return pu.BigQuantums
+	return new(big.Int).Set(pu.BigQuantums)
 }
+
 func (pu PositionUpdate) GetProductType() string {
 	// PositionUpdate is generic and doesn't have a product type.
 	return UnknownProductTYpe

--- a/protocol/x/subaccounts/types/update.go
+++ b/protocol/x/subaccounts/types/update.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
+
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
 
 type UpdateResult uint
@@ -83,6 +85,19 @@ type Update struct {
 	AssetUpdates []AssetUpdate
 	// A list of changes to make to any `PerpetualPositions` in the `Subaccount`.
 	PerpetualUpdates []PerpetualUpdate
+}
+
+// Validate checks if the `Update` is valid. An `Update` is invalid if:
+// - There are duplicate `AssetUpdates` positions.
+// - There are duplicate `PerpetualUpdates` positions.
+func (u *Update) Validate() error {
+	if lib.ContainsDuplicates(lib.MapSlice(u.AssetUpdates, func(a AssetUpdate) uint32 { return a.AssetId })) {
+		return ErrNonUniqueUpdatesPosition
+	}
+	if lib.ContainsDuplicates(lib.MapSlice(u.PerpetualUpdates, func(p PerpetualUpdate) uint32 { return p.PerpetualId })) {
+		return ErrNonUniqueUpdatesPosition
+	}
+	return nil
 }
 
 type AssetUpdate struct {


### PR DESCRIPTION
### Changelist
- Rename `ApplyUpdatesToPositions()` -> `CalculateNewPositionSizes()` to denote that no changes are happening, just the return value is used. This makes it less likely to be confused with functions that actually modify the structs like `UpdatePerpetualPositions` and `UpdateAssetPositions`
- Add a `Validate()` function to `type.Update` to check for duplicate updates. Not sure if this is needed in the long-run but make the code cleaner to check this "up front"

### Test Plan
TODO
