### PR TITLE
[TRA-470] update vault constant names

### DIFF
--- a/protocol/x/vault/keeper/params_test.go
+++ b/protocol/x/vault/keeper/params_test.go
@@ -55,7 +55,7 @@ func TestGetSetVaultParams(t *testing.T) {
 	k := tApp.App.VaultKeeper
 
 	// Get non-existent vault params.
-	_, exists := k.GetVaultParams(ctx, constants.Vault_Clob_0)
+	_, exists := k.GetVaultParams(ctx, constants.Vault_Clob0)
 	require.False(t, exists)
 
 	// Set vault params of vault clob 0.
@@ -66,15 +66,15 @@ func TestGetSetVaultParams(t *testing.T) {
 			Price:    123_456_789,
 		},
 	}
-	err := k.SetVaultParams(ctx, constants.Vault_Clob_0, vaultClob0Params)
+	err := k.SetVaultParams(ctx, constants.Vault_Clob0, vaultClob0Params)
 	require.NoError(t, err)
 
 	// Get vault params of vault clob 0.
-	params, exists := k.GetVaultParams(ctx, constants.Vault_Clob_0)
+	params, exists := k.GetVaultParams(ctx, constants.Vault_Clob0)
 	require.True(t, exists)
 	require.Equal(t, vaultClob0Params, params)
 
 	// Get vault params of vault clob 1.
-	_, exists = k.GetVaultParams(ctx, constants.Vault_Clob_1)
+	_, exists = k.GetVaultParams(ctx, constants.Vault_Clob1)
 	require.False(t, exists)
 }


### PR DESCRIPTION
### Changelist
vault constant names were not updated correctly when merging

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test cases to reflect changes in vault parameter constants, ensuring accurate and consistent references throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->