### PR TITLE
fix historical pnl endpoint name in docs

### DIFF
--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1354,7 +1354,7 @@ headers = {
 # baseURL = 'https://indexer.dydx.trade/v4'
 baseURL = 'https://dydx-testnet.imperator.co/v4'
 
-r = requests.get(f'{baseURL}/historical-pnl/parentSubaccount', params={
+r = requests.get(f'{baseURL}/historical-pnl/parentSubaccountNumber', params={
   'address': 'string',  'parentSubaccountNumber': '0.1'
 }, headers = headers)
 
@@ -1372,7 +1372,7 @@ const headers = {
 // const baseURL = 'https://indexer.dydx.trade/v4';
 const baseURL = 'https://dydx-testnet.imperator.co/v4';
 
-fetch(`${baseURL}/historical-pnl/parentSubaccount?address=string&parentSubaccountNumber=0.1`,
+fetch(`${baseURL}/historical-pnl/parentSubaccountNumber?address=string&parentSubaccountNumber=0.1`,
 {
   method: 'GET',
 
@@ -1386,7 +1386,7 @@ fetch(`${baseURL}/historical-pnl/parentSubaccount?address=string&parentSubaccoun
 
 ```
 
-`GET /historical-pnl/parentSubaccount`
+`GET /historical-pnl/parentSubaccountNumber`
 
 ### Parameters
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -1980,7 +1980,7 @@
         ]
       }
     },
-    "/historical-pnl/parentSubaccount": {
+    "/historical-pnl/parentSubaccountNumber": {
       "get": {
         "operationId": "GetHistoricalPnlForParentSubaccount",
         "responses": {

--- a/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
@@ -101,7 +101,7 @@ class HistoricalPnlController extends Controller {
     };
   }
 
-  @Get('/parentSubaccount')
+  @Get('/parentSubaccountNumber')
   async getHistoricalPnlForParentSubaccount(
     @Query() address: string,
       @Query() parentSubaccountNumber: number,


### PR DESCRIPTION
### Changelist
fix historical pnl endpoint name in docs

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to change the endpoint path from `/historical-pnl/parentSubaccount` to `/historical-pnl/parentSubaccountNumber`.

- **New Features**
  - Modified API endpoint to use `/historical-pnl/parentSubaccountNumber` for fetching historical P&L data related to a parent subaccount.

- **Bug Fixes**
  - Corrected endpoint path in API documentation and Swagger file for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->