### PR TITLE
Reject short-term orders in transactions with non-zero timeout height.

### DIFF
--- a/protocol/app/ante.go
+++ b/protocol/app/ante.go
@@ -132,23 +132,24 @@ type lockingAnteHandler struct {
 	globalLock   sync.Mutex
 	authStoreKey storetypes.StoreKey
 
-	setupContextDecorator    ante.SetUpContextDecorator
-	freeInfiniteGasDecorator customante.FreeInfiniteGasDecorator
-	extensionOptionsChecker  sdk.AnteDecorator
-	validateMsgType          customante.ValidateMsgTypeDecorator
-	txTimeoutHeight          ante.TxTimeoutHeightDecorator
-	validateMemo             ante.ValidateMemoDecorator
-	validateBasic            ante.ValidateBasicDecorator
-	validateSigCount         ante.ValidateSigCountDecorator
-	incrementSequence        ante.IncrementSequenceDecorator
-	sigVerification          customante.SigVerificationDecorator
-	consumeTxSizeGas         ante.ConsumeTxSizeGasDecorator
-	deductFee                ante.DeductFeeDecorator
-	setPubKey                ante.SetPubKeyDecorator
-	sigGasConsume            ante.SigGasConsumeDecorator
-	clobRateLimit            clobante.ClobRateLimitDecorator
-	clob                     clobante.ClobDecorator
-	marketUpdates            customante.ValidateMarketUpdateDecorator
+	setupContextDecorator        ante.SetUpContextDecorator
+	freeInfiniteGasDecorator     customante.FreeInfiniteGasDecorator
+	extensionOptionsChecker      sdk.AnteDecorator
+	validateMsgType              customante.ValidateMsgTypeDecorator
+	txTimeoutHeight              ante.TxTimeoutHeightDecorator
+	validateMemo                 ante.ValidateMemoDecorator
+	validateBasic                ante.ValidateBasicDecorator
+	validateSigCount             ante.ValidateSigCountDecorator
+	incrementSequence            ante.IncrementSequenceDecorator
+	sigVerification              customante.SigVerificationDecorator
+	consumeTxSizeGas             ante.ConsumeTxSizeGasDecorator
+	deductFee                    ante.DeductFeeDecorator
+	setPubKey                    ante.SetPubKeyDecorator
+	sigGasConsume                ante.SigGasConsumeDecorator
+	clobRateLimit                clobante.ClobRateLimitDecorator
+	clob                         clobante.ClobDecorator
+	marketUpdates                customante.ValidateMarketUpdateDecorator
+	rejectStOrderTxTimeoutHeight customante.RejectSTOrderTimeoutHeightDecorator
 }
 
 func (h *lockingAnteHandler) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
@@ -186,6 +187,9 @@ func (h *lockingAnteHandler) clobAnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 		return ctx, err
 	}
 	if ctx, err = h.validateBasic.AnteHandle(ctx, tx, simulate, noOpAnteHandle); err != nil {
+		return ctx, err
+	}
+	if ctx, err = h.rejectStOrderTxTimeoutHeight.AnteHandle(ctx, tx, simulate, noOpAnteHandle); err != nil {
 		return ctx, err
 	}
 	if ctx, err = h.txTimeoutHeight.AnteHandle(ctx, tx, simulate, noOpAnteHandle); err != nil {

--- a/protocol/app/ante/reject_storder_timeout_height.go
+++ b/protocol/app/ante/reject_storder_timeout_height.go
@@ -1,0 +1,59 @@
+package ante
+
+import (
+	errorsmod "cosmossdk.io/errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+type (
+	// RejecSTOrderTimeoutHeightDecorator defines an AnteHandler decorator that checks for a
+	// tx height timeout and rejects the transaction if a tx height timeout is defined and contains
+	// short-term orders.
+	RejectSTOrderTimeoutHeightDecorator struct{}
+
+	// TxWithTimeoutHeight defines the interface a tx must implement in order for
+	// RejectSTOrderTimeoutHeightDecorator to process the tx.
+	TxWithTimeoutHeight interface {
+		sdk.Tx
+
+		GetTimeoutHeight() uint64
+	}
+)
+
+// RejecSTOrderTimeoutHeightDecorator defines an AnteHandler decorator that checks for a
+// tx height timeout and rejects the transaction if a tx height timeout is defined and contains
+// short-term orders.
+func NewRejectSTOrderTimeoutHeightDecorator() RejectSTOrderTimeoutHeightDecorator {
+	return RejectSTOrderTimeoutHeightDecorator{}
+}
+
+// AnteHandle implements an AnteHandler decorator for the RejectTimeoutHeightDecorator
+// type where the tx is checked to see if it contains a non-zero height timeout and is a ST order.
+// If a height timeout is provided and a STOrder is in the tx, reject the transaction.
+func (txh RejectSTOrderTimeoutHeightDecorator) AnteHandle(
+	ctx sdk.Context, tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (sdk.Context, error) {
+	if !ShouldSkipSequenceValidation(tx.GetMsgs()) {
+		return next(ctx, tx, simulate)
+	}
+
+	timeoutTx, ok := tx.(TxWithTimeoutHeight)
+	// TimeoutHeightDecorator will handle error-ing on any transactions that don't implement the interface.
+	if !ok {
+		return next(ctx, tx, simulate)
+	}
+
+	timeoutHeight := timeoutTx.GetTimeoutHeight()
+	if timeoutHeight > 0 {
+		return ctx, errorsmod.Wrap(
+			sdkerrors.ErrInvalidRequest,
+			"a short term clob message may not have a non-zero timeout height, use goodTilBlock instead",
+		)
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/protocol/app/ante/reject_storder_timeout_height_test.go
+++ b/protocol/app/ante/reject_storder_timeout_height_test.go
@@ -1,0 +1,163 @@
+package ante_test
+
+import (
+	"testing"
+
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/tx"
+	assets "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dydxprotocol/v4-chain/protocol/app/ante"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+)
+
+var (
+	anteHandlerRejectError = errorsmod.Wrap(
+		sdkerrors.ErrInvalidRequest,
+		"a short term clob message may not have a non-zero timeout height, use goodTilBlock instead",
+	)
+)
+
+func TestRejectSTOrderTimeoutHeightDecorator_AnteHandle(t *testing.T) {
+	tests := map[string]struct {
+		msgs          []sdk.Msg
+		timeoutHeight uint64
+		expectedErr   error
+	}{
+		"do nothing for non-clob messages with zero timeout height": {
+			msgs: []sdk.Msg{
+				&banktypes.MsgSend{
+					FromAddress: constants.BobAccAddress.String(),
+					ToAddress:   constants.AliceAccAddress.String(),
+					Amount: []sdk.Coin{
+						sdk.NewCoin(assets.AssetUsdc.Denom, sdkmath.NewInt(1)),
+					},
+				},
+				&banktypes.MsgSend{
+					FromAddress: constants.BobAccAddress.String(),
+					ToAddress:   constants.AliceAccAddress.String(),
+					Amount: []sdk.Coin{
+						sdk.NewCoin(assets.AssetUsdc.Denom, sdkmath.NewInt(1)),
+					},
+				},
+			},
+			timeoutHeight: 0,
+		},
+		"do nothing for non-clob messages with non-zero timeout height": {
+			msgs: []sdk.Msg{
+				&banktypes.MsgSend{
+					FromAddress: constants.BobAccAddress.String(),
+					ToAddress:   constants.AliceAccAddress.String(),
+					Amount: []sdk.Coin{
+						sdk.NewCoin(assets.AssetUsdc.Denom, sdkmath.NewInt(1)),
+					},
+				},
+				&banktypes.MsgSend{
+					FromAddress: constants.BobAccAddress.String(),
+					ToAddress:   constants.AliceAccAddress.String(),
+					Amount: []sdk.Coin{
+						sdk.NewCoin(assets.AssetUsdc.Denom, sdkmath.NewInt(1)),
+					},
+				},
+			},
+			timeoutHeight: 1,
+		},
+		"do nothing for long-term place order with non-zero timeout height": {
+			msgs: []sdk.Msg{
+				constants.Msg_PlaceOrder_LongTerm,
+			},
+			timeoutHeight: 1,
+		},
+		"do nothing for long-term cancel order with non-zero timeout height": {
+			msgs: []sdk.Msg{
+				constants.Msg_CancelOrder_LongTerm,
+			},
+			timeoutHeight: 1,
+		},
+		"do nothing for short-term place order with zero timeout height": {
+			msgs: []sdk.Msg{
+				constants.Msg_PlaceOrder,
+			},
+			timeoutHeight: 0,
+		},
+		"reject short-term place order with non-zero timeout height": {
+			msgs: []sdk.Msg{
+				constants.Msg_PlaceOrder,
+			},
+			timeoutHeight: 1,
+			expectedErr:   anteHandlerRejectError,
+		},
+		"do nothing for short-term cancel order with zero timeout height": {
+			msgs: []sdk.Msg{
+				constants.Msg_CancelOrder,
+			},
+			timeoutHeight: 0,
+		},
+		"reject short-term cancel order with non-zero timeout height": {
+			msgs: []sdk.Msg{
+				constants.Msg_CancelOrder,
+			},
+			timeoutHeight: 1,
+			expectedErr:   anteHandlerRejectError,
+		},
+		"do nothing for short-term batch cancel with zero timeout height": {
+			msgs: []sdk.Msg{
+				constants.Msg_BatchCancel,
+			},
+			timeoutHeight: 0,
+		},
+		"reject short-term batch cancel with non-zero timeout height": {
+			msgs: []sdk.Msg{
+				constants.Msg_BatchCancel,
+			},
+			timeoutHeight: 1,
+			expectedErr:   anteHandlerRejectError,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).Build()
+			ctx := tApp.InitChain()
+
+			wrappedHandler := ante.NewRejectSTOrderTimeoutHeightDecorator()
+			anteHandler := sdk.ChainAnteDecorators(wrappedHandler)
+
+			// Empty private key, so tx's signature should be empty.
+			var (
+				privs   []cryptotypes.PrivKey
+				accSeqs []uint64
+				accNums []uint64
+			)
+
+			tx, err := tx.CreateTestTx(
+				ctx,
+				tc.msgs,
+				privs,
+				accNums,
+				accSeqs,
+				tApp.App.ChainID(),
+				signing.SignMode_SIGN_MODE_DIRECT,
+				tApp.App.TxConfig(),
+				tc.timeoutHeight,
+			)
+			require.NoError(t, err)
+
+			_, err = anteHandler(ctx, tx, false)
+			if tc.expectedErr != nil {
+				require.Error(t, err)
+				require.Error(t, tc.expectedErr, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/protocol/testutil/tx/msg_tx.go
+++ b/protocol/testutil/tx/msg_tx.go
@@ -2,11 +2,17 @@ package tx
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/dydxprotocol/v4-chain/protocol/app/module"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 )
 
@@ -41,4 +47,67 @@ func MustGetOnlySignerAddress(cdc codec.Codec, msg sdk.Msg) string {
 		panic(err)
 	}
 	return signer
+}
+
+// CreateTestTx is a helper function to create a tx given multiple inputs.
+func CreateTestTx(
+	ctx sdk.Context,
+	msgs []sdk.Msg,
+	privs []cryptotypes.PrivKey,
+	accNums, accSeqs []uint64,
+	chainID string, signMode signing.SignMode, txConfig client.TxConfig,
+	timeoutHeight uint64,
+) (xauthsigning.Tx, error) {
+	txBuilder := txConfig.NewTxBuilder()
+	txBuilder.SetTimeoutHeight(timeoutHeight)
+	err := txBuilder.SetMsgs(msgs...)
+	if err != nil {
+		panic(err)
+	}
+
+	// First round: we gather all the signer infos. We use the "set empty
+	// signature" hack to do that.
+	var sigsV2 []signing.SignatureV2
+	for i, priv := range privs {
+		sigV2 := signing.SignatureV2{
+			PubKey: priv.PubKey(),
+			Data: &signing.SingleSignatureData{
+				SignMode:  signMode,
+				Signature: nil,
+			},
+			Sequence: accSeqs[i],
+		}
+
+		sigsV2 = append(sigsV2, sigV2)
+	}
+	err = txBuilder.SetSignatures(sigsV2...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Second round: all signer infos are set, so each signer can sign.
+	sigsV2 = []signing.SignatureV2{}
+	for i, priv := range privs {
+		signerData := xauthsigning.SignerData{
+			Address:       sdk.AccAddress(priv.PubKey().Address()).String(),
+			ChainID:       chainID,
+			AccountNumber: accNums[i],
+			Sequence:      accSeqs[i],
+			PubKey:        priv.PubKey(),
+		}
+		sigV2, err := tx.SignWithPrivKey(
+			ctx, signMode, signerData,
+			txBuilder, priv, txConfig, accSeqs[i])
+		if err != nil {
+			return nil, err
+		}
+
+		sigsV2 = append(sigsV2, sigV2)
+	}
+	err = txBuilder.SetSignatures(sigsV2...)
+	if err != nil {
+		return nil, err
+	}
+
+	return txBuilder.GetTx(), nil
 }


### PR DESCRIPTION
### Changelist
Added an antehandler for clob messages that rejects any short-term clob messages in a transaction with non-zero `TxTimeoutHeight`.
Short-term clob messages (place order, cancel, batch cancel) already have `GoodTilBlock` to ensure they are not processed after a certain block height, adding a `TxTimeoutHeight` is not needed.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced transaction handling improvements with `RejectSTOrderTimeoutHeightDecorator` to enhance transaction validation by rejecting short-term orders with non-zero timeout heights.

- **Tests**
  - Added tests for `RejectSTOrderTimeoutHeightDecorator` to ensure proper validation and rejection of transactions with short-term orders and timeout heights.
  - Introduced `CreateTestTx` function in test utilities to facilitate the creation of test transactions with multiple inputs and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->