### PR TITLE
Reject short-term orders with 0 < TimeoutHeight < GoodTilBlock.

### DIFF
--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -112,7 +112,7 @@ func (cd ClobDecorator) AnteHandle(
 
 			// HOTFIX: Reject any short-term place orders in a transaction with a non-zero timeout height < good til block
 			if timeoutHeight := GetTimeoutHeight(tx); timeoutHeight > 0 &&
-				int(timeoutHeight) < int(msg.Order.GetGoodTilBlock()) && ctx.IsCheckTx() {
+				timeoutHeight < uint64(msg.Order.GetGoodTilBlock()) && ctx.IsCheckTx() {
 				log.InfoLog(
 					ctx,
 					"Rejected short-term place order with non-zero timeout height < goodTilBlock",

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -110,17 +110,17 @@ func (cd ClobDecorator) AnteHandle(
 				return next(ctx, tx, simulate)
 			}
 
-			// HOTFIX: Ignore any short-term place orders in a transaction with a timeout height.
-			if timeoutHeight := GetTimeoutHeight(tx); timeoutHeight > 0 && ctx.IsCheckTx() {
+			// HOTFIX: Ignore any short-term place orders in a transaction with a timeout height < good til block
+			if timeoutHeight := GetTimeoutHeight(tx); timeoutHeight > 0 && int(timeoutHeight) < int(msg.Order.GetGoodTilBlock()) && ctx.IsCheckTx() {
 				log.InfoLog(
 					ctx,
-					"Rejected short-term place order with non-zero timeout height",
+					"Rejected short-term place order with timeout height < goodTilBlock",
 					timeoutHeightLogKey,
 					timeoutHeight,
 				)
 				return ctx, errorsmod.Wrap(
 					sdkerrors.ErrInvalidRequest,
-					"a short term place order message may not have a non-zero timeout height, use goodTilBlock instead",
+					"a short term place order message may not have a timeout height less than goodTilBlock",
 				)
 			}
 

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -115,7 +115,7 @@ func (cd ClobDecorator) AnteHandle(
 				int(timeoutHeight) < int(msg.Order.GetGoodTilBlock()) && ctx.IsCheckTx() {
 				log.InfoLog(
 					ctx,
-					"Rejected short-term place order with timeout height < goodTilBlock",
+					"Rejected short-term place order with non-zero timeout height < goodTilBlock",
 					timeoutHeightLogKey,
 					timeoutHeight,
 				)

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -111,7 +111,8 @@ func (cd ClobDecorator) AnteHandle(
 			}
 
 			// HOTFIX: Ignore any short-term place orders in a transaction with a timeout height < good til block
-			if timeoutHeight := GetTimeoutHeight(tx); timeoutHeight > 0 && int(timeoutHeight) < int(msg.Order.GetGoodTilBlock()) && ctx.IsCheckTx() {
+			if timeoutHeight := GetTimeoutHeight(tx); timeoutHeight > 0 &&
+				int(timeoutHeight) < int(msg.Order.GetGoodTilBlock()) && ctx.IsCheckTx() {
 				log.InfoLog(
 					ctx,
 					"Rejected short-term place order with timeout height < goodTilBlock",

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -121,7 +121,7 @@ func (cd ClobDecorator) AnteHandle(
 				)
 				return ctx, errorsmod.Wrap(
 					sdkerrors.ErrInvalidRequest,
-					"a short term place order message may not have a timeout height less than goodTilBlock",
+					"timeout height (if non-zero) may not be less than `goodTilBlock` for a short-term place order",
 				)
 			}
 

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -110,7 +110,7 @@ func (cd ClobDecorator) AnteHandle(
 				return next(ctx, tx, simulate)
 			}
 
-			// HOTFIX: Ignore any short-term place orders in a transaction with a timeout height < good til block
+			// HOTFIX: Reject any short-term place orders in a transaction with a non-zero timeout height < good til block
 			if timeoutHeight := GetTimeoutHeight(tx); timeoutHeight > 0 &&
 				int(timeoutHeight) < int(msg.Order.GetGoodTilBlock()) && ctx.IsCheckTx() {
 				log.InfoLog(

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -223,16 +223,16 @@ func TestClobDecorator_MsgPlaceOrder(t *testing.T) {
 			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
 		// Test for hotfix.
-		"PlaceShortTermOrder is not called on keeper CheckTx if transaction timeout height is non-zero": {
+		"PlaceShortTermOrder is not called on keeper CheckTx if transaction timeout height < goodTilBlock": {
 			msgs:                      []sdk.Msg{constants.Msg_PlaceOrder},
 			useWithIsCheckTxContext:   true,
 			useWithIsRecheckTxContext: false,
 			isSimulate:                false,
 			expectedErr: errorsmod.Wrap(
 				sdkerrors.ErrInvalidRequest,
-				"a short term place order message may not have a non-zero timeout height, use goodTilBlock instead",
+				"a short term place order message may not have a timeout height less than goodTilBlock",
 			),
-			timeoutHeight: 1,
+			timeoutHeight: uint64(constants.Msg_PlaceOrder.Order.GetGoodTilBlock() - 1),
 			additionalAssertions: func(ctx sdk.Context, mck *mocks.ClobKeeper) {
 				mck.AssertNotCalled(
 					t,
@@ -241,6 +241,22 @@ func TestClobDecorator_MsgPlaceOrder(t *testing.T) {
 					constants.Msg_PlaceOrder,
 				)
 			},
+		},
+		"Successfully places a short term order using a single message with timeout height >= goodTilBlock": {
+			msgs: []sdk.Msg{constants.Msg_PlaceOrder},
+			setupMocks: func(ctx sdk.Context, mck *mocks.ClobKeeper) {
+				mck.On("PlaceShortTermOrder",
+					ctx,
+					constants.Msg_PlaceOrder,
+				).Return(
+					satypes.BaseQuantums(0),
+					clobtypes.Success,
+					nil,
+				)
+			},
+			useWithIsCheckTxContext: true,
+			expectedErr:             nil,
+			timeoutHeight:           uint64(constants.Msg_PlaceOrder.Order.GetGoodTilBlock()),
 		},
 	}
 


### PR DESCRIPTION
### Changelist
Update logic from #1849 to only reject orders with `TimeoutHeight` > 0 and `TimeoutHeight` < `GoodTilBlock`. If `TimeoutHeight` >= `GoodTilBlock`, the order cannot be in any matches in blocks > `GoodTilBlock` so they should always be valid for the `TimeoutHeight` check if `TimeoutHeight` >= `GoodTilBlock`. 

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order validation by ensuring short-term orders are only rejected if the transaction timeout height is less than the `goodTilBlock` value, enhancing order placement accuracy.

- **Tests**
  - Updated and added test cases to verify the new logic for placing short-term orders with timeout height conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->