### PR TITLE
[TRA-461] Add `RedeemShares` logic for vault withdrawal

### DIFF
--- a/protocol/x/vault/keeper/msg_server_deposit_to_vault.go
+++ b/protocol/x/vault/keeper/msg_server_deposit_to_vault.go
@@ -19,7 +19,7 @@ func (k msgServer) DepositToVault(
 	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
 	quoteQuantums := msg.QuoteQuantums.BigInt()
 
-	// Mint shares for the vault.
+	// Mint vault shares for the depositor.
 	err := k.MintShares(
 		ctx,
 		*msg.VaultId,
@@ -30,9 +30,12 @@ func (k msgServer) DepositToVault(
 		return nil, err
 	}
 
-	// Transfer from sender subaccount to vault.
-	// Note: Transfer should take place after minting shares for
-	// shares calculation to be correct.
+	// Transfer from depositor's subaccount to vault.
+	// IMPORTANT: Transfer should take place after minting shares for
+	// shares calculation to be correct. This is because minting shares
+	// depends on the vault's current equity. Therefore, if you transfer
+	// before minting shares, then minting shares will be based on the
+	// vault's equity after the deposit.
 	err = k.sendingKeeper.ProcessTransfer(
 		ctx,
 		&sendingtypes.Transfer{

--- a/protocol/x/vault/keeper/msg_server_withdraw_from_vault.go
+++ b/protocol/x/vault/keeper/msg_server_withdraw_from_vault.go
@@ -14,8 +14,15 @@ func (k msgServer) WithdrawFromVault(
 	// TODO(TRA-461): Validate.
 	// TODO(TRA-462): Calculate effective amount to withdraw + shares to redeem with slippage and user equity.
 	// TODO(TRA-461): Redeem shares for the vault.
+
 	// TODO(TRA-461): Transfer asset from vault to recipient subaccount.
-	// should transfer happen after redeeming shares? why?
+	// Transfer from vault to withdrawal subaccount.
+	// IMPORTANT: Transfer should take place after redeeming shares for
+	// shares calculation to be correct. This is because redeeming shares
+	// depends on the vault's current equity. Therefore, if you transfer
+	// before redeeming shares, then redeeming shares will be based on the
+	// vault's equity after the withdrawal.
+
 	// TODO(TRA-461): emit metric on vault equity.
 	// TODO(TRA-461): Get info on shares after the withdrawal for the response.
 	return &types.MsgWithdrawFromVaultResponse{}, nil

--- a/protocol/x/vault/keeper/orders.go
+++ b/protocol/x/vault/keeper/orders.go
@@ -25,6 +25,7 @@ func (k Keeper) RefreshAllVaultOrders(ctx sdk.Context) {
 	numActiveVaults := 0
 	totalSharesIterator := k.getTotalSharesIterator(ctx)
 	defer totalSharesIterator.Close()
+	// Note: the total shares for a given vault can be zero.
 	for ; totalSharesIterator.Valid(); totalSharesIterator.Next() {
 		vaultId, err := types.GetVaultIdFromStateKey(totalSharesIterator.Key())
 

--- a/protocol/x/vault/keeper/withdraw.go
+++ b/protocol/x/vault/keeper/withdraw.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"math/big"
+
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
@@ -41,4 +43,101 @@ func (k Keeper) ValidateWithdrawFromVault(
 	}
 
 	return nil
+}
+
+func (k Keeper) RedeemShares(
+	ctx sdk.Context,
+	vaultId types.VaultId,
+	owner string,
+	sharesToRedeem types.NumShares,
+) (quantumsToWithdraw *big.Int, err error) {
+	// **** Validate ****
+	// Validate that `sharesToRedeem` is positive.
+	sharesToRedeemInt := sharesToRedeem.NumShares.BigInt()
+	if sharesToRedeemInt.Sign() <= 0 {
+		return nil, errors.Wrapf(
+			types.ErrInvalidWithdrawalAmount,
+			"Shares to withdraw must be positive",
+		)
+	}
+	totalShares, vaultExists := k.GetTotalShares(ctx, vaultId)
+	totalShareInt := totalShares.NumShares.BigInt()
+	ownerShares, ownerSharesExist := k.GetOwnerShares(ctx, vaultId, owner)
+	ownerSharesInt := ownerShares.NumShares.BigInt()
+	// Validate that vault and owner shares exist.
+	if !vaultExists || !ownerSharesExist {
+		return nil, errors.Wrapf(
+			types.ErrOwnerShareNotFound,
+			"VaultId: %v, Owner: %v",
+			vaultId,
+			owner,
+		)
+	}
+	// Validate that owner shares and total shares are positive.
+	if ownerSharesInt.Sign() <= 0 || totalShareInt.Sign() <= 0 {
+		return nil, errors.Wrapf(
+			types.ErrNegativeShares,
+			"Owner/Total shares must be positive. OwnerShares: %v, TotalShares: %v",
+			ownerSharesInt,
+			totalShareInt,
+		)
+	}
+	// Validate that
+	// 1. `sharesToRedeem` are less than or equal to the owner shares and
+	// 2. owner shares are less than or equal to the total vault shares.
+	if ownerSharesInt.Cmp(sharesToRedeemInt) < 0 ||
+		totalShareInt.Cmp(ownerSharesInt) < 0 {
+		return nil, errors.Wrapf(
+			types.ErrInvalidWithdrawalAmount,
+			"VaultId: %v, TotalShares: %v, OwnerShares: %v, WithdrawalShares: %v",
+			vaultId,
+			totalShareInt,
+			ownerSharesInt,
+			sharesToRedeem.NumShares.BigInt(),
+		)
+	}
+
+	// **** Calculate Withdrawal Amount ****
+	// Calculate the amount of quantums corresponding to the shares to withdraw
+	equity, err := k.GetVaultEquity(ctx, vaultId)
+	if err != nil {
+		return nil, err
+	}
+	// Don't redeem shares if equity is non-positive.
+	// This shouldn't happen, but check as a defense in depth.
+	if equity.Sign() <= 0 {
+		return nil, errors.Wrapf(types.ErrNonPositiveEquity, "VaultId: %v, Equity: %v", vaultId, equity)
+	}
+	quantumsToWithdraw = new(big.Int).Set(equity)
+	quantumsToWithdraw = quantumsToWithdraw.Mul(quantumsToWithdraw, ownerShares.NumShares.BigInt())
+	// Note: `Quo` discards the remainder, so this keeps the remainder staying in vault.
+	quantumsToWithdraw = quantumsToWithdraw.Quo(quantumsToWithdraw, totalShares.NumShares.BigInt())
+
+	// **** Update Shares ****
+	// Decrease TotalShares of the vault by the amount of redeemed shares.
+	err = k.SetTotalShares(
+		ctx,
+		vaultId,
+		types.BigIntToNumShares(totalShareInt.Sub(totalShareInt, sharesToRedeemInt)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	// Decrease owner shares in the vault by the amount of redeemed shares.
+	err = k.SetOwnerShares(
+		ctx,
+		vaultId,
+		owner,
+		types.BigIntToNumShares(ownerSharesInt.Sub(ownerSharesInt, sharesToRedeemInt)),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// **** Cleanup ****
+	// Note: do not remove vault total shares that are zero, because the quoting strategy
+	// may depend on the total shares of the vault.
+	// TODO: clean up zero ownershares
+
+	return quantumsToWithdraw, nil
 }


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling in vault operations to include additional checks and more descriptive error messages.

- **Documentation**
  - Clarified comments related to minting vault shares and the order of operations for transferring funds during deposits and withdrawals.

- **New Features**
  - Introduced the `RedeemShares` functionality, allowing users to redeem vault shares and calculate withdrawal amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->