### PR TITLE
Add baseOpenInterest to perpetual_markets athena table

### DIFF
--- a/indexer/services/roundtable/src/lib/athena-ddl-tables/perpetual_markets.ts
+++ b/indexer/services/roundtable/src/lib/athena-ddl-tables/perpetual_markets.ts
@@ -21,7 +21,8 @@ const RAW_TABLE_COLUMNS: string = `
   \`subticksPerTick\` int,
   \`stepBaseQuantums\` int,
   \`liquidityTierId\` int,
-  \`marketType\` string
+  \`marketType\` string,
+  \`baseOpenInterest\` string
 `;
 const TABLE_COLUMNS: string = `
   "id",
@@ -39,7 +40,8 @@ const TABLE_COLUMNS: string = `
   "subticksPerTick",
   "stepBaseQuantums",
   "liquidityTierId",
-  "marketType"
+  "marketType",
+  ${castToDouble('baseOpenInterest')}
 `;
 
 export function generateRawTable(tablePrefix: string, rdsExportIdentifier: string): string {


### PR DESCRIPTION
### Changelist
Add baseOpenInterest to perpetual_markets athena table

### Test Plan

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new column `baseOpenInterest` to enhance data visibility in the perpetual markets table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->