### PR TITLE
[TRA-479] have vaults in best fee tier

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -302,7 +302,7 @@ type App struct {
 
 	DelayMsgKeeper delaymsgmodulekeeper.Keeper
 
-	FeeTiersKeeper feetiersmodulekeeper.Keeper
+	FeeTiersKeeper *feetiersmodulekeeper.Keeper
 
 	ListingKeeper listingmodulekeeper.Keeper
 
@@ -980,7 +980,7 @@ func New(
 	)
 	statsModule := statsmodule.NewAppModule(appCodec, app.StatsKeeper)
 
-	app.FeeTiersKeeper = *feetiersmodulekeeper.NewKeeper(
+	app.FeeTiersKeeper = feetiersmodulekeeper.NewKeeper(
 		appCodec,
 		app.StatsKeeper,
 		keys[feetiersmoduletypes.StoreKey],
@@ -1126,6 +1126,7 @@ func New(
 		},
 	)
 	vaultModule := vaultmodule.NewAppModule(appCodec, app.VaultKeeper)
+	app.FeeTiersKeeper.SetVaultKeeper(app.VaultKeeper)
 
 	app.ListingKeeper = *listingmodulekeeper.NewKeeper(
 		appCodec,

--- a/protocol/testutil/keeper/clob.go
+++ b/protocol/testutil/keeper/clob.go
@@ -31,6 +31,7 @@ import (
 	statskeeper "github.com/dydxprotocol/v4-chain/protocol/x/stats/keeper"
 	subkeeper "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	vaultkeeper "github.com/dydxprotocol/v4-chain/protocol/x/vault/keeper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,6 +46,7 @@ type ClobKeepersTestContext struct {
 	StatsKeeper       *statskeeper.Keeper
 	RewardsKeeper     *rewardskeeper.Keeper
 	SubaccountsKeeper *subkeeper.Keeper
+	VaultKeeper       *vaultkeeper.Keeper
 	StoreKey          storetypes.StoreKey
 	MemKey            storetypes.StoreKey
 	Cdc               *codec.ProtoCodec
@@ -114,9 +116,16 @@ func NewClobKeepersTestContextWithUninitializedMemStore(
 			db,
 			cdc,
 		)
+		ks.VaultKeeper, _ = createVaultKeeper(
+			stateStore,
+			db,
+			cdc,
+			indexerEventsTransientStoreKey,
+		)
 		ks.FeeTiersKeeper, _ = createFeeTiersKeeper(
 			stateStore,
 			ks.StatsKeeper,
+			ks.VaultKeeper,
 			db,
 			cdc,
 		)

--- a/protocol/testutil/keeper/feetiers.go
+++ b/protocol/testutil/keeper/feetiers.go
@@ -11,11 +11,13 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
 	statskeeper "github.com/dydxprotocol/v4-chain/protocol/x/stats/keeper"
+	vaultkeeper "github.com/dydxprotocol/v4-chain/protocol/x/vault/keeper"
 )
 
 func createFeeTiersKeeper(
 	stateStore storetypes.CommitMultiStore,
 	statsKeeper *statskeeper.Keeper,
+	vaultKeeper *vaultkeeper.Keeper,
 	db *dbm.MemDB,
 	cdc *codec.ProtoCodec,
 ) (*keeper.Keeper, storetypes.StoreKey) {
@@ -35,6 +37,7 @@ func createFeeTiersKeeper(
 		storeKey,
 		authorities,
 	)
+	k.SetVaultKeeper(vaultKeeper)
 
 	return k, storeKey
 }

--- a/protocol/testutil/keeper/rewards.go
+++ b/protocol/testutil/keeper/rewards.go
@@ -61,9 +61,16 @@ func RewardsKeepers(
 			db,
 			cdc,
 		)
+		vaultKeeper, _ := createVaultKeeper(
+			stateStore,
+			db,
+			cdc,
+			transientStoreKey,
+		)
 		feetiersKeeper, _ = createFeeTiersKeeper(
 			stateStore,
 			statsKeeper,
+			vaultKeeper,
 			db,
 			cdc,
 		)

--- a/protocol/x/feetiers/genesis_test.go
+++ b/protocol/x/feetiers/genesis_test.go
@@ -12,7 +12,7 @@ import (
 func TestGenesis(t *testing.T) {
 	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()
-	got := feetiers.ExportGenesis(ctx, tApp.App.FeeTiersKeeper)
+	got := feetiers.ExportGenesis(ctx, *tApp.App.FeeTiersKeeper)
 	require.NotNil(t, got)
 	require.Equal(t, types.DefaultGenesis(), got)
 }

--- a/protocol/x/feetiers/keeper/keeper.go
+++ b/protocol/x/feetiers/keeper/keeper.go
@@ -56,10 +56,10 @@ func (k *Keeper) SetVaultKeeper(vk types.VaultKeeper) {
 }
 
 func (k Keeper) getUserFeeTier(ctx sdk.Context, address string) (uint32, *types.PerpetualFeeTier) {
-	// Invariant: we know there is at least one tier and that the first tier has no requirements
 	tiers := k.GetPerpetualFeeParams(ctx).Tiers
 
 	// A vault is always in the highest tier.
+	// Invariant: there's at least one tier.
 	if k.vaultKeeper.IsVault(ctx, address) {
 		highestTierIdx := uint32(len(tiers) - 1)
 		return highestTierIdx, tiers[highestTierIdx]
@@ -68,6 +68,7 @@ func (k Keeper) getUserFeeTier(ctx sdk.Context, address string) (uint32, *types.
 	userStats := k.statsKeeper.GetUserStats(ctx, address)
 	globalStats := k.statsKeeper.GetGlobalStats(ctx)
 
+	// Invariant: we know there is at least one tier and that the first tier has no requirements
 	idx := uint32(0)
 
 	// Find the last tier we meet all requirements for

--- a/protocol/x/feetiers/keeper/keeper.go
+++ b/protocol/x/feetiers/keeper/keeper.go
@@ -17,6 +17,7 @@ type (
 	Keeper struct {
 		cdc         codec.BinaryCodec
 		statsKeeper types.StatsKeeper
+		vaultKeeper types.VaultKeeper
 		storeKey    storetypes.StoreKey
 		authorities map[string]struct{}
 	}
@@ -47,12 +48,26 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 
 func (k Keeper) InitializeForGenesis(ctx sdk.Context) {}
 
+// SetVaultKeeper sets the `VaultKeeper` reference in `FeeTiersKeeper`.
+// The reference is set with an explicit method call rather than during `NewKeeper`
+// due to the circular dependency `Clob` -> `Vault` -> `FeeTiers` -> `Clob`.
+func (k *Keeper) SetVaultKeeper(vk types.VaultKeeper) {
+	k.vaultKeeper = vk
+}
+
 func (k Keeper) getUserFeeTier(ctx sdk.Context, address string) (uint32, *types.PerpetualFeeTier) {
+	// Invariant: we know there is at least one tier and that the first tier has no requirements
+	tiers := k.GetPerpetualFeeParams(ctx).Tiers
+
+	// A vault is always in the highest tier.
+	if k.vaultKeeper.IsVault(ctx, address) {
+		highestTierIdx := uint32(len(tiers) - 1)
+		return highestTierIdx, tiers[highestTierIdx]
+	}
+
 	userStats := k.statsKeeper.GetUserStats(ctx, address)
 	globalStats := k.statsKeeper.GetGlobalStats(ctx)
 
-	// Invariant: we know there is at least one tier and that the first tier has no requirements
-	tiers := k.GetPerpetualFeeParams(ctx).Tiers
 	idx := uint32(0)
 
 	// Find the last tier we meet all requirements for

--- a/protocol/x/feetiers/keeper/keeper_test.go
+++ b/protocol/x/feetiers/keeper/keeper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
 	stattypes "github.com/dydxprotocol/v4-chain/protocol/x/stats/types"
 	"github.com/stretchr/testify/require"
@@ -19,12 +20,14 @@ func TestLogger(t *testing.T) {
 
 func TestGetPerpetualFeePpm(t *testing.T) {
 	tests := map[string]struct {
+		user                string
 		UserStats           *stattypes.UserStats
 		GlobalStats         *stattypes.GlobalStats
 		expectedTakerFeePpm int32
 		expectedMakerFeePpm int32
 	}{
-		"first tier": {
+		"regular user, first tier": {
+			"alice",
 			&stattypes.UserStats{
 				TakerNotional: 10,
 				MakerNotional: 10,
@@ -35,7 +38,8 @@ func TestGetPerpetualFeePpm(t *testing.T) {
 			10,
 			1,
 		},
-		"increased tier": {
+		"regular user, increased tier": {
+			"alice",
 			&stattypes.UserStats{
 				TakerNotional: 1_000,
 				MakerNotional: 150,
@@ -46,7 +50,8 @@ func TestGetPerpetualFeePpm(t *testing.T) {
 			20,
 			2,
 		},
-		"partial requirements doesn't increase tier": {
+		"regular user, partial requirements doesn't increase tier": {
+			"alice",
 			&stattypes.UserStats{
 				TakerNotional: 1_000,
 				MakerNotional: 1_000_000_000,
@@ -57,7 +62,8 @@ func TestGetPerpetualFeePpm(t *testing.T) {
 			20,
 			2,
 		},
-		"top tier": {
+		"regular user, top tier": {
+			"alice",
 			&stattypes.UserStats{
 				TakerNotional: 1_000,
 				MakerNotional: 1_000_000_000,
@@ -68,13 +74,25 @@ func TestGetPerpetualFeePpm(t *testing.T) {
 			30,
 			3,
 		},
+		"vault is top tier regardless of stats": {
+			constants.Vault_Clob0.ToModuleAccountAddress(),
+			&stattypes.UserStats{
+				TakerNotional: 10,
+				MakerNotional: 10,
+			},
+			&stattypes.GlobalStats{
+				NotionalTraded: 10_000,
+			},
+			30,
+			3,
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
-			user := "alice"
+			tApp.App.VaultKeeper.AddVaultToAddressStore(ctx, constants.Vault_Clob0)
 			k := tApp.App.FeeTiersKeeper
 			err := k.SetPerpetualFeeParams(
 				ctx,
@@ -104,11 +122,11 @@ func TestGetPerpetualFeePpm(t *testing.T) {
 			require.NoError(t, err)
 
 			statsKeeper := tApp.App.StatsKeeper
-			statsKeeper.SetUserStats(ctx, user, tc.UserStats)
+			statsKeeper.SetUserStats(ctx, tc.user, tc.UserStats)
 			statsKeeper.SetGlobalStats(ctx, tc.GlobalStats)
 
-			require.Equal(t, tc.expectedTakerFeePpm, k.GetPerpetualFeePpm(ctx, user, true))
-			require.Equal(t, tc.expectedMakerFeePpm, k.GetPerpetualFeePpm(ctx, user, false))
+			require.Equal(t, tc.expectedTakerFeePpm, k.GetPerpetualFeePpm(ctx, tc.user, true))
+			require.Equal(t, tc.expectedMakerFeePpm, k.GetPerpetualFeePpm(ctx, tc.user, false))
 		})
 	}
 }

--- a/protocol/x/feetiers/keeper/msg_server.go
+++ b/protocol/x/feetiers/keeper/msg_server.go
@@ -11,12 +11,12 @@ import (
 )
 
 type msgServer struct {
-	Keeper
+	Keeper types.FeeTiersKeeper
 }
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper types.FeeTiersKeeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
@@ -26,7 +26,7 @@ func (k msgServer) UpdatePerpetualFeeParams(
 	goCtx context.Context,
 	msg *types.MsgUpdatePerpetualFeeParams,
 ) (*types.MsgUpdatePerpetualFeeParamsResponse, error) {
-	if !k.HasAuthority(msg.Authority) {
+	if !k.Keeper.HasAuthority(msg.Authority) {
 		return nil, errorsmod.Wrapf(
 			govtypes.ErrInvalidSigner,
 			"invalid authority %s",
@@ -35,7 +35,7 @@ func (k msgServer) UpdatePerpetualFeeParams(
 	}
 
 	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
-	if err := k.SetPerpetualFeeParams(ctx, msg.Params); err != nil {
+	if err := k.Keeper.SetPerpetualFeeParams(ctx, msg.Params); err != nil {
 		return nil, err
 	}
 

--- a/protocol/x/feetiers/keeper/msg_server_test.go
+++ b/protocol/x/feetiers/keeper/msg_server_test.go
@@ -16,7 +16,7 @@ func setupMsgServer(t *testing.T) (keeper.Keeper, types.MsgServer, context.Conte
 	ctx := tApp.InitChain()
 	k := tApp.App.FeeTiersKeeper
 
-	return k, keeper.NewMsgServerImpl(k), ctx
+	return *k, keeper.NewMsgServerImpl(k), ctx
 }
 
 func TestMsgServer(t *testing.T) {

--- a/protocol/x/feetiers/module.go
+++ b/protocol/x/feetiers/module.go
@@ -96,12 +96,12 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper *keeper.Keeper
 }
 
 func NewAppModule(
 	cdc codec.Codec,
-	keeper keeper.Keeper,
+	keeper *keeper.Keeper,
 ) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),
@@ -129,12 +129,12 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 	// Initialize global index to index in genesis state
 	cdc.MustUnmarshalJSON(gs, &genState)
 
-	InitGenesis(ctx, am.keeper, genState)
+	InitGenesis(ctx, *am.keeper, genState)
 }
 
 // ExportGenesis returns the feetiers module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
-	genState := ExportGenesis(ctx, am.keeper)
+	genState := ExportGenesis(ctx, *am.keeper)
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/protocol/x/feetiers/types/expected_keepers.go
+++ b/protocol/x/feetiers/types/expected_keepers.go
@@ -10,3 +10,8 @@ type StatsKeeper interface {
 	GetUserStats(ctx sdk.Context, address string) *types.UserStats
 	GetGlobalStats(ctx sdk.Context) *types.GlobalStats
 }
+
+// VaultKeeper defines the expected vault keeper.
+type VaultKeeper interface {
+	IsVault(ctx sdk.Context, address string) bool
+}

--- a/protocol/x/feetiers/types/types.go
+++ b/protocol/x/feetiers/types/types.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type FeeTiersKeeper interface {
+	GetLowestMakerFee(ctx sdk.Context) int32
+	GetPerpetualFeePpm(ctx sdk.Context, address string, isTaker bool) int32
+	GetPerpetualFeeParams(
+		ctx sdk.Context,
+	) PerpetualFeeParams
+	SetPerpetualFeeParams(
+		ctx sdk.Context,
+		params PerpetualFeeParams,
+	) error
+	HasAuthority(authority string) bool
+}

--- a/protocol/x/vault/genesis.go
+++ b/protocol/x/vault/genesis.go
@@ -14,7 +14,11 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	if err := k.SetParams(ctx, genState.Params); err != nil {
 		panic(err)
 	}
-	// Set total shares, owner shares, and vault params of each vault.
+	// For each vault:
+	// 1. Set total shares
+	// 2. Set owner shares
+	// 3. Set vault params
+	// 4. Add to address store
 	for _, vault := range genState.Vaults {
 		if err := k.SetTotalShares(ctx, *vault.VaultId, *vault.TotalShares); err != nil {
 			panic(err)
@@ -29,6 +33,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 				panic(err)
 			}
 		}
+		k.AddVaultToAddressStore(ctx, *vault.VaultId)
 	}
 }
 

--- a/protocol/x/vault/keeper/msg_server_deposit_to_vault.go
+++ b/protocol/x/vault/keeper/msg_server_deposit_to_vault.go
@@ -30,6 +30,9 @@ func (k msgServer) DepositToVault(
 		return nil, err
 	}
 
+	// Add vault to address store.
+	k.AddVaultToAddressStore(ctx, *msg.VaultId)
+
 	// Transfer from sender subaccount to vault.
 	// Note: Transfer should take place after minting shares for
 	// shares calculation to be correct.

--- a/protocol/x/vault/keeper/msg_server_deposit_to_vault_test.go
+++ b/protocol/x/vault/keeper/msg_server_deposit_to_vault_test.go
@@ -362,6 +362,8 @@ func TestMsgDepositToVault(t *testing.T) {
 				vaultEquity, err := tApp.App.VaultKeeper.GetVaultEquity(ctx, tc.vaultId)
 				require.NoError(t, err)
 				require.Equal(t, tc.vaultEquityHistory[i], vaultEquity)
+				// Check that vault exists in address store.
+				require.True(t, tApp.App.VaultKeeper.IsVault(ctx, tc.vaultId.ToModuleAccountAddress()))
 			}
 		})
 	}

--- a/protocol/x/vault/keeper/vault.go
+++ b/protocol/x/vault/keeper/vault.go
@@ -98,6 +98,28 @@ func (k Keeper) DecommissionVault(
 	for ; ownerSharesIterator.Valid(); ownerSharesIterator.Next() {
 		ownerSharesStore.Delete(ownerSharesIterator.Key())
 	}
+
+	// Delete from vault address store.
+	vaultAddressStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.VaultAddressKeyPrefix))
+	vaultAddressStore.Delete([]byte(vaultId.ToModuleAccountAddress()))
+}
+
+// AddVaultToAddressStore adds a vault's address to the vault address store.
+func (k Keeper) AddVaultToAddressStore(
+	ctx sdk.Context,
+	vaultId types.VaultId,
+) {
+	vaultAddressStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.VaultAddressKeyPrefix))
+	vaultAddressStore.Set([]byte(vaultId.ToModuleAccountAddress()), []byte{})
+}
+
+// IsVault checks if a given address is a vault.
+func (k Keeper) IsVault(
+	ctx sdk.Context,
+	address string,
+) bool {
+	vaultAddressStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.VaultAddressKeyPrefix))
+	return vaultAddressStore.Has([]byte(address))
 }
 
 // GetAllVaults returns all vaults with their total shares, owner shares, and individual params.

--- a/protocol/x/vault/keeper/vault.go
+++ b/protocol/x/vault/keeper/vault.go
@@ -113,7 +113,7 @@ func (k Keeper) AddVaultToAddressStore(
 	vaultAddressStore.Set([]byte(vaultId.ToModuleAccountAddress()), []byte{})
 }
 
-// IsVault checks if a given address is a vault.
+// IsVault checks if a given address is the address of an existing vault.
 func (k Keeper) IsVault(
 	ctx sdk.Context,
 	address string,

--- a/protocol/x/vault/types/keys.go
+++ b/protocol/x/vault/types/keys.go
@@ -23,4 +23,7 @@ const (
 
 	// VaultParamsKeyPrefix is the prefix to retrieve all VaultParams.
 	VaultParamsKeyPrefix = "VaultParams:"
+
+	// VaultAddressKeyPrefix is the prefix to retrieve all vault addresses.
+	VaultAddressKeyPrefix = "VaultAddress:"
 )


### PR DESCRIPTION
### Changelist
have vaults in best fee tier

to achieve this
1. introduce a store in `x/vault` that stores vault addresses (add to this store when vaults are initialized and remove from this store when vaults are decommissioned)
2. in `x/feetiers`, return best tier if given address is a vault

### Test Plan
unit / integration tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `VaultKeeper` for enhanced vault management and integration with fee tiers.
  - Added new interfaces and methods for managing vault addresses and fee-related parameters.

- **Bug Fixes**
  - Corrected parameter types and initializations in various functions to ensure proper handling of vault and fee tiers.

- **Tests**
  - Included new test cases for vault functionality and updated existing test cases to accommodate new parameters and structures.

- **Documentation**
  - Updated function and struct declarations to reflect new parameters and types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->