### PR TITLE
[TRA-480] Implement functionality to acquire next market id

### DIFF
--- a/protocol/x/prices/types/keys.go
+++ b/protocol/x/prices/types/keys.go
@@ -16,4 +16,7 @@ const (
 
 	// MarketPriceKeyPrefix is the prefix to retrieve all MarketPrices
 	MarketPriceKeyPrefix = "Price:"
+
+	// NextIDKey is the key for the next market ID
+	NextMarketIDKey = "NextMarketID"
 )


### PR DESCRIPTION
### Changelist
This change adds a new store key to store the next market id to be used and getter/setter functions
Also provides a function to acquire a new market id

### Test Plan
Added tests

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to manage market IDs, allowing retrieval, updating, and acquisition of the next available market ID.
  - Added `NextMarketID` constant for efficient market ID management.

- **Tests**
  - Implemented `TestAcquireNextMarketID` to ensure the correctness of acquiring the next market ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->