### PR TITLE
[TRA-451] initialize vaults on start-up in local, dev, staging

### DIFF
--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -168,7 +168,7 @@ create_pregenesis_file() {
 	echo "Copying exchange config jsons to $TMP_EXCHANGE_CONFIG_JSON_DIR"
 	cp -R ./daemons/pricefeed/client/constants/testdata $TMP_EXCHANGE_CONFIG_JSON_DIR
 
-	edit_genesis "$VAL_CONFIG_DIR" "" "" "$TMP_EXCHANGE_CONFIG_JSON_DIR" "./testing/delaymsg_config" "STATUS_INITIALIZING" ""
+	edit_genesis "$VAL_CONFIG_DIR" "" "" "" "" "$TMP_EXCHANGE_CONFIG_JSON_DIR" "./testing/delaymsg_config" "STATUS_INITIALIZING" ""
 	overwrite_genesis_production
 }
 

--- a/protocol/testing/containertest/containertest.sh
+++ b/protocol/testing/containertest/containertest.sh
@@ -100,7 +100,7 @@ create_validators() {
 		# Using "*" as a subscript results in a single arg: "dydx1... dydx1... dydx1..."
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account` or `update_genesis_use_test_exchange`.
-		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
+		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" "" "" ""
 		# Configure the genesis file to only use the test exchange to compute index prices.
 		update_genesis_use_test_exchange "$VAL_CONFIG_DIR"
 

--- a/protocol/testing/e2etest-local/local.sh
+++ b/protocol/testing/e2etest-local/local.sh
@@ -99,7 +99,7 @@ create_validators() {
 		# Using "*" as a subscript results in a single arg: "dydx1... dydx1... dydx1..."
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
-		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
+		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" "" "" ""
 		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_all_markets_with_fixed_price_exchange "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "30"

--- a/protocol/testing/testnet-dev/dev.sh
+++ b/protocol/testing/testnet-dev/dev.sh
@@ -79,6 +79,24 @@ FAUCET_ACCOUNTS=(
 	"dydx1axstmx84qtv0avhjwek46v6tcmyc8agu03nafv" # backup #2
 )
 
+# Addresses of vaults.
+# Can use ../scripts/vault/get_vault.go to generate a vault's address.
+VAULT_ACCOUNTS=(
+	"dydx1c0m5x87llaunl5sgv3q5vd7j5uha26d2q2r2q0" # BTC vault
+	"dydx14rplxdyycc6wxmgl8fggppgq4774l70zt6phkw" # ETH vault
+	"dydx190te44zcctdgk0qmqtenve2m00g3r2dn7ntd72" # LINK vault
+	"dydx1a83cjn83vqh5ss2vccg6uuaeky7947xldp9r2e" # MATIC vault
+	"dydx1nkz8xcar6sxedw0yva6jzjplw7hfg6pp6e7h0l" # CRV vault
+)
+# Number of each vault above, which for CLOB vaults is the ID of the clob pair it quotes on.
+VAULT_NUMBERS=(
+	0 # BTC clob pair ID
+	1 # ETH clob pair ID
+	2 # LINK clob pair ID
+	3 # MATIC clob pair ID
+	4 # CRV clob pair ID
+)
+
 # Define dependencies for this script.
 # `jq` and `dasel` are used to manipulate json and yaml files respectively.
 install_prerequisites() {
@@ -134,7 +152,7 @@ create_validators() {
 		# Using "*" as a subscript results in a single arg: "dydx1... dydx1... dydx1..."
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
-		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
+		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "${VAULT_ACCOUNTS[*]}" "${VAULT_NUMBERS[*]}" "" "" "" ""
 		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "600"
 

--- a/protocol/testing/testnet-external/pregenesis.sh
+++ b/protocol/testing/testnet-external/pregenesis.sh
@@ -181,7 +181,7 @@ create_pregenesis_file() {
 	# Using "*" as a subscript results in a single arg: "dydx1... dydx1... dydx1..."
 	# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 	# Note: `edit_genesis` must be called before `add-genesis-account`.
-	edit_genesis "$VAL_CONFIG_DIR" "" "" "$TMP_EXCHANGE_CONFIG_JSON_DIR" "./testing/delaymsg_config" "" ""
+	edit_genesis "$VAL_CONFIG_DIR" "" "" "" "" "$TMP_EXCHANGE_CONFIG_JSON_DIR" "./testing/delaymsg_config" "" ""
 	overwrite_genesis_public_testnet
 
 	FAUCET_BALANCE="${FAUCET_NATIVE_TOKEN_BALANCE}$NATIVE_TOKEN"

--- a/protocol/testing/testnet-local/local.sh
+++ b/protocol/testing/testnet-local/local.sh
@@ -63,6 +63,18 @@ FAUCET_ACCOUNTS=(
 	"dydx1nzuttarf5k2j0nug5yzhr6p74t9avehn9hlh8m" # main faucet
 )
 
+# Addresses of vaults.
+# Can use ../scripts/vault/get_vault.go to generate a vault's address.
+VAULT_ACCOUNTS=(
+	"dydx1c0m5x87llaunl5sgv3q5vd7j5uha26d2q2r2q0" # BTC vault
+	"dydx14rplxdyycc6wxmgl8fggppgq4774l70zt6phkw" # ETH vault
+)
+# Number of each vault, which for CLOB vaults is the ID of the clob pair it quotes on.
+VAULT_NUMBERS=(
+	0 # BTC clob pair ID
+	1 # ETH clob pair ID
+)
+
 # Define dependencies for this script.
 # `jq` and `dasel` are used to manipulate json and yaml files respectively.
 install_prerequisites() {
@@ -100,7 +112,8 @@ create_validators() {
 		# Using "*" as a subscript results in a single arg: "dydx1... dydx1... dydx1..."
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
-		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
+		# edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "${VAULT_ACCOUNTS[*]}" "${VAULT_NUMBERS[*]}" "" "" "" ""
+		edit_genesis "$VAL_CONFIG_DIR" "" "${FAUCET_ACCOUNTS[*]}" "${VAULT_ACCOUNTS[*]}" "${VAULT_NUMBERS[*]}" "" "" "" ""
 		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "30"
 

--- a/protocol/testing/testnet-staging/staging.sh
+++ b/protocol/testing/testnet-staging/staging.sh
@@ -133,6 +133,24 @@ FAUCET_ACCOUNTS=(
 	"dydx1axstmx84qtv0avhjwek46v6tcmyc8agu03nafv" # backup #2
 )
 
+# Addresses of vaults.
+# Can use ../scripts/vault/get_vault.go to generate a vault's address.
+VAULT_ACCOUNTS=(
+	"dydx1c0m5x87llaunl5sgv3q5vd7j5uha26d2q2r2q0" # BTC vault
+	"dydx14rplxdyycc6wxmgl8fggppgq4774l70zt6phkw" # ETH vault
+	"dydx190te44zcctdgk0qmqtenve2m00g3r2dn7ntd72" # LINK vault
+	"dydx1a83cjn83vqh5ss2vccg6uuaeky7947xldp9r2e" # MATIC vault
+	"dydx1nkz8xcar6sxedw0yva6jzjplw7hfg6pp6e7h0l" # CRV vault
+)
+# Number of each vault above, which for CLOB vaults is the ID of the clob pair it quotes on.
+VAULT_NUMBERS=(
+	0 # BTC clob pair ID
+	1 # ETH clob pair ID
+	2 # LINK clob pair ID
+	3 # MATIC clob pair ID
+	4 # CRV clob pair ID
+)
+
 # Define dependencies for this script.
 # `jq` and `dasel` are used to manipulate json and yaml files respectively.
 install_prerequisites() {
@@ -188,7 +206,7 @@ create_validators() {
 		# Using "*" as a subscript results in a single arg: "dydx1... dydx1... dydx1..."
 		# Using "@" as a subscript results in separate args: "dydx1..." "dydx1..." "dydx1..."
 		# Note: `edit_genesis` must be called before `add-genesis-account`.
-		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "" "" "" ""
+		edit_genesis "$VAL_CONFIG_DIR" "${TEST_ACCOUNTS[*]}" "${FAUCET_ACCOUNTS[*]}" "${VAULT_ACCOUNTS[*]}" "${VAULT_NUMBERS[*]}" "" "" "" ""
 		update_genesis_use_test_volatile_market "$VAL_CONFIG_DIR"
 		update_genesis_complete_bridge_delay "$VAL_CONFIG_DIR" "600"
 


### PR DESCRIPTION
### Changelist
initialize vaults on start-up
- 2 vaults locally
- 5 vaults on dev and staging

can easily extend to more/fewer vaults

### Test Plan
tested by running localnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for vault accounts and numbers across various scripts.
  - Introduced default subaccount balance for vaults in genesis configuration.
  
- **Improvements**
  - Updated `edit_genesis` function calls to include vault account parameters for better configuration management.
  - Enhanced flexibility in passing arguments to scripts by reordering and adding parameters where necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->