### PR TITLE
[TRA-461] Add stateless + stateful validation for `MsgWithdrawFromVault`

### DIFF
--- a/protocol/testutil/constants/vault.go
+++ b/protocol/testutil/constants/vault.go
@@ -1,15 +1,12 @@
 package constants
 
 import (
-	"math/big"
-
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
 type VaultState struct {
 	VaultId     types.VaultId
-	Equity      *big.Int
 	OwnerShares []*types.OwnerShare
 }
 
@@ -25,7 +22,6 @@ var (
 
 	Vault_Clob0_SingleOwner_Alice0_1000 = VaultState{
 		VaultId: Vault_Clob0,
-		Equity:  big.NewInt(1000),
 		OwnerShares: []*types.OwnerShare{
 			{
 				Owner:  Alice_Num0.Owner,
@@ -35,7 +31,6 @@ var (
 	}
 	Vault_Clob0_MultiOwner_Alice0_1000_Bob0_2500 = VaultState{
 		VaultId: Vault_Clob0,
-		Equity:  big.NewInt(3500),
 		OwnerShares: []*types.OwnerShare{
 			{
 				Owner:  Alice_Num0.Owner,

--- a/protocol/testutil/constants/vault.go
+++ b/protocol/testutil/constants/vault.go
@@ -1,22 +1,55 @@
 package constants
 
 import (
+	"math/big"
+
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
+type VaultState struct {
+	VaultId     types.VaultId
+	Equity      *big.Int
+	OwnerShares []*types.OwnerShare
+}
+
 var (
-	Vault_Clob_0 = types.VaultId{
+	Vault_Clob0 = types.VaultId{
 		Type:   types.VaultType_VAULT_TYPE_CLOB,
 		Number: 0,
 	}
-	Vault_Clob_1 = types.VaultId{
+	Vault_Clob1 = types.VaultId{
 		Type:   types.VaultType_VAULT_TYPE_CLOB,
 		Number: 1,
 	}
 
+	Vault_Clob0_SingleOwner_Alice0_1000 = VaultState{
+		VaultId: Vault_Clob0,
+		Equity:  big.NewInt(1000),
+		OwnerShares: []*types.OwnerShare{
+			{
+				Owner:  Alice_Num0.Owner,
+				Shares: &types.NumShares{NumShares: dtypes.NewInt(1000)},
+			},
+		},
+	}
+	Vault_Clob0_MultiOwner_Alice0_1000_Bob0_2500 = VaultState{
+		VaultId: Vault_Clob0,
+		Equity:  big.NewInt(3500),
+		OwnerShares: []*types.OwnerShare{
+			{
+				Owner:  Alice_Num0.Owner,
+				Shares: &types.NumShares{NumShares: dtypes.NewInt(1000)},
+			},
+			{
+				Owner:  Bob_Num0.Owner,
+				Shares: &types.NumShares{NumShares: dtypes.NewInt(2500)},
+			},
+		},
+	}
+
 	MsgDepositToVault_Clob0_Alice0_100 = &types.MsgDepositToVault{
-		VaultId:       &Vault_Clob_0,
+		VaultId:       &Vault_Clob0,
 		SubaccountId:  &Alice_Num0,
 		QuoteQuantums: dtypes.NewInt(100),
 	}

--- a/protocol/x/vault/keeper/deposit.go
+++ b/protocol/x/vault/keeper/deposit.go
@@ -1,0 +1,101 @@
+package keeper
+
+import (
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+)
+
+// MintShares mints shares of a vault for `owner` based on `quantumsToDeposit` by:
+// 1. Increasing total shares of the vault.
+// 2. Increasing owner shares of the vault for given `owner`.
+func (k Keeper) MintShares(
+	ctx sdk.Context,
+	vaultId types.VaultId,
+	owner string,
+	quantumsToDeposit *big.Int,
+) error {
+	// Quantums to deposit should be positive.
+	if quantumsToDeposit.Sign() <= 0 {
+		return types.ErrInvalidDepositAmount
+	}
+	// Get existing TotalShares of the vault.
+	totalShares, exists := k.GetTotalShares(ctx, vaultId)
+	existingTotalShares := totalShares.NumShares.BigInt()
+	// Calculate shares to mint.
+	var sharesToMint *big.Int
+	if !exists || existingTotalShares.Sign() <= 0 {
+		// Mint `quoteQuantums` number of shares.
+		sharesToMint = new(big.Int).Set(quantumsToDeposit)
+		// Initialize existingTotalShares as 0.
+		existingTotalShares = big.NewInt(0)
+	} else {
+		// Get vault equity.
+		equity, err := k.GetVaultEquity(ctx, vaultId)
+		if err != nil {
+			return err
+		}
+		// Don't mint shares if equity is non-positive.
+		if equity.Sign() <= 0 {
+			return types.ErrNonPositiveEquity
+		}
+		// Mint `deposit (in quote quantums) * existing shares / vault equity (in quote quantums)`
+		// number of shares.
+		// For example:
+		// - a vault currently has 5000 shares and 4000 equity (in quote quantums)
+		// - each quote quantum is worth 5000 / 4000 = 1.25 shares
+		// - a deposit of 1000 quote quantums should thus be given 1000 * 1.25 = 1250 shares
+		sharesToMint = new(big.Int).Set(quantumsToDeposit)
+		sharesToMint = sharesToMint.Mul(sharesToMint, existingTotalShares)
+		sharesToMint = sharesToMint.Quo(sharesToMint, equity)
+
+		// Return error if `sharesToMint` is rounded down to 0.
+		if sharesToMint.Sign() == 0 {
+			return types.ErrZeroSharesToMint
+		}
+	}
+
+	// Increase TotalShares of the vault.
+	err := k.SetTotalShares(
+		ctx,
+		vaultId,
+		types.BigIntToNumShares(
+			existingTotalShares.Add(existingTotalShares, sharesToMint),
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Increase owner shares in the vault.
+	ownerShares, exists := k.GetOwnerShares(ctx, vaultId, owner)
+	if !exists {
+		// Set owner shares to be sharesToMint.
+		err := k.SetOwnerShares(
+			ctx,
+			vaultId,
+			owner,
+			types.BigIntToNumShares(sharesToMint),
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Increase existing owner shares by sharesToMint.
+		existingOwnerShares := ownerShares.NumShares.BigInt()
+		err = k.SetOwnerShares(
+			ctx,
+			vaultId,
+			owner,
+			types.BigIntToNumShares(
+				existingOwnerShares.Add(existingOwnerShares, sharesToMint),
+			),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/protocol/x/vault/keeper/deposit_test.go
+++ b/protocol/x/vault/keeper/deposit_test.go
@@ -1,0 +1,242 @@
+package keeper_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/cometbft/cometbft/types"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/util"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMintShares(t *testing.T) {
+	tests := map[string]struct {
+		/* --- Setup --- */
+		// Vault ID.
+		vaultId vaulttypes.VaultId
+		// Existing vault equity.
+		equity *big.Int
+		// Existing vault TotalShares.
+		totalShares *big.Int
+		// Owner that deposits.
+		owner string
+		// Existing owner shares.
+		ownerShares *big.Int
+		// Quote quantums to deposit.
+		quantumsToDeposit *big.Int
+
+		/* --- Expectations --- */
+		// Expected TotalShares after minting.
+		expectedTotalShares *big.Int
+		// Expected OwnerShares after minting.
+		expectedOwnerShares *big.Int
+		// Expected error.
+		expectedErr error
+	}{
+		"Equity 0, TotalShares 0, OwnerShares 0, Deposit 1000": {
+			vaultId:           constants.Vault_Clob0,
+			equity:            big.NewInt(0),
+			totalShares:       big.NewInt(0),
+			owner:             constants.AliceAccAddress.String(),
+			ownerShares:       big.NewInt(0),
+			quantumsToDeposit: big.NewInt(1_000),
+			// Should mint `1_000` shares.
+			expectedTotalShares: big.NewInt(1_000),
+			expectedOwnerShares: big.NewInt(1_000),
+		},
+		"Equity 0, TotalShares non-existent, OwnerShares non-existent, Deposit 12345654321": {
+			vaultId:           constants.Vault_Clob0,
+			equity:            big.NewInt(0),
+			owner:             constants.AliceAccAddress.String(),
+			quantumsToDeposit: big.NewInt(12_345_654_321),
+			// Should mint `12_345_654_321` shares.
+			expectedTotalShares: big.NewInt(12_345_654_321),
+			expectedOwnerShares: big.NewInt(12_345_654_321),
+		},
+		"Equity 1000, TotalShares non-existent, OwnerShares non-existent, Deposit 500": {
+			vaultId:           constants.Vault_Clob0,
+			equity:            big.NewInt(1_000),
+			owner:             constants.AliceAccAddress.String(),
+			quantumsToDeposit: big.NewInt(500),
+			// Should mint `500` shares.
+			expectedTotalShares: big.NewInt(500),
+			expectedOwnerShares: big.NewInt(500),
+		},
+		"Equity 4000, TotalShares 5000, OwnerShares 2500, Deposit 1000": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(4_000),
+			totalShares:       big.NewInt(5_000),
+			owner:             constants.AliceAccAddress.String(),
+			ownerShares:       big.NewInt(2_500),
+			quantumsToDeposit: big.NewInt(1_000),
+			// Should mint `1_250` shares.
+			expectedTotalShares: big.NewInt(6_250),
+			expectedOwnerShares: big.NewInt(3_750),
+		},
+		"Equity 1_000_000, TotalShares 2_000, OwnerShares 1, Deposit 1_000": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(1_000_000),
+			totalShares:       big.NewInt(2_000),
+			owner:             constants.BobAccAddress.String(),
+			ownerShares:       big.NewInt(1),
+			quantumsToDeposit: big.NewInt(1_000),
+			// Should mint `2` shares.
+			expectedTotalShares: big.NewInt(2_002),
+			expectedOwnerShares: big.NewInt(3),
+		},
+		"Equity 8000, TotalShares 4000, OwnerShares 101, Deposit 455": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(8_000),
+			totalShares:       big.NewInt(4_000),
+			owner:             constants.CarlAccAddress.String(),
+			ownerShares:       big.NewInt(101),
+			quantumsToDeposit: big.NewInt(455),
+			// Should mint `227.5` shares, round down to 227.
+			expectedTotalShares: big.NewInt(4_227),
+			expectedOwnerShares: big.NewInt(328),
+		},
+		"Equity 123456, TotalShares 654321, OwnerShares 0, Deposit 123456789": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(123_456),
+			totalShares:       big.NewInt(654_321),
+			owner:             constants.DaveAccAddress.String(),
+			quantumsToDeposit: big.NewInt(123_456_789),
+			// Should mint `654_325_181.727` shares, round down to 654_325_181.
+			expectedTotalShares: big.NewInt(654_979_502),
+			expectedOwnerShares: big.NewInt(654_325_181),
+		},
+		"Equity 1000000, TotalShares 1000, OwnerShares 0, Deposit 9_900": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(1_000_000),
+			totalShares:       big.NewInt(1_000),
+			owner:             constants.DaveAccAddress.String(),
+			quantumsToDeposit: big.NewInt(9_900),
+			// Should mint `9_900 * 1_000 / 1_000_000` shares, round down to 9.
+			expectedTotalShares: big.NewInt(1_009),
+			expectedOwnerShares: big.NewInt(9),
+		},
+		"Equity -1, TotalShares 10, Deposit 1": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(-1),
+			totalShares:       big.NewInt(10),
+			owner:             constants.AliceAccAddress.String(),
+			quantumsToDeposit: big.NewInt(1),
+			expectedErr:       vaulttypes.ErrNonPositiveEquity,
+		},
+		"Equity 1, TotalShares 1, Deposit 0": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(1),
+			totalShares:       big.NewInt(1),
+			owner:             constants.AliceAccAddress.String(),
+			quantumsToDeposit: big.NewInt(0),
+			expectedErr:       vaulttypes.ErrInvalidDepositAmount,
+		},
+		"Equity 0, TotalShares non-existent, Deposit -1": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(0),
+			owner:             constants.AliceAccAddress.String(),
+			quantumsToDeposit: big.NewInt(-1),
+			expectedErr:       vaulttypes.ErrInvalidDepositAmount,
+		},
+		"Equity 1000, TotalShares 1, Deposit 100": {
+			vaultId:           constants.Vault_Clob1,
+			equity:            big.NewInt(1_000),
+			totalShares:       big.NewInt(1),
+			owner:             constants.AliceAccAddress.String(),
+			quantumsToDeposit: big.NewInt(100),
+			expectedErr:       vaulttypes.ErrZeroSharesToMint,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Initialize tApp and ctx.
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+				genesis = testapp.DefaultGenesis()
+				// Initialize vault with its existing equity.
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *satypes.GenesisState) {
+						genesisState.Subaccounts = []satypes.Subaccount{
+							{
+								Id: tc.vaultId.ToSubaccountId(),
+								AssetPositions: []*satypes.AssetPosition{
+									testutil.CreateSingleAssetPosition(
+										0,
+										tc.equity,
+									),
+								},
+							},
+						}
+					},
+				)
+				return genesis
+			}).Build()
+			ctx := tApp.InitChain()
+
+			// Set vault's existing total shares if specified.
+			if tc.totalShares != nil {
+				err := tApp.App.VaultKeeper.SetTotalShares(
+					ctx,
+					tc.vaultId,
+					vaulttypes.BigIntToNumShares(tc.totalShares),
+				)
+				require.NoError(t, err)
+			}
+			// Set vault's existing owner shares if specified.
+			if tc.ownerShares != nil {
+				err := tApp.App.VaultKeeper.SetOwnerShares(
+					ctx,
+					tc.vaultId,
+					tc.owner,
+					vaulttypes.BigIntToNumShares(tc.ownerShares),
+				)
+				require.NoError(t, err)
+			}
+
+			// Mint shares.
+			err := tApp.App.VaultKeeper.MintShares(
+				ctx,
+				tc.vaultId,
+				tc.owner,
+				tc.quantumsToDeposit,
+			)
+			if tc.expectedErr != nil {
+				// Check that error is as expected.
+				require.ErrorContains(t, err, tc.expectedErr.Error())
+				// Check that TotalShares is unchanged.
+				totalShares, _ := tApp.App.VaultKeeper.GetTotalShares(ctx, tc.vaultId)
+				require.Equal(
+					t,
+					vaulttypes.BigIntToNumShares(tc.totalShares),
+					totalShares,
+				)
+				// Check that OwnerShares is unchanged.
+				ownerShares, _ := tApp.App.VaultKeeper.GetOwnerShares(ctx, tc.vaultId, tc.owner)
+				require.Equal(t, vaulttypes.BigIntToNumShares(tc.ownerShares), ownerShares)
+			} else {
+				require.NoError(t, err)
+				// Check that TotalShares is as expected.
+				totalShares, exists := tApp.App.VaultKeeper.GetTotalShares(ctx, tc.vaultId)
+				require.True(t, exists)
+				require.Equal(
+					t,
+					vaulttypes.BigIntToNumShares(tc.expectedTotalShares),
+					totalShares,
+				)
+				// Check that OwnerShares is as expected.
+				ownerShares, exists := tApp.App.VaultKeeper.GetOwnerShares(ctx, tc.vaultId, tc.owner)
+				require.True(t, exists)
+				require.Equal(
+					t,
+					vaulttypes.BigIntToNumShares(tc.expectedOwnerShares),
+					ownerShares,
+				)
+			}
+		})
+	}
+}

--- a/protocol/x/vault/keeper/grpc_query_shares_test.go
+++ b/protocol/x/vault/keeper/grpc_query_shares_test.go
@@ -31,7 +31,7 @@ func TestOwnerShares(t *testing.T) {
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
 				Number: 0,
 			},
-			vaultId: constants.Vault_Clob_0,
+			vaultId: constants.Vault_Clob0,
 			ownerShares: map[string]*big.Int{
 				constants.Alice_Num0.Owner: big.NewInt(100),
 				constants.Bob_Num0.Owner:   big.NewInt(200),
@@ -56,7 +56,7 @@ func TestOwnerShares(t *testing.T) {
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
 				Number: 1,
 			},
-			vaultId: constants.Vault_Clob_0,
+			vaultId: constants.Vault_Clob0,
 			ownerShares: map[string]*big.Int{
 				constants.Alice_Num0.Owner: big.NewInt(100),
 				constants.Bob_Num0.Owner:   big.NewInt(200),
@@ -65,7 +65,7 @@ func TestOwnerShares(t *testing.T) {
 		},
 		"Error: nil request": {
 			req:     nil,
-			vaultId: constants.Vault_Clob_0,
+			vaultId: constants.Vault_Clob0,
 			ownerShares: map[string]*big.Int{
 				constants.Alice_Num0.Owner: big.NewInt(100),
 				constants.Bob_Num0.Owner:   big.NewInt(200),

--- a/protocol/x/vault/keeper/grpc_query_vault_test.go
+++ b/protocol/x/vault/keeper/grpc_query_vault_test.go
@@ -40,7 +40,7 @@ func TestVault(t *testing.T) {
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
 				Number: 0,
 			},
-			vaultId:        constants.Vault_Clob_0,
+			vaultId:        constants.Vault_Clob0,
 			asset:          big.NewInt(100),
 			perpId:         0,
 			inventory:      big.NewInt(200),
@@ -52,7 +52,7 @@ func TestVault(t *testing.T) {
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
 				Number: 0,
 			},
-			vaultId:        constants.Vault_Clob_0,
+			vaultId:        constants.Vault_Clob0,
 			asset:          big.NewInt(100),
 			perpId:         0,
 			inventory:      big.NewInt(-200),
@@ -64,7 +64,7 @@ func TestVault(t *testing.T) {
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
 				Number: 1, // Non-existent vault.
 			},
-			vaultId:     constants.Vault_Clob_0,
+			vaultId:     constants.Vault_Clob0,
 			asset:       big.NewInt(100),
 			perpId:      0,
 			inventory:   big.NewInt(200),
@@ -73,7 +73,7 @@ func TestVault(t *testing.T) {
 		},
 		"Error: nil request": {
 			req:         nil,
-			vaultId:     constants.Vault_Clob_0,
+			vaultId:     constants.Vault_Clob0,
 			asset:       big.NewInt(100),
 			perpId:      0,
 			inventory:   big.NewInt(200),
@@ -159,12 +159,12 @@ func TestAllVaults(t *testing.T) {
 		"Success": {
 			req: &vaulttypes.QueryAllVaultsRequest{},
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: map[vaulttypes.VaultId]*big.Int{
-				constants.Vault_Clob_0: big.NewInt(100),
-				constants.Vault_Clob_1: big.NewInt(200),
+				constants.Vault_Clob0: big.NewInt(100),
+				constants.Vault_Clob1: big.NewInt(200),
 			},
 			assets: []*big.Int{
 				big.NewInt(1_000),
@@ -179,12 +179,12 @@ func TestAllVaults(t *testing.T) {
 		"Error: nil request": {
 			req: nil,
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: map[vaulttypes.VaultId]*big.Int{
-				constants.Vault_Clob_0: big.NewInt(100),
-				constants.Vault_Clob_1: big.NewInt(200),
+				constants.Vault_Clob0: big.NewInt(100),
+				constants.Vault_Clob1: big.NewInt(200),
 			},
 			assets: []*big.Int{
 				big.NewInt(1_000),

--- a/protocol/x/vault/keeper/msg_server_deposit_to_vault_test.go
+++ b/protocol/x/vault/keeper/msg_server_deposit_to_vault_test.go
@@ -62,7 +62,7 @@ func TestMsgDepositToVault(t *testing.T) {
 		vaultEquityHistory []*big.Int
 	}{
 		"Two successful deposits, Same depositor": {
-			vaultId: constants.Vault_Clob_0,
+			vaultId: constants.Vault_Clob0,
 			depositorSetups: []DepositorSetup{
 				{
 					depositor:        constants.Alice_Num0,
@@ -93,7 +93,7 @@ func TestMsgDepositToVault(t *testing.T) {
 			},
 		},
 		"Two successful deposits, Different depositors": {
-			vaultId: constants.Vault_Clob_0,
+			vaultId: constants.Vault_Clob0,
 			depositorSetups: []DepositorSetup{
 				{
 					depositor:        constants.Alice_Num0,
@@ -128,7 +128,7 @@ func TestMsgDepositToVault(t *testing.T) {
 			},
 		},
 		"One successful deposit, One failed deposit due to insufficient balance": {
-			vaultId: constants.Vault_Clob_1,
+			vaultId: constants.Vault_Clob1,
 			depositorSetups: []DepositorSetup{
 				{
 					depositor:        constants.Alice_Num0,
@@ -164,7 +164,7 @@ func TestMsgDepositToVault(t *testing.T) {
 			},
 		},
 		"One failed deposit due to incorrect signer, One successful deposit": {
-			vaultId: constants.Vault_Clob_1,
+			vaultId: constants.Vault_Clob1,
 			depositorSetups: []DepositorSetup{
 				{
 					depositor:        constants.Alice_Num0,
@@ -201,7 +201,7 @@ func TestMsgDepositToVault(t *testing.T) {
 			},
 		},
 		"Three failed deposits due to invalid deposit amount": {
-			vaultId: constants.Vault_Clob_1,
+			vaultId: constants.Vault_Clob1,
 			depositorSetups: []DepositorSetup{
 				{
 					depositor:        constants.Alice_Num0,

--- a/protocol/x/vault/keeper/msg_server_withdraw_from_vault.go
+++ b/protocol/x/vault/keeper/msg_server_withdraw_from_vault.go
@@ -6,23 +6,17 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
-// WithdrawFromVault withdraws from a vault to a subaccount.
+// WithdrawFromVault attempts to withdraw an asset from a vault to a subaccount.
 func (k msgServer) WithdrawFromVault(
 	goCtx context.Context,
 	msg *types.MsgWithdrawFromVault,
 ) (*types.MsgWithdrawFromVaultResponse, error) {
-	// TODO(TRA-461): validate
-
+	// TODO(TRA-461): Validate.
 	// TODO(TRA-462): Calculate effective amount to withdraw + shares to redeem with slippage and user equity.
-
 	// TODO(TRA-461): Redeem shares for the vault.
-
 	// TODO(TRA-461): Transfer asset from vault to recipient subaccount.
 	// should transfer happen after redeeming shares? why?
-
 	// TODO(TRA-461): emit metric on vault equity.
-
-	// TODO(TRA-461):: Get info on shares after the withdrawal.
-
+	// TODO(TRA-461): Get info on shares after the withdrawal for the response.
 	return &types.MsgWithdrawFromVaultResponse{}, nil
 }

--- a/protocol/x/vault/keeper/msg_server_withdraw_from_vault.go
+++ b/protocol/x/vault/keeper/msg_server_withdraw_from_vault.go
@@ -6,10 +6,23 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
-// TODO: implement
+// WithdrawFromVault withdraws from a vault to a subaccount.
 func (k msgServer) WithdrawFromVault(
 	goCtx context.Context,
 	msg *types.MsgWithdrawFromVault,
 ) (*types.MsgWithdrawFromVaultResponse, error) {
+	// TODO(TRA-461): validate
+
+	// TODO(TRA-462): Calculate effective amount to withdraw + shares to redeem with slippage and user equity.
+
+	// TODO(TRA-461): Redeem shares for the vault.
+
+	// TODO(TRA-461): Transfer asset from vault to recipient subaccount.
+	// should transfer happen after redeeming shares? why?
+
+	// TODO(TRA-461): emit metric on vault equity.
+
+	// TODO(TRA-461):: Get info on shares after the withdrawal.
+
 	return &types.MsgWithdrawFromVaultResponse{}, nil
 }

--- a/protocol/x/vault/keeper/msg_server_withdraw_from_vault_test.go
+++ b/protocol/x/vault/keeper/msg_server_withdraw_from_vault_test.go
@@ -1,0 +1,3 @@
+package keeper_test
+
+// TODO(TRA-461): add tests

--- a/protocol/x/vault/keeper/orders_test.go
+++ b/protocol/x/vault/keeper/orders_test.go
@@ -36,8 +36,8 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 	}{
 		"Two Vaults, Both Positive Shares, Both above Activation Threshold": {
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: []*big.Int{
 				big.NewInt(1_000),
@@ -51,8 +51,8 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 		},
 		"Two Vaults, One Positive Shares, One Zero Shares, Both above Activation Threshold": {
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: []*big.Int{
 				big.NewInt(1_000),
@@ -66,8 +66,8 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 		},
 		"Two Vaults, Both Zero Shares, Both above Activation Threshold": {
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: []*big.Int{
 				big.NewInt(0),
@@ -81,8 +81,8 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 		},
 		"Two Vaults, Both Positive Shares, Only One above Activation Threshold": {
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: []*big.Int{
 				big.NewInt(1_000),
@@ -96,8 +96,8 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 		},
 		"Two Vaults, Both Positive Shares, Both below Activation Threshold": {
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: []*big.Int{
 				big.NewInt(1_000),
@@ -252,7 +252,7 @@ func TestRefreshVaultClobOrders(t *testing.T) {
 		expectedErr error
 	}{
 		"Success - Refresh Orders from Vault for Clob Pair 0": {
-			vaultId: constants.Vault_Clob_0,
+			vaultId: constants.Vault_Clob0,
 		},
 		"Error - Refresh Orders from Vault for Clob Pair 4321 (non-existent clob pair)": {
 			vaultId: vaulttypes.VaultId{
@@ -354,7 +354,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 				OrderExpirationSeconds:           2,       // 2 seconds
 				ActivationThresholdQuoteQuantums: dtypes.NewInt(1_000_000_000),
 			},
-			vaultId:                    constants.Vault_Clob_0,
+			vaultId:                    constants.Vault_Clob0,
 			vaultAssetQuoteQuantums:    big.NewInt(1_000_000_000), // 1,000 USDC
 			vaultInventoryBaseQuantums: big.NewInt(0),
 			clobPair:                   constants.ClobPair_Btc,
@@ -414,7 +414,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 				OrderExpirationSeconds:           4,       // 4 seconds
 				ActivationThresholdQuoteQuantums: dtypes.NewInt(1_000_000_000),
 			},
-			vaultId:                    constants.Vault_Clob_1,
+			vaultId:                    constants.Vault_Clob1,
 			vaultAssetQuoteQuantums:    big.NewInt(2_000_000_000), // 2,000 USDC
 			vaultInventoryBaseQuantums: big.NewInt(-500_000_000),  // -0.5 ETH
 			clobPair:                   constants.ClobPair_Eth,
@@ -488,7 +488,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 				OrderExpirationSeconds:           4,         // 4 seconds
 				ActivationThresholdQuoteQuantums: dtypes.NewInt(1_000_000_000),
 			},
-			vaultId:                    constants.Vault_Clob_1,
+			vaultId:                    constants.Vault_Clob1,
 			vaultAssetQuoteQuantums:    big.NewInt(-2_000_000_000), // -2,000 USDC
 			vaultInventoryBaseQuantums: big.NewInt(1_000_000_000),  // 1 ETH
 			clobPair:                   constants.ClobPair_Eth,
@@ -550,7 +550,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 				OrderExpirationSeconds:           2,       // 2 seconds
 				ActivationThresholdQuoteQuantums: dtypes.NewInt(1_000_000_000),
 			},
-			vaultId:                    constants.Vault_Clob_1,
+			vaultId:                    constants.Vault_Clob1,
 			vaultAssetQuoteQuantums:    big.NewInt(1_000_000), // 1 USDC
 			vaultInventoryBaseQuantums: big.NewInt(0),
 			clobPair:                   constants.ClobPair_Eth,
@@ -566,7 +566,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 		},
 		"Error - Clob Pair doesn't exist": {
 			vaultParams: vaulttypes.DefaultParams(),
-			vaultId:     constants.Vault_Clob_0,
+			vaultId:     constants.Vault_Clob0,
 			clobPair:    constants.ClobPair_Eth,
 			marketParam: constants.TestMarketParams[1],
 			marketPrice: constants.TestMarketPrices[1],
@@ -575,7 +575,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 		},
 		"Error - Vault equity is zero": {
 			vaultParams:                vaulttypes.DefaultParams(),
-			vaultId:                    constants.Vault_Clob_0,
+			vaultId:                    constants.Vault_Clob0,
 			vaultAssetQuoteQuantums:    big.NewInt(0),
 			vaultInventoryBaseQuantums: big.NewInt(0),
 			clobPair:                   constants.ClobPair_Btc,
@@ -586,7 +586,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 		},
 		"Error - Vault equity is negative": {
 			vaultParams:                vaulttypes.DefaultParams(),
-			vaultId:                    constants.Vault_Clob_0,
+			vaultId:                    constants.Vault_Clob0,
 			vaultAssetQuoteQuantums:    big.NewInt(5_000_000), // 5 USDC
 			vaultInventoryBaseQuantums: big.NewInt(-10_000_000),
 			clobPair:                   constants.ClobPair_Btc,

--- a/protocol/x/vault/keeper/shares.go
+++ b/protocol/x/vault/keeper/shares.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"math/big"
-
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -120,97 +118,4 @@ func (k Keeper) GetAllOwnerShares(
 		})
 	}
 	return allOwnerShares
-}
-
-// MintShares mints shares of a vault for `owner` based on `quantumsToDeposit` by:
-// 1. Increasing total shares of the vault.
-// 2. Increasing owner shares of the vault for given `owner`.
-func (k Keeper) MintShares(
-	ctx sdk.Context,
-	vaultId types.VaultId,
-	owner string,
-	quantumsToDeposit *big.Int,
-) error {
-	// Quantums to deposit should be positive.
-	if quantumsToDeposit.Sign() <= 0 {
-		return types.ErrInvalidDepositAmount
-	}
-	// Get existing TotalShares of the vault.
-	totalShares, exists := k.GetTotalShares(ctx, vaultId)
-	existingTotalShares := totalShares.NumShares.BigInt()
-	// Calculate shares to mint.
-	var sharesToMint *big.Int
-	if !exists || existingTotalShares.Sign() <= 0 {
-		// Mint `quoteQuantums` number of shares.
-		sharesToMint = new(big.Int).Set(quantumsToDeposit)
-		// Initialize existingTotalShares as 0.
-		existingTotalShares = big.NewInt(0)
-	} else {
-		// Get vault equity.
-		equity, err := k.GetVaultEquity(ctx, vaultId)
-		if err != nil {
-			return err
-		}
-		// Don't mint shares if equity is non-positive.
-		if equity.Sign() <= 0 {
-			return types.ErrNonPositiveEquity
-		}
-		// Mint `deposit (in quote quantums) * existing shares / vault equity (in quote quantums)`
-		// number of shares.
-		// For example:
-		// - a vault currently has 5000 shares and 4000 equity (in quote quantums)
-		// - each quote quantum is worth 5000 / 4000 = 1.25 shares
-		// - a deposit of 1000 quote quantums should thus be given 1000 * 1.25 = 1250 shares
-		sharesToMint = new(big.Int).Set(quantumsToDeposit)
-		sharesToMint = sharesToMint.Mul(sharesToMint, existingTotalShares)
-		sharesToMint = sharesToMint.Quo(sharesToMint, equity)
-
-		// Return error if `sharesToMint` is rounded down to 0.
-		if sharesToMint.Sign() == 0 {
-			return types.ErrZeroSharesToMint
-		}
-	}
-
-	// Increase TotalShares of the vault.
-	err := k.SetTotalShares(
-		ctx,
-		vaultId,
-		types.BigIntToNumShares(
-			existingTotalShares.Add(existingTotalShares, sharesToMint),
-		),
-	)
-	if err != nil {
-		return err
-	}
-
-	// Increase owner shares in the vault.
-	ownerShares, exists := k.GetOwnerShares(ctx, vaultId, owner)
-	if !exists {
-		// Set owner shares to be sharesToMint.
-		err := k.SetOwnerShares(
-			ctx,
-			vaultId,
-			owner,
-			types.BigIntToNumShares(sharesToMint),
-		)
-		if err != nil {
-			return err
-		}
-	} else {
-		// Increase existing owner shares by sharesToMint.
-		existingOwnerShares := ownerShares.NumShares.BigInt()
-		err = k.SetOwnerShares(
-			ctx,
-			vaultId,
-			owner,
-			types.BigIntToNumShares(
-				existingOwnerShares.Add(existingOwnerShares, sharesToMint),
-			),
-		)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/protocol/x/vault/keeper/shares_test.go
+++ b/protocol/x/vault/keeper/shares_test.go
@@ -4,11 +4,8 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/cometbft/cometbft/types"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
-	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/util"
-	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 	"github.com/stretchr/testify/require"
 )
@@ -19,16 +16,16 @@ func TestGetSetTotalShares(t *testing.T) {
 	k := tApp.App.VaultKeeper
 
 	// Get total shares for a non-existing vault.
-	_, exists := k.GetTotalShares(ctx, constants.Vault_Clob_0)
+	_, exists := k.GetTotalShares(ctx, constants.Vault_Clob0)
 	require.Equal(t, false, exists)
 
 	// Set total shares for a vault and then get.
 	numShares := vaulttypes.BigIntToNumShares(
 		big.NewInt(7),
 	)
-	err := k.SetTotalShares(ctx, constants.Vault_Clob_0, numShares)
+	err := k.SetTotalShares(ctx, constants.Vault_Clob0, numShares)
 	require.NoError(t, err)
-	got, exists := k.GetTotalShares(ctx, constants.Vault_Clob_0)
+	got, exists := k.GetTotalShares(ctx, constants.Vault_Clob0)
 	require.Equal(t, true, exists)
 	require.Equal(t, numShares, got)
 
@@ -36,9 +33,9 @@ func TestGetSetTotalShares(t *testing.T) {
 	numShares = vaulttypes.BigIntToNumShares(
 		big.NewInt(456),
 	)
-	err = k.SetTotalShares(ctx, constants.Vault_Clob_1, numShares)
+	err = k.SetTotalShares(ctx, constants.Vault_Clob1, numShares)
 	require.NoError(t, err)
-	got, exists = k.GetTotalShares(ctx, constants.Vault_Clob_1)
+	got, exists = k.GetTotalShares(ctx, constants.Vault_Clob1)
 	require.Equal(t, true, exists)
 	require.Equal(t, numShares, got)
 
@@ -46,9 +43,9 @@ func TestGetSetTotalShares(t *testing.T) {
 	numShares = vaulttypes.BigIntToNumShares(
 		big.NewInt(0),
 	)
-	err = k.SetTotalShares(ctx, constants.Vault_Clob_1, numShares)
+	err = k.SetTotalShares(ctx, constants.Vault_Clob1, numShares)
 	require.NoError(t, err)
-	got, exists = k.GetTotalShares(ctx, constants.Vault_Clob_1)
+	got, exists = k.GetTotalShares(ctx, constants.Vault_Clob1)
 	require.Equal(t, true, exists)
 	require.Equal(t, numShares, got)
 
@@ -56,9 +53,9 @@ func TestGetSetTotalShares(t *testing.T) {
 	numShares = vaulttypes.BigIntToNumShares(
 		big.NewInt(7283133),
 	)
-	err = k.SetTotalShares(ctx, constants.Vault_Clob_0, numShares)
+	err = k.SetTotalShares(ctx, constants.Vault_Clob0, numShares)
 	require.NoError(t, err)
-	got, exists = k.GetTotalShares(ctx, constants.Vault_Clob_0)
+	got, exists = k.GetTotalShares(ctx, constants.Vault_Clob0)
 	require.Equal(t, true, exists)
 	require.Equal(t, numShares, got)
 
@@ -67,9 +64,9 @@ func TestGetSetTotalShares(t *testing.T) {
 	negativeShares := vaulttypes.BigIntToNumShares(
 		big.NewInt(-1),
 	)
-	err = k.SetTotalShares(ctx, constants.Vault_Clob_0, negativeShares)
+	err = k.SetTotalShares(ctx, constants.Vault_Clob0, negativeShares)
 	require.Equal(t, vaulttypes.ErrNegativeShares, err)
-	got, exists = k.GetTotalShares(ctx, constants.Vault_Clob_0)
+	got, exists = k.GetTotalShares(ctx, constants.Vault_Clob0)
 	require.Equal(t, true, exists)
 	require.Equal(
 		t,
@@ -87,16 +84,16 @@ func TestGetSetOwnerShares(t *testing.T) {
 	bob := constants.BobAccAddress.String()
 
 	// Get owners shares for Alice in vault clob 0.
-	_, exists := k.GetOwnerShares(ctx, constants.Vault_Clob_0, alice)
+	_, exists := k.GetOwnerShares(ctx, constants.Vault_Clob0, alice)
 	require.Equal(t, false, exists)
 
 	// Set owner shares for Alice in vault clob 0 and get.
 	numShares := vaulttypes.BigIntToNumShares(
 		big.NewInt(7),
 	)
-	err := k.SetOwnerShares(ctx, constants.Vault_Clob_0, alice, numShares)
+	err := k.SetOwnerShares(ctx, constants.Vault_Clob0, alice, numShares)
 	require.NoError(t, err)
-	got, exists := k.GetOwnerShares(ctx, constants.Vault_Clob_0, alice)
+	got, exists := k.GetOwnerShares(ctx, constants.Vault_Clob0, alice)
 	require.Equal(t, true, exists)
 	require.Equal(t, numShares, got)
 
@@ -104,9 +101,9 @@ func TestGetSetOwnerShares(t *testing.T) {
 	numShares = vaulttypes.BigIntToNumShares(
 		big.NewInt(456),
 	)
-	err = k.SetOwnerShares(ctx, constants.Vault_Clob_1, alice, numShares)
+	err = k.SetOwnerShares(ctx, constants.Vault_Clob1, alice, numShares)
 	require.NoError(t, err)
-	got, exists = k.GetOwnerShares(ctx, constants.Vault_Clob_1, alice)
+	got, exists = k.GetOwnerShares(ctx, constants.Vault_Clob1, alice)
 	require.Equal(t, true, exists)
 	require.Equal(t, numShares, got)
 
@@ -114,9 +111,9 @@ func TestGetSetOwnerShares(t *testing.T) {
 	numShares = vaulttypes.BigIntToNumShares(
 		big.NewInt(0),
 	)
-	err = k.SetOwnerShares(ctx, constants.Vault_Clob_1, bob, numShares)
+	err = k.SetOwnerShares(ctx, constants.Vault_Clob1, bob, numShares)
 	require.NoError(t, err)
-	got, exists = k.GetOwnerShares(ctx, constants.Vault_Clob_1, bob)
+	got, exists = k.GetOwnerShares(ctx, constants.Vault_Clob1, bob)
 	require.Equal(t, true, exists)
 	require.Equal(t, numShares, got)
 
@@ -125,9 +122,9 @@ func TestGetSetOwnerShares(t *testing.T) {
 	numSharesInvalid := vaulttypes.BigIntToNumShares(
 		big.NewInt(-1),
 	)
-	err = k.SetOwnerShares(ctx, constants.Vault_Clob_1, bob, numSharesInvalid)
+	err = k.SetOwnerShares(ctx, constants.Vault_Clob1, bob, numSharesInvalid)
 	require.ErrorIs(t, err, vaulttypes.ErrNegativeShares)
-	got, exists = k.GetOwnerShares(ctx, constants.Vault_Clob_1, bob)
+	got, exists = k.GetOwnerShares(ctx, constants.Vault_Clob1, bob)
 	require.Equal(t, true, exists)
 	require.Equal(t, numShares, got)
 }
@@ -138,7 +135,7 @@ func TestGetAllOwnerShares(t *testing.T) {
 	k := tApp.App.VaultKeeper
 
 	// Get all owner shares of a vault that has no owners.
-	allOwnerShares := k.GetAllOwnerShares(ctx, constants.Vault_Clob_0)
+	allOwnerShares := k.GetAllOwnerShares(ctx, constants.Vault_Clob0)
 	require.Equal(t, []*vaulttypes.OwnerShare{}, allOwnerShares)
 
 	// Set alice and bob as owners of a vault and get all owner shares.
@@ -147,12 +144,12 @@ func TestGetAllOwnerShares(t *testing.T) {
 	bob := constants.BobAccAddress.String()
 	bobShares := vaulttypes.BigIntToNumShares(big.NewInt(123))
 
-	err := k.SetOwnerShares(ctx, constants.Vault_Clob_0, alice, aliceShares)
+	err := k.SetOwnerShares(ctx, constants.Vault_Clob0, alice, aliceShares)
 	require.NoError(t, err)
-	err = k.SetOwnerShares(ctx, constants.Vault_Clob_0, bob, bobShares)
+	err = k.SetOwnerShares(ctx, constants.Vault_Clob0, bob, bobShares)
 	require.NoError(t, err)
 
-	allOwnerShares = k.GetAllOwnerShares(ctx, constants.Vault_Clob_0)
+	allOwnerShares = k.GetAllOwnerShares(ctx, constants.Vault_Clob0)
 	require.ElementsMatch(
 		t,
 		[]*vaulttypes.OwnerShare{
@@ -167,232 +164,4 @@ func TestGetAllOwnerShares(t *testing.T) {
 		},
 		allOwnerShares,
 	)
-}
-
-func TestMintShares(t *testing.T) {
-	tests := map[string]struct {
-		/* --- Setup --- */
-		// Vault ID.
-		vaultId vaulttypes.VaultId
-		// Existing vault equity.
-		equity *big.Int
-		// Existing vault TotalShares.
-		totalShares *big.Int
-		// Owner that deposits.
-		owner string
-		// Existing owner shares.
-		ownerShares *big.Int
-		// Quote quantums to deposit.
-		quantumsToDeposit *big.Int
-
-		/* --- Expectations --- */
-		// Expected TotalShares after minting.
-		expectedTotalShares *big.Int
-		// Expected OwnerShares after minting.
-		expectedOwnerShares *big.Int
-		// Expected error.
-		expectedErr error
-	}{
-		"Equity 0, TotalShares 0, OwnerShares 0, Deposit 1000": {
-			vaultId:           constants.Vault_Clob_0,
-			equity:            big.NewInt(0),
-			totalShares:       big.NewInt(0),
-			owner:             constants.AliceAccAddress.String(),
-			ownerShares:       big.NewInt(0),
-			quantumsToDeposit: big.NewInt(1_000),
-			// Should mint `1_000` shares.
-			expectedTotalShares: big.NewInt(1_000),
-			expectedOwnerShares: big.NewInt(1_000),
-		},
-		"Equity 0, TotalShares non-existent, OwnerShares non-existent, Deposit 12345654321": {
-			vaultId:           constants.Vault_Clob_0,
-			equity:            big.NewInt(0),
-			owner:             constants.AliceAccAddress.String(),
-			quantumsToDeposit: big.NewInt(12_345_654_321),
-			// Should mint `12_345_654_321` shares.
-			expectedTotalShares: big.NewInt(12_345_654_321),
-			expectedOwnerShares: big.NewInt(12_345_654_321),
-		},
-		"Equity 1000, TotalShares non-existent, OwnerShares non-existent, Deposit 500": {
-			vaultId:           constants.Vault_Clob_0,
-			equity:            big.NewInt(1_000),
-			owner:             constants.AliceAccAddress.String(),
-			quantumsToDeposit: big.NewInt(500),
-			// Should mint `500` shares.
-			expectedTotalShares: big.NewInt(500),
-			expectedOwnerShares: big.NewInt(500),
-		},
-		"Equity 4000, TotalShares 5000, OwnerShares 2500, Deposit 1000": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(4_000),
-			totalShares:       big.NewInt(5_000),
-			owner:             constants.AliceAccAddress.String(),
-			ownerShares:       big.NewInt(2_500),
-			quantumsToDeposit: big.NewInt(1_000),
-			// Should mint `1_250` shares.
-			expectedTotalShares: big.NewInt(6_250),
-			expectedOwnerShares: big.NewInt(3_750),
-		},
-		"Equity 1_000_000, TotalShares 2_000, OwnerShares 1, Deposit 1_000": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(1_000_000),
-			totalShares:       big.NewInt(2_000),
-			owner:             constants.BobAccAddress.String(),
-			ownerShares:       big.NewInt(1),
-			quantumsToDeposit: big.NewInt(1_000),
-			// Should mint `2` shares.
-			expectedTotalShares: big.NewInt(2_002),
-			expectedOwnerShares: big.NewInt(3),
-		},
-		"Equity 8000, TotalShares 4000, OwnerShares 101, Deposit 455": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(8_000),
-			totalShares:       big.NewInt(4_000),
-			owner:             constants.CarlAccAddress.String(),
-			ownerShares:       big.NewInt(101),
-			quantumsToDeposit: big.NewInt(455),
-			// Should mint `227.5` shares, round down to 227.
-			expectedTotalShares: big.NewInt(4_227),
-			expectedOwnerShares: big.NewInt(328),
-		},
-		"Equity 123456, TotalShares 654321, OwnerShares 0, Deposit 123456789": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(123_456),
-			totalShares:       big.NewInt(654_321),
-			owner:             constants.DaveAccAddress.String(),
-			quantumsToDeposit: big.NewInt(123_456_789),
-			// Should mint `654_325_181.727` shares, round down to 654_325_181.
-			expectedTotalShares: big.NewInt(654_979_502),
-			expectedOwnerShares: big.NewInt(654_325_181),
-		},
-		"Equity 1000000, TotalShares 1000, OwnerShares 0, Deposit 9_900": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(1_000_000),
-			totalShares:       big.NewInt(1_000),
-			owner:             constants.DaveAccAddress.String(),
-			quantumsToDeposit: big.NewInt(9_900),
-			// Should mint `9_900 * 1_000 / 1_000_000` shares, round down to 9.
-			expectedTotalShares: big.NewInt(1_009),
-			expectedOwnerShares: big.NewInt(9),
-		},
-		"Equity -1, TotalShares 10, Deposit 1": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(-1),
-			totalShares:       big.NewInt(10),
-			owner:             constants.AliceAccAddress.String(),
-			quantumsToDeposit: big.NewInt(1),
-			expectedErr:       vaulttypes.ErrNonPositiveEquity,
-		},
-		"Equity 1, TotalShares 1, Deposit 0": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(1),
-			totalShares:       big.NewInt(1),
-			owner:             constants.AliceAccAddress.String(),
-			quantumsToDeposit: big.NewInt(0),
-			expectedErr:       vaulttypes.ErrInvalidDepositAmount,
-		},
-		"Equity 0, TotalShares non-existent, Deposit -1": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(0),
-			owner:             constants.AliceAccAddress.String(),
-			quantumsToDeposit: big.NewInt(-1),
-			expectedErr:       vaulttypes.ErrInvalidDepositAmount,
-		},
-		"Equity 1000, TotalShares 1, Deposit 100": {
-			vaultId:           constants.Vault_Clob_1,
-			equity:            big.NewInt(1_000),
-			totalShares:       big.NewInt(1),
-			owner:             constants.AliceAccAddress.String(),
-			quantumsToDeposit: big.NewInt(100),
-			expectedErr:       vaulttypes.ErrZeroSharesToMint,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			// Initialize tApp and ctx.
-			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
-				genesis = testapp.DefaultGenesis()
-				// Initialize vault with its existing equity.
-				testapp.UpdateGenesisDocWithAppStateForModule(
-					&genesis,
-					func(genesisState *satypes.GenesisState) {
-						genesisState.Subaccounts = []satypes.Subaccount{
-							{
-								Id: tc.vaultId.ToSubaccountId(),
-								AssetPositions: []*satypes.AssetPosition{
-									testutil.CreateSingleAssetPosition(
-										0,
-										tc.equity,
-									),
-								},
-							},
-						}
-					},
-				)
-				return genesis
-			}).Build()
-			ctx := tApp.InitChain()
-
-			// Set vault's existing total shares if specified.
-			if tc.totalShares != nil {
-				err := tApp.App.VaultKeeper.SetTotalShares(
-					ctx,
-					tc.vaultId,
-					vaulttypes.BigIntToNumShares(tc.totalShares),
-				)
-				require.NoError(t, err)
-			}
-			// Set vault's existing owner shares if specified.
-			if tc.ownerShares != nil {
-				err := tApp.App.VaultKeeper.SetOwnerShares(
-					ctx,
-					tc.vaultId,
-					tc.owner,
-					vaulttypes.BigIntToNumShares(tc.ownerShares),
-				)
-				require.NoError(t, err)
-			}
-
-			// Mint shares.
-			err := tApp.App.VaultKeeper.MintShares(
-				ctx,
-				tc.vaultId,
-				tc.owner,
-				tc.quantumsToDeposit,
-			)
-			if tc.expectedErr != nil {
-				// Check that error is as expected.
-				require.ErrorContains(t, err, tc.expectedErr.Error())
-				// Check that TotalShares is unchanged.
-				totalShares, _ := tApp.App.VaultKeeper.GetTotalShares(ctx, tc.vaultId)
-				require.Equal(
-					t,
-					vaulttypes.BigIntToNumShares(tc.totalShares),
-					totalShares,
-				)
-				// Check that OwnerShares is unchanged.
-				ownerShares, _ := tApp.App.VaultKeeper.GetOwnerShares(ctx, tc.vaultId, tc.owner)
-				require.Equal(t, vaulttypes.BigIntToNumShares(tc.ownerShares), ownerShares)
-			} else {
-				require.NoError(t, err)
-				// Check that TotalShares is as expected.
-				totalShares, exists := tApp.App.VaultKeeper.GetTotalShares(ctx, tc.vaultId)
-				require.True(t, exists)
-				require.Equal(
-					t,
-					vaulttypes.BigIntToNumShares(tc.expectedTotalShares),
-					totalShares,
-				)
-				// Check that OwnerShares is as expected.
-				ownerShares, exists := tApp.App.VaultKeeper.GetOwnerShares(ctx, tc.vaultId, tc.owner)
-				require.True(t, exists)
-				require.Equal(
-					t,
-					vaulttypes.BigIntToNumShares(tc.expectedOwnerShares),
-					ownerShares,
-				)
-			}
-		})
-	}
 }

--- a/protocol/x/vault/keeper/vault_test.go
+++ b/protocol/x/vault/keeper/vault_test.go
@@ -30,8 +30,8 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 	}{
 		"Decommission no vault": {
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: []*big.Int{
 				big.NewInt(7),
@@ -48,8 +48,8 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 		},
 		"Decommission one vault": {
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: []*big.Int{
 				big.NewInt(7),
@@ -66,8 +66,8 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 		},
 		"Decommission two vaults": {
 			vaultIds: []vaulttypes.VaultId{
-				constants.Vault_Clob_0,
-				constants.Vault_Clob_1,
+				constants.Vault_Clob0,
+				constants.Vault_Clob1,
 			},
 			totalShares: []*big.Int{
 				big.NewInt(7),
@@ -160,19 +160,19 @@ func TestDecommissionVault(t *testing.T) {
 		owners []string
 	}{
 		"Total shares doesn't exist, no owners": {
-			vaultId: constants.Vault_Clob_0,
+			vaultId: constants.Vault_Clob0,
 		},
 		"Total shares exists, no owners": {
-			vaultId:           constants.Vault_Clob_0,
+			vaultId:           constants.Vault_Clob0,
 			totalSharesExists: true,
 		},
 		"Total shares exists, one owner": {
-			vaultId:           constants.Vault_Clob_1,
+			vaultId:           constants.Vault_Clob1,
 			totalSharesExists: true,
 			owners:            []string{constants.Alice_Num0.Owner},
 		},
 		"Total shares exists, two owners": {
-			vaultId:           constants.Vault_Clob_1,
+			vaultId:           constants.Vault_Clob1,
 			totalSharesExists: true,
 			owners: []string{
 				constants.Alice_Num0.Owner,

--- a/protocol/x/vault/keeper/withdraw.go
+++ b/protocol/x/vault/keeper/withdraw.go
@@ -1,0 +1,30 @@
+package keeper
+
+import (
+	"cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+)
+
+// ValidateWithdrawFromVault performs stateful validations on `MsgWithdrawFromVault`.
+func (k Keeper) ValidateWithdrawFromVault(
+	ctx sdk.Context,
+	msgWithdraw *types.MsgWithdrawFromVault,
+) error {
+	// 1. Vault exists.
+	if _, vaultExists := k.GetTotalShares(ctx, *msgWithdraw.GetVaultId()); !vaultExists {
+		return errors.Wrapf(types.ErrVaultNotFound, "VaultId: %v", *msgWithdraw.GetVaultId())
+	}
+
+	// 2. Subaccount has shares in the vault.
+	_, sharesExists := k.GetOwnerShares(ctx, *msgWithdraw.GetVaultId(), msgWithdraw.SubaccountId.GetOwner())
+	if !sharesExists {
+		return errors.Wrapf(
+			types.ErrOwnerShareNotFound,
+			"VaultId: %v, Owner: %v",
+			*msgWithdraw.GetVaultId(),
+			msgWithdraw.SubaccountId.GetOwner(),
+		)
+	}
+	return nil
+}

--- a/protocol/x/vault/keeper/withdraw_test.go
+++ b/protocol/x/vault/keeper/withdraw_test.go
@@ -50,47 +50,83 @@ func TestValidateWithdrawFromVault(t *testing.T) {
 		"Success: single owner": {
 			vaultState: constants.Vault_Clob0_SingleOwner_Alice0_1000,
 			msg: vaulttypes.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob0,
-				SubaccountId:  &constants.Alice_Num0,
-				QuoteQuantums: dtypes.NewInt(100),
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Alice_Num0,
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(1)},
 			},
 			expectedErr: nil,
 		},
 		"Success: multiple owners": {
 			vaultState: constants.Vault_Clob0_MultiOwner_Alice0_1000_Bob0_2500,
 			msg: vaulttypes.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob0,
-				SubaccountId:  &constants.Bob_Num0,
-				QuoteQuantums: dtypes.NewInt(100),
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Bob_Num0,
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(1)},
+			},
+			expectedErr: nil,
+		},
+		"Success: single owner, max shares": {
+			vaultState: constants.Vault_Clob0_SingleOwner_Alice0_1000,
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Alice_Num0,
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(1000)},
+			},
+			expectedErr: nil,
+		},
+		"Success: multiple owners, max shares": {
+			vaultState: constants.Vault_Clob0_MultiOwner_Alice0_1000_Bob0_2500,
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Bob_Num0,
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(2500)},
 			},
 			expectedErr: nil,
 		},
 		"Failure: no vault": {
 			vaultState: constants.VaultState{}, // nil vault state.
 			msg: vaulttypes.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob0, // vault 0 doesn't exist.
-				SubaccountId:  &constants.Alice_Num0,
-				QuoteQuantums: dtypes.NewInt(100),
+				VaultId:      &constants.Vault_Clob0, // vault 0 doesn't exist.
+				SubaccountId: &constants.Alice_Num0,
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(1)},
 			},
 			expectedErr: vaulttypes.ErrVaultNotFound,
 		},
 		"Failure: no matching vault": {
 			vaultState: constants.Vault_Clob0_SingleOwner_Alice0_1000,
 			msg: vaulttypes.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob1, // vault 1 doesn't exist.
-				SubaccountId:  &constants.Alice_Num0,
-				QuoteQuantums: dtypes.NewInt(100),
+				VaultId:      &constants.Vault_Clob1, // vault 1 doesn't exist.
+				SubaccountId: &constants.Alice_Num0,
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(1)},
 			},
 			expectedErr: vaulttypes.ErrVaultNotFound,
 		},
 		"Failure: no matching shares": {
 			vaultState: constants.Vault_Clob0_MultiOwner_Alice0_1000_Bob0_2500,
 			msg: vaulttypes.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob0,
-				SubaccountId:  &constants.Carl_Num0, // Carl doesn't have any shares.
-				QuoteQuantums: dtypes.NewInt(100),
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Carl_Num0, // Carl doesn't have any shares.
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(1)},
 			},
 			expectedErr: vaulttypes.ErrOwnerShareNotFound,
+		},
+		"Failure: single owner, shares greater than owner shares": {
+			vaultState: constants.Vault_Clob0_SingleOwner_Alice0_1000,
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Alice_Num0,
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(1001)},
+			},
+			expectedErr: vaulttypes.ErrInvalidWithdrawalAmount,
+		},
+		"Failure: multiple owners, shares greater than owner shares": {
+			vaultState: constants.Vault_Clob0_MultiOwner_Alice0_1000_Bob0_2500,
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Bob_Num0,
+				Shares:       &vaulttypes.NumShares{NumShares: dtypes.NewInt(2501)},
+			},
+			expectedErr: vaulttypes.ErrInvalidWithdrawalAmount,
 		},
 	}
 

--- a/protocol/x/vault/keeper/withdraw_test.go
+++ b/protocol/x/vault/keeper/withdraw_test.go
@@ -1,0 +1,121 @@
+package keeper_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/cometbft/cometbft/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func setVaultState(t *testing.T, tApp *testapp.TestApp, ctx sdk.Context, vaultState constants.VaultState) {
+	totalShares := big.NewInt(0)
+	for _, ownerShare := range vaultState.OwnerShares {
+		totalShares.Add(totalShares, ownerShare.Shares.NumShares.BigInt())
+
+		err := tApp.App.VaultKeeper.SetOwnerShares(
+			ctx,
+			vaultState.VaultId,
+			ownerShare.Owner,
+			*ownerShare.Shares,
+		)
+		require.NoError(t, err)
+	}
+
+	// Set vault's total shares.
+	err := tApp.App.VaultKeeper.SetTotalShares(
+		ctx,
+		vaultState.VaultId,
+		vaulttypes.BigIntToNumShares(totalShares),
+	)
+	require.NoError(t, err)
+}
+
+func TestValidateWithdrawFromVault(t *testing.T) {
+	tests := map[string]struct {
+		/* --- Setup --- */
+		vaultState constants.VaultState
+
+		/* --- Inputs --- */
+		msg vaulttypes.MsgWithdrawFromVault
+
+		/* --- Expectations --- */
+		expectedErr error
+	}{
+		"Success: single owner": {
+			vaultState: constants.Vault_Clob0_SingleOwner_Alice0_1000,
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:       &constants.Vault_Clob0,
+				SubaccountId:  &constants.Alice_Num0,
+				QuoteQuantums: dtypes.NewInt(100),
+			},
+			expectedErr: nil,
+		},
+		"Success: multiple owners": {
+			vaultState: constants.Vault_Clob0_MultiOwner_Alice0_1000_Bob0_2500,
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:       &constants.Vault_Clob0,
+				SubaccountId:  &constants.Bob_Num0,
+				QuoteQuantums: dtypes.NewInt(100),
+			},
+			expectedErr: nil,
+		},
+		"Failure: no vault": {
+			vaultState: constants.VaultState{}, // nil vault state.
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:       &constants.Vault_Clob0, // vault 0 doesn't exist.
+				SubaccountId:  &constants.Alice_Num0,
+				QuoteQuantums: dtypes.NewInt(100),
+			},
+			expectedErr: vaulttypes.ErrVaultNotFound,
+		},
+		"Failure: no matching vault": {
+			vaultState: constants.Vault_Clob0_SingleOwner_Alice0_1000,
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:       &constants.Vault_Clob1, // vault 1 doesn't exist.
+				SubaccountId:  &constants.Alice_Num0,
+				QuoteQuantums: dtypes.NewInt(100),
+			},
+			expectedErr: vaulttypes.ErrVaultNotFound,
+		},
+		"Failure: no matching shares": {
+			vaultState: constants.Vault_Clob0_MultiOwner_Alice0_1000_Bob0_2500,
+			msg: vaulttypes.MsgWithdrawFromVault{
+				VaultId:       &constants.Vault_Clob0,
+				SubaccountId:  &constants.Carl_Num0, // Carl doesn't have any shares.
+				QuoteQuantums: dtypes.NewInt(100),
+			},
+			expectedErr: vaulttypes.ErrOwnerShareNotFound,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Initialize tApp and ctx.
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+				return testapp.DefaultGenesis()
+			}).Build()
+			ctx := tApp.InitChain()
+
+			// Set vault's state if not nil.
+			if tc.vaultState.VaultId != (vaulttypes.VaultId{}) {
+				setVaultState(t, tApp, ctx, tc.vaultState)
+			}
+
+			// Run.
+			err := tApp.App.VaultKeeper.ValidateWithdrawFromVault(ctx, &tc.msg)
+
+			// Validate
+			if tc.expectedErr != nil {
+				require.ErrorContains(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -100,9 +100,4 @@ var (
 		19,
 		"Owner share not found",
 	)
-	ErrNotEnoughOwnerShare = errorsmod.Register(
-		ModuleName,
-		20,
-		"Owner share is less than or equal to zero",
-	)
 )

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -85,4 +85,24 @@ var (
 		16,
 		"TotalShares does not match sum of OwnerShares",
 	)
+	ErrInvalidWithdrawalAmount = errorsmod.Register(
+		ModuleName,
+		17,
+		"Withdrawal amount is invalid",
+	)
+	ErrVaultNotFound = errorsmod.Register(
+		ModuleName,
+		18,
+		"Vault not found",
+	)
+	ErrOwnerShareNotFound = errorsmod.Register(
+		ModuleName,
+		19,
+		"Owner share not found",
+	)
+	ErrNotEnoughOwnerShare = errorsmod.Register(
+		ModuleName,
+		20,
+		"Owner share is less than or equal to zero",
+	)
 )

--- a/protocol/x/vault/types/msg_withdraw_from_vault.go
+++ b/protocol/x/vault/types/msg_withdraw_from_vault.go
@@ -5,15 +5,15 @@ import (
 	"github.com/cosmos/cosmos-sdk/types"
 )
 
-var _ types.Msg = &MsgDepositToVault{}
+var _ types.Msg = &MsgWithdrawFromVault{}
 
-// ValidateBasic performs stateless validation on a MsgDepositToVault.
-func (msg *MsgDepositToVault) ValidateBasic() error {
+// ValidateBasic performs stateless validation on a MsgWithdrawFromVault.
+func (msg *MsgWithdrawFromVault) ValidateBasic() error {
 	// Note: msg signer must be the owner of the subaccount.
 	// This is enforced by the following notatino on the msg proto:
 	//    option (cosmos.msg.v1.signer) = "subaccount_id"
 
-	// Validate subaccount to deposit from.
+	// Validate subaccount to withdraw to.
 	if err := msg.SubaccountId.Validate(); err != nil {
 		return err
 	}
@@ -21,7 +21,7 @@ func (msg *MsgDepositToVault) ValidateBasic() error {
 	// Validate that quote quantums is positive and an uint64.
 	quoteQuantums := msg.QuoteQuantums.BigInt()
 	if quoteQuantums.Sign() <= 0 || !quoteQuantums.IsUint64() {
-		return errors.Wrap(ErrInvalidDepositAmount, "quote quantums must be strictly positive and less than 2^64")
+		return errors.Wrap(ErrInvalidWithdrawalAmount, "quote quantums must be strictly positive and less than 2^64")
 	}
 
 	return nil

--- a/protocol/x/vault/types/msg_withdraw_from_vault.go
+++ b/protocol/x/vault/types/msg_withdraw_from_vault.go
@@ -18,10 +18,9 @@ func (msg *MsgWithdrawFromVault) ValidateBasic() error {
 		return err
 	}
 
-	// Validate that quote quantums is positive and an uint64.
-	quoteQuantums := msg.QuoteQuantums.BigInt()
-	if quoteQuantums.Sign() <= 0 || !quoteQuantums.IsUint64() {
-		return errors.Wrap(ErrInvalidWithdrawalAmount, "quote quantums must be strictly positive and less than 2^64")
+	// Validate that `shares` is positive.
+	if msg.Shares.NumShares.Sign() <= 0 {
+		return errors.Wrap(ErrInvalidWithdrawalAmount, "shares must be strictly positive")
 	}
 
 	return nil

--- a/protocol/x/vault/types/msg_withdraw_from_vault_test.go
+++ b/protocol/x/vault/types/msg_withdraw_from_vault_test.go
@@ -12,27 +12,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMsgDepositToVault_ValidateBasic(t *testing.T) {
+func TestMsgWithdrawFromVault_ValidateBasic(t *testing.T) {
 	tests := map[string]struct {
-		msg         types.MsgDepositToVault
+		msg         types.MsgWithdrawFromVault
 		expectedErr string
 	}{
 		"Success": {
-			msg: types.MsgDepositToVault{
+			msg: types.MsgWithdrawFromVault{
 				VaultId:       &constants.Vault_Clob0,
 				SubaccountId:  &constants.Alice_Num0,
 				QuoteQuantums: dtypes.NewInt(1),
 			},
 		},
 		"Success: max uint64 quote quantums": {
-			msg: types.MsgDepositToVault{
+			msg: types.MsgWithdrawFromVault{
 				VaultId:       &constants.Vault_Clob0,
 				SubaccountId:  &constants.Alice_Num0,
 				QuoteQuantums: dtypes.NewIntFromUint64(math.MaxUint64),
 			},
 		},
 		"Failure: quote quantums greater than max uint64": {
-			msg: types.MsgDepositToVault{
+			msg: types.MsgWithdrawFromVault{
 				VaultId:      &constants.Vault_Clob0,
 				SubaccountId: &constants.Alice_Num0,
 				QuoteQuantums: dtypes.NewIntFromBigInt(
@@ -42,26 +42,26 @@ func TestMsgDepositToVault_ValidateBasic(t *testing.T) {
 					),
 				),
 			},
-			expectedErr: "Deposit amount is invalid",
+			expectedErr: "Withdrawal amount is invalid",
 		},
 		"Failure: zero quote quantums": {
-			msg: types.MsgDepositToVault{
+			msg: types.MsgWithdrawFromVault{
 				VaultId:       &constants.Vault_Clob0,
 				SubaccountId:  &constants.Alice_Num0,
 				QuoteQuantums: dtypes.NewInt(0),
 			},
-			expectedErr: "Deposit amount is invalid",
+			expectedErr: "Withdrawal amount is invalid",
 		},
 		"Failure: negative quote quantums": {
-			msg: types.MsgDepositToVault{
+			msg: types.MsgWithdrawFromVault{
 				VaultId:       &constants.Vault_Clob0,
 				SubaccountId:  &constants.Alice_Num0,
 				QuoteQuantums: dtypes.NewInt(-1),
 			},
-			expectedErr: "Deposit amount is invalid",
+			expectedErr: "Withdrawal amount is invalid",
 		},
 		"Failure: invalid subaccount owner": {
-			msg: types.MsgDepositToVault{
+			msg: types.MsgWithdrawFromVault{
 				VaultId: &constants.Vault_Clob0,
 				SubaccountId: &satypes.SubaccountId{
 					Owner:  "invalid-owner",

--- a/protocol/x/vault/types/msg_withdraw_from_vault_test.go
+++ b/protocol/x/vault/types/msg_withdraw_from_vault_test.go
@@ -19,46 +19,38 @@ func TestMsgWithdrawFromVault_ValidateBasic(t *testing.T) {
 	}{
 		"Success": {
 			msg: types.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob0,
-				SubaccountId:  &constants.Alice_Num0,
-				QuoteQuantums: dtypes.NewInt(1),
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Alice_Num0,
+				Shares:       &types.NumShares{dtypes.NewInt(1)},
 			},
 		},
-		"Success: max uint64 quote quantums": {
-			msg: types.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob0,
-				SubaccountId:  &constants.Alice_Num0,
-				QuoteQuantums: dtypes.NewIntFromUint64(math.MaxUint64),
-			},
-		},
-		"Failure: quote quantums greater than max uint64": {
+		"Success: shares greater than max uint64": {
 			msg: types.MsgWithdrawFromVault{
 				VaultId:      &constants.Vault_Clob0,
 				SubaccountId: &constants.Alice_Num0,
-				QuoteQuantums: dtypes.NewIntFromBigInt(
+				Shares: &types.NumShares{dtypes.NewIntFromBigInt(
 					new(big.Int).Add(
 						new(big.Int).SetUint64(math.MaxUint64),
 						new(big.Int).SetUint64(1),
 					),
-				),
+				)},
 			},
-			expectedErr: "Withdrawal amount is invalid",
 		},
-		"Failure: zero quote quantums": {
+		"Failure: zero shares": {
 			msg: types.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob0,
-				SubaccountId:  &constants.Alice_Num0,
-				QuoteQuantums: dtypes.NewInt(0),
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Alice_Num0,
+				Shares:       &types.NumShares{dtypes.NewInt(0)},
 			},
-			expectedErr: "Withdrawal amount is invalid",
+			expectedErr: "shares must be strictly positive: Withdrawal amount is invalid",
 		},
-		"Failure: negative quote quantums": {
+		"Failure: negative shares": {
 			msg: types.MsgWithdrawFromVault{
-				VaultId:       &constants.Vault_Clob0,
-				SubaccountId:  &constants.Alice_Num0,
-				QuoteQuantums: dtypes.NewInt(-1),
+				VaultId:      &constants.Vault_Clob0,
+				SubaccountId: &constants.Alice_Num0,
+				Shares:       &types.NumShares{dtypes.NewInt(-1)},
 			},
-			expectedErr: "Withdrawal amount is invalid",
+			expectedErr: "shares must be strictly positive: Withdrawal amount is invalid",
 		},
 		"Failure: invalid subaccount owner": {
 			msg: types.MsgWithdrawFromVault{
@@ -67,7 +59,7 @@ func TestMsgWithdrawFromVault_ValidateBasic(t *testing.T) {
 					Owner:  "invalid-owner",
 					Number: 0,
 				},
-				QuoteQuantums: dtypes.NewInt(1),
+				Shares: &types.NumShares{dtypes.NewInt(1)},
 			},
 			expectedErr: "subaccount id owner is an invalid address",
 		},

--- a/protocol/x/vault/types/vault_id_test.go
+++ b/protocol/x/vault/types/vault_id_test.go
@@ -18,11 +18,11 @@ func TestToString(t *testing.T) {
 		expectedStr string
 	}{
 		"Vault for Clob Pair 0": {
-			vaultId:     constants.Vault_Clob_0,
+			vaultId:     constants.Vault_Clob0,
 			expectedStr: "VAULT_TYPE_CLOB-0",
 		},
 		"Vault for Clob Pair 1": {
-			vaultId:     constants.Vault_Clob_1,
+			vaultId:     constants.Vault_Clob1,
 			expectedStr: "VAULT_TYPE_CLOB-1",
 		},
 		"Vault, missing type and number": {
@@ -58,13 +58,13 @@ func TestToStateKey(t *testing.T) {
 	require.Equal(
 		t,
 		[]byte("VAULT_TYPE_CLOB-0"),
-		constants.Vault_Clob_0.ToStateKey(),
+		constants.Vault_Clob0.ToStateKey(),
 	)
 
 	require.Equal(
 		t,
 		[]byte("VAULT_TYPE_CLOB-1"),
-		constants.Vault_Clob_1.ToStateKey(),
+		constants.Vault_Clob1.ToStateKey(),
 	)
 }
 
@@ -79,11 +79,11 @@ func TestGetVaultIdFromStateKey(t *testing.T) {
 	}{
 		"Vault for Clob Pair 0": {
 			stateKey:        []byte("VAULT_TYPE_CLOB-0"),
-			expectedVaultId: constants.Vault_Clob_0,
+			expectedVaultId: constants.Vault_Clob0,
 		},
 		"Vault for Clob Pair 1": {
 			stateKey:        []byte("VAULT_TYPE_CLOB-1"),
-			expectedVaultId: constants.Vault_Clob_1,
+			expectedVaultId: constants.Vault_Clob1,
 		},
 		"Empty bytes": {
 			stateKey:    []byte{},
@@ -120,12 +120,12 @@ func TestToModuleAccountAddress(t *testing.T) {
 	require.Equal(
 		t,
 		authtypes.NewModuleAddress("vault-VAULT_TYPE_CLOB-0").String(),
-		constants.Vault_Clob_0.ToModuleAccountAddress(),
+		constants.Vault_Clob0.ToModuleAccountAddress(),
 	)
 	require.Equal(
 		t,
 		authtypes.NewModuleAddress("vault-VAULT_TYPE_CLOB-1").String(),
-		constants.Vault_Clob_1.ToModuleAccountAddress(),
+		constants.Vault_Clob1.ToModuleAccountAddress(),
 	)
 }
 
@@ -133,17 +133,17 @@ func TestToSubaccountId(t *testing.T) {
 	require.Equal(
 		t,
 		satypes.SubaccountId{
-			Owner:  constants.Vault_Clob_0.ToModuleAccountAddress(),
+			Owner:  constants.Vault_Clob0.ToModuleAccountAddress(),
 			Number: 0,
 		},
-		*constants.Vault_Clob_0.ToSubaccountId(),
+		*constants.Vault_Clob0.ToSubaccountId(),
 	)
 	require.Equal(
 		t,
 		satypes.SubaccountId{
-			Owner:  constants.Vault_Clob_1.ToModuleAccountAddress(),
+			Owner:  constants.Vault_Clob1.ToModuleAccountAddress(),
 			Number: 0,
 		},
-		*constants.Vault_Clob_1.ToSubaccountId(),
+		*constants.Vault_Clob1.ToSubaccountId(),
 	)
 }


### PR DESCRIPTION
### Changelist
* keeper -> `ValidateWithdrawFromVault` does stateful validations like 1) vault exists and 2) subaccount has shares in the vault and 3) owner shares > withdraw shares
* types -> `ValidateBasic` does stateless validations like 1) subaccount is valid format and 2) quote quantum is positive + uint64

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `VaultState` struct to manage vault details including `VaultId`, `Equity`, and `OwnerShares`.
	- Added new vault instances for single and multiple owners.

- **Bug Fixes**
	- Updated references to ensure consistency in vault naming conventions for better clarity.

- **Tests**
	- Added test cases for validating withdrawal functionality ensuring robust vault operations and various owner scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->