### PR TITLE
Add CLI snapshot commands

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -244,13 +244,13 @@ func initRootCmd(
 
 	rootCmd.AddCommand(rosettaCmd.RosettaCommand(tempApp.InterfaceRegistry(), tempApp.AppCodec()))
 
-    rootCmd.AddCommand(
-        snapshot.Cmd(
-            func(logger log.Logger, db dbm.DB, writer io.Writer, options servertypes.AppOptions) servertypes.Application {
-                return appInterceptor(newApp(logger, db, writer, options))
-            },
-        ),
-    )
+	rootCmd.AddCommand(
+		snapshot.Cmd(
+			func(logger log.Logger, db dbm.DB, writer io.Writer, options servertypes.AppOptions) servertypes.Application {
+				return appInterceptor(newApp(logger, db, writer, options))
+			},
+		),
+	)
 }
 
 // autoCliOpts returns options based upon the modules in the dYdX v4 app.

--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
+	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	runtimeservices "github.com/cosmos/cosmos-sdk/runtime/services"
@@ -242,6 +243,14 @@ func initRootCmd(
 	)
 
 	rootCmd.AddCommand(rosettaCmd.RosettaCommand(tempApp.InterfaceRegistry(), tempApp.AppCodec()))
+
+    rootCmd.AddCommand(
+        snapshot.Cmd(
+            func(logger log.Logger, db dbm.DB, writer io.Writer, options servertypes.AppOptions) servertypes.Application {
+                return appInterceptor(newApp(logger, db, writer, options))
+            },
+        ),
+    )
 }
 
 // autoCliOpts returns options based upon the modules in the dYdX v4 app.


### PR DESCRIPTION
### Changelist
Adds CLI snapshot commands

The following commands are available at dydxprotocold snapshots [command]:

    list: list local snapshots
    load: Load a snapshot archive file into snapshot store
    restore: Restore app state from local snapshot
    export: Export app state to snapshot store
    dump: Dump the snapshot as portable archive format
    delete: Delete a local snapshot

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a snapshot command for enhanced functionality within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->