### PR TITLE
[CT-988] Include position quote balance in nc and mmr calculations

### DIFF
--- a/protocol/indexer/events/subaccount_update.go
+++ b/protocol/indexer/events/subaccount_update.go
@@ -1,8 +1,12 @@
 package events
 
 import (
+	"math/big"
+
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
-	"github.com/dydxprotocol/v4-chain/protocol/indexer/protocol/v1"
+	v1 "github.com/dydxprotocol/v4-chain/protocol/indexer/protocol/v1"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+	salib "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/lib"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -21,6 +25,36 @@ func NewSubaccountUpdateEvent(
 			updatedPerpetualPositions,
 			fundingPayments,
 		),
-		UpdatedAssetPositions: v1.AssetPositionsToIndexerAssetPositions(updatedAssetPositions),
+		UpdatedAssetPositions: v1.AssetPositionsToIndexerAssetPositions(
+			AddQuoteBalanceFromPerpetualPositions(
+				updatedPerpetualPositions,
+				updatedAssetPositions,
+			),
+		),
 	}
+}
+
+func AddQuoteBalanceFromPerpetualPositions(
+	perpetualPositions []*satypes.PerpetualPosition,
+	assetPositions []*satypes.AssetPosition,
+) []*satypes.AssetPosition {
+	quoteBalance := new(big.Int)
+	for _, position := range perpetualPositions {
+		quoteBalance.Add(quoteBalance, position.GetQuoteBalance())
+	}
+
+	if quoteBalance.Sign() == 0 {
+		return assetPositions
+	}
+
+	// Add the quote balance to asset positions.
+	return salib.CalculateUpdatedAssetPositions(
+		assetPositions,
+		[]satypes.AssetUpdate{
+			{
+				AssetId:          assettypes.AssetUsdc.Id,
+				BigQuantumsDelta: quoteBalance,
+			},
+		},
+	)
 }

--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -451,13 +451,13 @@ func (k Keeper) GetBankruptcyPriceInQuoteQuantums(
 	// with a position size of `PS + deltaQuantums`.
 	// Note that we are intentionally not calculating `DNNV` from `deltaQuantums`
 	// directly to avoid rounding errors.
-	riskPosOld := perplib.GetNetCollateralAndMarginRequirements(
+	riskPosOld := perplib.GetPositionNetNotionalValueAndMarginRequirements(
 		perpetual,
 		marketPrice,
 		liquidityTier,
 		psBig,
 	)
-	riskPosNew := perplib.GetNetCollateralAndMarginRequirements(
+	riskPosNew := perplib.GetPositionNetNotionalValueAndMarginRequirements(
 		perpetual,
 		marketPrice,
 		liquidityTier,
@@ -541,7 +541,7 @@ func (k Keeper) GetFillablePrice(
 		return nil, err
 	}
 
-	riskPos := perplib.GetNetCollateralAndMarginRequirements(
+	riskPos := perplib.GetPositionNetNotionalValueAndMarginRequirements(
 		perpetual,
 		marketPrice,
 		liquidityTier,

--- a/protocol/x/perpetuals/lib/lib.go
+++ b/protocol/x/perpetuals/lib/lib.go
@@ -36,9 +36,9 @@ func GetSettlementPpmWithPerpetual(
 	return result, fundingIndex
 }
 
-// GetNetCollateralAndMarginRequirements returns the net collateral, initial margin requirement,
+// GetPositionNetNotionalValueAndMarginRequirements returns the net collateral, initial margin requirement,
 // and maintenance margin requirement in quote quantums, given the position size in base quantums.
-func GetNetCollateralAndMarginRequirements(
+func GetPositionNetNotionalValueAndMarginRequirements(
 	perpetual types.Perpetual,
 	marketPrice pricestypes.MarketPrice,
 	liquidityTier types.LiquidityTier,
@@ -62,6 +62,27 @@ func GetNetCollateralAndMarginRequirements(
 		IMR: imr,
 		MMR: mmr,
 	}
+}
+
+// GetNetCollateralAndMarginRequirements returns the net collateral, initial margin requirement,
+// and maintenance margin requirement in quote quantums, given the position size in base quantums.
+func GetNetCollateralAndMarginRequirements(
+	perpetual types.Perpetual,
+	marketPrice pricestypes.MarketPrice,
+	liquidityTier types.LiquidityTier,
+	quantums *big.Int,
+	quoteBalance *big.Int,
+) (
+	risk margin.Risk,
+) {
+	risk = GetPositionNetNotionalValueAndMarginRequirements(
+		perpetual,
+		marketPrice,
+		liquidityTier,
+		quantums,
+	)
+	risk.NC.Add(risk.NC, quoteBalance)
+	return risk
 }
 
 // GetNetNotionalInQuoteQuantums returns the net notional in quote quantums, which can be

--- a/protocol/x/perpetuals/lib/lib_test.go
+++ b/protocol/x/perpetuals/lib/lib_test.go
@@ -159,24 +159,42 @@ func TestGetNetCollateralAndMarginRequirements(t *testing.T) {
 		marketPrice   pricestypes.MarketPrice
 		liquidityTier types.LiquidityTier
 		quantums      *big.Int
+		quoteBalance  *big.Int
 	}{
 		"zero quantums": {
 			perpetual:     testPerpetual,
 			marketPrice:   testMarketPrice,
 			liquidityTier: testLiquidityTier,
 			quantums:      big.NewInt(0),
+			quoteBalance:  big.NewInt(0),
 		},
 		"positive quantums": {
 			perpetual:     testPerpetual,
 			marketPrice:   testMarketPrice,
 			liquidityTier: testLiquidityTier,
 			quantums:      big.NewInt(1_000_000_000_000),
+			quoteBalance:  big.NewInt(0),
 		},
 		"negative quantums": {
 			perpetual:     testPerpetual,
 			marketPrice:   testMarketPrice,
 			liquidityTier: testLiquidityTier,
 			quantums:      big.NewInt(-1_000_000_000_000),
+			quoteBalance:  big.NewInt(0),
+		},
+		"positive quote balance": {
+			perpetual:     testPerpetual,
+			marketPrice:   testMarketPrice,
+			liquidityTier: testLiquidityTier,
+			quantums:      big.NewInt(-1_000_000_000_000),
+			quoteBalance:  big.NewInt(1_000_000_000_000),
+		},
+		"negative quote balance": {
+			perpetual:     testPerpetual,
+			marketPrice:   testMarketPrice,
+			liquidityTier: testLiquidityTier,
+			quantums:      big.NewInt(1_000_000_000_000),
+			quoteBalance:  big.NewInt(-1_000_000_000_000),
 		},
 	}
 	for name, test := range tests {
@@ -197,8 +215,9 @@ func TestGetNetCollateralAndMarginRequirements(t *testing.T) {
 				test.marketPrice,
 				test.liquidityTier,
 				test.quantums,
+				test.quoteBalance,
 			)
-			require.Equal(t, enc, risk.NC)
+			require.Equal(t, 0, new(big.Int).Add(enc, test.quoteBalance).Cmp(risk.NC))
 			require.Equal(t, eimr, risk.IMR)
 			require.Equal(t, emmr, risk.MMR)
 		})

--- a/protocol/x/subaccounts/lib/updates.go
+++ b/protocol/x/subaccounts/lib/updates.go
@@ -299,6 +299,7 @@ func CalculateUpdatedPerpetualPositions(
 			positionsMap[update.PerpetualId] = &types.PerpetualPosition{
 				PerpetualId:  update.PerpetualId,
 				Quantums:     dtypes.NewIntFromBigInt(update.GetBigQuantums()),
+				QuoteBalance: dtypes.ZeroInt(),
 				FundingIndex: perpInfo.Perpetual.FundingIndex,
 			}
 		}

--- a/protocol/x/subaccounts/lib/updates.go
+++ b/protocol/x/subaccounts/lib/updates.go
@@ -363,6 +363,7 @@ func GetRiskForSubaccount(
 			perpInfo.Price,
 			perpInfo.LiquidityTier,
 			pos.GetBigQuantums(),
+			pos.GetQuoteBalance(),
 		)
 		risk.AddInPlace(r)
 	}

--- a/protocol/x/subaccounts/types/position_size.go
+++ b/protocol/x/subaccounts/types/position_size.go
@@ -92,6 +92,15 @@ func (m *PerpetualPosition) GetBigQuantums() *big.Int {
 	return m.Quantums.BigInt()
 }
 
+// Get the perpetual position quote balance in big.Int.
+func (m *PerpetualPosition) GetQuoteBalance() *big.Int {
+	if m == nil {
+		return new(big.Int)
+	}
+
+	return m.QuoteBalance.BigInt()
+}
+
 func (m *PerpetualPosition) GetIsLong() bool {
 	if m == nil {
 		return false

--- a/protocol/x/subaccounts/types/position_size.go
+++ b/protocol/x/subaccounts/types/position_size.go
@@ -94,7 +94,7 @@ func (m *PerpetualPosition) GetBigQuantums() *big.Int {
 
 // Get the perpetual position quote balance in big.Int.
 func (m *PerpetualPosition) GetQuoteBalance() *big.Int {
-	if m == nil {
+	if m == nil || m.QuoteBalance.IsNil() {
 		return new(big.Int)
 	}
 


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to retrieve the perpetual position quote balance for better risk calculations.
  - Added functionality to calculate and update asset positions using quote balances from perpetual positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->