### PR TITLE
Align screen & geoblock compliance endpoints

### DIFF
--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -5,7 +5,10 @@
 
 Base URLs:
 
-* <a href=""></a>
+* For **the deployment by DYDX token holders**, use <a href="https://indexer.dydx.trade/v4">https://indexer.dydx.trade/v4</a>
+* For **Testnet**, use <a href="https://dydx-testnet.imperator.co/v4">https://dydx-testnet.imperator.co/v4</a>
+
+Note: Messages on Indexer WebSocket feeds are typically more recent than data fetched via Indexer's REST API, because the latter is backed by read replicas of the databases that feed the former. Ordinarily this difference is minimal (less than a second), but it might become prolonged under load. Please see [Indexer Architecture](https://dydx.exchange/blog/v4-deep-dive-indexer) for more information.
 
 # Authentication
 
@@ -23,7 +26,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/addresses/{address}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/addresses/{address}', headers = headers)
 
 print(r.json())
 
@@ -35,7 +42,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/addresses/{address}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/addresses/{address}`,
 {
   method: 'GET',
 
@@ -66,7 +77,7 @@ fetch('/addresses/{address}',
   "subaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0,
+      "subaccountNumber": 0.1,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -86,7 +97,7 @@ fetch('/addresses/{address}',
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         },
         "property2": {
           "market": "string",
@@ -104,7 +115,7 @@ fetch('/addresses/{address}',
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         }
       },
       "assetPositions": {
@@ -113,14 +124,14 @@ fetch('/addresses/{address}',
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         }
       },
       "marginEnabled": true,
@@ -154,7 +165,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/addresses/{address}/subaccountNumber/{subaccountNumber}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}', headers = headers)
 
 print(r.json())
 
@@ -166,7 +181,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/addresses/{address}/subaccountNumber/{subaccountNumber}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
 {
   method: 'GET',
 
@@ -196,7 +215,7 @@ fetch('/addresses/{address}/subaccountNumber/{subaccountNumber}',
 ```json
 {
   "address": "string",
-  "subaccountNumber": 0,
+  "subaccountNumber": 0.1,
   "equity": "string",
   "freeCollateral": "string",
   "openPerpetualPositions": {
@@ -216,7 +235,7 @@ fetch('/addresses/{address}/subaccountNumber/{subaccountNumber}',
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     },
     "property2": {
       "market": "string",
@@ -234,7 +253,7 @@ fetch('/addresses/{address}/subaccountNumber/{subaccountNumber}',
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   },
   "assetPositions": {
@@ -243,14 +262,14 @@ fetch('/addresses/{address}/subaccountNumber/{subaccountNumber}',
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     },
     "property2": {
       "symbol": "string",
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   },
   "marginEnabled": true,
@@ -281,7 +300,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}', headers = headers)
 
 print(r.json())
 
@@ -293,7 +316,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}`,
 {
   method: 'GET',
 
@@ -323,13 +350,13 @@ fetch('/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}',
 ```json
 {
   "address": "string",
-  "parentSubaccountNumber": 0,
+  "parentSubaccountNumber": 0.1,
   "equity": "string",
   "freeCollateral": "string",
   "childSubaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0,
+      "subaccountNumber": 0.1,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -349,7 +376,7 @@ fetch('/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}',
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         },
         "property2": {
           "market": "string",
@@ -367,7 +394,7 @@ fetch('/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}',
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         }
       },
       "assetPositions": {
@@ -376,14 +403,14 @@ fetch('/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}',
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         }
       },
       "marginEnabled": true,
@@ -416,8 +443,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/assetPositions', params={
-  'address': 'string',  'subaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/assetPositions', params={
+  'address': 'string',  'subaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -430,7 +461,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/assetPositions?address=string&subaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/assetPositions?address=string&subaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -465,7 +500,7 @@ fetch('/assetPositions?address=string&subaccountNumber=0',
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -493,8 +528,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/assetPositions/parentSubaccountNumber', params={
-  'address': 'string',  'parentSubaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/assetPositions/parentSubaccountNumber', params={
+  'address': 'string',  'parentSubaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -507,7 +546,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/assetPositions/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/assetPositions/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -542,7 +585,7 @@ fetch('/assetPositions/parentSubaccountNumber?address=string&parentSubaccountNum
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -570,7 +613,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/candles/perpetualMarkets/{ticker}', params={
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/candles/perpetualMarkets/{ticker}', params={
   'resolution': '1MIN'
 }, headers = headers)
 
@@ -584,7 +631,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/candles/perpetualMarkets/{ticker}?resolution=1MIN',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/candles/perpetualMarkets/{ticker}?resolution=1MIN`,
 {
   method: 'GET',
 
@@ -639,7 +690,7 @@ fetch('/candles/perpetualMarkets/{ticker}?resolution=1MIN',
       "close": "string",
       "baseTokenVolume": "string",
       "usdVolume": "string",
-      "trades": 0,
+      "trades": 0.1,
       "startingOpenInterest": "string",
       "id": "string"
     }
@@ -669,7 +720,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/compliance/screen/{address}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/compliance/screen/{address}', headers = headers)
 
 print(r.json())
 
@@ -681,7 +736,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/compliance/screen/{address}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/compliance/screen/{address}`,
 {
   method: 'GET',
 
@@ -737,8 +796,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/fills', params={
-  'address': 'string',  'subaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/fills', params={
+  'address': 'string',  'subaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -751,7 +814,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/fills?address=string&subaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/fills?address=string&subaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -793,9 +860,9 @@ fetch('/fills?address=string&subaccountNumber=0',
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "fills": [
     {
       "id": "string",
@@ -811,7 +878,7 @@ fetch('/fills?address=string&subaccountNumber=0',
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -839,8 +906,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/fills/parentSubaccount', params={
-  'address': 'string',  'parentSubaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/fills/parentSubaccount', params={
+  'address': 'string',  'parentSubaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -853,7 +924,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/fills/parentSubaccount?address=string&parentSubaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/fills/parentSubaccount?address=string&parentSubaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -895,9 +970,9 @@ fetch('/fills/parentSubaccount?address=string&parentSubaccountNumber=0',
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "fills": [
     {
       "id": "string",
@@ -913,7 +988,7 @@ fetch('/fills/parentSubaccount?address=string&parentSubaccountNumber=0',
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -941,7 +1016,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/height', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/height', headers = headers)
 
 print(r.json())
 
@@ -953,7 +1032,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/height',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/height`,
 {
   method: 'GET',
 
@@ -1002,7 +1085,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/historicalBlockTradingRewards/{address}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/historicalBlockTradingRewards/{address}', headers = headers)
 
 print(r.json())
 
@@ -1014,7 +1101,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/historicalBlockTradingRewards/{address}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/historicalBlockTradingRewards/{address}`,
 {
   method: 'GET',
 
@@ -1077,7 +1168,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/historicalFunding/{ticker}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/historicalFunding/{ticker}', headers = headers)
 
 print(r.json())
 
@@ -1089,7 +1184,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/historicalFunding/{ticker}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/historicalFunding/{ticker}`,
 {
   method: 'GET',
 
@@ -1154,8 +1253,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/historical-pnl', params={
-  'address': 'string',  'subaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/historical-pnl', params={
+  'address': 'string',  'subaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -1168,7 +1271,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/historical-pnl?address=string&subaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/historical-pnl?address=string&subaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -1203,9 +1310,9 @@ fetch('/historical-pnl?address=string&subaccountNumber=0',
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "historicalPnl": [
     {
       "id": "string",
@@ -1243,8 +1350,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/historical-pnl/parentSubaccount', params={
-  'address': 'string',  'parentSubaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/historical-pnl/parentSubaccount', params={
+  'address': 'string',  'parentSubaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -1257,7 +1368,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/historical-pnl/parentSubaccount?address=string&parentSubaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/historical-pnl/parentSubaccount?address=string&parentSubaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -1292,9 +1407,9 @@ fetch('/historical-pnl/parentSubaccount?address=string&parentSubaccountNumber=0'
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "historicalPnl": [
     {
       "id": "string",
@@ -1332,7 +1447,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/historicalTradingRewardAggregations/{address}', params={
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/historicalTradingRewardAggregations/{address}', params={
   'period': 'DAILY'
 }, headers = headers)
 
@@ -1346,7 +1465,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/historicalTradingRewardAggregations/{address}?period=DAILY',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/historicalTradingRewardAggregations/{address}?period=DAILY`,
 {
   method: 'GET',
 
@@ -1421,7 +1544,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/orderbooks/perpetualMarket/{ticker}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/orderbooks/perpetualMarket/{ticker}', headers = headers)
 
 print(r.json())
 
@@ -1433,7 +1560,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/orderbooks/perpetualMarket/{ticker}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/orderbooks/perpetualMarket/{ticker}`,
 {
   method: 'GET',
 
@@ -1498,8 +1629,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/orders', params={
-  'address': 'string',  'subaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/orders', params={
+  'address': 'string',  'subaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -1512,7 +1647,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/orders?address=string&subaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/orders?address=string&subaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -1586,7 +1725,7 @@ fetch('/orders?address=string&subaccountNumber=0',
     "ticker": "string",
     "updatedAt": "string",
     "updatedAtHeight": "string",
-    "subaccountNumber": 0
+    "subaccountNumber": 0.1
   }
 ]
 ```
@@ -1684,8 +1823,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/orders/parentSubaccountNumber', params={
-  'address': 'string',  'parentSubaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/orders/parentSubaccountNumber', params={
+  'address': 'string',  'parentSubaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -1698,7 +1841,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/orders/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/orders/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -1772,7 +1919,7 @@ fetch('/orders/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
     "ticker": "string",
     "updatedAt": "string",
     "updatedAtHeight": "string",
-    "subaccountNumber": 0
+    "subaccountNumber": 0.1
   }
 ]
 ```
@@ -1870,7 +2017,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/orders/{orderId}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/orders/{orderId}', headers = headers)
 
 print(r.json())
 
@@ -1882,7 +2033,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/orders/{orderId}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/orders/{orderId}`,
 {
   method: 'GET',
 
@@ -1932,7 +2087,7 @@ fetch('/orders/{orderId}',
   "ticker": "string",
   "updatedAt": "string",
   "updatedAtHeight": "string",
-  "subaccountNumber": 0
+  "subaccountNumber": 0.1
 }
 ```
 
@@ -1958,7 +2113,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/perpetualMarkets', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/perpetualMarkets', headers = headers)
 
 print(r.json())
 
@@ -1970,7 +2129,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/perpetualMarkets',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/perpetualMarkets`,
 {
   method: 'GET',
 
@@ -2007,17 +2170,17 @@ fetch('/perpetualMarkets',
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0,
+      "trades24H": 0.1,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0,
-      "quantumConversionExponent": 0,
+      "atomicResolution": 0.1,
+      "quantumConversionExponent": 0.1,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0,
-      "subticksPerTick": 0,
+      "stepBaseQuantums": 0.1,
+      "subticksPerTick": 0.1,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -2030,17 +2193,17 @@ fetch('/perpetualMarkets',
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0,
+      "trades24H": 0.1,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0,
-      "quantumConversionExponent": 0,
+      "atomicResolution": 0.1,
+      "quantumConversionExponent": 0.1,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0,
-      "subticksPerTick": 0,
+      "stepBaseQuantums": 0.1,
+      "subticksPerTick": 0.1,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -2072,8 +2235,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/perpetualPositions', params={
-  'address': 'string',  'subaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/perpetualPositions', params={
+  'address': 'string',  'subaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -2086,7 +2253,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/perpetualPositions?address=string&subaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/perpetualPositions?address=string&subaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -2144,7 +2315,7 @@ fetch('/perpetualPositions?address=string&subaccountNumber=0',
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -2172,8 +2343,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/perpetualPositions/parentSubaccountNumber', params={
-  'address': 'string',  'parentSubaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/perpetualPositions/parentSubaccountNumber', params={
+  'address': 'string',  'parentSubaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -2186,7 +2361,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/perpetualPositions/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/perpetualPositions/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -2244,7 +2423,7 @@ fetch('/perpetualPositions/parentSubaccountNumber?address=string&parentSubaccoun
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -2272,7 +2451,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/sparklines', params={
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/sparklines', params={
   'timePeriod': 'ONE_DAY'
 }, headers = headers)
 
@@ -2286,7 +2469,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/sparklines?timePeriod=ONE_DAY',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/sparklines?timePeriod=ONE_DAY`,
 {
   method: 'GET',
 
@@ -2352,7 +2539,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/time', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/time', headers = headers)
 
 print(r.json())
 
@@ -2364,7 +2555,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/time',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/time`,
 {
   method: 'GET',
 
@@ -2387,7 +2582,7 @@ fetch('/time',
 ```json
 {
   "iso": "string",
-  "epoch": 0
+  "epoch": 0.1
 }
 ```
 
@@ -2413,7 +2608,11 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/trades/perpetualMarket/{ticker}', headers = headers)
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/trades/perpetualMarket/{ticker}', headers = headers)
 
 print(r.json())
 
@@ -2425,7 +2624,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/trades/perpetualMarket/{ticker}',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/trades/perpetualMarket/{ticker}`,
 {
   method: 'GET',
 
@@ -2457,9 +2660,9 @@ fetch('/trades/perpetualMarket/{ticker}',
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "trades": [
     {
       "id": "string",
@@ -2496,8 +2699,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/transfers', params={
-  'address': 'string',  'subaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/transfers', params={
+  'address': 'string',  'subaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -2510,7 +2717,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/transfers?address=string&subaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/transfers?address=string&subaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -2543,18 +2754,18 @@ fetch('/transfers?address=string&subaccountNumber=0',
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0,
+        "subaccountNumber": 0.1,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0,
+        "subaccountNumber": 0.1,
         "address": "string"
       },
       "size": "string",
@@ -2590,8 +2801,12 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('/transfers/parentSubaccountNumber', params={
-  'address': 'string',  'parentSubaccountNumber': '0'
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/transfers/parentSubaccountNumber', params={
+  'address': 'string',  'parentSubaccountNumber': '0.1'
 }, headers = headers)
 
 print(r.json())
@@ -2604,7 +2819,11 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('/transfers/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/transfers/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -2637,18 +2856,18 @@ fetch('/transfers/parentSubaccountNumber?address=string&parentSubaccountNumber=0
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0,
+        "subaccountNumber": 0.1,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0,
+        "subaccountNumber": 0.1,
         "address": "string"
       },
       "size": "string",
@@ -2767,7 +2986,7 @@ This operation does not require authentication
   "unrealizedPnl": "string",
   "closedAt": "string",
   "exitPrice": "string",
-  "subaccountNumber": 0
+  "subaccountNumber": 0.1
 }
 
 ```
@@ -2818,7 +3037,7 @@ This operation does not require authentication
     "unrealizedPnl": "string",
     "closedAt": "string",
     "exitPrice": "string",
-    "subaccountNumber": 0
+    "subaccountNumber": 0.1
   },
   "property2": {
     "market": "string",
@@ -2836,7 +3055,7 @@ This operation does not require authentication
     "unrealizedPnl": "string",
     "closedAt": "string",
     "exitPrice": "string",
-    "subaccountNumber": 0
+    "subaccountNumber": 0.1
   }
 }
 
@@ -2861,7 +3080,7 @@ This operation does not require authentication
   "side": "LONG",
   "size": "string",
   "assetId": "string",
-  "subaccountNumber": 0
+  "subaccountNumber": 0.1
 }
 
 ```
@@ -2890,14 +3109,14 @@ This operation does not require authentication
     "side": "LONG",
     "size": "string",
     "assetId": "string",
-    "subaccountNumber": 0
+    "subaccountNumber": 0.1
   },
   "property2": {
     "symbol": "string",
     "side": "LONG",
     "size": "string",
     "assetId": "string",
-    "subaccountNumber": 0
+    "subaccountNumber": 0.1
   }
 }
 
@@ -2919,7 +3138,7 @@ This operation does not require authentication
 ```json
 {
   "address": "string",
-  "subaccountNumber": 0,
+  "subaccountNumber": 0.1,
   "equity": "string",
   "freeCollateral": "string",
   "openPerpetualPositions": {
@@ -2939,7 +3158,7 @@ This operation does not require authentication
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     },
     "property2": {
       "market": "string",
@@ -2957,7 +3176,7 @@ This operation does not require authentication
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   },
   "assetPositions": {
@@ -2966,14 +3185,14 @@ This operation does not require authentication
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     },
     "property2": {
       "symbol": "string",
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   },
   "marginEnabled": true,
@@ -3009,7 +3228,7 @@ This operation does not require authentication
   "subaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0,
+      "subaccountNumber": 0.1,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -3029,7 +3248,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         },
         "property2": {
           "market": "string",
@@ -3047,7 +3266,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         }
       },
       "assetPositions": {
@@ -3056,14 +3275,14 @@ This operation does not require authentication
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         }
       },
       "marginEnabled": true,
@@ -3093,13 +3312,13 @@ This operation does not require authentication
 ```json
 {
   "address": "string",
-  "parentSubaccountNumber": 0,
+  "parentSubaccountNumber": 0.1,
   "equity": "string",
   "freeCollateral": "string",
   "childSubaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0,
+      "subaccountNumber": 0.1,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -3119,7 +3338,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         },
         "property2": {
           "market": "string",
@@ -3137,7 +3356,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         }
       },
       "assetPositions": {
@@ -3146,14 +3365,14 @@ This operation does not require authentication
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0
+          "subaccountNumber": 0.1
         }
       },
       "marginEnabled": true,
@@ -3190,7 +3409,7 @@ This operation does not require authentication
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -3251,7 +3470,7 @@ This operation does not require authentication
   "close": "string",
   "baseTokenVolume": "string",
   "usdVolume": "string",
-  "trades": 0,
+  "trades": 0.1,
   "startingOpenInterest": "string",
   "id": "string"
 }
@@ -3295,7 +3514,7 @@ This operation does not require authentication
       "close": "string",
       "baseTokenVolume": "string",
       "usdVolume": "string",
-      "trades": 0,
+      "trades": 0.1,
       "startingOpenInterest": "string",
       "id": "string"
     }
@@ -3538,7 +3757,7 @@ This operation does not require authentication
   "createdAtHeight": "string",
   "orderId": "string",
   "clientMetadata": "string",
-  "subaccountNumber": 0
+  "subaccountNumber": 0.1
 }
 
 ```
@@ -3571,9 +3790,9 @@ This operation does not require authentication
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "fills": [
     {
       "id": "string",
@@ -3589,7 +3808,7 @@ This operation does not require authentication
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -3776,9 +3995,9 @@ This operation does not require authentication
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "historicalPnl": [
     {
       "id": "string",
@@ -4108,7 +4327,7 @@ or
   "ticker": "string",
   "updatedAt": "string",
   "updatedAtHeight": "string",
-  "subaccountNumber": 0
+  "subaccountNumber": 0.1
 }
 
 ```
@@ -4210,17 +4429,17 @@ or
   "oraclePrice": "string",
   "priceChange24H": "string",
   "volume24H": "string",
-  "trades24H": 0,
+  "trades24H": 0.1,
   "nextFundingRate": "string",
   "initialMarginFraction": "string",
   "maintenanceMarginFraction": "string",
   "openInterest": "string",
-  "atomicResolution": 0,
-  "quantumConversionExponent": 0,
+  "atomicResolution": 0.1,
+  "quantumConversionExponent": 0.1,
   "tickSize": "string",
   "stepSize": "string",
-  "stepBaseQuantums": 0,
-  "subticksPerTick": 0,
+  "stepBaseQuantums": 0.1,
+  "subticksPerTick": 0.1,
   "marketType": "CROSS",
   "openInterestLowerCap": "string",
   "openInterestUpperCap": "string",
@@ -4272,17 +4491,17 @@ or
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0,
+      "trades24H": 0.1,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0,
-      "quantumConversionExponent": 0,
+      "atomicResolution": 0.1,
+      "quantumConversionExponent": 0.1,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0,
-      "subticksPerTick": 0,
+      "stepBaseQuantums": 0.1,
+      "subticksPerTick": 0.1,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -4295,17 +4514,17 @@ or
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0,
+      "trades24H": 0.1,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0,
-      "quantumConversionExponent": 0,
+      "atomicResolution": 0.1,
+      "quantumConversionExponent": 0.1,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0,
-      "subticksPerTick": 0,
+      "stepBaseQuantums": 0.1,
+      "subticksPerTick": 0.1,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -4349,7 +4568,7 @@ or
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0
+      "subaccountNumber": 0.1
     }
   ]
 }
@@ -4422,7 +4641,7 @@ or
 ```json
 {
   "iso": "string",
-  "epoch": 0
+  "epoch": 0.1
 }
 
 ```
@@ -4501,9 +4720,9 @@ or
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "trades": [
     {
       "id": "string",
@@ -4566,11 +4785,11 @@ or
 {
   "id": "string",
   "sender": {
-    "subaccountNumber": 0,
+    "subaccountNumber": 0.1,
     "address": "string"
   },
   "recipient": {
-    "subaccountNumber": 0,
+    "subaccountNumber": 0.1,
     "address": "string"
   },
   "size": "string",
@@ -4610,18 +4829,18 @@ or
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0,
+        "subaccountNumber": 0.1,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0,
+        "subaccountNumber": 0.1,
         "address": "string"
       },
       "size": "string",
@@ -4654,18 +4873,18 @@ or
 
 ```json
 {
-  "pageSize": 0,
-  "totalResults": 0,
-  "offset": 0,
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0,
+        "subaccountNumber": 0.1,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0,
+        "subaccountNumber": 0.1,
         "address": "string"
       },
       "size": "string",

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -5,10 +5,7 @@
 
 Base URLs:
 
-* For **the deployment by DYDX token holders**, use <a href="https://indexer.dydx.trade/v4">https://indexer.dydx.trade/v4</a>
-* For **Testnet**, use <a href="https://dydx-testnet.imperator.co/v4">https://dydx-testnet.imperator.co/v4</a>
-
-Note: Messages on Indexer WebSocket feeds are typically more recent than data fetched via Indexer's REST API, because the latter is backed by read replicas of the databases that feed the former. Ordinarily this difference is minimal (less than a second), but it might become prolonged under load. Please see [Indexer Architecture](https://dydx.exchange/blog/v4-deep-dive-indexer) for more information.
+* <a href=""></a>
 
 # Authentication
 
@@ -26,11 +23,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/addresses/{address}', headers = headers)
+r = requests.get('/addresses/{address}', headers = headers)
 
 print(r.json())
 
@@ -42,11 +35,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/addresses/{address}`,
+fetch('/addresses/{address}',
 {
   method: 'GET',
 
@@ -77,7 +66,7 @@ fetch(`${baseURL}/addresses/{address}`,
   "subaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0.1,
+      "subaccountNumber": 0,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -97,7 +86,7 @@ fetch(`${baseURL}/addresses/{address}`,
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -115,7 +104,7 @@ fetch(`${baseURL}/addresses/{address}`,
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -124,14 +113,14 @@ fetch(`${baseURL}/addresses/{address}`,
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "marginEnabled": true,
@@ -165,11 +154,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}', headers = headers)
+r = requests.get('/addresses/{address}/subaccountNumber/{subaccountNumber}', headers = headers)
 
 print(r.json())
 
@@ -181,11 +166,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
+fetch('/addresses/{address}/subaccountNumber/{subaccountNumber}',
 {
   method: 'GET',
 
@@ -215,7 +196,7 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
 ```json
 {
   "address": "string",
-  "subaccountNumber": 0.1,
+  "subaccountNumber": 0,
   "equity": "string",
   "freeCollateral": "string",
   "openPerpetualPositions": {
@@ -235,7 +216,7 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     },
     "property2": {
       "market": "string",
@@ -253,7 +234,7 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   },
   "assetPositions": {
@@ -262,14 +243,14 @@ fetch(`${baseURL}/addresses/{address}/subaccountNumber/{subaccountNumber}`,
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     },
     "property2": {
       "symbol": "string",
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   },
   "marginEnabled": true,
@@ -300,11 +281,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}', headers = headers)
+r = requests.get('/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}', headers = headers)
 
 print(r.json())
 
@@ -316,11 +293,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}`,
+fetch('/addresses/{address}/parentSubaccountNumber/{parentSubaccountNumber}',
 {
   method: 'GET',
 
@@ -350,13 +323,13 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
 ```json
 {
   "address": "string",
-  "parentSubaccountNumber": 0.1,
+  "parentSubaccountNumber": 0,
   "equity": "string",
   "freeCollateral": "string",
   "childSubaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0.1,
+      "subaccountNumber": 0,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -376,7 +349,7 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -394,7 +367,7 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -403,14 +376,14 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "marginEnabled": true,
@@ -443,12 +416,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/assetPositions', params={
-  'address': 'string',  'subaccountNumber': '0.1'
+r = requests.get('/assetPositions', params={
+  'address': 'string',  'subaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -461,11 +430,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/assetPositions?address=string&subaccountNumber=0.1`,
+fetch('/assetPositions?address=string&subaccountNumber=0',
 {
   method: 'GET',
 
@@ -500,7 +465,7 @@ fetch(`${baseURL}/assetPositions?address=string&subaccountNumber=0.1`,
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -528,12 +493,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/assetPositions/parentSubaccountNumber', params={
-  'address': 'string',  'parentSubaccountNumber': '0.1'
+r = requests.get('/assetPositions/parentSubaccountNumber', params={
+  'address': 'string',  'parentSubaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -546,11 +507,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/assetPositions/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
+fetch('/assetPositions/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
 {
   method: 'GET',
 
@@ -585,7 +542,7 @@ fetch(`${baseURL}/assetPositions/parentSubaccountNumber?address=string&parentSub
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -613,11 +570,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/candles/perpetualMarkets/{ticker}', params={
+r = requests.get('/candles/perpetualMarkets/{ticker}', params={
   'resolution': '1MIN'
 }, headers = headers)
 
@@ -631,11 +584,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/candles/perpetualMarkets/{ticker}?resolution=1MIN`,
+fetch('/candles/perpetualMarkets/{ticker}?resolution=1MIN',
 {
   method: 'GET',
 
@@ -690,7 +639,7 @@ fetch(`${baseURL}/candles/perpetualMarkets/{ticker}?resolution=1MIN`,
       "close": "string",
       "baseTokenVolume": "string",
       "usdVolume": "string",
-      "trades": 0.1,
+      "trades": 0,
       "startingOpenInterest": "string",
       "id": "string"
     }
@@ -720,11 +669,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/compliance/screen/{address}', headers = headers)
+r = requests.get('/compliance/screen/{address}', headers = headers)
 
 print(r.json())
 
@@ -736,11 +681,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/compliance/screen/{address}`,
+fetch('/compliance/screen/{address}',
 {
   method: 'GET',
 
@@ -796,12 +737,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/fills', params={
-  'address': 'string',  'subaccountNumber': '0.1'
+r = requests.get('/fills', params={
+  'address': 'string',  'subaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -814,11 +751,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/fills?address=string&subaccountNumber=0.1`,
+fetch('/fills?address=string&subaccountNumber=0',
 {
   method: 'GET',
 
@@ -860,9 +793,9 @@ fetch(`${baseURL}/fills?address=string&subaccountNumber=0.1`,
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "fills": [
     {
       "id": "string",
@@ -878,7 +811,7 @@ fetch(`${baseURL}/fills?address=string&subaccountNumber=0.1`,
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -906,12 +839,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/fills/parentSubaccount', params={
-  'address': 'string',  'parentSubaccountNumber': '0.1'
+r = requests.get('/fills/parentSubaccount', params={
+  'address': 'string',  'parentSubaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -924,11 +853,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/fills/parentSubaccount?address=string&parentSubaccountNumber=0.1`,
+fetch('/fills/parentSubaccount?address=string&parentSubaccountNumber=0',
 {
   method: 'GET',
 
@@ -970,9 +895,9 @@ fetch(`${baseURL}/fills/parentSubaccount?address=string&parentSubaccountNumber=0
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "fills": [
     {
       "id": "string",
@@ -988,7 +913,7 @@ fetch(`${baseURL}/fills/parentSubaccount?address=string&parentSubaccountNumber=0
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -1016,11 +941,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/height', headers = headers)
+r = requests.get('/height', headers = headers)
 
 print(r.json())
 
@@ -1032,11 +953,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/height`,
+fetch('/height',
 {
   method: 'GET',
 
@@ -1085,11 +1002,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/historicalBlockTradingRewards/{address}', headers = headers)
+r = requests.get('/historicalBlockTradingRewards/{address}', headers = headers)
 
 print(r.json())
 
@@ -1101,11 +1014,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/historicalBlockTradingRewards/{address}`,
+fetch('/historicalBlockTradingRewards/{address}',
 {
   method: 'GET',
 
@@ -1168,11 +1077,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/historicalFunding/{ticker}', headers = headers)
+r = requests.get('/historicalFunding/{ticker}', headers = headers)
 
 print(r.json())
 
@@ -1184,11 +1089,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/historicalFunding/{ticker}`,
+fetch('/historicalFunding/{ticker}',
 {
   method: 'GET',
 
@@ -1253,12 +1154,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/historical-pnl', params={
-  'address': 'string',  'subaccountNumber': '0.1'
+r = requests.get('/historical-pnl', params={
+  'address': 'string',  'subaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -1271,11 +1168,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/historical-pnl?address=string&subaccountNumber=0.1`,
+fetch('/historical-pnl?address=string&subaccountNumber=0',
 {
   method: 'GET',
 
@@ -1310,9 +1203,9 @@ fetch(`${baseURL}/historical-pnl?address=string&subaccountNumber=0.1`,
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "historicalPnl": [
     {
       "id": "string",
@@ -1350,12 +1243,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/historical-pnl/parentSubaccount', params={
-  'address': 'string',  'parentSubaccountNumber': '0.1'
+r = requests.get('/historical-pnl/parentSubaccount', params={
+  'address': 'string',  'parentSubaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -1368,11 +1257,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/historical-pnl/parentSubaccount?address=string&parentSubaccountNumber=0.1`,
+fetch('/historical-pnl/parentSubaccount?address=string&parentSubaccountNumber=0',
 {
   method: 'GET',
 
@@ -1407,9 +1292,9 @@ fetch(`${baseURL}/historical-pnl/parentSubaccount?address=string&parentSubaccoun
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "historicalPnl": [
     {
       "id": "string",
@@ -1447,11 +1332,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/historicalTradingRewardAggregations/{address}', params={
+r = requests.get('/historicalTradingRewardAggregations/{address}', params={
   'period': 'DAILY'
 }, headers = headers)
 
@@ -1465,11 +1346,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/historicalTradingRewardAggregations/{address}?period=DAILY`,
+fetch('/historicalTradingRewardAggregations/{address}?period=DAILY',
 {
   method: 'GET',
 
@@ -1544,11 +1421,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/orderbooks/perpetualMarket/{ticker}', headers = headers)
+r = requests.get('/orderbooks/perpetualMarket/{ticker}', headers = headers)
 
 print(r.json())
 
@@ -1560,11 +1433,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/orderbooks/perpetualMarket/{ticker}`,
+fetch('/orderbooks/perpetualMarket/{ticker}',
 {
   method: 'GET',
 
@@ -1629,12 +1498,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/orders', params={
-  'address': 'string',  'subaccountNumber': '0.1'
+r = requests.get('/orders', params={
+  'address': 'string',  'subaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -1647,11 +1512,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/orders?address=string&subaccountNumber=0.1`,
+fetch('/orders?address=string&subaccountNumber=0',
 {
   method: 'GET',
 
@@ -1725,7 +1586,7 @@ fetch(`${baseURL}/orders?address=string&subaccountNumber=0.1`,
     "ticker": "string",
     "updatedAt": "string",
     "updatedAtHeight": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   }
 ]
 ```
@@ -1823,12 +1684,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/orders/parentSubaccountNumber', params={
-  'address': 'string',  'parentSubaccountNumber': '0.1'
+r = requests.get('/orders/parentSubaccountNumber', params={
+  'address': 'string',  'parentSubaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -1841,11 +1698,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/orders/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
+fetch('/orders/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
 {
   method: 'GET',
 
@@ -1919,7 +1772,7 @@ fetch(`${baseURL}/orders/parentSubaccountNumber?address=string&parentSubaccountN
     "ticker": "string",
     "updatedAt": "string",
     "updatedAtHeight": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   }
 ]
 ```
@@ -2017,11 +1870,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/orders/{orderId}', headers = headers)
+r = requests.get('/orders/{orderId}', headers = headers)
 
 print(r.json())
 
@@ -2033,11 +1882,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/orders/{orderId}`,
+fetch('/orders/{orderId}',
 {
   method: 'GET',
 
@@ -2087,7 +1932,7 @@ fetch(`${baseURL}/orders/{orderId}`,
   "ticker": "string",
   "updatedAt": "string",
   "updatedAtHeight": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 ```
 
@@ -2113,11 +1958,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/perpetualMarkets', headers = headers)
+r = requests.get('/perpetualMarkets', headers = headers)
 
 print(r.json())
 
@@ -2129,11 +1970,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/perpetualMarkets`,
+fetch('/perpetualMarkets',
 {
   method: 'GET',
 
@@ -2170,17 +2007,17 @@ fetch(`${baseURL}/perpetualMarkets`,
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0.1,
+      "trades24H": 0,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0.1,
-      "quantumConversionExponent": 0.1,
+      "atomicResolution": 0,
+      "quantumConversionExponent": 0,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0.1,
-      "subticksPerTick": 0.1,
+      "stepBaseQuantums": 0,
+      "subticksPerTick": 0,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -2193,17 +2030,17 @@ fetch(`${baseURL}/perpetualMarkets`,
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0.1,
+      "trades24H": 0,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0.1,
-      "quantumConversionExponent": 0.1,
+      "atomicResolution": 0,
+      "quantumConversionExponent": 0,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0.1,
-      "subticksPerTick": 0.1,
+      "stepBaseQuantums": 0,
+      "subticksPerTick": 0,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -2235,12 +2072,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/perpetualPositions', params={
-  'address': 'string',  'subaccountNumber': '0.1'
+r = requests.get('/perpetualPositions', params={
+  'address': 'string',  'subaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -2253,11 +2086,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/perpetualPositions?address=string&subaccountNumber=0.1`,
+fetch('/perpetualPositions?address=string&subaccountNumber=0',
 {
   method: 'GET',
 
@@ -2315,7 +2144,7 @@ fetch(`${baseURL}/perpetualPositions?address=string&subaccountNumber=0.1`,
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -2343,12 +2172,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/perpetualPositions/parentSubaccountNumber', params={
-  'address': 'string',  'parentSubaccountNumber': '0.1'
+r = requests.get('/perpetualPositions/parentSubaccountNumber', params={
+  'address': 'string',  'parentSubaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -2361,11 +2186,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/perpetualPositions/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
+fetch('/perpetualPositions/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
 {
   method: 'GET',
 
@@ -2423,7 +2244,7 @@ fetch(`${baseURL}/perpetualPositions/parentSubaccountNumber?address=string&paren
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -2451,11 +2272,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/sparklines', params={
+r = requests.get('/sparklines', params={
   'timePeriod': 'ONE_DAY'
 }, headers = headers)
 
@@ -2469,11 +2286,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/sparklines?timePeriod=ONE_DAY`,
+fetch('/sparklines?timePeriod=ONE_DAY',
 {
   method: 'GET',
 
@@ -2539,11 +2352,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/time', headers = headers)
+r = requests.get('/time', headers = headers)
 
 print(r.json())
 
@@ -2555,11 +2364,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/time`,
+fetch('/time',
 {
   method: 'GET',
 
@@ -2582,7 +2387,7 @@ fetch(`${baseURL}/time`,
 ```json
 {
   "iso": "string",
-  "epoch": 0.1
+  "epoch": 0
 }
 ```
 
@@ -2608,11 +2413,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/trades/perpetualMarket/{ticker}', headers = headers)
+r = requests.get('/trades/perpetualMarket/{ticker}', headers = headers)
 
 print(r.json())
 
@@ -2624,11 +2425,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/trades/perpetualMarket/{ticker}`,
+fetch('/trades/perpetualMarket/{ticker}',
 {
   method: 'GET',
 
@@ -2660,9 +2457,9 @@ fetch(`${baseURL}/trades/perpetualMarket/{ticker}`,
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "trades": [
     {
       "id": "string",
@@ -2699,12 +2496,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/transfers', params={
-  'address': 'string',  'subaccountNumber': '0.1'
+r = requests.get('/transfers', params={
+  'address': 'string',  'subaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -2717,11 +2510,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/transfers?address=string&subaccountNumber=0.1`,
+fetch('/transfers?address=string&subaccountNumber=0',
 {
   method: 'GET',
 
@@ -2754,18 +2543,18 @@ fetch(`${baseURL}/transfers?address=string&subaccountNumber=0.1`,
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -2801,12 +2590,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-# For the deployment by DYDX token holders, use
-# baseURL = 'https://indexer.dydx.trade/v4'
-baseURL = 'https://dydx-testnet.imperator.co/v4'
-
-r = requests.get(f'{baseURL}/transfers/parentSubaccountNumber', params={
-  'address': 'string',  'parentSubaccountNumber': '0.1'
+r = requests.get('/transfers/parentSubaccountNumber', params={
+  'address': 'string',  'parentSubaccountNumber': '0'
 }, headers = headers)
 
 print(r.json())
@@ -2819,11 +2604,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-// For the deployment by DYDX token holders, use
-// const baseURL = 'https://indexer.dydx.trade/v4';
-const baseURL = 'https://dydx-testnet.imperator.co/v4';
-
-fetch(`${baseURL}/transfers/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
+fetch('/transfers/parentSubaccountNumber?address=string&parentSubaccountNumber=0',
 {
   method: 'GET',
 
@@ -2856,18 +2637,18 @@ fetch(`${baseURL}/transfers/parentSubaccountNumber?address=string&parentSubaccou
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -2986,7 +2767,7 @@ This operation does not require authentication
   "unrealizedPnl": "string",
   "closedAt": "string",
   "exitPrice": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 
 ```
@@ -3037,7 +2818,7 @@ This operation does not require authentication
     "unrealizedPnl": "string",
     "closedAt": "string",
     "exitPrice": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   },
   "property2": {
     "market": "string",
@@ -3055,7 +2836,7 @@ This operation does not require authentication
     "unrealizedPnl": "string",
     "closedAt": "string",
     "exitPrice": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   }
 }
 
@@ -3080,7 +2861,7 @@ This operation does not require authentication
   "side": "LONG",
   "size": "string",
   "assetId": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 
 ```
@@ -3109,14 +2890,14 @@ This operation does not require authentication
     "side": "LONG",
     "size": "string",
     "assetId": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   },
   "property2": {
     "symbol": "string",
     "side": "LONG",
     "size": "string",
     "assetId": "string",
-    "subaccountNumber": 0.1
+    "subaccountNumber": 0
   }
 }
 
@@ -3138,7 +2919,7 @@ This operation does not require authentication
 ```json
 {
   "address": "string",
-  "subaccountNumber": 0.1,
+  "subaccountNumber": 0,
   "equity": "string",
   "freeCollateral": "string",
   "openPerpetualPositions": {
@@ -3158,7 +2939,7 @@ This operation does not require authentication
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     },
     "property2": {
       "market": "string",
@@ -3176,7 +2957,7 @@ This operation does not require authentication
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   },
   "assetPositions": {
@@ -3185,14 +2966,14 @@ This operation does not require authentication
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     },
     "property2": {
       "symbol": "string",
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   },
   "marginEnabled": true,
@@ -3228,7 +3009,7 @@ This operation does not require authentication
   "subaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0.1,
+      "subaccountNumber": 0,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -3248,7 +3029,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -3266,7 +3047,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -3275,14 +3056,14 @@ This operation does not require authentication
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "marginEnabled": true,
@@ -3312,13 +3093,13 @@ This operation does not require authentication
 ```json
 {
   "address": "string",
-  "parentSubaccountNumber": 0.1,
+  "parentSubaccountNumber": 0,
   "equity": "string",
   "freeCollateral": "string",
   "childSubaccounts": [
     {
       "address": "string",
-      "subaccountNumber": 0.1,
+      "subaccountNumber": 0,
       "equity": "string",
       "freeCollateral": "string",
       "openPerpetualPositions": {
@@ -3338,7 +3119,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "market": "string",
@@ -3356,7 +3137,7 @@ This operation does not require authentication
           "unrealizedPnl": "string",
           "closedAt": null,
           "exitPrice": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "assetPositions": {
@@ -3365,14 +3146,14 @@ This operation does not require authentication
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         },
         "property2": {
           "symbol": "string",
           "side": "LONG",
           "size": "string",
           "assetId": "string",
-          "subaccountNumber": 0.1
+          "subaccountNumber": 0
         }
       },
       "marginEnabled": true,
@@ -3409,7 +3190,7 @@ This operation does not require authentication
       "side": "LONG",
       "size": "string",
       "assetId": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -3470,7 +3251,7 @@ This operation does not require authentication
   "close": "string",
   "baseTokenVolume": "string",
   "usdVolume": "string",
-  "trades": 0.1,
+  "trades": 0,
   "startingOpenInterest": "string",
   "id": "string"
 }
@@ -3514,7 +3295,7 @@ This operation does not require authentication
       "close": "string",
       "baseTokenVolume": "string",
       "usdVolume": "string",
-      "trades": 0.1,
+      "trades": 0,
       "startingOpenInterest": "string",
       "id": "string"
     }
@@ -3757,7 +3538,7 @@ This operation does not require authentication
   "createdAtHeight": "string",
   "orderId": "string",
   "clientMetadata": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 
 ```
@@ -3790,9 +3571,9 @@ This operation does not require authentication
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "fills": [
     {
       "id": "string",
@@ -3808,7 +3589,7 @@ This operation does not require authentication
       "createdAtHeight": "string",
       "orderId": "string",
       "clientMetadata": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -3995,9 +3776,9 @@ This operation does not require authentication
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "historicalPnl": [
     {
       "id": "string",
@@ -4327,7 +4108,7 @@ or
   "ticker": "string",
   "updatedAt": "string",
   "updatedAtHeight": "string",
-  "subaccountNumber": 0.1
+  "subaccountNumber": 0
 }
 
 ```
@@ -4429,17 +4210,17 @@ or
   "oraclePrice": "string",
   "priceChange24H": "string",
   "volume24H": "string",
-  "trades24H": 0.1,
+  "trades24H": 0,
   "nextFundingRate": "string",
   "initialMarginFraction": "string",
   "maintenanceMarginFraction": "string",
   "openInterest": "string",
-  "atomicResolution": 0.1,
-  "quantumConversionExponent": 0.1,
+  "atomicResolution": 0,
+  "quantumConversionExponent": 0,
   "tickSize": "string",
   "stepSize": "string",
-  "stepBaseQuantums": 0.1,
-  "subticksPerTick": 0.1,
+  "stepBaseQuantums": 0,
+  "subticksPerTick": 0,
   "marketType": "CROSS",
   "openInterestLowerCap": "string",
   "openInterestUpperCap": "string",
@@ -4491,17 +4272,17 @@ or
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0.1,
+      "trades24H": 0,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0.1,
-      "quantumConversionExponent": 0.1,
+      "atomicResolution": 0,
+      "quantumConversionExponent": 0,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0.1,
-      "subticksPerTick": 0.1,
+      "stepBaseQuantums": 0,
+      "subticksPerTick": 0,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -4514,17 +4295,17 @@ or
       "oraclePrice": "string",
       "priceChange24H": "string",
       "volume24H": "string",
-      "trades24H": 0.1,
+      "trades24H": 0,
       "nextFundingRate": "string",
       "initialMarginFraction": "string",
       "maintenanceMarginFraction": "string",
       "openInterest": "string",
-      "atomicResolution": 0.1,
-      "quantumConversionExponent": 0.1,
+      "atomicResolution": 0,
+      "quantumConversionExponent": 0,
       "tickSize": "string",
       "stepSize": "string",
-      "stepBaseQuantums": 0.1,
-      "subticksPerTick": 0.1,
+      "stepBaseQuantums": 0,
+      "subticksPerTick": 0,
       "marketType": "CROSS",
       "openInterestLowerCap": "string",
       "openInterestUpperCap": "string",
@@ -4568,7 +4349,7 @@ or
       "unrealizedPnl": "string",
       "closedAt": "string",
       "exitPrice": "string",
-      "subaccountNumber": 0.1
+      "subaccountNumber": 0
     }
   ]
 }
@@ -4641,7 +4422,7 @@ or
 ```json
 {
   "iso": "string",
-  "epoch": 0.1
+  "epoch": 0
 }
 
 ```
@@ -4720,9 +4501,9 @@ or
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "trades": [
     {
       "id": "string",
@@ -4785,11 +4566,11 @@ or
 {
   "id": "string",
   "sender": {
-    "subaccountNumber": 0.1,
+    "subaccountNumber": 0,
     "address": "string"
   },
   "recipient": {
-    "subaccountNumber": 0.1,
+    "subaccountNumber": 0,
     "address": "string"
   },
   "size": "string",
@@ -4829,18 +4610,18 @@ or
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",
@@ -4873,18 +4654,18 @@ or
 
 ```json
 {
-  "pageSize": 0.1,
-  "totalResults": 0.1,
-  "offset": 0.1,
+  "pageSize": 0,
+  "totalResults": 0,
+  "offset": 0,
   "transfers": [
     {
       "id": "string",
       "sender": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "recipient": {
-        "subaccountNumber": 0.1,
+        "subaccountNumber": 0,
         "address": "string"
       },
       "size": "string",

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -123,6 +123,7 @@ class ComplianceV2Controller extends Controller {
           return {
             status: complianceStatus[0].status,
             reason: complianceStatus[0].reason,
+            updatedAt: complianceStatus[0].updatedAt,
           };
         }
       }


### PR DESCRIPTION
### Changelist
In `GET /screen` endpoint:
Only update the `compliance_status` table if the status is not `CLOSE_ONLY`/`BLOCKED`.
If there is an existing `compliance_status` row for an address, return it rather than `COMPLIANT` status.

### Test Plan
unit tested

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Tests**
  - Added test cases for handling compliance statuses based on address restrictions, including scenarios for restricted addresses and existing compliance data.

- **Refactor**
  - Refined logic for compliance status retrieval and updates in the `ComplianceV2Controller` class, enhancing data handling and return structures.

These changes improve the accuracy and robustness of compliance status updates and retrieval processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->