### PR TITLE
[TRA-417] Allocate market mapper revshare for appropriate markets

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1030,6 +1030,7 @@ func New(
 		app.BankKeeper,
 		app.PerpetualsKeeper,
 		app.BlockTimeKeeper,
+		app.RevShareKeeper,
 		app.IndexerEventManager,
 	)
 	subaccountsModule := subaccountsmodule.NewAppModule(

--- a/protocol/testutil/keeper/clob.go
+++ b/protocol/testutil/keeper/clob.go
@@ -138,6 +138,7 @@ func NewClobKeepersTestContextWithUninitializedMemStore(
 			bankKeeper,
 			ks.PerpetualsKeeper,
 			ks.BlockTimeKeeper,
+			revShareKeeper,
 			indexerEventsTransientStoreKey,
 			true,
 		)

--- a/protocol/testutil/keeper/prices.go
+++ b/protocol/testutil/keeper/prices.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	revsharetypes "github.com/dydxprotocol/v4-chain/protocol/x/revshare/types"
+
 	"github.com/cosmos/gogoproto/proto"
 
 	storetypes "cosmossdk.io/store/types"
@@ -115,6 +117,13 @@ func CreateTestMarkets(t testing.TB, ctx sdk.Context, k *keeper.Keeper) {
 			},
 		})
 		require.NoError(t, err)
+
+		// update all markets to not have revenue share
+		k.RevShareKeeper.SetMarketMapperRevShareDetails(
+			ctx,
+			uint32(i),
+			revsharetypes.MarketMapperRevShareDetails{ExpirationTs: 0},
+		)
 	}
 }
 

--- a/protocol/testutil/keeper/sending.go
+++ b/protocol/testutil/keeper/sending.go
@@ -92,6 +92,7 @@ func SendingKeepersWithSubaccountsKeeper(t testing.TB, saKeeper types.Subaccount
 				ks.BankKeeper,
 				ks.PerpetualsKeeper,
 				blockTimeKeeper,
+				revShareKeeper,
 				transientStoreKey,
 				true,
 			)

--- a/protocol/testutil/keeper/subaccounts.go
+++ b/protocol/testutil/keeper/subaccounts.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	revsharekeeper "github.com/dydxprotocol/v4-chain/protocol/x/revshare/keeper"
+
 	"github.com/cosmos/gogoproto/proto"
 
 	dbm "github.com/cosmos/cosmos-db"
@@ -30,10 +32,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
-func SubaccountsKeepers(
-	t testing.TB,
-	msgSenderEnabled bool,
-) (
+func SubaccountsKeepers(t testing.TB, msgSenderEnabled bool) (
 	ctx sdk.Context,
 	keeper *keeper.Keeper,
 	pricesKeeper *priceskeeper.Keeper,
@@ -42,6 +41,7 @@ func SubaccountsKeepers(
 	bankKeeper *bankkeeper.BaseKeeper,
 	assetsKeeper *asskeeper.Keeper,
 	blocktimeKeeper *blocktimekeeper.Keeper,
+	revShareKeeper *revsharekeeper.Keeper,
 	storeKey storetypes.StoreKey,
 ) {
 	var mockTimeProvider *mocks.TimeProvider
@@ -53,7 +53,7 @@ func SubaccountsKeepers(
 		transientStoreKey storetypes.StoreKey,
 	) []GenesisInitializer {
 		// Define necessary keepers here for unit tests
-		revShareKeeper, _, _ := createRevShareKeeper(stateStore, db, cdc)
+		revShareKeeper, _, _ = createRevShareKeeper(stateStore, db, cdc)
 		pricesKeeper, _, _, mockTimeProvider = createPricesKeeper(
 			stateStore,
 			db,
@@ -77,17 +77,18 @@ func SubaccountsKeepers(
 			bankKeeper,
 			perpetualsKeeper,
 			blocktimeKeeper,
+			revShareKeeper,
 			transientStoreKey,
 			msgSenderEnabled,
 		)
 
-		return []GenesisInitializer{pricesKeeper, perpetualsKeeper, assetsKeeper, keeper}
+		return []GenesisInitializer{pricesKeeper, perpetualsKeeper, assetsKeeper, revShareKeeper, keeper}
 	})
 
 	// Mock time provider response for market creation.
 	mockTimeProvider.On("Now").Return(constants.TimeT)
 
-	return ctx, keeper, pricesKeeper, perpetualsKeeper, accountKeeper, bankKeeper, assetsKeeper, blocktimeKeeper, storeKey
+	return ctx, keeper, pricesKeeper, perpetualsKeeper, accountKeeper, bankKeeper, assetsKeeper, blocktimeKeeper, revShareKeeper, storeKey
 }
 
 func createSubaccountsKeeper(
@@ -98,6 +99,7 @@ func createSubaccountsKeeper(
 	bk types.BankKeeper,
 	pk *perpskeeper.Keeper,
 	btk *blocktimekeeper.Keeper,
+	rsk *revsharekeeper.Keeper,
 	transientStoreKey storetypes.StoreKey,
 	msgSenderEnabled bool,
 ) (*keeper.Keeper, storetypes.StoreKey) {
@@ -116,6 +118,7 @@ func createSubaccountsKeeper(
 		bk,
 		pk,
 		btk,
+		rsk,
 		mockIndexerEventsManager,
 	)
 

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -426,13 +426,33 @@ func (k Keeper) persistMatchedOrders(
 		)
 	}
 
+	// TODO: get perpetual from perpetualId once and pass it to the functions that need the full
+	// perpetual object. This will reduce the number of times we need to get the perpetual from the
+	// keeper.
+
 	if err := k.subaccountsKeeper.TransferInsuranceFundPayments(ctx, insuranceFundDelta, perpetualId); err != nil {
 		return takerUpdateResult, makerUpdateResult, err
 	}
 
 	// Transfer the fee amount from subacounts module to fee collector module account.
 	bigTotalFeeQuoteQuantums := new(big.Int).Add(bigTakerFeeQuoteQuantums, bigMakerFeeQuoteQuantums)
-	if err := k.subaccountsKeeper.TransferFeesToFeeCollectorModule(
+	//if err := k.subaccountsKeeper.TransferFeesToFeeCollectorModule(
+	//	ctx,
+	//	assettypes.AssetUsdc.Id,
+	//	bigTotalFeeQuoteQuantums,
+	//	perpetualId,
+	//); err != nil {
+	//	return takerUpdateResult, makerUpdateResult, errorsmod.Wrapf(
+	//		types.ErrSubaccountFeeTransferFailed,
+	//		"persistMatchedOrders: subaccounts (%v, %v) updated, but fee transfer (bigFeeQuoteQuantums: %v)"+
+	//			" to fee-collector failed. Err: %v",
+	//		matchWithOrders.MakerOrder.GetSubaccountId(),
+	//		matchWithOrders.TakerOrder.GetSubaccountId(),
+	//		bigTotalFeeQuoteQuantums,
+	//		err,
+	//	)
+	//}
+	if err := k.subaccountsKeeper.DistributeFees(
 		ctx,
 		assettypes.AssetUsdc.Id,
 		bigTotalFeeQuoteQuantums,

--- a/protocol/x/clob/types/expected_keepers.go
+++ b/protocol/x/clob/types/expected_keepers.go
@@ -73,6 +73,12 @@ type SubaccountsKeeper interface {
 		ctx sdk.Context,
 		perpetualId uint32,
 	) (sdk.AccAddress, error)
+	DistributeFees(
+		ctx sdk.Context,
+		assetId uint32,
+		quantums *big.Int,
+		perpetualId uint32,
+	) error
 }
 
 type AssetsKeeper interface {

--- a/protocol/x/prices/keeper/keeper.go
+++ b/protocol/x/prices/keeper/keeper.go
@@ -27,7 +27,7 @@ type (
 		authorities                    map[string]struct{}
 		currencyPairIDCache            *CurrencyPairIDCache
 		currencyPairIdCacheInitialized *atomic.Bool
-		revShareKeeper                 types.RevShareKeeper
+		RevShareKeeper                 types.RevShareKeeper
 	}
 )
 
@@ -52,7 +52,7 @@ func NewKeeper(
 		authorities:                    lib.UniqueSliceToSet(authorities),
 		currencyPairIDCache:            NewCurrencyPairIDCache(),
 		currencyPairIdCacheInitialized: &atomic.Bool{}, // Initialized to false
-		revShareKeeper:                 revShareKeeper,
+		RevShareKeeper:                 revShareKeeper,
 	}
 }
 

--- a/protocol/x/prices/keeper/market.go
+++ b/protocol/x/prices/keeper/market.go
@@ -90,7 +90,7 @@ func (k Keeper) CreateMarket(
 	metrics.SetMarketPairForTelemetry(marketParam.Id, marketParam.Pair)
 
 	// create a new market rev share
-	k.revShareKeeper.CreateNewMarketRevShare(ctx, marketParam.Id)
+	k.RevShareKeeper.CreateNewMarketRevShare(ctx, marketParam.Id)
 
 	return marketParam, nil
 }

--- a/protocol/x/prices/types/expected_keepers.go
+++ b/protocol/x/prices/types/expected_keepers.go
@@ -3,6 +3,8 @@ package types
 import (
 	"context"
 
+	"github.com/dydxprotocol/v4-chain/protocol/x/revshare/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -19,4 +21,9 @@ type BankKeeper interface {
 // RevShareKeeper defines the expected revshare keeper used for simulations.
 type RevShareKeeper interface {
 	CreateNewMarketRevShare(ctx sdk.Context, marketId uint32)
+	SetMarketMapperRevShareDetails(
+		ctx sdk.Context,
+		marketId uint32,
+		params types.MarketMapperRevShareDetails,
+	)
 }

--- a/protocol/x/revshare/keeper/revshare.go
+++ b/protocol/x/revshare/keeper/revshare.go
@@ -77,30 +77,29 @@ func (k Keeper) CreateNewMarketRevShare(ctx sdk.Context, marketId uint32) {
 	k.SetMarketMapperRevShareDetails(ctx, marketId, details)
 }
 
-func (k Keeper) GetRevenueShareForPerpetual(ctx sdk.Context, perpetualId uint32) (
-	address string,
+func (k Keeper) GetMarketMapperRevenueShareForMarket(ctx sdk.Context, marketId uint32) (
+	address sdk.AccAddress,
 	revenueSharePpm uint32,
 	err error,
 ) {
-	// get the perpetual market id
-	marketId, err := k.perpetualsKeeper.GetPerpetual(ctx, k, perpetualId)
-	if err != nil {
-		return "", 0, err
-	}
-
 	// get the revenue share details for the market
 	revShareDetails, err := k.GetMarketMapperRevShareDetails(ctx, marketId)
 	if err != nil {
-		return "", 0, err
+		return nil, 0, err
 	}
 
 	// check if the rev share details are expired
 	if revShareDetails.ExpirationTs < uint64(ctx.BlockTime().Unix()) {
-		return "", 0, fmt.Errorf("Revenue share expired for market: %d", marketId)
+		return nil, 0, nil
 	}
 
 	// Get revenue share params
 	revShareParams := k.GetMarketMapperRevenueShareParams(ctx)
 
-	return revShareParams.Address, revShareParams.RevenueSharePpm, nil
+	revShareAddr, err := sdk.AccAddressFromBech32(revShareParams.Address)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return revShareAddr, revShareParams.RevenueSharePpm, nil
 }

--- a/protocol/x/revshare/types/expected_keepers.go
+++ b/protocol/x/revshare/types/expected_keepers.go
@@ -1,1 +1,11 @@
 package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+)
+
+type PerpetualsKeeper interface {
+	// Function to get perpetual details from the module store
+	GetPerpetual(ctx sdk.Context, perpetualId uint32) (perpetual perptypes.Perpetual, err error)
+}

--- a/protocol/x/revshare/types/expected_keepers.go
+++ b/protocol/x/revshare/types/expected_keepers.go
@@ -1,11 +1,1 @@
 package types
-
-import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
-)
-
-type PerpetualsKeeper interface {
-	// Function to get perpetual details from the module store
-	GetPerpetual(ctx sdk.Context, perpetualId uint32) (perpetual perptypes.Perpetual, err error)
-}

--- a/protocol/x/subaccounts/genesis_test.go
+++ b/protocol/x/subaccounts/genesis_test.go
@@ -34,7 +34,7 @@ func TestGenesis(t *testing.T) {
 		},
 	}
 
-	ctx, k, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
+	ctx, k, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
 	subaccounts.InitGenesis(ctx, *k, genesisState)
 	assertSubaccountUpdateEventsInIndexerBlock(t, k, ctx, 2)
 	got := subaccounts.ExportGenesis(ctx, *k)

--- a/protocol/x/subaccounts/keeper/grpc_query_collateral_pool_test.go
+++ b/protocol/x/subaccounts/keeper/grpc_query_collateral_pool_test.go
@@ -52,7 +52,7 @@ func TestQueryCollateralPoolAddress(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
+			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
 			keepertest.CreateTestMarkets(t, ctx, pricesKeeper)
 			keepertest.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
 			keepertest.CreateTestPerpetuals(t, ctx, perpetualsKeeper)

--- a/protocol/x/subaccounts/keeper/grpc_query_subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/grpc_query_subaccount_test.go
@@ -19,7 +19,7 @@ import (
 var _ = strconv.IntSize
 
 func TestSubaccountQuerySingle(t *testing.T) {
-	ctx, keeper, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
+	ctx, keeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
 	msgs := createNSubaccount(keeper, ctx, 2, big.NewInt(1_000))
 	for _, tc := range []struct {
 		desc     string
@@ -90,7 +90,7 @@ func TestSubaccountQuerySingle(t *testing.T) {
 }
 
 func TestSubaccountQueryPaginated(t *testing.T) {
-	ctx, keeper, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
+	ctx, keeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
 	msgs := createNSubaccount(keeper, ctx, 5, big.NewInt(1_000))
 
 	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllSubaccountRequest {

--- a/protocol/x/subaccounts/keeper/grpc_query_withdrawal_and_transfers_blocked_info_test.go
+++ b/protocol/x/subaccounts/keeper/grpc_query_withdrawal_and_transfers_blocked_info_test.go
@@ -267,7 +267,10 @@ func TestQueryWithdrawalAndTransfersBlockedInfo(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, _, blocktimeKeeper, _ := keepertest.SubaccountsKeepers(t, true)
+			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, _, blocktimeKeeper, _, _ := keepertest.SubaccountsKeepers(
+				t,
+				true,
+			)
 			keepertest.CreateTestMarkets(t, ctx, pricesKeeper)
 			keepertest.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
 			keepertest.CreateTestPerpetuals(t, ctx, perpetualsKeeper)

--- a/protocol/x/subaccounts/keeper/keeper.go
+++ b/protocol/x/subaccounts/keeper/keeper.go
@@ -19,6 +19,7 @@ type (
 		bankKeeper          types.BankKeeper
 		perpetualsKeeper    types.PerpetualsKeeper
 		blocktimeKeeper     types.BlocktimeKeeper
+		revShareKeeper      types.RevShareKeeper
 		indexerEventManager indexer_manager.IndexerEventManager
 	}
 )
@@ -30,6 +31,7 @@ func NewKeeper(
 	bankKeeper types.BankKeeper,
 	perpetualsKeeper types.PerpetualsKeeper,
 	blocktimeKeeper types.BlocktimeKeeper,
+	revShareKeeper types.RevShareKeeper,
 	indexerEventManager indexer_manager.IndexerEventManager,
 ) *Keeper {
 	return &Keeper{
@@ -39,6 +41,7 @@ func NewKeeper(
 		bankKeeper:          bankKeeper,
 		perpetualsKeeper:    perpetualsKeeper,
 		blocktimeKeeper:     blocktimeKeeper,
+		revShareKeeper:      revShareKeeper,
 		indexerEventManager: indexerEventManager,
 	}
 }

--- a/protocol/x/subaccounts/keeper/negative_tnc_subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/negative_tnc_subaccount_test.go
@@ -224,7 +224,10 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Setup keeper state and test parameters.
-			ctx, subaccountsKeeper, pricesKeeper, perpetualsKeeper, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
+			ctx, subaccountsKeeper, pricesKeeper, perpetualsKeeper, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(
+				t,
+				true,
+			)
 			keepertest.CreateTestMarkets(t, ctx, pricesKeeper)
 			keepertest.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
 			keepertest.CreateTestPerpetuals(t, ctx, perpetualsKeeper)
@@ -247,7 +250,7 @@ func TestGetSetNegativeTncSubaccountSeenAtBlock(t *testing.T) {
 
 func TestGetSetNegativeTncSubaccountSeenAtBlock_PanicsOnDecreasingBlock(t *testing.T) {
 	// Setup keeper state and test parameters.
-	ctx, subaccountsKeeper, pricesKeeper, perpetualsKeeper, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
+	ctx, subaccountsKeeper, pricesKeeper, perpetualsKeeper, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, true)
 	keepertest.CreateTestMarkets(t, ctx, pricesKeeper)
 	keepertest.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
 	keepertest.CreateTestPerpetuals(t, ctx, perpetualsKeeper)

--- a/protocol/x/subaccounts/keeper/safety_heap_state_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_state_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGetSetSubaccountAtIndex(t *testing.T) {
 	// Setup keeper state and test parameters.
-	ctx, subaccountsKeeper, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
+	ctx, subaccountsKeeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
 
 	// Write a couple of subaccounts to the store.
 	store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, types.Long)
@@ -60,7 +60,7 @@ func TestGetSetSubaccountAtIndex(t *testing.T) {
 
 func TestGetSetSubaccountHeapIndex(t *testing.T) {
 	// Setup keeper state and test parameters.
-	ctx, subaccountsKeeper, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
+	ctx, subaccountsKeeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
 
 	// Write a couple of subaccounts to the store.
 	store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, types.Long)
@@ -109,7 +109,7 @@ func TestGetSetSubaccountHeapIndex(t *testing.T) {
 
 func TestGetSetSafetyHeapLength(t *testing.T) {
 	// Setup keeper state and test parameters.
-	ctx, subaccountsKeeper, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
+	ctx, subaccountsKeeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
 
 	// Write a couple of subaccounts to the store.
 	store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, types.Long)

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -153,7 +153,7 @@ func TestGetCollateralPool(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(
 			name, func(t *testing.T) {
-				ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _ := testutil.SubaccountsKeepers(
+				ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _, _ := testutil.SubaccountsKeepers(
 					t,
 					true,
 				)
@@ -188,7 +188,7 @@ func TestGetCollateralPool(t *testing.T) {
 }
 
 func TestSubaccountGet(t *testing.T) {
-	ctx, keeper, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
+	ctx, keeper, _, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
 	items := createNSubaccount(keeper, ctx, 10, big.NewInt(1_000))
 	for _, item := range items {
 		rst := keeper.GetSubaccount(ctx,
@@ -202,7 +202,7 @@ func TestSubaccountGet(t *testing.T) {
 }
 
 func TestSubaccountSet_Empty(t *testing.T) {
-	ctx, keeper, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
+	ctx, keeper, _, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
 	keeper.SetSubaccount(ctx, types.Subaccount{
 		Id: &constants.Alice_Num0,
 	})
@@ -220,7 +220,7 @@ func TestSubaccountSet_Empty(t *testing.T) {
 }
 
 func TestSubaccountGetNonExistent(t *testing.T) {
-	ctx, keeper, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
+	ctx, keeper, _, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
 	id := types.SubaccountId{
 		Owner:  "non-existent",
 		Number: uint32(123),
@@ -234,7 +234,7 @@ func TestSubaccountGetNonExistent(t *testing.T) {
 }
 
 func TestGetAllSubaccount(t *testing.T) {
-	ctx, keeper, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
+	ctx, keeper, _, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
 	items := createNSubaccount(keeper, ctx, 10, big.NewInt(1_000))
 	require.Equal(
 		t,
@@ -275,7 +275,7 @@ func TestForEachSubaccount(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, keeper, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
+			ctx, keeper, _, _, _, _, _, _, _, _ := testutil.SubaccountsKeepers(t, true)
 			items := createNSubaccount(keeper, ctx, tc.numSubaccountsInState, big.NewInt(1_000))
 			collectedSubaccounts := make([]types.Subaccount, 0)
 			i := 0
@@ -2787,7 +2787,7 @@ func TestUpdateSubaccounts(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, keeper, pricesKeeper, perpetualsKeeper, _, bankKeeper, assetsKeeper, _, _ := testutil.SubaccountsKeepers(
+			ctx, keeper, pricesKeeper, perpetualsKeeper, _, bankKeeper, assetsKeeper, _, _, _ := testutil.SubaccountsKeepers(
 				t,
 				tc.msgSenderEnabled,
 			)
@@ -4231,7 +4231,7 @@ func TestUpdateSubaccounts_WithdrawalsBlocked(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _ := testutil.SubaccountsKeepers(
+			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _, _ := testutil.SubaccountsKeepers(
 				t,
 				tc.msgSenderEnabled,
 			)
@@ -5342,7 +5342,10 @@ func TestCanUpdateSubaccounts(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _ := testutil.SubaccountsKeepers(t, true)
+			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _, _ := testutil.SubaccountsKeepers(
+				t,
+				true,
+			)
 			testutil.CreateTestMarkets(t, ctx, pricesKeeper)
 			testutil.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
 
@@ -5778,7 +5781,10 @@ func TestGetNetCollateralAndMarginRequirements(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _ := testutil.SubaccountsKeepers(t, true)
+			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _, _ := testutil.SubaccountsKeepers(
+				t,
+				true,
+			)
 			testutil.CreateTestMarkets(t, ctx, pricesKeeper)
 			testutil.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
 

--- a/protocol/x/subaccounts/module_test.go
+++ b/protocol/x/subaccounts/module_test.go
@@ -39,7 +39,7 @@ func createAppModule(t *testing.T) subaccounts.AppModule {
 func createAppModuleWithKeeper(t *testing.T) (subaccounts.AppModule, *sa_keeper.Keeper, sdk.Context) {
 	appCodec := codec.NewProtoCodec(module.InterfaceRegistry)
 
-	ctx, keeper, _, _, _, _, _, _, _ := keeper.SubaccountsKeepers(t, true)
+	ctx, keeper, _, _, _, _, _, _, _, _ := keeper.SubaccountsKeepers(t, true)
 
 	return subaccounts.NewAppModule(
 		appCodec,

--- a/protocol/x/subaccounts/types/expected_keepers.go
+++ b/protocol/x/subaccounts/types/expected_keepers.go
@@ -96,3 +96,14 @@ type BankKeeper interface {
 type BlocktimeKeeper interface {
 	GetDowntimeInfoFor(ctx sdk.Context, duration time.Duration) blocktimetypes.AllDowntimeInfo_DowntimeInfo
 }
+
+type RevShareKeeper interface {
+	GetMarketMapperRevenueShareForMarket(
+		ctx sdk.Context,
+		marketId uint32,
+	) (
+		address sdk.AccAddress,
+		revenueSharePpm uint32,
+		err error,
+	)
+}


### PR DESCRIPTION
### Changelist
This change calculates the market mapper revenue share for a trade in a specific market and transfers the share amount to the market mapper address

### Test Plan
Added tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
