### PR TITLE
[OTE-407][OTE-409][OTE-426]Update wasm bindings to use custom encoder

### DIFF
--- a/protocol/contracts/dydx-messages-example/src/contract.rs
+++ b/protocol/contracts/dydx-messages-example/src/contract.rs
@@ -37,40 +37,7 @@ pub fn execute(
 ) -> Result<Response<DydxMsg>, ContractError> {
     match msg {
         ExecuteMsg::DydxMsg(dydx_msg) => {
-            match dydx_msg{
-                DydxMsg::DepositToSubaccount { sender, recipient, asset_id, quantums } => {
-                    let deposit = DydxMsg::DepositToSubaccount {
-                        sender: sender,
-                        recipient: recipient,
-                        asset_id: asset_id,
-                        quantums: quantums,
-                    };
-                    Ok(Response::new().add_message(deposit))
-                }
-                DydxMsg::WithdrawFromSubaccount { sender, recipient, asset_id, quantums } => {
-                    let withdraw = DydxMsg::WithdrawFromSubaccount {
-                        sender: sender,
-                        recipient: recipient,
-                        asset_id: asset_id,
-                        quantums: quantums,
-                    };
-                    Ok(Response::new().add_message(withdraw))
-                }
-                DydxMsg::PlaceOrder { order } => {
-                    let place_order = DydxMsg::PlaceOrder {
-                        order: order,
-                    };
-                    Ok(Response::new().add_message(place_order))
-                }
-                DydxMsg::CancelOrder { order_id, good_til_oneof } => {
-                    let cancel_order = DydxMsg::CancelOrder {
-                        order_id: order_id,
-                        good_til_oneof: good_til_oneof,
-                    };
-                    Ok(Response::new().add_message(cancel_order))
-                }
-                _ => Err(ContractError::InvalidDydxMsg{}),
-            }
+            Ok(Response::new().add_message(dydx_msg))
         }
     }
 }

--- a/protocol/contracts/dydx-messages-example/src/msg.rs
+++ b/protocol/contracts/dydx-messages-example/src/msg.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin};
-use dydx_cosmwasm::{OrderConditionType, OrderSide, OrderTimeInForce, SubaccountId, Order, OrderId, Transfer};
+use dydx_cosmwasm::{OrderConditionType, OrderSide, OrderTimeInForce, SubaccountId};
 use cw_utils::Expiration;
 use dydx_cosmwasm::MarketPriceResponse;
 use dydx_cosmwasm::DydxMsg;

--- a/protocol/dydx-cosmwasm/src/lib.rs
+++ b/protocol/dydx-cosmwasm/src/lib.rs
@@ -6,7 +6,7 @@ mod dydx_types;
 mod proto_structs;
 mod serializable_int;
 
-pub use msg::{DydxMsg, Transfer, Order, OrderSide, OrderTimeInForce, OrderConditionType, OrderId};
+pub use msg::{DydxMsg, OrderSide, OrderTimeInForce, OrderConditionType};
 pub use querier::DydxQuerier;
 pub use query::{
     MarketPriceResponse, PerpetualClobDetailsResponse, SubaccountResponse, DydxQuery, DydxQueryWrapper};

--- a/protocol/dydx-cosmwasm/src/msg.rs
+++ b/protocol/dydx-cosmwasm/src/msg.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::*;
 use cosmwasm_std::{
-  to_json_binary,
+  to_json_string,
   CosmosMsg,
   CustomMsg,
 };
@@ -39,18 +39,21 @@ pub enum OrderConditionType {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum DydxMsg {
-  DepositToSubaccount {
+  // Maps to https://github.com/dydxprotocol/v4-chain/blob/main/proto/dydxprotocol/sending/transfer.proto#L31 message on protocol
+  DepositToSubaccountV1 {
     recipient: SubaccountId,
     asset_id: u32,
     quantums: u64,
   },
-    WithdrawFromSubaccount {
+  // Maps to https://github.com/dydxprotocol/v4-chain/blob/main/proto/dydxprotocol/sending/transfer.proto#L50 message on protocol
+    WithdrawFromSubaccountV1 {
         subaccount_number: u32,
         recipient: String,
         asset_id: u32,
         quantums: u64,
     },
-  PlaceOrder{
+  // Maps to https://github.com/dydxprotocol/v4-chain/blob/main/proto/dydxprotocol/clob/tx.proto#L78 message on protocol
+  PlaceOrderV1{
     subaccount_number: u32,
     client_id: u32,
     order_flags: u32,
@@ -65,7 +68,8 @@ pub enum DydxMsg {
     condition_type: OrderConditionType,
     conditional_order_trigger_subticks: u64,
   },
-  CancelOrder {
+  // Maps to https://github.com/dydxprotocol/v4-chain/blob/main/proto/dydxprotocol/clob/tx.proto#L84 on protocol
+  CancelOrderV1 {
     subaccount_number: u32,
     client_id: u32,
     order_flags: u32,
@@ -88,7 +92,7 @@ mod tests {
   
   #[test]
   fn deposit_to_subaccount_msg_json_validation() {
-    let msg: DydxMsg = DydxMsg::DepositToSubaccount {
+    let msg: DydxMsg = DydxMsg::DepositToSubaccountV1 {
       recipient: SubaccountId {
         owner: "b".to_string(),
         number: 0,
@@ -96,31 +100,31 @@ mod tests {
       asset_id: 0,
       quantums: 10000000000,
     };
-    let json = to_json_binary(&msg).unwrap();
+    let json = to_json_string(&msg).unwrap();
     assert_eq!(
       String::from_utf8_lossy(&json),
-      r#"{"deposit_to_subaccount":{"recipient":{"owner":"b","number":0},"asset_id":0,"quantums":10000000000}}"#
+      r#"{"deposit_to_subaccount_v1":{"recipient":{"owner":"b","number":0},"asset_id":0,"quantums":10000000000}}"#
     );
   }
 
   #[test]
   fn withdraw_from_subaccount_msg_json_validation() {
-    let msg: DydxMsg = DydxMsg::WithdrawFromSubaccount {
+    let msg: DydxMsg = DydxMsg::WithdrawFromSubaccountV1 {
       subaccount_number: 0,
       recipient: "b".to_string(),
       asset_id: 0,
       quantums: 10000000000,
     };
-    let json = to_json_binary(&msg).unwrap();
+    let json = to_json_string(&msg).unwrap();
     assert_eq!(
       String::from_utf8_lossy(&json),
-      r#"{"withdraw_from_subaccount":{"subaccount_number":0,"recipient":"b","asset_id":0,"quantums":10000000000}}"#
+      r#"{"withdraw_from_subaccount_v1":{"subaccount_number":0,"recipient":"b","asset_id":0,"quantums":10000000000}}"#
     );
   }
 
   #[test]
   fn place_order_msg_json_validation() {
-    let msg: DydxMsg = DydxMsg::PlaceOrder {
+    let msg: DydxMsg = DydxMsg::PlaceOrderV1 {
       subaccount_number: 0,
       client_id: 0,
       order_flags: 0,
@@ -135,26 +139,26 @@ mod tests {
       condition_type: OrderConditionType::StopLoss,
       conditional_order_trigger_subticks: 10000000000,
     };
-    let json = to_json_binary(&msg).unwrap();
+    let json = to_json_string(&msg).unwrap();
     assert_eq!(
       String::from_utf8_lossy(&json),
-      r#"{"place_order":{"subaccount_number":0,"client_id":0,"order_flags":0,"clob_pair_id":0,"side":1,"quantums":10000000000,"subticks":10000000000,"good_til_block_time":0,"time_in_force":1,"reduce_only":false,"client_metadata":0,"condition_type":1,"conditional_order_trigger_subticks":10000000000}}"#
+      r#"{"place_order_v1":{"subaccount_number":0,"client_id":0,"order_flags":0,"clob_pair_id":0,"side":1,"quantums":10000000000,"subticks":10000000000,"good_til_block_time":0,"time_in_force":1,"reduce_only":false,"client_metadata":0,"condition_type":1,"conditional_order_trigger_subticks":10000000000}}"#
     );
   }
   
   #[test]
   fn cancel_order_msg_json_validation() {
-    let msg: DydxMsg = DydxMsg::CancelOrder {
+    let msg: DydxMsg = DydxMsg::CancelOrderV1 {
       subaccount_number: 0,
       client_id: 0,
       order_flags: 0,
       clob_pair_id: 0,
       good_til_block_time: 0,
     };
-    let json = to_json_binary(&msg).unwrap();
+    let json = to_json_string(&msg).unwrap();
     assert_eq!(
       String::from_utf8_lossy(&json),
-      r#"{"cancel_order":{"subaccount_number":0,"client_id":0,"order_flags":0,"clob_pair_id":0,"good_til_block_time":0}}"#
+      r#"{"cancel_order_v1":{"subaccount_number":0,"client_id":0,"order_flags":0,"clob_pair_id":0,"good_til_block_time":0}}"#
     );
   }
 }

--- a/protocol/wasmbinding/bindings/msg.go
+++ b/protocol/wasmbinding/bindings/msg.go
@@ -5,26 +5,26 @@ import (
 )
 
 type DydxCustomWasmMessage struct {
-	DepositToSubaccount    *DepositToSubaccount    `json:"deposit_to_subaccount,omitempty"`
-	WithdrawFromSubaccount *WithdrawFromSubaccount `json:"withdraw_from_subaccount,omitempty"`
-	PlaceOrder             *PlaceOrder             `json:"place_order,omitempty"`
-	CancelOrder            *CancelOrder            `json:"cancel_order,omitempty"`
+	DepositToSubaccountV1    *DepositToSubaccountV1    `json:"deposit_to_subaccount_v1,omitempty"`
+	WithdrawFromSubaccountV1 *WithdrawFromSubaccountV1 `json:"withdraw_from_subaccount_v1,omitempty"`
+	PlaceOrderV1             *PlaceOrderV1             `json:"place_order_v1,omitempty"`
+	CancelOrderV1            *CancelOrderV1            `json:"cancel_order_v1,omitempty"`
 }
 
-type DepositToSubaccount struct {
+type DepositToSubaccountV1 struct {
 	Recipient subaccounttypes.SubaccountId `json:"recipient"`
 	AssetId   uint32                       `json:"asset_id"`
 	Quantums  uint64                       `json:"quantums"`
 }
 
-type WithdrawFromSubaccount struct {
+type WithdrawFromSubaccountV1 struct {
 	SubaccountNumber uint32 `json:"subaccount_number"`
 	Recipient        string `json:"recipient"`
 	AssetId          uint32 `json:"asset_id"`
 	Quantums         uint64 `json:"quantums"`
 }
 
-type PlaceOrder struct {
+type PlaceOrderV1 struct {
 	SubaccountNumber                uint32 `json:"subaccount_number"`
 	ClientId                        uint32 `json:"client_id"`
 	OrderFLags                      uint32 `json:"order_flags"`
@@ -39,7 +39,7 @@ type PlaceOrder struct {
 	ConditionalOrderTriggerSubticks uint64 `json:"conditional_order_trigger_subticks"`
 }
 
-type CancelOrder struct {
+type CancelOrderV1 struct {
 	SubaccountNumber uint32 `json:"subaccount_number"`
 	ClientId         uint32 `json:"client_id"`
 	OrderFLags       uint32 `json:"order_flags"`

--- a/protocol/wasmbinding/bindings/msg.go
+++ b/protocol/wasmbinding/bindings/msg.go
@@ -1,15 +1,48 @@
 package bindings
 
 import (
-	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
-
-	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	subaccounttypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
-type SendingMsg struct {
-	CreateTransfer         *sendingtypes.MsgCreateTransfer         `json:"create_transfer,omitempty"`
-	DepositToSubaccount    *sendingtypes.MsgDepositToSubaccount    `json:"deposit_to_subaccount,omitempty"`
-	WithdrawFromSubaccount *sendingtypes.MsgWithdrawFromSubaccount `json:"withdraw_from_subaccount,omitempty"`
-	PlaceOrder             *clobtypes.MsgPlaceOrder                `json:"place_order,omitempty"`
-	CancelOrder            *clobtypes.MsgCancelOrder               `json:"cancel_order,omitempty"`
+type DydxCustomWasmMessage struct {
+	DepositToSubaccount    *DepositToSubaccount    `json:"deposit_to_subaccount,omitempty"`
+	WithdrawFromSubaccount *WithdrawFromSubaccount `json:"withdraw_from_subaccount,omitempty"`
+	PlaceOrder             *PlaceOrder             `json:"place_order,omitempty"`
+	CancelOrder            *CancelOrder            `json:"cancel_order,omitempty"`
+}
+
+type DepositToSubaccount struct {
+	Recipient subaccounttypes.SubaccountId `json:"recipient"`
+	AssetId   uint32                       `json:"asset_id"`
+	Quantums  uint64                       `json:"quantums"`
+}
+
+type WithdrawFromSubaccount struct {
+	SubaccountNumber uint32 `json:"subaccount_number"`
+	Recipient        string `json:"recipient"`
+	AssetId          uint32 `json:"asset_id"`
+	Quantums         uint64 `json:"quantums"`
+}
+
+type PlaceOrder struct {
+	SubaccountNumber                uint32 `json:"subaccount_number"`
+	ClientId                        uint32 `json:"client_id"`
+	OrderFLags                      uint32 `json:"order_flags"`
+	ClobPairId                      uint32 `json:"clob_pair_id"`
+	Side                            int32  `json:"side"`
+	Quantums                        uint64 `json:"quantums"`
+	Subticks                        uint64 `json:"subticks"`
+	GoodTilBlockTime                uint32 `json:"good_til_block_time"`
+	ReduceOnly                      bool   `json:"reduce_only"`
+	ClientMetadata                  uint32 `json:"client_metadata"`
+	ConditionType                   int32  `json:"condition_type"`
+	ConditionalOrderTriggerSubticks uint64 `json:"conditional_order_trigger_subticks"`
+}
+
+type CancelOrder struct {
+	SubaccountNumber uint32 `json:"subaccount_number"`
+	ClientId         uint32 `json:"client_id"`
+	OrderFLags       uint32 `json:"order_flags"`
+	ClobPairId       uint32 `json:"clob_pair_id"`
+	GoodTilBlockTime uint32 `json:"good_til_block_time"`
 }

--- a/protocol/wasmbinding/msg_plugin.go
+++ b/protocol/wasmbinding/msg_plugin.go
@@ -13,27 +13,26 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
-// DispatchMsg executes on the contractMsg.
-func CustomEncoder(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {
+func EncodeDydxCustomWasmMessage(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {
 	var customMessage bindings.DydxCustomWasmMessage
 	if err := json.Unmarshal(msg, &customMessage); err != nil {
 		return []sdk.Msg{}, wasmvmtypes.InvalidRequest{Err: "Error parsing DydxCustomWasmMessage"}
 	}
 	switch {
-	case customMessage.DepositToSubaccount != nil:
-		return EncodeDepositToSubaccount(sender, customMessage.DepositToSubaccount)
-	case customMessage.WithdrawFromSubaccount != nil:
-		return EncodeWithdrawFromSubaccount(sender, customMessage.WithdrawFromSubaccount)
-	case customMessage.PlaceOrder != nil:
-		return EncodePlaceOrder(sender, customMessage.PlaceOrder)
-	case customMessage.CancelOrder != nil:
-		return EncodeCancelOrder(sender, customMessage.CancelOrder)
+	case customMessage.DepositToSubaccountV1 != nil:
+		return EncodeDepositToSubaccountV1(sender, customMessage.DepositToSubaccountV1)
+	case customMessage.WithdrawFromSubaccountV1 != nil:
+		return EncodeWithdrawFromSubaccountV1(sender, customMessage.WithdrawFromSubaccountV1)
+	case customMessage.PlaceOrderV1 != nil:
+		return EncodePlaceOrderV1(sender, customMessage.PlaceOrderV1)
+	case customMessage.CancelOrderV1 != nil:
+		return EncodeCancelOrderV1(sender, customMessage.CancelOrderV1)
 	default:
 		return nil, wasmvmtypes.InvalidRequest{Err: "Unknown Dydx Wasm Message"}
 	}
 }
 
-func EncodeDepositToSubaccount(sender sdk.AccAddress, depositToSubaccount *bindings.DepositToSubaccount) ([]sdk.Msg, error) {
+func EncodeDepositToSubaccountV1(sender sdk.AccAddress, depositToSubaccount *bindings.DepositToSubaccountV1) ([]sdk.Msg, error) {
 	if depositToSubaccount == nil {
 		return nil, wasmvmtypes.InvalidRequest{Err: "Invalid deposit to subaccount request: No deposit data provided"}
 	}
@@ -47,7 +46,9 @@ func EncodeDepositToSubaccount(sender sdk.AccAddress, depositToSubaccount *bindi
 	return []sdk.Msg{depositToSubaccountMsg}, nil
 }
 
-func EncodeWithdrawFromSubaccount(sender sdk.AccAddress, withdrawFromSubaccount *bindings.WithdrawFromSubaccount) ([]sdk.Msg, error) {
+// This function is called from https://github.com/CosmWasm/wasmd/blob/main/x/wasm/keeper/handler_plugin_encoders.go#L96
+// which enforces sender to be the contract address
+func EncodeWithdrawFromSubaccountV1(sender sdk.AccAddress, withdrawFromSubaccount *bindings.WithdrawFromSubaccountV1) ([]sdk.Msg, error) {
 	if withdrawFromSubaccount == nil {
 		return nil, wasmvmtypes.InvalidRequest{Err: "Invalid withdraw from subaccount request: No withdraw data provided"}
 	}
@@ -64,7 +65,7 @@ func EncodeWithdrawFromSubaccount(sender sdk.AccAddress, withdrawFromSubaccount 
 	return []sdk.Msg{withdrawFromSubaccountMsg}, nil
 }
 
-func EncodePlaceOrder(sender sdk.AccAddress, placeOrder *bindings.PlaceOrder) ([]sdk.Msg, error) {
+func EncodePlaceOrderV1(sender sdk.AccAddress, placeOrder *bindings.PlaceOrderV1) ([]sdk.Msg, error) {
 	if placeOrder == nil {
 		return nil, wasmvmtypes.InvalidRequest{Err: "Invalid place order request: No order data provided"}
 	}
@@ -93,7 +94,7 @@ func EncodePlaceOrder(sender sdk.AccAddress, placeOrder *bindings.PlaceOrder) ([
 	return []sdk.Msg{placeOrderMsg}, nil
 }
 
-func EncodeCancelOrder(sender sdk.AccAddress, cancelOrder *bindings.CancelOrder) ([]sdk.Msg, error) {
+func EncodeCancelOrderV1(sender sdk.AccAddress, cancelOrder *bindings.CancelOrderV1) ([]sdk.Msg, error) {
 	if cancelOrder == nil {
 		return nil, wasmvmtypes.InvalidRequest{Err: "Invalid cancel order request: No order data provided"}
 	}

--- a/protocol/wasmbinding/msg_plugin.go
+++ b/protocol/wasmbinding/msg_plugin.go
@@ -3,136 +3,112 @@ package wasmbinding
 import (
 	"encoding/json"
 
-	errorsmod "cosmossdk.io/errors"
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	bindings "github.com/dydxprotocol/v4-chain/protocol/wasmbinding/bindings"
 
-	sendingkeeper "github.com/dydxprotocol/v4-chain/protocol/x/sending/keeper"
-	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
-
-	clobkeeper "github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
-// TODO(OTE-409): add checks for contract addresses
-
-// CustomMessageDecorator returns decorator for custom CosmWasm bindings messages
-func CustomMessageDecorator(sending *sendingkeeper.Keeper, clob *clobkeeper.Keeper) func(wasmkeeper.Messenger) wasmkeeper.Messenger {
-	return func(old wasmkeeper.Messenger) wasmkeeper.Messenger {
-		return &CustomMessenger{
-			wrapped: old,
-			sending: sending,
-			clob:    clob,
-		}
-	}
-}
-
-type CustomMessenger struct {
-	wrapped wasmkeeper.Messenger
-	sending *sendingkeeper.Keeper
-	clob    *clobkeeper.Keeper
-}
-
-var _ wasmkeeper.Messenger = (*CustomMessenger)(nil)
-
 // DispatchMsg executes on the contractMsg.
-func (m *CustomMessenger) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) ([]sdk.Event, [][]byte, error) {
-	if msg.Custom != nil {
-		// only handle the happy path where this is really creating / minting / swapping ...
-		// leave everything else for the wrapped version
-		var contractMsg bindings.SendingMsg
-		// print the custom message in string format
-		if err := json.Unmarshal(msg.Custom, &contractMsg); err != nil {
-			return nil, nil, errorsmod.Wrap(err, "Error Unmarshalling Custom Message")
-		}
-		if contractMsg.CreateTransfer != nil {
-			return m.createTransfer(ctx, contractAddr, contractMsg.CreateTransfer)
-		}
-		if contractMsg.DepositToSubaccount != nil {
-			return m.depositToSubaccount(ctx, contractAddr, contractMsg.DepositToSubaccount)
-		}
-		if contractMsg.WithdrawFromSubaccount != nil {
-			return m.withdrawFromSubaccount(ctx, contractAddr, contractMsg.WithdrawFromSubaccount)
-		}
-		if contractMsg.PlaceOrder != nil {
-			return m.placeOrder(ctx, contractAddr, contractMsg.PlaceOrder)
-		}
-		if contractMsg.CancelOrder != nil {
-			return m.cancelOrder(ctx, contractAddr, contractMsg.CancelOrder)
-		}
-		return nil, nil, wasmvmtypes.InvalidRequest{Err: "Unknown custom message"}
+func CustomEncoder(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {
+	var customMessage bindings.DydxCustomWasmMessage
+	if err := json.Unmarshal(msg, &customMessage); err != nil {
+		return []sdk.Msg{}, wasmvmtypes.InvalidRequest{Err: "Error parsing DydxCustomWasmMessage"}
 	}
-	return m.wrapped.DispatchMsg(ctx, contractAddr, contractIBCPortID, msg)
+	switch {
+	case customMessage.DepositToSubaccount != nil:
+		return EncodeDepositToSubaccount(sender, customMessage.DepositToSubaccount)
+	case customMessage.WithdrawFromSubaccount != nil:
+		return EncodeWithdrawFromSubaccount(sender, customMessage.WithdrawFromSubaccount)
+	case customMessage.PlaceOrder != nil:
+		return EncodePlaceOrder(sender, customMessage.PlaceOrder)
+	case customMessage.CancelOrder != nil:
+		return EncodeCancelOrder(sender, customMessage.CancelOrder)
+	default:
+		return nil, wasmvmtypes.InvalidRequest{Err: "Unknown Dydx Wasm Message"}
+	}
 }
 
-func (m *CustomMessenger) createTransfer(ctx sdk.Context, contractAddr sdk.AccAddress, createTransfer *sendingtypes.MsgCreateTransfer) ([]sdk.Event, [][]byte, error) {
-	if createTransfer == nil {
-		return nil, nil, wasmvmtypes.InvalidRequest{Err: "Invalid create transfer request: No transfer data provided"}
-	}
-	err := m.sending.ProcessTransfer(ctx, createTransfer.Transfer)
-	return nil, nil, err
-}
-
-func (m *CustomMessenger) depositToSubaccount(ctx sdk.Context, contractAddr sdk.AccAddress, depositToSubaccount *sendingtypes.MsgDepositToSubaccount) ([]sdk.Event, [][]byte, error) {
+func EncodeDepositToSubaccount(sender sdk.AccAddress, depositToSubaccount *bindings.DepositToSubaccount) ([]sdk.Msg, error) {
 	if depositToSubaccount == nil {
-		return nil, nil, wasmvmtypes.InvalidRequest{Err: "Invalid deposit to subaccount request: No deposit data provided"}
+		return nil, wasmvmtypes.InvalidRequest{Err: "Invalid deposit to subaccount request: No deposit data provided"}
 	}
 
-	err := m.sending.ProcessDepositToSubaccount(ctx, depositToSubaccount)
-	return nil, nil, err
+	depositToSubaccountMsg := &sendingtypes.MsgDepositToSubaccount{
+		Sender:    sender.String(),
+		Recipient: depositToSubaccount.Recipient,
+		AssetId:   depositToSubaccount.AssetId,
+		Quantums:  depositToSubaccount.Quantums,
+	}
+	return []sdk.Msg{depositToSubaccountMsg}, nil
 }
 
-func (m *CustomMessenger) withdrawFromSubaccount(ctx sdk.Context, contractAddr sdk.AccAddress, withdrawFromSubaccount *sendingtypes.MsgWithdrawFromSubaccount) ([]sdk.Event, [][]byte, error) {
+func EncodeWithdrawFromSubaccount(sender sdk.AccAddress, withdrawFromSubaccount *bindings.WithdrawFromSubaccount) ([]sdk.Msg, error) {
 	if withdrawFromSubaccount == nil {
-		return nil, nil, wasmvmtypes.InvalidRequest{Err: "Invalid withdraw from subaccount request: No withdraw data provided"}
+		return nil, wasmvmtypes.InvalidRequest{Err: "Invalid withdraw from subaccount request: No withdraw data provided"}
 	}
 
-	err := m.sending.ProcessWithdrawFromSubaccount(ctx, withdrawFromSubaccount)
-	return nil, nil, err
-
+	withdrawFromSubaccountMsg := &sendingtypes.MsgWithdrawFromSubaccount{
+		Sender: types.SubaccountId{
+			Owner:  sender.String(),
+			Number: withdrawFromSubaccount.SubaccountNumber,
+		},
+		Recipient: withdrawFromSubaccount.Recipient,
+		AssetId:   withdrawFromSubaccount.AssetId,
+		Quantums:  withdrawFromSubaccount.Quantums,
+	}
+	return []sdk.Msg{withdrawFromSubaccountMsg}, nil
 }
 
-func parseAddress(addr string) (sdk.AccAddress, error) {
-	parsed, err := sdk.AccAddressFromBech32(addr)
-	if err != nil {
-		return nil, err
-	}
-	err = sdk.VerifyAddressFormat(parsed)
-	if err != nil {
-		return nil, err
-	}
-	return parsed, nil
-}
-
-func (m *CustomMessenger) placeOrder(
-	ctx sdk.Context,
-	contractAddr sdk.AccAddress,
-	placeOrder *clobtypes.MsgPlaceOrder,
-) ([]sdk.Event, [][]byte, error) {
+func EncodePlaceOrder(sender sdk.AccAddress, placeOrder *bindings.PlaceOrder) ([]sdk.Msg, error) {
 	if placeOrder == nil {
-		return nil, nil, wasmvmtypes.InvalidRequest{Err: "Invalid place order request: No order data provided"}
+		return nil, wasmvmtypes.InvalidRequest{Err: "Invalid place order request: No order data provided"}
 	}
-	if ctx.IsCheckTx() || ctx.IsReCheckTx() {
-		return nil, nil, nil
+
+	placeOrderMsg := &clobtypes.MsgPlaceOrder{
+		Order: clobtypes.Order{
+			OrderId: clobtypes.OrderId{
+				SubaccountId: types.SubaccountId{
+					Owner:  sender.String(),
+					Number: placeOrder.SubaccountNumber,
+				},
+				ClientId:   placeOrder.ClientId,
+				OrderFlags: placeOrder.OrderFLags,
+				ClobPairId: placeOrder.ClobPairId,
+			},
+			Side:                            clobtypes.Order_Side(placeOrder.Side),
+			Quantums:                        placeOrder.Quantums,
+			Subticks:                        placeOrder.Subticks,
+			GoodTilOneof:                    &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: placeOrder.GoodTilBlockTime},
+			ReduceOnly:                      placeOrder.ReduceOnly,
+			ClientMetadata:                  placeOrder.ClientMetadata,
+			ConditionType:                   clobtypes.Order_ConditionType(placeOrder.ConditionType),
+			ConditionalOrderTriggerSubticks: placeOrder.ConditionalOrderTriggerSubticks,
+		},
 	}
-	err := m.clob.HandleMsgPlaceOrder(ctx, placeOrder, false)
-	return nil, nil, err
+	return []sdk.Msg{placeOrderMsg}, nil
 }
 
-func (m *CustomMessenger) cancelOrder(
-	ctx sdk.Context,
-	contractAddr sdk.AccAddress,
-	cancelOrder *clobtypes.MsgCancelOrder,
-) ([]sdk.Event, [][]byte, error) {
+func EncodeCancelOrder(sender sdk.AccAddress, cancelOrder *bindings.CancelOrder) ([]sdk.Msg, error) {
 	if cancelOrder == nil {
-		return nil, nil, wasmvmtypes.InvalidRequest{Err: "Invalid cancel order request: No order data provided"}
+		return nil, wasmvmtypes.InvalidRequest{Err: "Invalid cancel order request: No order data provided"}
 	}
-	if ctx.IsCheckTx() || ctx.IsReCheckTx() {
-		return nil, nil, nil
+
+	cancelOrderMsg := &clobtypes.MsgCancelOrder{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: types.SubaccountId{
+				Owner:  sender.String(),
+				Number: cancelOrder.SubaccountNumber,
+			},
+			ClientId:   cancelOrder.ClientId,
+			OrderFlags: cancelOrder.OrderFLags,
+			ClobPairId: cancelOrder.ClobPairId,
+		},
+		GoodTilOneof: &clobtypes.MsgCancelOrder_GoodTilBlockTime{GoodTilBlockTime: cancelOrder.GoodTilBlockTime},
 	}
-	err := m.clob.HandleMsgCancelOrder(ctx, cancelOrder)
-	return nil, nil, err
+	return []sdk.Msg{cancelOrderMsg}, nil
 }

--- a/protocol/wasmbinding/wasm.go
+++ b/protocol/wasmbinding/wasm.go
@@ -19,9 +19,9 @@ func RegisterCustomPlugins(
 	queryPluginOpt := wasmkeeper.WithQueryPlugins(&wasmkeeper.QueryPlugins{
 		Custom: CustomQuerier(wasmQueryPlugin),
 	})
-	messengerDecoratorOpt := wasmkeeper.WithMessageHandlerDecorator(
-		CustomMessageDecorator(sendingKeeper, clobKeeper),
-	)
+	messengerDecoratorOpt := wasmkeeper.WithMessageEncoders(&wasmkeeper.MessageEncoders{
+		Custom: CustomEncoder,
+	})
 
 	return []wasmkeeper.Option{
 		queryPluginOpt,

--- a/protocol/wasmbinding/wasm.go
+++ b/protocol/wasmbinding/wasm.go
@@ -20,7 +20,7 @@ func RegisterCustomPlugins(
 		Custom: CustomQuerier(wasmQueryPlugin),
 	})
 	messengerDecoratorOpt := wasmkeeper.WithMessageEncoders(&wasmkeeper.MessageEncoders{
-		Custom: CustomEncoder,
+		Custom: EncodeDydxCustomWasmMessage,
 	})
 
 	return []wasmkeeper.Option{


### PR DESCRIPTION
### Changelist
- Updates wasm keeper to use custom encoder
- Updates message schemas for rust and golang
- Adds rust tests for schemas
- GetSigners is called by the default message handler, we dont need to add this ourselves

### Test Plan
Added rust unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
