### PR TITLE
Ignore short-term clob messages with non-zero tx timeout.

### DIFF
--- a/protocol/testutil/sdk/tx/tx.go
+++ b/protocol/testutil/sdk/tx/tx.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"context"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -18,10 +19,12 @@ func CreateTestTx(
 	accSeqs []uint64,
 	chainID string,
 	msgs []sdk.Msg,
+	timeoutHeight uint64,
 ) (xauthsigning.Tx, error) {
 	encodingConfig := app.GetEncodingConfig()
 	clientCtx := client.Context{}.WithTxConfig(encodingConfig.TxConfig)
 	txBuilder := clientCtx.TxConfig.NewTxBuilder()
+	txBuilder.SetTimeoutHeight(timeoutHeight)
 	err := txBuilder.SetMsgs(msgs...)
 	if err != nil {
 		return nil, err

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -115,7 +115,7 @@ func (cd ClobDecorator) AnteHandle(
 
 			// HOTFIX: Ignore any short-term place orders in a transaction with a timeout height.
 			if timeoutHeight > 0 && ctx.IsCheckTx() {
-				log.InfoLog(
+				log.WarnLog(
 					ctx,
 					"Ignored short-term place order with non-zero timeout height",
 					timeoutHeightLogKey,

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -90,7 +90,7 @@ func (cd ClobDecorator) AnteHandle(
 
 			// HOTFIX: Ignore any short-term clob messages in a transaction with a timeout height.
 			if timeoutHeight > 0 {
-				log.ErrorLog(
+				log.InfoLog(
 					ctx,
 					"Ignored short-term cancel order with non-zero timeout height",
 					timeoutHeightLogKey,
@@ -126,7 +126,7 @@ func (cd ClobDecorator) AnteHandle(
 
 			// HOTFIX: Ignore any short-term clob messages in a transaction with a timeout height.
 			if timeoutHeight > 0 {
-				log.ErrorLog(
+				log.InfoLog(
 					ctx,
 					"Ignored short-term place order with non-zero timeout height",
 					timeoutHeightLogKey,
@@ -161,7 +161,7 @@ func (cd ClobDecorator) AnteHandle(
 
 		// HOTFIX: Ignore any short-term clob messages in a transaction with a timeout height.
 		if timeoutHeight > 0 {
-			log.ErrorLog(
+			log.InfoLog(
 				ctx,
 				"Ignored short-term batch cancel with non-zero timeout height",
 				timeoutHeightLogKey,

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -255,6 +255,7 @@ func IsShortTermClobMsgTx(ctx sdk.Context, tx sdk.Tx) (bool, error) {
 	return true, nil
 }
 
+// HasNonZeroTimeoutHeight checks if a given transaction has a non-zero timeout height set.
 func HasNonZeroTimeoutHeight(tx sdk.Tx) bool {
 	timeoutTx, ok := tx.(sdk.TxWithTimeoutHeight)
 	if !ok {

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -113,7 +113,7 @@ func (cd ClobDecorator) AnteHandle(
 				return next(ctx, tx, simulate)
 			}
 
-			// HOTFIX: Ignore any short-term clob messages in a transaction with a timeout height.
+			// HOTFIX: Ignore any short-term place orders in a transaction with a timeout height.
 			if timeoutHeight > 0 && ctx.IsCheckTx() {
 				log.InfoLog(
 					ctx,

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -72,9 +72,6 @@ func (cd ClobDecorator) AnteHandle(
 		)
 	}
 
-	// HOTFIX: Ignore any short-term clob messages in a transaction with a timeout height.
-	timeoutHeight := GetTimeoutHeight(tx)
-
 	msgs := tx.GetMsgs()
 	var msg = msgs[0]
 
@@ -114,10 +111,10 @@ func (cd ClobDecorator) AnteHandle(
 			}
 
 			// HOTFIX: Ignore any short-term place orders in a transaction with a timeout height.
-			if timeoutHeight > 0 && ctx.IsCheckTx() {
+			if timeoutHeight := GetTimeoutHeight(tx); timeoutHeight > 0 && ctx.IsCheckTx() {
 				log.InfoLog(
 					ctx,
-					"Ignored short-term place order with non-zero timeout height",
+					"Rejected short-term place order with non-zero timeout height",
 					timeoutHeightLogKey,
 					timeoutHeight,
 				)

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -115,7 +115,7 @@ func (cd ClobDecorator) AnteHandle(
 
 			// HOTFIX: Ignore any short-term place orders in a transaction with a timeout height.
 			if timeoutHeight > 0 && ctx.IsCheckTx() {
-				log.WarnLog(
+				log.InfoLog(
 					ctx,
 					"Ignored short-term place order with non-zero timeout height",
 					timeoutHeightLogKey,

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -28,7 +28,9 @@ type TestCase struct {
 	useWithIsCheckTxContext   bool
 	useWithIsRecheckTxContext bool
 	isSimulate                bool
+	timeoutHeight             uint64
 	expectedErr               error
+	additionalAssertions      func(ctx sdk.Context, mck *mocks.ClobKeeper)
 }
 
 func runTestCase(t *testing.T, tc TestCase) {
@@ -60,7 +62,7 @@ func runTestCase(t *testing.T, tc TestCase) {
 	// Create Test Transaction.
 	priv1, _, _ := testdata.KeyTestPubAddr()
 	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
-	tx, err := txtest.CreateTestTx(privs, accNums, accSeqs, "dydx", tc.msgs)
+	tx, err := txtest.CreateTestTx(privs, accNums, accSeqs, "dydx", tc.msgs, tc.timeoutHeight)
 	require.NoError(t, err)
 
 	// Call Antehandler.
@@ -76,6 +78,10 @@ func runTestCase(t *testing.T, tc TestCase) {
 	// Assert mock expectations.
 	result := mockClobKeeper.AssertExpectations(t)
 	require.True(t, result)
+
+	if tc.additionalAssertions != nil {
+		tc.additionalAssertions(ctx, mockClobKeeper)
+	}
 }
 
 func TestClobDecorator_MsgPlaceOrder(t *testing.T) {
@@ -214,6 +220,23 @@ func TestClobDecorator_MsgPlaceOrder(t *testing.T) {
 			msgs:                    []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_Send},
 			useWithIsCheckTxContext: true,
 			expectedErr:             sdkerrors.ErrInvalidRequest,
+		},
+		// Test for hotfix.
+		"PlaceShortTermOrder is not called on keeper CheckTx if transaction timeout height is non-zero": {
+			msgs:                      []sdk.Msg{constants.Msg_PlaceOrder},
+			useWithIsCheckTxContext:   true,
+			useWithIsRecheckTxContext: false,
+			isSimulate:                false,
+			expectedErr:               nil,
+			timeoutHeight:             1,
+			additionalAssertions: func(ctx sdk.Context, mck *mocks.ClobKeeper) {
+				mck.AssertNotCalled(
+					t,
+					"PlaceShortTermOrder",
+					ctx,
+					constants.Msg_PlaceOrder,
+				)
+			},
 		},
 	}
 
@@ -530,6 +553,26 @@ func TestClobDecorator_MsgCancelOrder(t *testing.T) {
 			msgs:                    []sdk.Msg{constants.Msg_CancelOrder, constants.Msg_Send},
 			useWithIsCheckTxContext: true,
 			expectedErr:             sdkerrors.ErrInvalidRequest,
+		},
+		// Test for hotfix.
+		"CancelShortTermOrder is not called on keeper CheckTx if transaction timeout height is non-zero": {
+			msgs:                      []sdk.Msg{constants.Msg_CancelOrder},
+			useWithIsCheckTxContext:   true,
+			useWithIsRecheckTxContext: false,
+			isSimulate:                false,
+			expectedErr:               nil,
+			timeoutHeight:             1,
+			additionalAssertions: func(ctx sdk.Context, mck *mocks.ClobKeeper) {
+				mck.AssertNotCalled(
+					t,
+					"CancelShortTermOrder",
+					ctx,
+					clobtypes.NewMsgCancelOrderShortTerm(
+						constants.Msg_CancelOrder.OrderId,
+						constants.Msg_CancelOrder.GetGoodTilBlock(),
+					),
+				)
+			},
 		},
 	}
 


### PR DESCRIPTION
### Changelist
Short-term orders with non-zero transaction timeouts are invalid as `GoodTilBlock` already ensures they are not processed. Ignore such place order transactions in the ante handler during `CheckTx`.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented a hotfix to ignore short-term clob messages in transactions with a non-zero timeout height, enhancing transaction reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->