### PR TITLE
[TRA-418] Add upgrade handler and test for x/revshare module state initialization

### DIFF
--- a/protocol/app/upgrades.go
+++ b/protocol/app/upgrades.go
@@ -31,6 +31,8 @@ func (app *App) setupUpgradeHandlers() {
 			app.ModuleManager,
 			app.configurator,
 			app.ClobKeeper,
+			app.RevShareKeeper,
+			app.PricesKeeper,
 		),
 	)
 }

--- a/protocol/app/upgrades/v6.0.0/upgrade.go
+++ b/protocol/app/upgrades/v6.0.0/upgrade.go
@@ -7,11 +7,14 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	indexershared "github.com/dydxprotocol/v4-chain/protocol/indexer/shared"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	pricetypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	revsharetypes "github.com/dydxprotocol/v4-chain/protocol/x/revshare/types"
 )
 
 func removeStatefulFOKOrders(ctx sdk.Context, k clobtypes.ClobKeeper) {
@@ -39,10 +42,38 @@ func removeStatefulFOKOrders(ctx sdk.Context, k clobtypes.ClobKeeper) {
 	}
 }
 
+func initRevShareModuleState(
+	ctx sdk.Context,
+	revShareKeeper revsharetypes.RevShareKeeper,
+	priceKeeper pricetypes.PricesKeeper,
+) {
+	// Initialize the rev share module state.
+	params := revsharetypes.MarketMapperRevenueShareParams{
+		Address:         authtypes.NewModuleAddress(authtypes.FeeCollectorName).String(),
+		RevenueSharePpm: 0,
+		ValidDays:       0,
+	}
+	err := revShareKeeper.SetMarketMapperRevenueShareParams(ctx, params)
+	if err != nil {
+		panic(fmt.Sprintf("failed to set market mapper revenue share params: %s", err))
+	}
+
+	// Initialize the rev share details for all existing markets.
+	markets := priceKeeper.GetAllMarketParams(ctx)
+	for _, market := range markets {
+		revShareDetails := revsharetypes.MarketMapperRevShareDetails{
+			ExpirationTs: 0,
+		}
+		revShareKeeper.SetMarketMapperRevShareDetails(ctx, market.Id, revShareDetails)
+	}
+}
+
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
 	clobKeeper clobtypes.ClobKeeper,
+	revShareKeeper revsharetypes.RevShareKeeper,
+	priceKeeper pricetypes.PricesKeeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		sdkCtx := lib.UnwrapSDKContext(ctx, "app/upgrades")
@@ -50,6 +81,9 @@ func CreateUpgradeHandler(
 
 		// Remove all stateful FOK orders from state.
 		removeStatefulFOKOrders(sdkCtx, clobKeeper)
+
+		// Initialize the rev share module state.
+		initRevShareModuleState(sdkCtx, revShareKeeper, priceKeeper)
 
 		sdkCtx.Logger().Info("Successfully removed stateful orders from state")
 

--- a/protocol/app/upgrades/v6.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v6.0.0/upgrade_container_test.go
@@ -1,10 +1,10 @@
-//go:build all || container_test
-
 package v_6_0_0_test
 
 import (
 	"testing"
 	"time"
+
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/gogoproto/proto"
@@ -216,31 +216,31 @@ func postUpgradeMarketMapperRevShareChecks(node *containertest.Node, t *testing.
 	require.Equal(t, params.Params.ValidDays, uint32(0))
 
 	// Get all markets list
-	//marketsList := pricestypes.MarketParamList{}
-	//resp, err := containertest.Query(
-	//	node,
-	//	pricestypes.NewQueryClient,
-	//	pricestypes.QueryClient.GetAllMarketParams,
-	//	&pricestypes.QueryGetAllMarketParamsRequest{},
-	//)
-	//require.NoError(t, err)
-	//err = proto.Unmarshal(resp.Data, &marketsList)
-	//require.NoError(t, err)
-	//
-	//// Check that all rev share details are set to the default value
-	//for _, market := range marketsList.Markets {
-	//	revShareDetails := revsharetypes.MarketMapperRevShareDetails{}
-	//	resp, err := containertest.Query(
-	//		node,
-	//		revsharetypes.NewQueryClient,
-	//		revsharetypes.QueryClient.MarketMapperRevShareDetails,
-	//		&revsharetypes.QueryMarketMapperRevShareDetails{
-	//			MarketId: market.Id,
-	//		},
-	//	)
-	//	require.NoError(t, err)
-	//	err = proto.Unmarshal(resp.Data, &revShareDetails)
-	//	require.NoError(t, err)
-	//	require.Equal(t, revShareDetails.ExpirationTs, uint64(0))
-	//}
+	marketParams := pricestypes.QueryAllMarketParamsResponse{}
+	resp, err = containertest.Query(
+		node,
+		pricestypes.NewQueryClient,
+		pricestypes.QueryClient.AllMarketParams,
+		&pricestypes.QueryAllMarketParamsRequest{},
+	)
+	require.NoError(t, err)
+	err = proto.UnmarshalText(resp.String(), &marketParams)
+	require.NoError(t, err)
+
+	// Check that all rev share details are set to the default value
+	for _, market := range marketParams.MarketParams {
+		revShareDetails := revsharetypes.QueryMarketMapperRevShareDetailsResponse{}
+		resp, err := containertest.Query(
+			node,
+			revsharetypes.NewQueryClient,
+			revsharetypes.QueryClient.MarketMapperRevShareDetails,
+			&revsharetypes.QueryMarketMapperRevShareDetails{
+				MarketId: market.Id,
+			},
+		)
+		require.NoError(t, err)
+		err = proto.UnmarshalText(resp.String(), &revShareDetails)
+		require.NoError(t, err)
+		require.Equal(t, revShareDetails.Details.ExpirationTs, uint64(0))
+	}
 }

--- a/protocol/app/upgrades/v6.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v6.0.0/upgrade_container_test.go
@@ -1,3 +1,5 @@
+//go:build all || container_test
+
 package v_6_0_0_test
 
 import (

--- a/protocol/x/revshare/types/types.go
+++ b/protocol/x/revshare/types/types.go
@@ -1,0 +1,26 @@
+package types
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+type RevShareKeeper interface {
+	// MarketMapperRevenueShareParams
+	SetMarketMapperRevenueShareParams(
+		ctx sdk.Context,
+		params MarketMapperRevenueShareParams,
+	) (err error)
+	GetMarketMapperRevenueShareParams(
+		ctx sdk.Context,
+	) (params MarketMapperRevenueShareParams)
+
+	// MarketMapperRevShareDetails
+	SetMarketMapperRevShareDetails(
+		ctx sdk.Context,
+		marketId uint32,
+		params MarketMapperRevShareDetails,
+	)
+	GetMarketMapperRevShareDetails(
+		ctx sdk.Context,
+		marketId uint32,
+	) (params MarketMapperRevShareDetails, err error)
+	CreateNewMarketRevShare(ctx sdk.Context, marketId uint32)
+}


### PR DESCRIPTION
### Changelist
Add initialization for the x/revshare module chain state in the v6 upgrade handler
Add upgrade test

### Test Plan
Added test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to manage market revenue share parameters and details post-upgrade, enhancing market operations.

- **Tests**
  - Added checks for revenue share parameters and market details to ensure proper functionality after the upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->