### PR TITLE
[TRA-475]: Add Transfer Between endpoint

### DIFF
--- a/indexer/packages/postgres/src/stores/subaccount-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-table.ts
@@ -1,6 +1,7 @@
 import { IndexerSubaccountId } from '@dydxprotocol-indexer/v4-protos';
 import { PartialModelObject, QueryBuilder } from 'objection';
 
+import config from '../config';
 import { BUFFER_ENCODING_UTF_8, DEFAULT_POSTGRES_OPTIONS } from '../constants';
 import {
   verifyAllRequiredFields,
@@ -21,7 +22,6 @@ import {
   QueryableField,
   SubaccountUpdateObject,
 } from '../types';
-import config from '../config';
 
 export function uuid(address: string, subaccountNumber: number): string {
   // TODO(IND-483): Fix all uuid string substitutions to use Array.join.

--- a/indexer/packages/postgres/src/stores/subaccount-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-table.ts
@@ -21,6 +21,7 @@ import {
   QueryableField,
   SubaccountUpdateObject,
 } from '../types';
+import config from '../config';
 
 export function uuid(address: string, subaccountNumber: number): string {
   // TODO(IND-483): Fix all uuid string substitutions to use Array.join.
@@ -187,4 +188,17 @@ export async function update(
   const updatedSubaccount = await subaccount.$query().patch(fields as PartialModelObject<SubaccountModel>).returning('*');
   // The objection types mistakenly think the query returns an array of Subaccounts.
   return updatedSubaccount as unknown as (SubaccountFromDatabase | undefined);
+}
+
+export async function deleteById(
+  id: string,
+  options: Options = { txId: undefined },
+): Promise<void> {
+  if (config.NODE_ENV !== 'test') {
+    throw new Error('Subaccount deletion is not allowed in non-test environments');
+  }
+
+  await SubaccountModel.query(
+    Transaction.get(options.txId),
+  ).deleteById(id);
 }

--- a/indexer/packages/postgres/src/stores/transfer-table.ts
+++ b/indexer/packages/postgres/src/stores/transfer-table.ts
@@ -439,7 +439,7 @@ export async function getNetTransfersBetweenSubaccountIds(
 ): Promise<string> {
   const queryString: string = `
   SELECT 
-    SUM(sub."size") AS "totalSize"
+    COALESCE(SUM(sub."size"), '0') AS "totalSize"
   FROM (
     SELECT DISTINCT 
       "size" AS "size",
@@ -466,11 +466,6 @@ export async function getNetTransfersBetweenSubaccountIds(
   } = await rawQuery(queryString, options);
 
   // Should only ever return a single row
-  if (result.rows[0].totalSize === null) {
-    // If not transfers between the two subaccounts exist, then psql returns null
-    return '0';
-  }
-
   return result.rows[0].totalSize;
 }
 

--- a/indexer/packages/postgres/src/stores/transfer-table.ts
+++ b/indexer/packages/postgres/src/stores/transfer-table.ts
@@ -431,6 +431,49 @@ export async function getNetTransfersPerSubaccount(
   return convertToSubaccountAssetMap(assetsPerSubaccount);
 }
 
+export async function getNetTransfersBetweenSubaccountIds(
+  sourceSubaccountId: string,
+  recipientSubaccountId: string,
+  assetId: string,
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
+): Promise<string> {
+  const queryString: string = `
+  SELECT 
+    SUM(sub."size") AS "totalSize"
+  FROM (
+    SELECT DISTINCT 
+      "size" AS "size",
+      "id"
+    FROM 
+      "transfers"
+    WHERE "transfers"."assetId" = '${assetId}'
+    AND "transfers"."senderSubaccountId" = '${sourceSubaccountId}'
+    AND "transfers"."recipientSubaccountId" = '${recipientSubaccountId}'
+    UNION 
+    SELECT DISTINCT 
+      -"size" AS "size",
+      "id"
+    FROM 
+      "transfers"
+    WHERE "transfers"."assetId" = '${assetId}'
+    AND "transfers"."senderSubaccountId" = '${recipientSubaccountId}'
+    AND "transfers"."recipientSubaccountId" = '${sourceSubaccountId}'
+  ) AS sub
+  `;
+
+  const result: {
+    rows: { totalSize: string }[],
+  } = await rawQuery(queryString, options);
+
+  // Should only ever return a single row
+  if (result.rows[0].totalSize === null) {
+    // If not transfers between the two subaccounts exist, then psql returns null
+    return '0';
+  }
+
+  return result.rows[0].totalSize;
+}
+
 export async function create(
   transferToCreate: TransferCreateObject,
   options: Options = { txId: undefined },

--- a/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
@@ -1,5 +1,7 @@
 import {
   dbHelpers,
+  IsoString,
+  SubaccountTable,
   testConstants,
   testMocks,
   TransferCreateObject,
@@ -7,9 +9,15 @@ import {
   TransferType,
   WalletTable,
 } from '@dydxprotocol-indexer/postgres';
-import { ParentSubaccountTransferResponseObject, RequestMethod, TransferResponseObject } from '../../../../src/types';
+import {
+  ParentSubaccountTransferResponseObject,
+  RequestMethod,
+  TransferBetweenRequest,
+  TransferBetweenResponse,
+  TransferResponseObject,
+} from '../../../../src/types';
 import request from 'supertest';
-import { sendRequest } from '../../../helpers/helpers';
+import { getQueryString, sendRequest } from '../../../helpers/helpers';
 import {
   createdDateTime, createdHeight,
   defaultAsset,
@@ -17,6 +25,7 @@ import {
   defaultWalletAddress,
   isolatedSubaccountId,
 } from '@dydxprotocol-indexer/postgres/build/__tests__/helpers/constants';
+import Big from 'big.js';
 
 describe('transfers-controller#V4', () => {
   beforeAll(async () => {
@@ -990,6 +999,166 @@ describe('transfers-controller#V4', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('GET /transfers/between', () => {
+    beforeEach(async () => {
+      await testMocks.seedData();
+    });
+
+    afterEach(async () => {
+      await dbHelpers.clearData();
+    });
+
+    const firstTransfer: TransferCreateObject = testConstants.defaultTransfer;
+    const secondTransfer: TransferCreateObject = {
+      ...testConstants.defaultTransfer,
+      size: '5',
+      createdAt: testConstants.createdDateTime.plus({ minutes: 1 }).toISO(),
+      createdAtHeight: testConstants.createdHeight + 1,
+      eventId: testConstants.defaultTendermintEventId2,
+    };
+
+    const firstTransferResponse: TransferResponseObject = {
+      id: TransferTable.uuid(
+        firstTransfer.eventId,
+        firstTransfer.assetId,
+        firstTransfer.senderSubaccountId,
+        firstTransfer.recipientSubaccountId,
+      ),
+      sender: {
+        address: testConstants.defaultSubaccount.address,
+        subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
+      },
+      recipient: {
+        address: testConstants.defaultSubaccount2.address,
+        subaccountNumber: testConstants.defaultSubaccount2.subaccountNumber,
+      },
+      size: firstTransfer.size,
+      createdAt: firstTransfer.createdAt,
+      createdAtHeight: firstTransfer.createdAtHeight,
+      symbol: 'USDC',
+      type: TransferType.TRANSFER_OUT,
+      transactionHash: firstTransfer.transactionHash,
+    };
+    const secondTransferResponse: TransferResponseObject = {
+      ...firstTransferResponse,
+      id: TransferTable.uuid(
+        secondTransfer.eventId,
+        secondTransfer.assetId,
+        secondTransfer.senderSubaccountId,
+        secondTransfer.recipientSubaccountId,
+      ),
+      size: secondTransfer.size,
+      createdAt: secondTransfer.createdAt,
+      createdAtHeight: secondTransfer.createdAtHeight,
+    };
+
+    async function getTransferBetweenResponse(
+      createdBeforeOrAtHeight?: number,
+      createdBeforeOrAt?: IsoString,
+    ): Promise<TransferBetweenResponse> {
+      const queryParams: TransferBetweenRequest = {
+        sourceAddress: testConstants.defaultSubaccount.address,
+        sourceSubaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
+        recipientAddress: testConstants.defaultSubaccount2.address,
+        recipientSubaccountNumber: testConstants.defaultSubaccount2.subaccountNumber,
+      };
+
+      if (createdBeforeOrAtHeight) {
+        queryParams.createdBeforeOrAtHeight = createdBeforeOrAtHeight;
+      }
+
+      if (createdBeforeOrAt) {
+        queryParams.createdBeforeOrAt = createdBeforeOrAt;
+      }
+
+      const response: request.Response = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/transfers/between?${getQueryString(queryParams as any)}`,
+      });
+
+      return response.body;
+    }
+
+    it('Returns successfully when there are no transfers between wallets', async () => {
+      await dbHelpers.clearData();
+
+      const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse();
+      expect(transferBetweenResponse.transfers).toHaveLength(0);
+      expect(transferBetweenResponse.totalNetTransfers).toEqual('0');
+    });
+
+    it('Returns successfully when source subaccount does not exist', async () => {
+      await SubaccountTable.deleteById(testConstants.defaultSubaccountId);
+
+      const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse();
+      expect(transferBetweenResponse.transfers).toHaveLength(0);
+      expect(transferBetweenResponse.totalNetTransfers).toEqual('0');
+    });
+
+    it('Returns successfully when recipient subaccount does not exist', async () => {
+      await SubaccountTable.deleteById(testConstants.defaultSubaccountId2);
+
+      const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse();
+      expect(transferBetweenResponse.transfers).toHaveLength(0);
+      expect(transferBetweenResponse.totalNetTransfers).toEqual('0');
+
+    });
+
+    it('Returns successfully with transfers with net transfers', async () => {
+      await Promise.all([
+        TransferTable.create(firstTransfer),
+        TransferTable.create(secondTransfer),
+      ]);
+
+      const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse();
+      expect(transferBetweenResponse.transfers).toHaveLength(2);
+      expect(transferBetweenResponse.transfers).toEqual([
+        secondTransferResponse,
+        firstTransferResponse,
+      ]);
+      expect(transferBetweenResponse.totalNetTransfers).toEqual(
+        Big(firstTransfer.size).plus(secondTransfer.size).toFixed(),
+      );
+    });
+
+    it('Successfully filters by createdBeforeOrAtHeight', async () => {
+      await Promise.all([
+        TransferTable.create(firstTransfer),
+        TransferTable.create(secondTransfer),
+      ]);
+
+      const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse(
+        +firstTransfer.createdAtHeight,
+      );
+      expect(transferBetweenResponse.transfers).toHaveLength(1);
+      expect(transferBetweenResponse.transfers).toEqual([
+        firstTransferResponse,
+      ]);
+      expect(transferBetweenResponse.totalNetTransfers).toEqual(
+        Big(firstTransfer.size).plus(secondTransfer.size).toFixed(),
+      );
+    });
+
+    it('Successfully filters by createdBeforeOrAt', async () => {
+      await Promise.all([
+        TransferTable.create(firstTransfer),
+        TransferTable.create(secondTransfer),
+      ]);
+
+      const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse(
+        undefined,
+        firstTransfer.createdAt,
+      );
+      expect(transferBetweenResponse.transfers).toHaveLength(1);
+      expect(transferBetweenResponse.transfers).toEqual([
+        firstTransferResponse,
+      ]);
+      expect(transferBetweenResponse.totalNetTransfers).toEqual(
+        Big(firstTransfer.size).plus(secondTransfer.size).toFixed(),
+      );
     });
   });
 });

--- a/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
@@ -1086,7 +1086,7 @@ describe('transfers-controller#V4', () => {
       await dbHelpers.clearData();
 
       const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse();
-      expect(transferBetweenResponse.transfers).toHaveLength(0);
+      expect(transferBetweenResponse.transfersSubset).toHaveLength(0);
       expect(transferBetweenResponse.totalNetTransfers).toEqual('0');
     });
 
@@ -1094,7 +1094,7 @@ describe('transfers-controller#V4', () => {
       await SubaccountTable.deleteById(testConstants.defaultSubaccountId);
 
       const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse();
-      expect(transferBetweenResponse.transfers).toHaveLength(0);
+      expect(transferBetweenResponse.transfersSubset).toHaveLength(0);
       expect(transferBetweenResponse.totalNetTransfers).toEqual('0');
     });
 
@@ -1102,20 +1102,20 @@ describe('transfers-controller#V4', () => {
       await SubaccountTable.deleteById(testConstants.defaultSubaccountId2);
 
       const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse();
-      expect(transferBetweenResponse.transfers).toHaveLength(0);
+      expect(transferBetweenResponse.transfersSubset).toHaveLength(0);
       expect(transferBetweenResponse.totalNetTransfers).toEqual('0');
 
     });
 
-    it('Returns successfully with transfers with net transfers', async () => {
+    it('Returns successfully with transfers and net transfers', async () => {
       await Promise.all([
         TransferTable.create(firstTransfer),
         TransferTable.create(secondTransfer),
       ]);
 
       const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse();
-      expect(transferBetweenResponse.transfers).toHaveLength(2);
-      expect(transferBetweenResponse.transfers).toEqual([
+      expect(transferBetweenResponse.transfersSubset).toHaveLength(2);
+      expect(transferBetweenResponse.transfersSubset).toEqual([
         secondTransferResponse,
         firstTransferResponse,
       ]);
@@ -1133,8 +1133,8 @@ describe('transfers-controller#V4', () => {
       const transferBetweenResponse: TransferBetweenResponse = await getTransferBetweenResponse(
         +firstTransfer.createdAtHeight,
       );
-      expect(transferBetweenResponse.transfers).toHaveLength(1);
-      expect(transferBetweenResponse.transfers).toEqual([
+      expect(transferBetweenResponse.transfersSubset).toHaveLength(1);
+      expect(transferBetweenResponse.transfersSubset).toEqual([
         firstTransferResponse,
       ]);
       expect(transferBetweenResponse.totalNetTransfers).toEqual(
@@ -1152,8 +1152,8 @@ describe('transfers-controller#V4', () => {
         undefined,
         firstTransfer.createdAt,
       );
-      expect(transferBetweenResponse.transfers).toHaveLength(1);
-      expect(transferBetweenResponse.transfers).toEqual([
+      expect(transferBetweenResponse.transfersSubset).toHaveLength(1);
+      expect(transferBetweenResponse.transfersSubset).toEqual([
         firstTransferResponse,
       ]);
       expect(transferBetweenResponse.totalNetTransfers).toEqual(

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -2907,7 +2907,7 @@ headers = {
 # baseURL = 'https://indexer.dydx.trade/v4'
 baseURL = 'https://dydx-testnet.imperator.co/v4'
 
-r = requests.get(f'{baseURL}/transfers/compare', params={
+r = requests.get(f'{baseURL}/transfers/between', params={
   'sourceAddress': 'string',  'sourceSubaccountNumber': '0.1',  'recipientAddress': 'string',  'recipientSubaccountNumber': '0.1'
 }, headers = headers)
 
@@ -2925,7 +2925,7 @@ const headers = {
 // const baseURL = 'https://indexer.dydx.trade/v4';
 const baseURL = 'https://dydx-testnet.imperator.co/v4';
 
-fetch(`${baseURL}/transfers/compare?sourceAddress=string&sourceSubaccountNumber=0.1&recipientAddress=string&recipientSubaccountNumber=0.1`,
+fetch(`${baseURL}/transfers/between?sourceAddress=string&sourceSubaccountNumber=0.1&recipientAddress=string&recipientSubaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -2939,7 +2939,7 @@ fetch(`${baseURL}/transfers/compare?sourceAddress=string&sourceSubaccountNumber=
 
 ```
 
-`GET /transfers/compare`
+`GET /transfers/between`
 
 ### Parameters
 
@@ -2961,7 +2961,7 @@ fetch(`${baseURL}/transfers/compare?sourceAddress=string&sourceSubaccountNumber=
   "pageSize": 0.1,
   "totalResults": 0.1,
   "offset": 0.1,
-  "transfers": [
+  "transfersSubset": [
     {
       "id": "string",
       "sender": {
@@ -5023,7 +5023,7 @@ or
   "pageSize": 0.1,
   "totalResults": 0.1,
   "offset": 0.1,
-  "transfers": [
+  "transfersSubset": [
     {
       "id": "string",
       "sender": {
@@ -5054,6 +5054,6 @@ or
 |pageSize|number(double)|false|none|none|
 |totalResults|number(double)|false|none|none|
 |offset|number(double)|false|none|none|
-|transfers|[[TransferResponseObject](#schematransferresponseobject)]|true|none|none|
+|transfersSubset|[[TransferResponseObject](#schematransferresponseobject)]|true|none|none|
 |totalNetTransfers|string|true|none|none|
 

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -2891,6 +2891,109 @@ fetch(`${baseURL}/transfers/parentSubaccountNumber?address=string&parentSubaccou
 This operation does not require authentication
 </aside>
 
+## GetTransferBetween
+
+<a id="opIdGetTransferBetween"></a>
+
+> Code samples
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/transfers/compare', params={
+  'sourceAddress': 'string',  'sourceSubaccountNumber': '0.1',  'recipientAddress': 'string',  'recipientSubaccountNumber': '0.1'
+}, headers = headers)
+
+print(r.json())
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+};
+
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/transfers/compare?sourceAddress=string&sourceSubaccountNumber=0.1&recipientAddress=string&recipientSubaccountNumber=0.1`,
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+`GET /transfers/compare`
+
+### Parameters
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|sourceAddress|query|string|true|none|
+|sourceSubaccountNumber|query|number(double)|true|none|
+|recipientAddress|query|string|true|none|
+|recipientSubaccountNumber|query|number(double)|true|none|
+|createdBeforeOrAtHeight|query|number(double)|false|none|
+|createdBeforeOrAt|query|[IsoString](#schemaisostring)|false|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
+  "transfers": [
+    {
+      "id": "string",
+      "sender": {
+        "subaccountNumber": 0.1,
+        "address": "string"
+      },
+      "recipient": {
+        "subaccountNumber": 0.1,
+        "address": "string"
+      },
+      "size": "string",
+      "createdAt": "string",
+      "createdAtHeight": "string",
+      "symbol": "string",
+      "type": "TRANSFER_IN",
+      "transactionHash": "string"
+    }
+  ],
+  "totalNetTransfers": "string"
+}
+```
+
+### Responses
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Ok|[TransferBetweenResponse](#schematransferbetweenresponse)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
 # Schemas
 
 ## PerpetualPositionStatus
@@ -4907,4 +5010,50 @@ or
 |totalResults|number(double)|false|none|none|
 |offset|number(double)|false|none|none|
 |transfers|[[TransferResponseObject](#schematransferresponseobject)]|true|none|none|
+
+## TransferBetweenResponse
+
+<a id="schematransferbetweenresponse"></a>
+<a id="schema_TransferBetweenResponse"></a>
+<a id="tocStransferbetweenresponse"></a>
+<a id="tocstransferbetweenresponse"></a>
+
+```json
+{
+  "pageSize": 0.1,
+  "totalResults": 0.1,
+  "offset": 0.1,
+  "transfers": [
+    {
+      "id": "string",
+      "sender": {
+        "subaccountNumber": 0.1,
+        "address": "string"
+      },
+      "recipient": {
+        "subaccountNumber": 0.1,
+        "address": "string"
+      },
+      "size": "string",
+      "createdAt": "string",
+      "createdAtHeight": "string",
+      "symbol": "string",
+      "type": "TRANSFER_IN",
+      "transactionHash": "string"
+    }
+  ],
+  "totalNetTransfers": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|pageSize|number(double)|false|none|none|
+|totalResults|number(double)|false|none|none|
+|offset|number(double)|false|none|none|
+|transfers|[[TransferResponseObject](#schematransferresponseobject)]|true|none|none|
+|totalNetTransfers|string|true|none|none|
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -1286,6 +1286,37 @@
         ],
         "type": "object",
         "additionalProperties": false
+      },
+      "TransferBetweenResponse": {
+        "properties": {
+          "pageSize": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalResults": {
+            "type": "number",
+            "format": "double"
+          },
+          "offset": {
+            "type": "number",
+            "format": "double"
+          },
+          "transfers": {
+            "items": {
+              "$ref": "#/components/schemas/TransferResponseObject"
+            },
+            "type": "array"
+          },
+          "totalNetTransfers": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "transfers",
+          "totalNetTransfers"
+        ],
+        "type": "object",
+        "additionalProperties": false
       }
     },
     "securitySchemes": {}
@@ -2838,6 +2869,77 @@
             "schema": {
               "format": "double",
               "type": "number"
+            }
+          }
+        ]
+      }
+    },
+    "/transfers/compare": {
+      "get": {
+        "operationId": "GetTransferBetween",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferBetweenResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sourceAddress",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sourceSubaccountNumber",
+            "required": true,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "recipientAddress",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "recipientSubaccountNumber",
+            "required": true,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "createdBeforeOrAtHeight",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "createdBeforeOrAt",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/IsoString"
             }
           }
         ]

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -1301,7 +1301,7 @@
             "type": "number",
             "format": "double"
           },
-          "transfers": {
+          "transfersSubset": {
             "items": {
               "$ref": "#/components/schemas/TransferResponseObject"
             },
@@ -1312,7 +1312,7 @@
           }
         },
         "required": [
-          "transfers",
+          "transfersSubset",
           "totalNetTransfers"
         ],
         "type": "object",
@@ -2874,7 +2874,7 @@
         ]
       }
     },
-    "/transfers/compare": {
+    "/transfers/between": {
       "get": {
         "operationId": "GetTransferBetween",
         "responses": {

--- a/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
@@ -236,7 +236,7 @@ class TransfersController extends Controller {
     };
   }
 
-  @Get('/compare')
+  @Get('/between')
   async getTransferBetween(
     @Query() sourceAddress: string,
       @Query() sourceSubaccountNumber: number,
@@ -282,7 +282,7 @@ class TransfersController extends Controller {
     ]);
 
     return {
-      transfers: transfers.map((transfer: TransferFromDatabase) => {
+      transfersSubset: transfers.map((transfer: TransferFromDatabase) => {
         return transferToResponseObject(transfer, idToAsset, idToSubaccount, sourceSubaccountId);
       }),
       totalNetTransfers,
@@ -411,7 +411,7 @@ router.get(
 
     try {
       const controllers: TransfersController = new TransfersController();
-      const response: TransferResponse = await controllers.getTransferBetween(
+      const response: TransferBetweenResponse = await controllers.getTransferBetween(
         sourceAddress,
         sourceSubaccountNumber,
         recipientAddress,
@@ -423,7 +423,7 @@ router.get(
       return res.send(response);
     } catch (error) {
       return handleControllerError(
-        'TransfersController GET /compare',
+        'TransfersController GET /between',
         'Transfers error',
         error,
         req,
@@ -431,7 +431,7 @@ router.get(
       );
     } finally {
       stats.timing(
-        `${config.SERVICE_NAME}.${controllerName}.get_transfers_compare.timing`,
+        `${config.SERVICE_NAME}.${controllerName}.get_transfers_between.timing`,
         Date.now() - start,
       );
     }

--- a/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
@@ -14,6 +14,7 @@ import {
   TransferColumns,
   TransferFromDatabase,
   TransferTable,
+  USDC_ASSET_ID,
 } from '@dydxprotocol-indexer/postgres';
 import express from 'express';
 import { matchedData } from 'express-validator';
@@ -33,6 +34,7 @@ import {
   CheckPaginationSchema,
   CheckParentSubaccountSchema,
   CheckSubaccountSchema,
+  CheckTransferBetweenSchema,
 } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
@@ -48,6 +50,8 @@ import {
   ParentSubaccountTransferRequest,
   ParentSubaccountTransferResponse,
   ParentSubaccountTransferResponseObject,
+  TransferBetweenRequest,
+  TransferBetweenResponse,
 } from '../../../types';
 
 const router: express.Router = express.Router();
@@ -69,7 +73,11 @@ class TransfersController extends Controller {
     // TODO(DEC-656): Change to a cache in Redis similar to Librarian instead of querying DB.
     const [subaccount, {
       results: transfers, limit: pageSize, offset, total,
-    }, assets] = await Promise.all([
+    }, idToAsset]: [
+      SubaccountFromDatabase | undefined,
+      PaginationFromDatabase<TransferFromDatabase>,
+      AssetById,
+    ] = await Promise.all([
       SubaccountTable.findById(
         subaccountId,
       ),
@@ -94,10 +102,7 @@ class TransfersController extends Controller {
             ],
         },
       ),
-      AssetTable.findAll(
-        {},
-        [],
-      ),
+      getAssetById(),
     ]);
     if (subaccount === undefined) {
       throw new NotFoundError(
@@ -119,21 +124,7 @@ class TransfersController extends Controller {
       ...recipientSubaccountIds,
       ...senderSubaccountIds,
     ]);
-    const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll(
-      {
-        id: subaccountIds,
-      },
-      [],
-    );
-    const idToSubaccount: SubaccountById = _.keyBy(
-      subaccounts,
-      SubaccountColumns.id,
-    );
-
-    const idToAsset: AssetById = _.keyBy(
-      assets,
-      AssetColumns.id,
-    );
+    const idToSubaccount: SubaccountById = await idToSubaccountFromSubaccountIds(subaccountIds);
 
     return {
       transfers: transfers.map((transfer: TransferFromDatabase) => {
@@ -166,10 +157,10 @@ class TransfersController extends Controller {
       limit: pageSize,
       offset,
       total,
-    }, assets]: [
+    }, idToAsset]: [
       SubaccountFromDatabase[] | undefined,
       PaginationFromDatabase<TransferFromDatabase>,
-      AssetFromDatabase[]
+      AssetById,
     ] = await
     Promise.all([
       SubaccountTable.findAll(
@@ -197,10 +188,7 @@ class TransfersController extends Controller {
             ],
         },
       ),
-      AssetTable.findAll(
-        {},
-        [],
-      ),
+      getAssetById(),
     ]);
     if (subaccounts === undefined || subaccounts.length === 0) {
       throw new NotFoundError(
@@ -222,21 +210,7 @@ class TransfersController extends Controller {
       ...recipientSubaccountIds,
       ...senderSubaccountIds,
     ]);
-    const allSubaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll(
-      {
-        id: allSubaccountIds,
-      },
-      [],
-    );
-    const idToSubaccount: SubaccountById = _.keyBy(
-      allSubaccounts,
-      SubaccountColumns.id,
-    );
-
-    const idToAsset: AssetById = _.keyBy(
-      assets,
-      AssetColumns.id,
-    );
+    const idToSubaccount: SubaccountById = await idToSubaccountFromSubaccountIds(allSubaccountIds);
 
     const transfersWithParentSubaccount: ParentSubaccountTransferResponseObject[] = transfers.map(
       (transfer: TransferFromDatabase) => {
@@ -259,6 +233,59 @@ class TransfersController extends Controller {
       pageSize,
       totalResults: total,
       offset,
+    };
+  }
+
+  @Get('/compare')
+  async getTransferBetween(
+    @Query() sourceAddress: string,
+      @Query() sourceSubaccountNumber: number,
+      @Query() recipientAddress: string,
+      @Query() recipientSubaccountNumber: number,
+      @Query() createdBeforeOrAtHeight?: number,
+      @Query() createdBeforeOrAt?: IsoString,
+  ): Promise<TransferBetweenResponse> {
+    const sourceSubaccountId: string = SubaccountTable.uuid(sourceAddress, sourceSubaccountNumber);
+    const recipientSubaccountId: string = SubaccountTable.uuid(
+      recipientAddress,
+      recipientSubaccountNumber,
+    );
+
+    const [
+      transfers,
+      idToSubaccount,
+      idToAsset,
+      totalNetTransfers,
+    ]: [
+      TransferFromDatabase[],
+      SubaccountById,
+      AssetById,
+      string,
+    ] = await Promise.all([
+      TransferTable.findAll({
+        limit: config.API_LIMIT_V4,
+        senderSubaccountId: [sourceSubaccountId, recipientSubaccountId],
+        recipientSubaccountId: [sourceSubaccountId, recipientSubaccountId],
+        assetId: [USDC_ASSET_ID],
+        createdBeforeOrAt,
+        createdBeforeOrAtHeight: createdBeforeOrAtHeight
+          ? createdBeforeOrAtHeight.toString()
+          : undefined,
+      }, [], { orderBy: [[TransferColumns.createdAtHeight, Ordering.DESC]] }),
+      idToSubaccountFromSubaccountIds([sourceSubaccountId, recipientSubaccountId]),
+      getAssetById(),
+      TransferTable.getNetTransfersBetweenSubaccountIds(
+        sourceSubaccountId,
+        recipientSubaccountId,
+        USDC_ASSET_ID,
+      ),
+    ]);
+
+    return {
+      transfers: transfers.map((transfer: TransferFromDatabase) => {
+        return transferToResponseObject(transfer, idToAsset, idToSubaccount, sourceSubaccountId);
+      }),
+      totalNetTransfers,
     };
   }
 }
@@ -363,5 +390,74 @@ router.get(
     }
   },
 );
+
+router.get(
+  '/between',
+  rateLimiterMiddleware(getReqRateLimiter),
+  ...CheckTransferBetweenSchema,
+  handleValidationErrors,
+  complianceAndGeoCheck,
+  ExportResponseCodeStats({ controllerName }),
+  async (req: express.Request, res: express.Response) => {
+    const start: number = Date.now();
+    const {
+      sourceAddress,
+      sourceSubaccountNumber,
+      recipientAddress,
+      recipientSubaccountNumber,
+      createdBeforeOrAtHeight,
+      createdBeforeOrAt,
+    }: TransferBetweenRequest = matchedData(req) as TransferBetweenRequest;
+
+    try {
+      const controllers: TransfersController = new TransfersController();
+      const response: TransferResponse = await controllers.getTransferBetween(
+        sourceAddress,
+        sourceSubaccountNumber,
+        recipientAddress,
+        recipientSubaccountNumber,
+        createdBeforeOrAtHeight,
+        createdBeforeOrAt,
+      );
+
+      return res.send(response);
+    } catch (error) {
+      return handleControllerError(
+        'TransfersController GET /compare',
+        'Transfers error',
+        error,
+        req,
+        res,
+      );
+    } finally {
+      stats.timing(
+        `${config.SERVICE_NAME}.${controllerName}.get_transfers_compare.timing`,
+        Date.now() - start,
+      );
+    }
+  },
+);
+
+async function getAssetById(): Promise<AssetById> {
+  const assets: AssetFromDatabase[] = await AssetTable.findAll({}, []);
+  return _.keyBy(assets, AssetColumns.id);
+}
+
+async function idToSubaccountFromSubaccountIds(
+  subaccountIds: string[],
+): Promise<SubaccountById> {
+  const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll(
+    {
+      id: subaccountIds,
+    },
+    [],
+  );
+
+  const idToSubaccount: SubaccountById = _.keyBy(
+    subaccounts,
+    SubaccountColumns.id,
+  );
+  return idToSubaccount;
+}
 
 export default router;

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -125,6 +125,32 @@ const createdOnOrAfterSchemaRecord: Record<string, ParamSchema> = {
   },
 };
 
+const transferBetweenSchemaRecord: Record<string, ParamSchema> = {
+  ...createdBeforeOrAtSchemaRecord,
+  sourceAddress: {
+    in: ['params', 'query'],
+    isString: true,
+  },
+  sourceSubaccountNumber: {
+    in: ['params', 'query'],
+    isInt: {
+      options: { gt: -1, lt: MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER + 1 },
+    },
+    errorMessage: 'subaccountNumber must be a non-negative integer less than 128001',
+  },
+  recipientAddress: {
+    in: ['params', 'query'],
+    isString: true,
+  },
+  recipientSubaccountNumber: {
+    in: ['params', 'query'],
+    isInt: {
+      options: { gt: -1, lt: MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER + 1 },
+    },
+    errorMessage: 'subaccountNumber must be a non-negative integer less than 128001',
+  },
+};
+
 export const CheckLimitSchema = checkSchema(limitSchemaRecord);
 
 export const CheckPaginationSchema = checkSchema(paginationSchemaRecord);
@@ -184,3 +210,5 @@ export const CheckHistoricalBlockTradingRewardsSchema = checkSchema({
     errorMessage: 'startingBeforeOrAtHeight must be a non-negative integer',
   },
 });
+
+export const CheckTransferBetweenSchema = checkSchema(transferBetweenSchemaRecord);

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -202,7 +202,7 @@ export interface TransferBetweenResponse extends PaginationResponse {
   // Indexer will return data in descending order with the first transfer
   // being the most recent transfer. Will always return up to 100 transfers.
   // Transfers are categorized from the perspective of the source subaccount
-  transfers: TransferResponseObject[],
+  transfersSubset: TransferResponseObject[],
 
   // Given that source subaccount is the trader and the recipient subaccount
   // is the vault, total net transfer should always be positive

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -198,6 +198,17 @@ export interface ParentSubaccountTransferResponseObject {
   transactionHash: string,
 }
 
+export interface TransferBetweenResponse extends PaginationResponse {
+  // Indexer will return data in descending order with the first transfer
+  // being the most recent transfer. Will always return up to 100 transfers.
+  // Transfers are categorized from the perspective of the source subaccount
+  transfers: TransferResponseObject[],
+
+  // Given that source subaccount is the trader and the recipient subaccount
+  // is the vault, total net transfer should always be positive
+  totalNetTransfers: string,
+}
+
 /* ------- PNL TICKS TYPES ------- */
 
 export interface HistoricalPnlResponse extends PaginationResponse {
@@ -372,10 +383,12 @@ export interface TickerRequest {
   ticker?: string,
 }
 
-export interface LimitAndCreatedBeforeRequest extends LimitRequest {
+interface CreatedBeforeRequest {
   createdBeforeOrAtHeight?: number,
   createdBeforeOrAt?: IsoString,
 }
+
+export interface LimitAndCreatedBeforeRequest extends LimitRequest, CreatedBeforeRequest {}
 
 export interface LimitAndEffectiveBeforeRequest extends LimitRequest {
   effectiveBeforeOrAtHeight?: number,
@@ -406,6 +419,13 @@ export interface TransferRequest
 
 export interface ParentSubaccountTransferRequest
   extends ParentSubaccountRequest, LimitAndCreatedBeforeRequest, PaginationRequest {
+}
+
+export interface TransferBetweenRequest extends CreatedBeforeRequest {
+  sourceAddress: string,
+  sourceSubaccountNumber: number,
+  recipientAddress: string,
+  recipientSubaccountNumber: number,
 }
 
 export interface FillRequest


### PR DESCRIPTION
### Changelist
Add support for `/v4/transfers/between` endpoint to show transfers between two subaccounts

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `GetTransferBetween` API endpoint for retrieving transfer details between subaccounts.
  - Added functionality to calculate net transfers between specific subaccount IDs.

- **Bug Fixes**
  - Enhanced error handling by ensuring deletions are only allowed in test environments.

- **Documentation**
  - Updated API documentation to include new `GetTransferBetween` endpoint with code samples in Python and JavaScript.

- **Tests**
  - Added new test suite for comparing transfers between wallets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->