### PR TITLE
[TRA-444] Emit a metric to record market mapper revenue per market

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -302,6 +302,7 @@ const (
 	GetSubaccount                         = "get_subaccount"
 	UpdateSubaccounts                     = "update_subaccounts"
 	SubaccountOwner                       = "subaccount_owner"
+	MarketMapperRevenue                   = "market_mapper_revenue"
 
 	// Liquidation Daemon.
 	CheckCollateralizationForSubaccounts     = "check_collateralization_for_subaccounts"

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -302,7 +302,7 @@ const (
 	GetSubaccount                         = "get_subaccount"
 	UpdateSubaccounts                     = "update_subaccounts"
 	SubaccountOwner                       = "subaccount_owner"
-	MarketMapperRevenue                   = "market_mapper_revenue"
+	MarketMapperRevenueDistribution       = "market_mapper_revenue_distribution"
 
 	// Liquidation Daemon.
 	CheckCollateralizationForSubaccounts     = "check_collateralization_for_subaccounts"

--- a/protocol/x/subaccounts/keeper/transfer.go
+++ b/protocol/x/subaccounts/keeper/transfer.go
@@ -269,7 +269,7 @@ func (k Keeper) DistributeFees(
 		metrics.GetLabelForIntValue(metrics.MarketId, int(perpetual.Params.MarketId)),
 	}
 	metrics.AddSampleWithLabels(
-		metrics.MarketMapperRevenue,
+		metrics.MarketMapperRevenueDistribution,
 		metrics.GetMetricValueFromBigInt(marketMapperShare),
 		labels...,
 	)


### PR DESCRIPTION
### Changelist
Emit a metric to record market mapper revenue per market

### Test Plan
Look at datadog

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added metric tracking for fees transferred to the market mapper. 

- **Chores**
    - Removed outdated TODO comment related to monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->