### PR TITLE
Log order id and good til block of rejected st orders.

### DIFF
--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -14,6 +14,8 @@ import (
 
 var (
 	timeoutHeightLogKey = "TimeoutHeight"
+	orderIdLogKey       = "OrderId"
+	goodTilBlockLogKey  = "GoodTilBlock"
 )
 
 // ClobDecorator is an AnteDecorator which is responsible for:
@@ -118,6 +120,10 @@ func (cd ClobDecorator) AnteHandle(
 					"Rejected short-term place order with non-zero timeout height < goodTilBlock",
 					timeoutHeightLogKey,
 					timeoutHeight,
+					orderIdLogKey,
+					msg.Order.OrderId,
+					goodTilBlockLogKey,
+					msg.Order.GetGoodTilBlock(),
 				)
 				return ctx, errorsmod.Wrap(
 					sdkerrors.ErrInvalidRequest,


### PR DESCRIPTION
### Changelist
Add additional logging when rejecting ST orders to have better visibility as to who is sending the order and the difference between `TimeoutHeight` and `GoodTilBlock`.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
