### PR TITLE
Remove `getFillQuoteQuantums()` function

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -119,7 +119,6 @@ const (
 	CreateClobPair                                          = "create_clob_pair"
 	Expired                                                 = "expired"
 	FullyFilled                                             = "fully_filled"
-	GetFillQuoteQuantums                                    = "get_fill_quote_quantums"
 	Hydrate                                                 = "hydrate"
 	IsLong                                                  = "is_long"
 	IterateOverPendingMatches                               = "iterate_over_pending_matches"

--- a/protocol/x/clob/keeper/grpc_query_mev_node_to_node.go
+++ b/protocol/x/clob/keeper/grpc_query_mev_node_to_node.go
@@ -31,27 +31,16 @@ func (k Keeper) MevNodeToNodeCalculation(
 
 	blockProposerPnL, validatorPnL := k.InitializeCumulativePnLsFromRequest(ctx, req)
 
-	if err := k.CalculateSubaccountPnLForMevMatches(
+	k.CalculateSubaccountPnLForMevMatches(
 		ctx,
 		blockProposerPnL,
 		req.BlockProposerMatches,
-	); err != nil {
-		log.ErrorLogWithError(ctx, "Failed to calculate match PnL for block proposer", err,
-			"mev_matches", req.BlockProposerMatches,
-		)
-		return nil, err
-	}
-
-	if err := k.CalculateSubaccountPnLForMevMatches(
+	)
+	k.CalculateSubaccountPnLForMevMatches(
 		ctx,
 		validatorPnL,
 		req.ValidatorMevMetrics.ValidatorMevMatches,
-	); err != nil {
-		log.ErrorLogWithError(ctx, "Failed to calculate match PnL for validator", err,
-			"mev_matches", req.ValidatorMevMetrics.ValidatorMevMatches,
-		)
-		return nil, err
-	}
+	)
 
 	mevAndVolumePerClob := make(
 		[]types.MevNodeToNodeCalculationResponse_MevAndVolumePerClob,

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -659,14 +659,11 @@ func (k Keeper) GetLiquidationInsuranceFundDelta(
 	// Get the delta quantums and delta quote quantums.
 	clobPair := k.mustGetClobPairForPerpetualId(ctx, perpetualId)
 	deltaQuantums := new(big.Int).SetUint64(fillAmount)
-	deltaQuoteQuantums, err := getFillQuoteQuantums(
-		clobPair,
+	deltaQuoteQuantums := types.FillAmountToQuoteQuantums(
 		subticks,
 		satypes.BaseQuantums(fillAmount),
+		clobPair.QuantumConversionExponent,
 	)
-	if err != nil {
-		return nil, err
-	}
 	if isBuy {
 		deltaQuoteQuantums.Neg(deltaQuoteQuantums)
 	} else {

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -102,10 +102,11 @@ func (k Keeper) ProcessSingleMatch(
 	makerSubticks := makerMatchableOrder.GetOrderSubticks()
 
 	// Calculate the number of quote quantums for the match based on the maker order subticks.
-	bigFillQuoteQuantums, err := getFillQuoteQuantums(clobPair, makerSubticks, fillAmount)
-	if err != nil {
-		return false, takerUpdateResult, makerUpdateResult, err
-	}
+	bigFillQuoteQuantums := types.FillAmountToQuoteQuantums(
+		makerSubticks,
+		fillAmount,
+		clobPair.QuantumConversionExponent,
+	)
 
 	if bigFillQuoteQuantums.Sign() == 0 {
 		// Note: If `subticks`, `baseQuantums`, are small enough, `quantumConversionExponent` is negative,


### PR DESCRIPTION
### Changelist
- Remove extra getFillQuoteQuantums() function which just wraps FillAmountToQuoteQuantums() and throws errors in certain cases unnecessarily
- This allows removal of `error` return value from some upstream functions
