### PR TITLE
Revert "Increase conditional order trigger multiplier to 25 

### DIFF
--- a/protocol/testutil/constants/orders.go
+++ b/protocol/testutil/constants/orders.go
@@ -932,13 +932,6 @@ var (
 		Subticks:     50_500_000_000,
 		GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 10},
 	}
-	Order_Carl_Num1_Id0_Clob0_Buy1BTC_Price51500_GTB10 = clobtypes.Order{
-		OrderId:      clobtypes.OrderId{SubaccountId: Carl_Num1, ClientId: 0, ClobPairId: 0},
-		Side:         clobtypes.Order_SIDE_BUY,
-		Quantums:     100_000_000,
-		Subticks:     51_500_000_000,
-		GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 10},
-	}
 	Order_Dave_Num0_Id2_Clob0_Sell1BTC_Price49500_GTB10 = clobtypes.Order{
 		OrderId:      clobtypes.OrderId{SubaccountId: Dave_Num0, ClientId: 2, ClobPairId: 0},
 		Side:         clobtypes.Order_SIDE_SELL,
@@ -1092,13 +1085,6 @@ var (
 		Side:         clobtypes.Order_SIDE_SELL,
 		Quantums:     1_000_000_000,
 		Subticks:     3_030_000_000,
-		GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 10},
-	}
-	Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price48500_GTB10 = clobtypes.Order{
-		OrderId:      clobtypes.OrderId{SubaccountId: Dave_Num1, ClientId: 0, ClobPairId: 0},
-		Side:         clobtypes.Order_SIDE_SELL,
-		Quantums:     100_000_000,
-		Subticks:     48_500_000_000,
 		GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 10},
 	}
 	Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price49500_GTB10 = clobtypes.Order{

--- a/protocol/testutil/constants/stateful_orders.go
+++ b/protocol/testutil/constants/stateful_orders.go
@@ -871,20 +871,6 @@ var (
 		ConditionType:                   clobtypes.Order_CONDITION_TYPE_TAKE_PROFIT,
 		ConditionalOrderTriggerSubticks: 20,
 	}
-	ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_48700 = clobtypes.Order{
-		OrderId: clobtypes.OrderId{
-			SubaccountId: Alice_Num0,
-			ClientId:     0,
-			OrderFlags:   clobtypes.OrderIdFlags_Conditional,
-			ClobPairId:   0,
-		},
-		Side:                            clobtypes.Order_SIDE_BUY,
-		Quantums:                        100_000_000,
-		Subticks:                        50_000_000_000,
-		GoodTilOneof:                    &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
-		ConditionType:                   clobtypes.Order_CONDITION_TYPE_TAKE_PROFIT,
-		ConditionalOrderTriggerSubticks: 48_700_000_000,
-	}
 	ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49700 = clobtypes.Order{
 		OrderId: clobtypes.OrderId{
 			SubaccountId: Alice_Num0,
@@ -984,20 +970,6 @@ var (
 		ConditionType:                   clobtypes.Order_CONDITION_TYPE_STOP_LOSS,
 		ConditionalOrderTriggerSubticks: 50_300_000_000,
 	}
-	ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_51300 = clobtypes.Order{
-		OrderId: clobtypes.OrderId{
-			SubaccountId: Alice_Num0,
-			ClientId:     0,
-			OrderFlags:   clobtypes.OrderIdFlags_Conditional,
-			ClobPairId:   0,
-		},
-		Side:                            clobtypes.Order_SIDE_BUY,
-		Quantums:                        100_000_000,
-		Subticks:                        50_000_000_000,
-		GoodTilOneof:                    &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
-		ConditionType:                   clobtypes.Order_CONDITION_TYPE_STOP_LOSS,
-		ConditionalOrderTriggerSubticks: 51_300_000_000,
-	}
 	ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_50001 = clobtypes.Order{
 		OrderId: clobtypes.OrderId{
 			SubaccountId: Bob_Num0,
@@ -1039,34 +1011,6 @@ var (
 		GoodTilOneof:                    &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
 		ConditionType:                   clobtypes.Order_CONDITION_TYPE_TAKE_PROFIT,
 		ConditionalOrderTriggerSubticks: 50_300_000_000,
-	}
-	ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_51300 = clobtypes.Order{
-		OrderId: clobtypes.OrderId{
-			SubaccountId: Bob_Num0,
-			ClientId:     0,
-			OrderFlags:   clobtypes.OrderIdFlags_Conditional,
-			ClobPairId:   0,
-		},
-		Side:                            clobtypes.Order_SIDE_SELL,
-		Quantums:                        100_000_000,
-		Subticks:                        50_000_000_000,
-		GoodTilOneof:                    &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
-		ConditionType:                   clobtypes.Order_CONDITION_TYPE_TAKE_PROFIT,
-		ConditionalOrderTriggerSubticks: 51_300_000_000,
-	}
-	ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_48700 = clobtypes.Order{
-		OrderId: clobtypes.OrderId{
-			SubaccountId: Bob_Num0,
-			ClientId:     0,
-			OrderFlags:   clobtypes.OrderIdFlags_Conditional,
-			ClobPairId:   0,
-		},
-		Side:                            clobtypes.Order_SIDE_SELL,
-		Quantums:                        100_000_000,
-		Subticks:                        50_000_000_000,
-		GoodTilOneof:                    &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
-		ConditionType:                   clobtypes.Order_CONDITION_TYPE_STOP_LOSS,
-		ConditionalOrderTriggerSubticks: 48_700_000_000,
 	}
 	ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49700 = clobtypes.Order{
 		OrderId: clobtypes.OrderId{

--- a/protocol/x/clob/e2e/conditional_orders_test.go
+++ b/protocol/x/clob/e2e/conditional_orders_test.go
@@ -1014,24 +1014,24 @@ func TestConditionalOrder_TriggeringUsingMatchedPrice(t *testing.T) {
 				constants.Dave_Num1_500000USD,
 			},
 			ordersForFirstBlock: []clobtypes.Order{
-				// Trigger price is $48,700.
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_48700,
+				// Trigger price is $49,700.
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49700,
 			},
 			ordersForSecondBlock: []clobtypes.Order{
-				// Create a match with price $48,500.
+				// Create a match with price $49,500.
 				// This price can trigger the conditional order if unbounded.
-				// The bounded price is $50,000 - $50,000 * 2.5% = $48,750, which would not trigger the conditional order.
-				constants.Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price48500_GTB10,
+				// The bounded price is $50,000 - $50,000 * 0.5% = $49,750, which would not trigger the conditional order.
+				constants.Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price49500_GTB10,
 				constants.Order_Carl_Num1_Id0_Clob0_Buy1BTC_Price50003_GTB10,
 			},
 
 			expectedExistInState: map[clobtypes.OrderId]bool{
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_48700.OrderId: true,
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49995.OrderId: true,
 			},
 			expectedInTriggeredStateAfterBlock: map[uint32]map[clobtypes.OrderId]bool{
-				2: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_48700.OrderId: false},
-				3: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_48700.OrderId: false},
-				4: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_48700.OrderId: false},
+				2: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49995.OrderId: false},
+				3: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49995.OrderId: false},
+				4: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_TP_49995.OrderId: false},
 			},
 		},
 		"StopLoss/Buy conditional order is placed and not triggered by matched price": {
@@ -1065,24 +1065,24 @@ func TestConditionalOrder_TriggeringUsingMatchedPrice(t *testing.T) {
 				constants.Dave_Num1_500000USD,
 			},
 			ordersForFirstBlock: []clobtypes.Order{
-				// Trigger price is $51,300.
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_51300,
+				// Trigger price is $50,300.
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50300,
 			},
 			ordersForSecondBlock: []clobtypes.Order{
-				// Create a match with price $51,500.
+				// Create a match with price $50,500.
 				// This price can trigger the conditional order if unbounded.
-				// The bounded price is $50,000 + $50,000 * 2.5% = $51,250, which would not trigger the conditional order.
-				constants.Order_Carl_Num1_Id0_Clob0_Buy1BTC_Price51500_GTB10,
+				// The bounded price is $50,000 + $50,000 * 0.5% = $50,250, which would not trigger the conditional order.
+				constants.Order_Carl_Num1_Id0_Clob0_Buy1BTC_Price50500_GTB10,
 				constants.Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price49997_GTB10,
 			},
 
 			expectedExistInState: map[clobtypes.OrderId]bool{
-				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_51300.OrderId: true,
+				constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50005.OrderId: true,
 			},
 			expectedInTriggeredStateAfterBlock: map[uint32]map[clobtypes.OrderId]bool{
-				2: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_51300.OrderId: false},
-				3: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_51300.OrderId: false},
-				4: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_51300.OrderId: false},
+				2: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50005.OrderId: false},
+				3: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50005.OrderId: false},
+				4: {constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50005.OrderId: false},
 			},
 		},
 		"TakeProfit/Sell conditional order is placed and not triggered by matched price": {
@@ -1116,24 +1116,24 @@ func TestConditionalOrder_TriggeringUsingMatchedPrice(t *testing.T) {
 				constants.Dave_Num1_500000USD,
 			},
 			ordersForFirstBlock: []clobtypes.Order{
-				// Trigger price is $51,300.
-				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_51300,
+				// Trigger price is $50,300.
+				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_50300,
 			},
 			ordersForSecondBlock: []clobtypes.Order{
-				// Create a match with price $51,500.
+				// Create a match with price $50,500.
 				// This price can trigger the conditional order if unbounded.
-				// The bounded price is $50,000 + $50,000 * 2.5% = $51,250, which would not trigger the conditional order.
-				constants.Order_Carl_Num1_Id0_Clob0_Buy1BTC_Price51500_GTB10,
+				// The bounded price is $50,000 + $50,000 * 0.5% = $50,250, which would not trigger the conditional order.
+				constants.Order_Carl_Num1_Id0_Clob0_Buy1BTC_Price50500_GTB10,
 				constants.Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price49997_GTB10,
 			},
 
 			expectedExistInState: map[clobtypes.OrderId]bool{
-				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_51300.OrderId: true,
+				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_50005.OrderId: true,
 			},
 			expectedInTriggeredStateAfterBlock: map[uint32]map[clobtypes.OrderId]bool{
-				2: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_51300.OrderId: false},
-				3: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_51300.OrderId: false},
-				4: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_51300.OrderId: false},
+				2: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_50005.OrderId: false},
+				3: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_50005.OrderId: false},
+				4: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_TP_50005.OrderId: false},
 			},
 		},
 		"StopLoss/Sell conditional order is placed and not triggered by matched price": {
@@ -1167,24 +1167,24 @@ func TestConditionalOrder_TriggeringUsingMatchedPrice(t *testing.T) {
 				constants.Dave_Num1_500000USD,
 			},
 			ordersForFirstBlock: []clobtypes.Order{
-				// Trigger price is $48,700.
-				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_48700,
+				// Trigger price is $49,700.
+				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49700,
 			},
 			ordersForSecondBlock: []clobtypes.Order{
-				// Create a match with price $48,500.
+				// Create a match with price $49,500.
 				// This price can trigger the conditional order if unbounded.
-				// The bounded price is $50,000 - $50,000 * 2.5% = $48,750, which would not trigger the conditional order.
-				constants.Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price48500_GTB10,
+				// The bounded price is $50,000 - $50,000 * 0.5% = $49,750, which would not trigger the conditional order.
+				constants.Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price49500_GTB10,
 				constants.Order_Carl_Num1_Id0_Clob0_Buy1BTC_Price50003_GTB10,
 			},
 
 			expectedExistInState: map[clobtypes.OrderId]bool{
-				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_48700.OrderId: true,
+				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49995.OrderId: true,
 			},
 			expectedInTriggeredStateAfterBlock: map[uint32]map[clobtypes.OrderId]bool{
-				2: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_48700.OrderId: false},
-				3: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_48700.OrderId: false},
-				4: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_48700.OrderId: false},
+				2: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49995.OrderId: false},
+				3: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49995.OrderId: false},
+				4: {constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10_SL_49995.OrderId: false},
 			},
 		},
 		"TakeProfit/Buy conditional order is placed and triggered immediately by matched price": {

--- a/protocol/x/clob/types/constants.go
+++ b/protocol/x/clob/types/constants.go
@@ -25,4 +25,4 @@ const StatefulOrderTimeWindow time.Duration = 95 * 24 * time.Hour // 95 days.
 // The lower bound is calculated as:
 //
 //	lower_bound = (1 - min_price_change_ppm / 1_000_000 * conditional_order_trigger_multiplier) * oracle_price
-const ConditionalOrderTriggerMultiplier uint64 = 25
+const ConditionalOrderTriggerMultiplier uint64 = 5


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated trigger prices and bounded prices for conditional orders, improving calculation accuracy and test coverage.
  
- **Bug Fixes**
  - Adjusted multiplier for `ConditionalOrderTriggerMultiplier` to ensure correct lower-bound calculations for order time windows.

- **Tests**
  - Enhanced test scenarios for conditional orders, including TakeProfit and StopLoss, to reflect updated trigger and bounded price calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->