### PR TITLE
Set heartbeat defaults

### DIFF
--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -30,8 +30,8 @@ export const configSchema = {
     default: 250,
   }),
 
-  WS_HEARTBEAT_INTERVAL_MS: parseInteger(),
-  WS_HEARTBEAT_TIMEOUT_MS: parseInteger(),
+  WS_HEARTBEAT_INTERVAL_MS: parseInteger({ default: 30_000 }),
+  WS_HEARTBEAT_TIMEOUT_MS: parseInteger({ default: 10_000 }),
 
   RATE_LIMIT_ENABLED: parseBoolean({ default: true }),
   RATE_LIMIT_SUBSCRIBE_POINTS: parseNumber({ default: 2 }),


### PR DESCRIPTION
### Changelist
Set heartbeat defaults
Currently, it's taken from https://github.com/dydxprotocol/v4-chain/blob/3ee5be004a3dcb407a1a741c53b3ce990b67f99c/indexer/services/socks/.env#L3 which is a bit confusing in prod

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated default settings to improve WebSocket connection stability:
    - Heartbeat Interval: 30 seconds
    - Heartbeat Timeout: 10 seconds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->