### PR TITLE
[TRA-483] Implement functionality to acquire next perpetual id

### DIFF
--- a/protocol/x/perpetuals/types/keys.go
+++ b/protocol/x/perpetuals/types/keys.go
@@ -34,6 +34,9 @@ const (
 
 	// UpdatedOIKeyPrefix is the key to retrieve the updated OI for the module.
 	UpdatedOIKeyPrefix = "UpdatedOI"
+
+	// NextPerpetualIDKey is the key to retrieve the next perpetual id to be used
+	NextPerpetualIDKey = "NextPerpetualID"
 )
 
 // Module Accounts


### PR DESCRIPTION
### Changelist
This change adds a new store key to store the next perpetual id to be used and getter/setter functions
Also provides a function to acquire a new perpetual id

### Test Plan
Added tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new functions for managing perpetual IDs, including retrieval, setting, and acquisition.
  
- **Tests**
  - Enhanced tests to verify the correct acquisition and increment of perpetual IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->