### PR TITLE
feat(oe): Deprecate `marketToCreatedAt` on prices keeper

### DIFF
--- a/protocol/x/prices/keeper/keeper.go
+++ b/protocol/x/prices/keeper/keeper.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"fmt"
 	"sync/atomic"
-	"time"
 
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
@@ -23,7 +22,6 @@ type (
 		indexPriceCache                *pricefeedtypes.MarketToExchangePrices
 		timeProvider                   libtime.TimeProvider
 		indexerEventManager            indexer_manager.IndexerEventManager
-		marketToCreatedAt              map[uint32]time.Time
 		authorities                    map[string]struct{}
 		currencyPairIDCache            *CurrencyPairIDCache
 		currencyPairIdCacheInitialized *atomic.Bool
@@ -48,7 +46,6 @@ func NewKeeper(
 		indexPriceCache:                indexPriceCache,
 		timeProvider:                   timeProvider,
 		indexerEventManager:            indexerEventManager,
-		marketToCreatedAt:              map[uint32]time.Time{},
 		authorities:                    lib.UniqueSliceToSet(authorities),
 		currencyPairIDCache:            NewCurrencyPairIDCache(),
 		currencyPairIdCacheInitialized: &atomic.Bool{}, // Initialized to false

--- a/protocol/x/prices/keeper/market.go
+++ b/protocol/x/prices/keeper/market.go
@@ -86,33 +86,12 @@ func (k Keeper) CreateMarket(
 		),
 	)
 
-	k.marketToCreatedAt[marketParam.Id] = k.timeProvider.Now()
 	metrics.SetMarketPairForTelemetry(marketParam.Id, marketParam.Pair)
 
 	// create a new market rev share
 	k.RevShareKeeper.CreateNewMarketRevShare(ctx, marketParam.Id)
 
 	return marketParam, nil
-}
-
-// IsRecentlyAvailable returns true if the market was recently made available to the pricefeed daemon. A market is
-// considered recently available either if it was recently created, or if the pricefeed daemon was recently started. If
-// an index price does not exist for a recently available market, the protocol does not consider this an error
-// condition, as it is expected that the pricefeed daemon will eventually provide a price for the market within a
-// few seconds.
-func (k Keeper) IsRecentlyAvailable(ctx sdk.Context, marketId uint32) bool {
-	createdAt, ok := k.marketToCreatedAt[marketId]
-
-	if !ok {
-		return false
-	}
-
-	// The comparison condition considers both market age and price daemon warmup time because a market can be
-	// created before or after the daemon starts. We use block height as a proxy for daemon warmup time because
-	// the price daemon is started when the gRPC service comes up, which typically occurs just before the first
-	// block is processed.
-	return k.timeProvider.Now().Sub(createdAt) < types.MarketIsRecentDuration ||
-		ctx.BlockHeight() < types.PriceDaemonInitializationBlocks
 }
 
 // GetAllMarketParamPrices returns a slice of MarketParam, MarketPrice tuples for all markets.

--- a/protocol/x/prices/types/configs.go
+++ b/protocol/x/prices/types/configs.go
@@ -1,8 +1,5 @@
 package types
 
-import "time"
-
 const (
-	MarketIsRecentDuration          = 20 * time.Second
 	PriceDaemonInitializationBlocks = 20
 )


### PR DESCRIPTION
### Changelist
Deprecate `marketToCreatedAt`, an in-memory object used only to adjust log levels. This is motivated by OE integration which requires:
- Access to in-memory object on keepers to be thread safe
- Write to in-memory objects on keepers to occur after canonical block is finalized
Also fix a bug that causes excessive logging. 

Since `marketToCreatedAt` doesn't provide much value to protocol, deprecating it is the easiest option. 


### Test Plan
Covered by existing tests. 

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved market creation and availability logic by removing outdated time-based checks.
  - Enhanced logging for non-existent market prices.

- **Refactor**
  - Simplified internal data structures and removed unnecessary imports to optimize performance.

- **Tests**
  - Updated test cases to reflect changes in market availability logic, removing obsolete tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->