### PR TITLE
[CT-950] safety heap methods

### DIFF
--- a/protocol/x/subaccounts/keeper/safety_heap.go
+++ b/protocol/x/subaccounts/keeper/safety_heap.go
@@ -70,9 +70,12 @@ func (k Keeper) MustRemoveElementAtIndex(
 	k.DeleteSubaccountAtIndex(store, length-1)
 	k.SetSafetyHeapLength(store, length-1)
 
-	// Heapify down the element at the given index
+	// Heapify down and up the element at the given index
 	// to restore the heap property.
-	k.HeapifyDown(ctx, store, index)
+	if index < length-1 {
+		k.HeapifyDown(ctx, store, index)
+		k.HeapifyUp(ctx, store, index)
+	}
 }
 
 // HeapifyUp moves the element at the given index up the heap

--- a/protocol/x/subaccounts/keeper/safety_heap.go
+++ b/protocol/x/subaccounts/keeper/safety_heap.go
@@ -1,0 +1,174 @@
+package keeper
+
+import (
+	"cosmossdk.io/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+)
+
+// RemoveSubaccountFromSafetyHeap removes a subaccount from the safety heap
+// given a peretual and side.
+func (k Keeper) RemoveSubaccountFromSafetyHeap(
+	ctx sdk.Context,
+	subaccountId types.SubaccountId,
+	perpetualId uint32,
+	side types.SafetyHeapPositionSide,
+) {
+	store := k.GetSafetyHeapStore(ctx, perpetualId, side)
+	index := k.MustGetSubaccountHeapIndex(store, subaccountId)
+	k.MustRemoveElementAtIndex(ctx, store, index)
+}
+
+// AddSubaccountToSafetyHeap adds a subaccount to the safety heap
+// given a perpetual and side.
+func (k Keeper) AddSubaccountToSafetyHeap(
+	ctx sdk.Context,
+	subaccountId types.SubaccountId,
+	perpetualId uint32,
+	side types.SafetyHeapPositionSide,
+) {
+	store := k.GetSafetyHeapStore(ctx, perpetualId, side)
+	k.Insert(ctx, store, subaccountId)
+}
+
+// Heap methods
+
+// Insert inserts a subaccount into the safety heap.
+func (k Keeper) Insert(
+	ctx sdk.Context,
+	store prefix.Store,
+	subaccountId types.SubaccountId,
+) {
+	// Add the subaccount to the end of the heap.
+	length := k.GetSafetyHeapLength(store)
+	k.SetSubaccountAtIndex(store, subaccountId, length)
+
+	// Increment the size of the heap.
+	k.SetSafetyHeapLength(store, length+1)
+
+	// Heapify up the element at the end of the heap
+	// to restore the heap property.
+	k.HeapifyUp(ctx, store, length)
+}
+
+// MustRemoveElementAtIndex removes the element at the given index
+// from the safety heap.
+func (k Keeper) MustRemoveElementAtIndex(
+	ctx sdk.Context,
+	store prefix.Store,
+	index uint32,
+) {
+	length := k.GetSafetyHeapLength(store)
+	if index >= length {
+		panic(types.ErrSafetyHeapSubaccountNotFoundAtIndex)
+	}
+
+	// Swap the element with the last element.
+	k.Swap(store, index, length-1)
+
+	// Remove the last element.
+	k.DeleteSubaccountAtIndex(store, length-1)
+	k.SetSafetyHeapLength(store, length-1)
+
+	// Heapify down the element at the given index
+	// to restore the heap property.
+	k.HeapifyDown(ctx, store, index)
+}
+
+// HeapifyUp moves the element at the given index up the heap
+// until the heap property is restored.
+func (k Keeper) HeapifyUp(
+	ctx sdk.Context,
+	store prefix.Store,
+	index uint32,
+) {
+	if index == 0 {
+		return
+	}
+
+	parentIndex := (index - 1) / 2
+	if k.Less(ctx, store, index, parentIndex) {
+		k.Swap(store, index, parentIndex)
+		k.HeapifyUp(ctx, store, parentIndex)
+	}
+}
+
+// HeapifyDown moves the element at the given index down the heap
+// until the heap property is restored.
+func (k Keeper) HeapifyDown(
+	ctx sdk.Context,
+	store prefix.Store,
+	index uint32,
+) {
+	leftIndex, rightIndex := 2*index+1, 2*index+2
+
+	length := k.GetSafetyHeapLength(store)
+	if rightIndex < length && k.Less(ctx, store, rightIndex, leftIndex) {
+		// Compare the current node with the right child
+		// if right child exists and is less than the left child.
+		if k.Less(ctx, store, rightIndex, index) {
+			k.Swap(store, index, rightIndex)
+			k.HeapifyDown(ctx, store, rightIndex)
+		}
+	} else if leftIndex < length {
+		// Compare the current node with the left child
+		// if left child exists.
+		if k.Less(ctx, store, leftIndex, index) {
+			k.Swap(store, index, leftIndex)
+			k.HeapifyDown(ctx, store, leftIndex)
+		}
+	}
+}
+
+// Swap swaps the elements at the given indices.
+func (k Keeper) Swap(
+	store prefix.Store,
+	index1 uint32,
+	index2 uint32,
+) {
+	// No-op case
+	if index1 == index2 {
+		return
+	}
+
+	first := k.MustGetSubaccountAtIndex(store, index1)
+	second := k.MustGetSubaccountAtIndex(store, index2)
+	k.SetSubaccountAtIndex(store, first, index2)
+	k.SetSubaccountAtIndex(store, second, index1)
+}
+
+// Less returns true if the element at the first index is less than
+// the element at the second index.
+func (k Keeper) Less(
+	ctx sdk.Context,
+	store prefix.Store,
+	first uint32,
+	second uint32,
+) bool {
+	firstSubaccountId := k.MustGetSubaccountAtIndex(store, first)
+	secondSubaccountId := k.MustGetSubaccountAtIndex(store, second)
+
+	firstRisk, err := k.GetNetCollateralAndMarginRequirements(
+		ctx,
+		types.Update{
+			SubaccountId: firstSubaccountId,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	secondRisk, err := k.GetNetCollateralAndMarginRequirements(
+		ctx,
+		types.Update{
+			SubaccountId: secondSubaccountId,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// Compare the risks of the two subaccounts and sort
+	// them in descending order.
+	return firstRisk.Cmp(secondRisk) > 0
+}

--- a/protocol/x/subaccounts/keeper/safety_heap_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_test.go
@@ -29,7 +29,7 @@ func TestSafetyHeapInsertRemoveMin(t *testing.T) {
 	for i := 0; i < totalSubaccounts; i++ {
 		subaccount := satypes.Subaccount{
 			Id: &satypes.SubaccountId{
-				Owner: types.MustBech32ifyAddressBytes(
+				Owner: sdk.MustBech32ifyAddressBytes(
 					config.Bech32PrefixAccAddr,
 					constants.AliceAccAddress,
 				),

--- a/protocol/x/subaccounts/keeper/safety_heap_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"cosmossdk.io/store/prefix"
-	"github.com/cosmos/cosmos-sdk/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/app/config"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
@@ -115,7 +114,7 @@ func TestSafetyHeapInsertRemoveIndex(t *testing.T) {
 	for i := 0; i < totalSubaccounts; i++ {
 		subaccount := satypes.Subaccount{
 			Id: &satypes.SubaccountId{
-				Owner: types.MustBech32ifyAddressBytes(
+				Owner: sdk.MustBech32ifyAddressBytes(
 					config.Bech32PrefixAccAddr,
 					constants.AliceAccAddress,
 				),

--- a/protocol/x/subaccounts/keeper/safety_heap_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_test.go
@@ -51,7 +51,12 @@ func TestSafetyHeapInsertRemoval(t *testing.T) {
 		store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, satypes.Long)
 		for _, subaccount := range allSubaccounts {
 			subaccountsKeeper.SetSubaccount(ctx, subaccount)
-			subaccountsKeeper.Insert(ctx, store, *subaccount.Id)
+			subaccountsKeeper.AddSubaccountToSafetyHeap(
+				ctx,
+				*subaccount.Id,
+				0,
+				satypes.Long,
+			)
 		}
 
 		// Make sure subaccounts are sorted correctly.
@@ -62,7 +67,12 @@ func TestSafetyHeapInsertRemoval(t *testing.T) {
 			require.Equal(t, uint32(i), subaccountId.Number)
 
 			// Remove the subaccount from the heap.
-			subaccountsKeeper.MustRemoveElementAtIndex(ctx, store, 0)
+			subaccountsKeeper.RemoveSubaccountFromSafetyHeap(
+				ctx,
+				subaccountId,
+				0,
+				satypes.Long,
+			)
 		}
 	}
 }

--- a/protocol/x/subaccounts/keeper/safety_heap_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_test.go
@@ -45,6 +45,7 @@ func TestSafetyHeapInsertRemoval(t *testing.T) {
 		// Setup keeper state and test parameters.
 		ctx, subaccountsKeeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
 
+		// Shuffle the subaccounts so that insertion order is random.
 		slices.Shuffle(allSubaccounts)
 
 		store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, satypes.Long)

--- a/protocol/x/subaccounts/keeper/safety_heap_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	"math/big"
-	"math/rand"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/types"
@@ -12,6 +11,7 @@ import (
 	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/util"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/typ.v4/slices"
 )
 
 func TestSafetyHeapInsertRemoval(t *testing.T) {
@@ -45,9 +45,7 @@ func TestSafetyHeapInsertRemoval(t *testing.T) {
 		// Setup keeper state and test parameters.
 		ctx, subaccountsKeeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
 
-		rand.Shuffle(len(allSubaccounts), func(i, j int) {
-			allSubaccounts[i], allSubaccounts[j] = allSubaccounts[j], allSubaccounts[i]
-		})
+		slices.Shuffle(allSubaccounts)
 
 		store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, satypes.Long)
 		for i, subaccount := range allSubaccounts {

--- a/protocol/x/subaccounts/keeper/safety_heap_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_test.go
@@ -2,19 +2,23 @@ package keeper_test
 
 import (
 	"math/big"
+	"math/rand"
 	"testing"
 
+	"cosmossdk.io/store/prefix"
 	"github.com/cosmos/cosmos-sdk/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/app/config"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/util"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/typ.v4/slices"
 )
 
-func TestSafetyHeapInsertRemoval(t *testing.T) {
+func TestSafetyHeapInsertRemoveMin(t *testing.T) {
 	perpetualId := uint32(0)
 	side := satypes.Long
 	totalSubaccounts := 1000
@@ -97,5 +101,99 @@ func TestSafetyHeapInsertRemoval(t *testing.T) {
 				subaccountsKeeper.GetSafetyHeapLength(store),
 			)
 		}
+	}
+}
+
+func TestSafetyHeapInsertRemoveIndex(t *testing.T) {
+	perpetualId := uint32(0)
+	side := satypes.Long
+	totalSubaccounts := 100
+
+	// Create 1000 subaccounts with balances ranging from -500 to 500.
+	// The subaccounts should be sorted by balance.
+	allSubaccounts := make([]satypes.Subaccount, 0)
+	for i := 0; i < totalSubaccounts; i++ {
+		subaccount := satypes.Subaccount{
+			Id: &satypes.SubaccountId{
+				Owner: types.MustBech32ifyAddressBytes(
+					config.Bech32PrefixAccAddr,
+					constants.AliceAccAddress,
+				),
+				Number: uint32(i),
+			},
+			AssetPositions: testutil.CreateUsdcAssetPositions(
+				// Create asset positions with balances ranging from -500 to 500.
+				big.NewInt(int64(i - totalSubaccounts/2)),
+			),
+		}
+
+		// Handle special case.
+		if i-totalSubaccounts/2 == 0 {
+			subaccount.AssetPositions = nil
+		}
+
+		allSubaccounts = append(allSubaccounts, subaccount)
+	}
+
+	for iter := 0; iter < 100; iter++ {
+		// Setup keeper state and test parameters.
+		ctx, subaccountsKeeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
+
+		// Shuffle the subaccounts so that insertion order is random.
+		slices.Shuffle(allSubaccounts)
+
+		store := subaccountsKeeper.GetSafetyHeapStore(ctx, perpetualId, side)
+		for i, subaccount := range allSubaccounts {
+			subaccountsKeeper.SetSubaccount(ctx, subaccount)
+			subaccountsKeeper.AddSubaccountToSafetyHeap(
+				ctx,
+				*subaccount.Id,
+				perpetualId,
+				side,
+			)
+
+			require.Equal(
+				t,
+				uint32(i+1),
+				subaccountsKeeper.GetSafetyHeapLength(store),
+			)
+		}
+
+		for i := totalSubaccounts; i > 0; i-- {
+			// Remove a random subaccount from the heap.
+			index := rand.Intn(i)
+
+			subaccountId := subaccountsKeeper.MustGetSubaccountAtIndex(store, uint32(index))
+			subaccountsKeeper.RemoveSubaccountFromSafetyHeap(
+				ctx,
+				subaccountId,
+				perpetualId,
+				side,
+			)
+
+			require.Equal(
+				t,
+				uint32(i-1),
+				subaccountsKeeper.GetSafetyHeapLength(store),
+			)
+
+			// Verify that the heap property is restored.
+			verifyHeapProperties(t, subaccountsKeeper, ctx, store, 0)
+		}
+	}
+}
+
+func verifyHeapProperties(t *testing.T, k *keeper.Keeper, ctx sdk.Context, store prefix.Store, index uint32) {
+	length := k.GetSafetyHeapLength(store)
+	leftChild, rightChild := 2*index+1, 2*index+2
+
+	if leftChild < length {
+		require.True(t, k.Less(ctx, store, index, leftChild))
+		verifyHeapProperties(t, k, ctx, store, leftChild)
+	}
+
+	if rightChild < length {
+		require.True(t, k.Less(ctx, store, index, rightChild))
+		verifyHeapProperties(t, k, ctx, store, rightChild)
 	}
 }

--- a/protocol/x/subaccounts/keeper/safety_heap_test.go
+++ b/protocol/x/subaccounts/keeper/safety_heap_test.go
@@ -1,0 +1,68 @@
+package keeper_test
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/app/config"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
+	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/util"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafetyHeapInsertRemoval(t *testing.T) {
+
+	allSubaccounts := make([]satypes.Subaccount, 0)
+	for i := 0; i < 1000; i++ {
+		subaccount := satypes.Subaccount{
+			Id: &satypes.SubaccountId{
+				Owner: types.MustBech32ifyAddressBytes(
+					config.Bech32PrefixAccAddr,
+					constants.AliceAccAddress,
+				),
+				Number: uint32(i),
+			},
+			AssetPositions: testutil.CreateUsdcAssetPositions(
+				// Create asset positions with balances ranging from -500 to 500.
+				big.NewInt(int64(i - 500)),
+			),
+		}
+
+		// Handle special case.
+		if i == 500 {
+			subaccount.AssetPositions = nil
+		}
+
+		allSubaccounts = append(allSubaccounts, subaccount)
+	}
+
+	for iter := 0; iter < 100; iter++ {
+		// Setup keeper state and test parameters.
+		ctx, subaccountsKeeper, _, _, _, _, _, _, _, _ := keepertest.SubaccountsKeepers(t, false)
+
+		rand.Shuffle(len(allSubaccounts), func(i, j int) {
+			allSubaccounts[i], allSubaccounts[j] = allSubaccounts[j], allSubaccounts[i]
+		})
+
+		store := subaccountsKeeper.GetSafetyHeapStore(ctx, 0, satypes.Long)
+		for _, subaccount := range allSubaccounts {
+			subaccountsKeeper.SetSubaccount(ctx, subaccount)
+			subaccountsKeeper.Insert(ctx, store, *subaccount.Id)
+		}
+
+		// Make sure subaccounts are sorted correctly.
+		for i := 0; i < 1000; i++ {
+			subaccountId := subaccountsKeeper.MustGetSubaccountAtIndex(store, uint32(0))
+
+			// Subaccounts should be sorted by asset position balance.
+			require.Equal(t, uint32(i), subaccountId.Number)
+
+			// Remove the subaccount from the heap.
+			subaccountsKeeper.MustRemoveElementAtIndex(ctx, store, 0)
+		}
+	}
+}


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to manage a safety heap, allowing insertion, removal, and heap operations for subaccounts.
  
- **Tests**
	- Added tests to ensure correct sorting and maintenance of heap properties during subaccount operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->