### PR TITLE
[TRA-468] add cli cmds to query revshare state

### DIFF
--- a/protocol/x/revshare/client/cli/query.go
+++ b/protocol/x/revshare/client/cli/query.go
@@ -20,5 +20,8 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
+	cmd.AddCommand(CmdQueryRevShareParams())
+	cmd.AddCommand(CmdQueryRevShareDetailsForMarket())
+
 	return cmd
 }

--- a/protocol/x/revshare/client/cli/query_params.go
+++ b/protocol/x/revshare/client/cli/query_params.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/dydxprotocol/v4-chain/protocol/x/revshare/types"
+	"github.com/spf13/cobra"
+)
+
+func CmdQueryRevShareParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revshare-params",
+		Short: "revshare params",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			queryClient := types.NewQueryClient(clientCtx)
+			res, err := queryClient.MarketMapperRevenueShareParams(
+				context.Background(),
+				&types.QueryMarketMapperRevenueShareParams{},
+			)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdQueryRevShareDetailsForMarket() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revshare-details-for-market [market-id]",
+		Short: "revshare details for a market",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			queryClient := types.NewQueryClient(clientCtx)
+
+			argId := args[0]
+
+			marketId, err := strconv.ParseUint(argId, 10, 32)
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.MarketMapperRevShareDetails(
+				context.Background(),
+				&types.QueryMarketMapperRevShareDetails{
+					MarketId: uint32(marketId),
+				},
+			)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}


### PR DESCRIPTION
### Changelist
Add cli cmds to query market mapper revenue share params and market details

Example

➜  build git:(tra468) ✗ ./dydxprotocold q revshare revshare-details-for-market 38
2:00PM INF Overriding [consensus.timeout_propose] from 3s to software constant: 1.5s
details:
  expiration_ts: "1720135699"
➜  build git:(tra468) ✗ ./dydxprotocold q revshare revshare-params
2:00PM INF Overriding [consensus.timeout_propose] from 3s to software constant: 1.5s
params:
  address: dydx1324sgvzac3y8xm79g59052ukwynztm62w5axhz
  revenue_share_ppm: 100000
  valid_days: 1

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line interface for querying revenue share parameters.
  - Added a command for querying revenue share details for a specific market.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->