### PR TITLE
Remove unnecessary `ProductKeeper` abstraction

### DIFF
--- a/protocol/testing/e2e/gov/add_new_market_test.go
+++ b/protocol/testing/e2e/gov/add_new_market_test.go
@@ -20,15 +20,13 @@ import (
 	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
 )
 
 const (
 	NumBlocksAfterTradingEnabled = 50
 	TestMarketId                 = 1001
-	// Expected response log when a order is submitted but oracle price is zero.
-	// https://github.com/dydxprotocol/v4-chain/blob/5ee11ed/protocol/x/perpetuals/keeper/perpetual.go#L1514-L1517
-	ExpectedPlaceOrderCheckTxResponseLog = "recovered: type: perpetual, id: 1001: product position is not updatable"
 )
 
 var (
@@ -392,9 +390,10 @@ func TestAddNewMarketProposal(t *testing.T) {
 				require.Conditionf(t, resp.IsErr, "Expected CheckTx to error. Response: %+v", resp)
 				require.Contains(t,
 					resp.Log,
-					ExpectedPlaceOrderCheckTxResponseLog,
+					satypes.ErrProductPositionNotUpdatable.Error(),
 					"expected CheckTx response log to contain: %s, got: %s",
-					ExpectedPlaceOrderCheckTxResponseLog, resp.Log,
+					satypes.ErrProductPositionNotUpdatable,
+					resp.Log,
 				)
 
 				// Advance to the next block and check chain is not halted.

--- a/protocol/x/subaccounts/types/expected_keepers.go
+++ b/protocol/x/subaccounts/types/expected_keepers.go
@@ -11,9 +11,7 @@ import (
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
-// ProductKeeper represents a generic interface for a keeper
-// of a product.
-type ProductKeeper interface {
+type AssetsKeeper interface {
 	IsPositionUpdatable(
 		ctx sdk.Context,
 		id uint32,
@@ -21,10 +19,6 @@ type ProductKeeper interface {
 		updatable bool,
 		err error,
 	)
-}
-
-type AssetsKeeper interface {
-	ProductKeeper
 	ConvertAssetToCoin(
 		ctx sdk.Context,
 		assetId uint32,
@@ -37,7 +31,13 @@ type AssetsKeeper interface {
 }
 
 type PerpetualsKeeper interface {
-	ProductKeeper
+	IsPositionUpdatable(
+		ctx sdk.Context,
+		id uint32,
+	) (
+		updatable bool,
+		err error,
+	)
 	GetPerpetual(
 		ctx sdk.Context,
 		perpetualId uint32,

--- a/protocol/x/subaccounts/types/position_size.go
+++ b/protocol/x/subaccounts/types/position_size.go
@@ -8,12 +8,6 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 )
 
-const (
-	AssetProductType     = "asset"
-	PerpetualProductType = "perpetual"
-	UnknownProductTYpe   = "unknown"
-)
-
 // PositionSize is an interface for expressing the size of a position
 type PositionSize interface {
 	// Returns true if and only if the position size is positive.
@@ -21,7 +15,6 @@ type PositionSize interface {
 	// Returns the signed position size in big.Int.
 	GetBigQuantums() *big.Int
 	GetId() uint32
-	GetProductType() string
 }
 
 type PositionUpdate struct {
@@ -74,10 +67,6 @@ func (m *AssetPosition) GetIsLong() bool {
 	return m.GetBigQuantums().Sign() > 0
 }
 
-func (m *AssetPosition) GetProductType() string {
-	return AssetProductType
-}
-
 func (m *PerpetualPosition) GetId() uint32 {
 	return m.GetPerpetualId()
 }
@@ -110,10 +99,6 @@ func (m *PerpetualPosition) GetIsLong() bool {
 	return m.GetBigQuantums().Sign() > 0
 }
 
-func (m *PerpetualPosition) GetProductType() string {
-	return PerpetualProductType
-}
-
 func (au AssetUpdate) GetIsLong() bool {
 	return au.GetBigQuantums().Sign() > 0
 }
@@ -126,10 +111,6 @@ func (au AssetUpdate) GetId() uint32 {
 	return au.AssetId
 }
 
-func (au AssetUpdate) GetProductType() string {
-	return AssetProductType
-}
-
 func (pu PerpetualUpdate) GetBigQuantums() *big.Int {
 	return pu.BigQuantumsDelta
 }
@@ -140,10 +121,6 @@ func (pu PerpetualUpdate) GetId() uint32 {
 
 func (pu PerpetualUpdate) GetIsLong() bool {
 	return pu.GetBigQuantums().Sign() > 0
-}
-
-func (pu PerpetualUpdate) GetProductType() string {
-	return PerpetualProductType
 }
 
 func (pu PositionUpdate) GetId() uint32 {
@@ -160,8 +137,4 @@ func (pu PositionUpdate) SetBigQuantums(bigQuantums *big.Int) {
 
 func (pu PositionUpdate) GetBigQuantums() *big.Int {
 	return pu.BigQuantums
-}
-func (pu PositionUpdate) GetProductType() string {
-	// PositionUpdate is generic and doesn't have a product type.
-	return UnknownProductTYpe
 }


### PR DESCRIPTION
### Changelist
Remove unnecessary `ProductKeeper` abstraction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error handling for duplicate update IDs in position updates.
- **Refactor**
  - Simplified code structure by integrating `checkPositionUpdatable` directly into the update validation process.
  - Consolidated product type handling by removing specific constants and methods.
  - Merged `ProductKeeper` interface methods into `AssetsKeeper` and `PerpetualsKeeper` interfaces, streamlining the code.
- **Tests**
  - Updated test cases to reference new error message constants related to product position updatability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->