### PR TITLE
add raydium url to localnet slinky

### DIFF
--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -113,9 +113,11 @@ services:
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
   slinky0:
-    image: ghcr.io/skip-mev/slinky-sidecar:v1.0.0
+    image: ghcr.io/skip-mev/slinky-sidecar:v1.0.1
     entrypoint: >
       sh -c "slinky --marketmap-provider dydx_api --market-map-endpoint http://dydxprotocold0:1317 --update-market-config-path /etc/market.json --log-std-out-level error"
+    environment:
+      - SLINKY_CONFIG_PROVIDERS_RAYDIUM_API_API_ENDPOINTS_0_URL=${RAYDIUM_URL}
     ports:
       - "8080:8080"
       - "8002:8002" # metrics


### PR DESCRIPTION
### Changelist
Allow passing in RAYDIUM_URL as a env var to localnet's slinky

### Test Plan
Tested this by spinning up localnet and ran https://github.com/dydxprotocol/v4-web/blob/ce9180e1d8d48c4739782c60a0aafaddc09bdc10/scripts/validate-other-market-data.ts against it with RAYDIUM_URL set, which successfully queried prices for raydium markets.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
