### PR TITLE
[TRA-446] include vault shares in genesis state

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/genesis.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/genesis.ts
@@ -1,4 +1,6 @@
 import { Params, ParamsSDKType } from "./params";
+import { VaultId, VaultIdSDKType, NumShares, NumSharesSDKType } from "./vault";
+import { OwnerShare, OwnerShareSDKType } from "./query";
 import * as _m0 from "protobufjs/minimal";
 import { DeepPartial } from "../../helpers";
 /** GenesisState defines `x/vault`'s genesis state. */
@@ -6,17 +8,48 @@ import { DeepPartial } from "../../helpers";
 export interface GenesisState {
   /** The parameters of the module. */
   params?: Params;
+  /** The vaults. */
+
+  vaults: Vault[];
 }
 /** GenesisState defines `x/vault`'s genesis state. */
 
 export interface GenesisStateSDKType {
   /** The parameters of the module. */
   params?: ParamsSDKType;
+  /** The vaults. */
+
+  vaults: VaultSDKType[];
+}
+/** Vault defines the total shares and owner shares of a vault. */
+
+export interface Vault {
+  /** The ID of the vault. */
+  vaultId?: VaultId;
+  /** The total number of shares in the vault. */
+
+  totalShares?: NumShares;
+  /** The shares of each owner in the vault. */
+
+  ownerShares: OwnerShare[];
+}
+/** Vault defines the total shares and owner shares of a vault. */
+
+export interface VaultSDKType {
+  /** The ID of the vault. */
+  vault_id?: VaultIdSDKType;
+  /** The total number of shares in the vault. */
+
+  total_shares?: NumSharesSDKType;
+  /** The shares of each owner in the vault. */
+
+  owner_shares: OwnerShareSDKType[];
 }
 
 function createBaseGenesisState(): GenesisState {
   return {
-    params: undefined
+    params: undefined,
+    vaults: []
   };
 }
 
@@ -24,6 +57,10 @@ export const GenesisState = {
   encode(message: GenesisState, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.params !== undefined) {
       Params.encode(message.params, writer.uint32(10).fork()).ldelim();
+    }
+
+    for (const v of message.vaults) {
+      Vault.encode(v!, writer.uint32(18).fork()).ldelim();
     }
 
     return writer;
@@ -42,6 +79,10 @@ export const GenesisState = {
           message.params = Params.decode(reader, reader.uint32());
           break;
 
+        case 2:
+          message.vaults.push(Vault.decode(reader, reader.uint32()));
+          break;
+
         default:
           reader.skipType(tag & 7);
           break;
@@ -54,6 +95,72 @@ export const GenesisState = {
   fromPartial(object: DeepPartial<GenesisState>): GenesisState {
     const message = createBaseGenesisState();
     message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
+    message.vaults = object.vaults?.map(e => Vault.fromPartial(e)) || [];
+    return message;
+  }
+
+};
+
+function createBaseVault(): Vault {
+  return {
+    vaultId: undefined,
+    totalShares: undefined,
+    ownerShares: []
+  };
+}
+
+export const Vault = {
+  encode(message: Vault, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.vaultId !== undefined) {
+      VaultId.encode(message.vaultId, writer.uint32(10).fork()).ldelim();
+    }
+
+    if (message.totalShares !== undefined) {
+      NumShares.encode(message.totalShares, writer.uint32(18).fork()).ldelim();
+    }
+
+    for (const v of message.ownerShares) {
+      OwnerShare.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Vault {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVault();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.vaultId = VaultId.decode(reader, reader.uint32());
+          break;
+
+        case 2:
+          message.totalShares = NumShares.decode(reader, reader.uint32());
+          break;
+
+        case 3:
+          message.ownerShares.push(OwnerShare.decode(reader, reader.uint32()));
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<Vault>): Vault {
+    const message = createBaseVault();
+    message.vaultId = object.vaultId !== undefined && object.vaultId !== null ? VaultId.fromPartial(object.vaultId) : undefined;
+    message.totalShares = object.totalShares !== undefined && object.totalShares !== null ? NumShares.fromPartial(object.totalShares) : undefined;
+    message.ownerShares = object.ownerShares?.map(e => OwnerShare.fromPartial(e)) || [];
     return message;
   }
 

--- a/proto/dydxprotocol/vault/genesis.proto
+++ b/proto/dydxprotocol/vault/genesis.proto
@@ -3,6 +3,8 @@ package dydxprotocol.vault;
 
 import "gogoproto/gogo.proto";
 import "dydxprotocol/vault/params.proto";
+import "dydxprotocol/vault/query.proto";
+import "dydxprotocol/vault/vault.proto";
 
 option go_package = "github.com/dydxprotocol/v4-chain/protocol/x/vault/types";
 
@@ -10,4 +12,16 @@ option go_package = "github.com/dydxprotocol/v4-chain/protocol/x/vault/types";
 message GenesisState {
   // The parameters of the module.
   Params params = 1 [ (gogoproto.nullable) = false ];
+  // The vaults.
+  repeated Vault vaults = 2;
+}
+
+// Vault defines the total shares and owner shares of a vault.
+message Vault {
+  // The ID of the vault.
+  VaultId vault_id = 1;
+  // The total number of shares in the vault.
+  NumShares total_shares = 2;
+  // The shares of each owner in the vault.
+  repeated OwnerShare owner_shares = 3;
 }

--- a/protocol/app/testdata/default_genesis_state.json
+++ b/protocol/app/testdata/default_genesis_state.json
@@ -474,7 +474,8 @@
       "order_size_pct_ppm": 100000,
       "order_expiration_seconds": 2,
       "activation_threshold_quote_quantums": "1000000000"
-    }
+    },
+    "vaults": []
   },
   "vest": {
     "vest_entries": [

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -1825,7 +1825,8 @@
         "skew_factor_ppm": 2000000,
         "spread_buffer_ppm": 1500,
         "spread_min_ppm": 10000
-      }
+      },
+      "vaults": []
     },
     "vest": {
       "vest_entries": [

--- a/protocol/testing/containertest/preupgrade_genesis.json
+++ b/protocol/testing/containertest/preupgrade_genesis.json
@@ -2315,7 +2315,8 @@
         "order_size_pct_ppm": 100000,
         "order_expiration_seconds": 2,
         "activation_threshold_quote_quantums": "1000000000"
-      }
+      },
+      "vaults": []
     },
     "vest": {
       "vest_entries": [

--- a/protocol/testing/containertest/preupgrade_genesis.json
+++ b/protocol/testing/containertest/preupgrade_genesis.json
@@ -2315,8 +2315,7 @@
         "order_size_pct_ppm": 100000,
         "order_expiration_seconds": 2,
         "activation_threshold_quote_quantums": "1000000000"
-      },
-      "vaults": []
+      }
     },
     "vest": {
       "vest_entries": [

--- a/protocol/testutil/constants/genesis.go
+++ b/protocol/testutil/constants/genesis.go
@@ -1511,7 +1511,8 @@ const GenesisState = `{
         "order_size_pct_ppm": 100000,
         "order_expiration_seconds": 2,
         "activation_threshold_quote_quantums": "1000000000"
-      }
+      },
+      "vaults": []
     },
     "vest": {
       "vest_entries": [

--- a/protocol/x/vault/genesis.go
+++ b/protocol/x/vault/genesis.go
@@ -10,15 +10,32 @@ import (
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	k.InitializeForGenesis(ctx)
 
+	// Set params.
 	if err := k.SetParams(ctx, genState.Params); err != nil {
 		panic(err)
+	}
+	// Set total shares and owner shares of each vault.
+	for _, vault := range genState.Vaults {
+		if err := k.SetTotalShares(ctx, *vault.VaultId, *vault.TotalShares); err != nil {
+			panic(err)
+		}
+		for _, ownerShares := range vault.OwnerShares {
+			if err := k.SetOwnerShares(ctx, *vault.VaultId, ownerShares.Owner, *ownerShares.Shares); err != nil {
+				panic(err)
+			}
+		}
 	}
 }
 
 // ExportGenesis returns the module's exported genesis.
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
+
+	// Export params.
 	genesis.Params = k.GetParams(ctx)
+
+	// Export vaults.
+	genesis.Vaults = k.GetAllVaults(ctx)
 
 	return genesis
 }

--- a/protocol/x/vault/keeper/shares.go
+++ b/protocol/x/vault/keeper/shares.go
@@ -101,6 +101,27 @@ func (k Keeper) getVaultOwnerSharesStore(
 	return prefix.NewStore(store, vaultId.ToStateKeyPrefix())
 }
 
+// GetAllOwnerShares gets all owner shares of a given vault.
+func (k Keeper) GetAllOwnerShares(
+	ctx sdk.Context,
+	vaultId types.VaultId,
+) []*types.OwnerShare {
+	allOwnerShares := []*types.OwnerShare{}
+	ownerSharesStore := k.getVaultOwnerSharesStore(ctx, vaultId)
+	ownerSharesIterator := storetypes.KVStorePrefixIterator(ownerSharesStore, []byte{})
+	defer ownerSharesIterator.Close()
+	for ; ownerSharesIterator.Valid(); ownerSharesIterator.Next() {
+		owner := string(ownerSharesIterator.Key())
+		var ownerShares types.NumShares
+		k.cdc.MustUnmarshal(ownerSharesIterator.Value(), &ownerShares)
+		allOwnerShares = append(allOwnerShares, &types.OwnerShare{
+			Owner:  owner,
+			Shares: &ownerShares,
+		})
+	}
+	return allOwnerShares
+}
+
 // MintShares mints shares of a vault for `owner` based on `quantumsToDeposit` by:
 // 1. Increasing total shares of the vault.
 // 2. Increasing owner shares of the vault for given `owner`.

--- a/protocol/x/vault/keeper/shares_test.go
+++ b/protocol/x/vault/keeper/shares_test.go
@@ -132,6 +132,41 @@ func TestGetSetOwnerShares(t *testing.T) {
 	require.Equal(t, numShares, got)
 }
 
+func TestGetAllOwnerShares(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+	k := tApp.App.VaultKeeper
+
+	// Get all owner shares of a vault that has no owners.
+	allOwnerShares := k.GetAllOwnerShares(ctx, constants.Vault_Clob_0)
+	require.Equal(t, []*vaulttypes.OwnerShare{}, allOwnerShares)
+
+	// Set alice and bob as owners of a vault and get all owner shares.
+	alice := constants.AliceAccAddress.String()
+	aliceShares := vaulttypes.BigIntToNumShares(big.NewInt(7))
+	bob := constants.BobAccAddress.String()
+	bobShares := vaulttypes.BigIntToNumShares(big.NewInt(123))
+
+	k.SetOwnerShares(ctx, constants.Vault_Clob_0, alice, aliceShares)
+	k.SetOwnerShares(ctx, constants.Vault_Clob_0, bob, bobShares)
+
+	allOwnerShares = k.GetAllOwnerShares(ctx, constants.Vault_Clob_0)
+	require.ElementsMatch(
+		t,
+		[]*vaulttypes.OwnerShare{
+			{
+				Owner:  alice,
+				Shares: &aliceShares,
+			},
+			{
+				Owner:  bob,
+				Shares: &bobShares,
+			},
+		},
+		allOwnerShares,
+	)
+}
+
 func TestMintShares(t *testing.T) {
 	tests := map[string]struct {
 		/* --- Setup --- */

--- a/protocol/x/vault/keeper/shares_test.go
+++ b/protocol/x/vault/keeper/shares_test.go
@@ -147,8 +147,10 @@ func TestGetAllOwnerShares(t *testing.T) {
 	bob := constants.BobAccAddress.String()
 	bobShares := vaulttypes.BigIntToNumShares(big.NewInt(123))
 
-	k.SetOwnerShares(ctx, constants.Vault_Clob_0, alice, aliceShares)
-	k.SetOwnerShares(ctx, constants.Vault_Clob_0, bob, bobShares)
+	err := k.SetOwnerShares(ctx, constants.Vault_Clob_0, alice, aliceShares)
+	require.NoError(t, err)
+	err = k.SetOwnerShares(ctx, constants.Vault_Clob_0, bob, bobShares)
+	require.NoError(t, err)
 
 	allOwnerShares = k.GetAllOwnerShares(ctx, constants.Vault_Clob_0)
 	require.ElementsMatch(

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -75,4 +75,14 @@ var (
 		14,
 		"OrderSize is invalid",
 	)
+	ErrInvalidOwner = errorsmod.Register(
+		ModuleName,
+		15,
+		"Owner is invalid",
+	)
+	ErrMismatchedTotalAndOwnerShares = errorsmod.Register(
+		ModuleName,
+		16,
+		"TotalShares does not match sum of OwnerShares",
+	)
 )

--- a/protocol/x/vault/types/genesis.go
+++ b/protocol/x/vault/types/genesis.go
@@ -10,5 +10,32 @@ func DefaultGenesis() *GenesisState {
 // Validate performs basic genesis state validation returning an error upon any
 // failure.
 func (gs GenesisState) Validate() error {
-	return gs.Params.Validate()
+	// Validate params.
+	if err := gs.Params.Validate(); err != nil {
+		return err
+	}
+
+	// Validate vaults, ensuring that for each vault:
+	// 1. TotalShares is non-negative.
+	// 2. OwnerShares is non-negative.
+	// 3. TotalShares is equal to the sum of OwnerShares.
+	// 4. Owner is not empty.
+	for _, vault := range gs.Vaults {
+		totalShares := vault.TotalShares.NumShares.BigInt()
+		if totalShares.Sign() == -1 {
+			return ErrNegativeShares
+		}
+		for _, ownerShares := range vault.OwnerShares {
+			if ownerShares.Owner == "" {
+				return ErrInvalidOwner
+			} else if ownerShares.Shares.NumShares.Sign() == -1 {
+				return ErrNegativeShares
+			}
+			totalShares.Sub(totalShares, ownerShares.Shares.NumShares.BigInt())
+		}
+		if totalShares.Sign() != 0 {
+			return ErrMismatchedTotalAndOwnerShares
+		}
+	}
+	return nil
 }

--- a/protocol/x/vault/types/genesis.pb.go
+++ b/protocol/x/vault/types/genesis.pb.go
@@ -27,6 +27,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type GenesisState struct {
 	// The parameters of the module.
 	Params Params `protobuf:"bytes,1,opt,name=params,proto3" json:"params"`
+	// The vaults.
+	Vaults []*Vault `protobuf:"bytes,2,rep,name=vaults,proto3" json:"vaults,omitempty"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -69,27 +71,107 @@ func (m *GenesisState) GetParams() Params {
 	return Params{}
 }
 
+func (m *GenesisState) GetVaults() []*Vault {
+	if m != nil {
+		return m.Vaults
+	}
+	return nil
+}
+
+// Vault defines the total shares and owner shares of a vault.
+type Vault struct {
+	// The ID of the vault.
+	VaultId *VaultId `protobuf:"bytes,1,opt,name=vault_id,json=vaultId,proto3" json:"vault_id,omitempty"`
+	// The total number of shares in the vault.
+	TotalShares *NumShares `protobuf:"bytes,2,opt,name=total_shares,json=totalShares,proto3" json:"total_shares,omitempty"`
+	// The shares of each owner in the vault.
+	OwnerShares []*OwnerShare `protobuf:"bytes,3,rep,name=owner_shares,json=ownerShares,proto3" json:"owner_shares,omitempty"`
+}
+
+func (m *Vault) Reset()         { *m = Vault{} }
+func (m *Vault) String() string { return proto.CompactTextString(m) }
+func (*Vault) ProtoMessage()    {}
+func (*Vault) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4be4a747b209e41c, []int{1}
+}
+func (m *Vault) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Vault) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Vault.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Vault) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Vault.Merge(m, src)
+}
+func (m *Vault) XXX_Size() int {
+	return m.Size()
+}
+func (m *Vault) XXX_DiscardUnknown() {
+	xxx_messageInfo_Vault.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Vault proto.InternalMessageInfo
+
+func (m *Vault) GetVaultId() *VaultId {
+	if m != nil {
+		return m.VaultId
+	}
+	return nil
+}
+
+func (m *Vault) GetTotalShares() *NumShares {
+	if m != nil {
+		return m.TotalShares
+	}
+	return nil
+}
+
+func (m *Vault) GetOwnerShares() []*OwnerShare {
+	if m != nil {
+		return m.OwnerShares
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*GenesisState)(nil), "dydxprotocol.vault.GenesisState")
+	proto.RegisterType((*Vault)(nil), "dydxprotocol.vault.Vault")
 }
 
 func init() { proto.RegisterFile("dydxprotocol/vault/genesis.proto", fileDescriptor_4be4a747b209e41c) }
 
 var fileDescriptor_4be4a747b209e41c = []byte{
-	// 195 bytes of a gzipped FileDescriptorProto
+	// 324 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x48, 0xa9, 0x4c, 0xa9,
 	0x28, 0x28, 0xca, 0x2f, 0xc9, 0x4f, 0xce, 0xcf, 0xd1, 0x2f, 0x4b, 0x2c, 0xcd, 0x29, 0xd1, 0x4f,
 	0x4f, 0xcd, 0x4b, 0x2d, 0xce, 0x2c, 0xd6, 0x03, 0x0b, 0x0b, 0x09, 0x21, 0xab, 0xd0, 0x03, 0xab,
 	0x90, 0x12, 0x49, 0xcf, 0x4f, 0xcf, 0x07, 0x8b, 0xe9, 0x83, 0x58, 0x10, 0x95, 0x52, 0xf2, 0x58,
-	0xcc, 0x2a, 0x48, 0x2c, 0x4a, 0xcc, 0x85, 0x1a, 0xa5, 0xe4, 0xc1, 0xc5, 0xe3, 0x0e, 0x31, 0x3b,
-	0xb8, 0x24, 0xb1, 0x24, 0x55, 0xc8, 0x82, 0x8b, 0x0d, 0x22, 0x2f, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1,
-	0x6d, 0x24, 0xa5, 0x87, 0x69, 0x97, 0x5e, 0x00, 0x58, 0x85, 0x13, 0xcb, 0x89, 0x7b, 0xf2, 0x0c,
-	0x41, 0x50, 0xf5, 0x4e, 0x81, 0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91,
-	0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c, 0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0x65,
-	0x9e, 0x9e, 0x59, 0x92, 0x51, 0x9a, 0xa4, 0x97, 0x9c, 0x9f, 0xab, 0x8f, 0xea, 0x1e, 0x13, 0xdd,
-	0xe4, 0x8c, 0xc4, 0xcc, 0x3c, 0x7d, 0xb8, 0x48, 0x05, 0xd4, 0x8d, 0x25, 0x95, 0x05, 0xa9, 0xc5,
-	0x49, 0x6c, 0x60, 0x71, 0x63, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0x10, 0x33, 0x07, 0xda, 0x12,
-	0x01, 0x00, 0x00,
+	0xcc, 0x2a, 0x48, 0x2c, 0x4a, 0xcc, 0x85, 0x1a, 0x25, 0x25, 0x87, 0x45, 0x41, 0x61, 0x69, 0x6a,
+	0x51, 0x25, 0x1e, 0x79, 0x30, 0x09, 0x91, 0x57, 0xaa, 0xe6, 0xe2, 0x71, 0x87, 0xb8, 0x2d, 0xb8,
+	0x24, 0xb1, 0x24, 0x55, 0xc8, 0x82, 0x8b, 0x0d, 0x62, 0xbe, 0x04, 0xa3, 0x02, 0xa3, 0x06, 0xb7,
+	0x91, 0x94, 0x1e, 0xa6, 0x5b, 0xf5, 0x02, 0xc0, 0x2a, 0x9c, 0x58, 0x4e, 0xdc, 0x93, 0x67, 0x08,
+	0x82, 0xaa, 0x17, 0x32, 0xe4, 0x62, 0x03, 0xcb, 0x16, 0x4b, 0x30, 0x29, 0x30, 0x6b, 0x70, 0x1b,
+	0x49, 0x62, 0xd3, 0x19, 0x06, 0x22, 0x83, 0xa0, 0x0a, 0x95, 0x8e, 0x30, 0x72, 0xb1, 0x82, 0x45,
+	0x84, 0xcc, 0xb8, 0x38, 0xc0, 0x62, 0xf1, 0x99, 0x29, 0x50, 0x8b, 0xa5, 0x71, 0x6a, 0xf7, 0x4c,
+	0x09, 0x62, 0x2f, 0x83, 0x30, 0x84, 0x1c, 0xb8, 0x78, 0x4a, 0xf2, 0x4b, 0x12, 0x73, 0xe2, 0x8b,
+	0x33, 0x12, 0x8b, 0x52, 0x41, 0x56, 0x83, 0xf4, 0xca, 0x62, 0xd3, 0xeb, 0x57, 0x9a, 0x1b, 0x0c,
+	0x56, 0x14, 0xc4, 0x0d, 0xd6, 0x02, 0xe1, 0x08, 0x39, 0x72, 0xf1, 0xe4, 0x97, 0xe7, 0xa5, 0x16,
+	0xc1, 0x4c, 0x60, 0x06, 0x3b, 0x5e, 0x0e, 0x9b, 0x09, 0xfe, 0x20, 0x75, 0x60, 0x6d, 0x41, 0xdc,
+	0xf9, 0x70, 0x76, 0xb1, 0x53, 0xe0, 0x89, 0x47, 0x72, 0x8c, 0x17, 0x1e, 0xc9, 0x31, 0x3e, 0x78,
+	0x24, 0xc7, 0x38, 0xe1, 0xb1, 0x1c, 0xc3, 0x85, 0xc7, 0x72, 0x0c, 0x37, 0x1e, 0xcb, 0x31, 0x44,
+	0x99, 0xa7, 0x67, 0x96, 0x64, 0x94, 0x26, 0xe9, 0x25, 0xe7, 0xe7, 0xea, 0xa3, 0x46, 0x84, 0x89,
+	0x6e, 0x72, 0x46, 0x62, 0x66, 0x9e, 0x3e, 0x5c, 0xa4, 0x02, 0x1a, 0x39, 0x25, 0x95, 0x05, 0xa9,
+	0xc5, 0x49, 0x6c, 0x60, 0x71, 0x63, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xf8, 0x13, 0x40, 0x00,
+	0x4c, 0x02, 0x00, 0x00,
 }
 
 func (m *GenesisState) Marshal() (dAtA []byte, err error) {
@@ -112,6 +194,20 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.Vaults) > 0 {
+		for iNdEx := len(m.Vaults) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Vaults[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenesis(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
 	{
 		size, err := m.Params.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
@@ -122,6 +218,67 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	i--
 	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *Vault) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Vault) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Vault) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.OwnerShares) > 0 {
+		for iNdEx := len(m.OwnerShares) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.OwnerShares[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenesis(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.TotalShares != nil {
+		{
+			size, err := m.TotalShares.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintGenesis(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.VaultId != nil {
+		{
+			size, err := m.VaultId.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintGenesis(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
 	return len(dAtA) - i, nil
 }
 
@@ -144,6 +301,35 @@ func (m *GenesisState) Size() (n int) {
 	_ = l
 	l = m.Params.Size()
 	n += 1 + l + sovGenesis(uint64(l))
+	if len(m.Vaults) > 0 {
+		for _, e := range m.Vaults {
+			l = e.Size()
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *Vault) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.VaultId != nil {
+		l = m.VaultId.Size()
+		n += 1 + l + sovGenesis(uint64(l))
+	}
+	if m.TotalShares != nil {
+		l = m.TotalShares.Size()
+		n += 1 + l + sovGenesis(uint64(l))
+	}
+	if len(m.OwnerShares) > 0 {
+		for _, e := range m.OwnerShares {
+			l = e.Size()
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -212,6 +398,196 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Vaults", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Vaults = append(m.Vaults, &Vault{})
+			if err := m.Vaults[len(m.Vaults)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenesis(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Vault) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenesis
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Vault: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Vault: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VaultId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.VaultId == nil {
+				m.VaultId = &VaultId{}
+			}
+			if err := m.VaultId.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalShares", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.TotalShares == nil {
+				m.TotalShares = &NumShares{}
+			}
+			if err := m.TotalShares.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OwnerShares", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.OwnerShares = append(m.OwnerShares, &OwnerShare{})
+			if err := m.OwnerShares[len(m.OwnerShares)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex


### PR DESCRIPTION
### Changelist
include vault total / owner shares in genesis state

besides general benefits of exporting state, this enables a network to automatically start with existing vaults (e.g. for testing purposes)

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `Vault` entity with fields for total shares, owner shares, and ID.
  - Added functionality to handle vaults and owner shares in the genesis state.
  
- **Bug Fixes**
  - Ensured validation checks for vault parameters to avoid inconsistencies in ownership and shares.

- **Tests**
  - Added tests to verify the retrieval and accuracy of owner shares for a vault.

- **Documentation**
  - Updated genesis state JSON files to include empty `vaults` array for clarity and initialization purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->