### PR TITLE
[TRA-484] Implement functionality to acquire next clob pair id

### DIFF
--- a/protocol/x/clob/keeper/clob_pair.go
+++ b/protocol/x/clob/keeper/clob_pair.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 
+	gogotypes "github.com/cosmos/gogoproto/types"
+
 	storetypes "cosmossdk.io/store/types"
 
 	errorsmod "cosmossdk.io/errors"
@@ -692,4 +694,37 @@ func (k Keeper) IsPerpetualClobPairActive(
 	}
 
 	return clobPair.Status == types.ClobPair_STATUS_ACTIVE, nil
+}
+
+// GetNextClobPairID returns the next clob pair id to be used from the module store
+func (k Keeper) GetNextClobPairID(ctx sdk.Context) uint32 {
+	store := ctx.KVStore(k.storeKey)
+	b := store.Get([]byte(types.NextClobPairIDKey))
+	var result gogotypes.UInt32Value
+	k.cdc.MustUnmarshal(b, &result)
+	return result.Value
+}
+
+// SetNextClobPairID sets the next clob pair id to be used
+func (k Keeper) SetNextClobPairID(ctx sdk.Context, nextID uint32) {
+	store := ctx.KVStore(k.storeKey)
+	value := gogotypes.UInt32Value{Value: nextID}
+	store.Set([]byte(types.NextClobPairIDKey), k.cdc.MustMarshal(&value))
+}
+
+// AcquireNextClobPairID returns the next clob pair id to be used and increments
+// the next clob pair id
+func (k Keeper) AcquireNextClobPairID(ctx sdk.Context) uint32 {
+	nextID := k.GetNextClobPairID(ctx)
+	// if clob pair id already exists, increment until we find one that doesn't
+	for {
+		_, found := k.GetClobPair(ctx, types.ClobPairId(nextID))
+		if !found {
+			break
+		}
+		nextID++
+	}
+
+	k.SetNextClobPairID(ctx, nextID+1)
+	return nextID
 }

--- a/protocol/x/clob/keeper/clob_pair_test.go
+++ b/protocol/x/clob/keeper/clob_pair_test.go
@@ -1142,7 +1142,7 @@ func TestClobPairValidate(t *testing.T) {
 
 func TestAcquireNextClobPairID(t *testing.T) {
 	memClob := memclob.NewMemClobPriceTimePriority(false)
-	mockIndexerEventManager := &mocks.IndexerEventManager{}
+	mockIndexerEventManager := indexer_manager.NewIndexerEventManagerNoop()
 	ks := keepertest.NewClobKeepersTestContext(t, memClob, &mocks.BankKeeper{}, mockIndexerEventManager)
 	existingClobPairs := 10
 	keepertest.CreateNClobPair(
@@ -1152,7 +1152,7 @@ func TestAcquireNextClobPairID(t *testing.T) {
 		ks.PricesKeeper,
 		ks.Ctx,
 		existingClobPairs,
-		mockIndexerEventManager,
+		&mocks.IndexerEventManager{},
 	)
 
 	// Acquire next clob pair ID.
@@ -1181,28 +1181,6 @@ func TestAcquireNextClobPairID(t *testing.T) {
 		clobtest.WithId(nextClobPairIDFromStore),
 		clobtest.WithPerpetualId(perp.Params.Id),
 	)
-
-	mockIndexerEventManager.On(
-		"AddTxnEvent",
-		ks.Ctx,
-		indexerevents.SubtypePerpetualMarket,
-		indexerevents.PerpetualMarketEventVersion,
-		indexer_manager.GetBytes(
-			indexerevents.NewPerpetualMarketCreateEvent(
-				clobtest.MustPerpetualId(*clobPair),
-				clobPair.Id,
-				perp.Params.Ticker,
-				perp.Params.MarketId,
-				clobPair.Status,
-				clobPair.QuantumConversionExponent,
-				perp.Params.AtomicResolution,
-				clobPair.SubticksPerTick,
-				clobPair.StepBaseQuantums,
-				perp.Params.LiquidityTier,
-				perp.Params.MarketType,
-			),
-		),
-	).Return()
 
 	_, err = ks.ClobKeeper.CreatePerpetualClobPair(
 		ks.Ctx,

--- a/protocol/x/clob/types/keys.go
+++ b/protocol/x/clob/types/keys.go
@@ -68,6 +68,9 @@ const (
 	// UntriggeredConditionalOrderKeyPrefix is the key to retrieve an untriggered conditional order and
 	// information about when it was placed.
 	UntriggeredConditionalOrderKeyPrefix = StatefulOrderKeyPrefix + "U:"
+
+	// NextClobPairIDKey is the key to retrieve the next ClobPair ID to be used.
+	NextClobPairIDKey = "NextClobPairID"
 )
 
 // Memstore


### PR DESCRIPTION
### Changelist
This change adds a new store key to store the next clob pair id to be used and getter/setter functions
Also provides a function to acquire a new clob pair id

### Test Plan
Added tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented functionality to manage and acquire the next CLOB pair ID in the module store.
  
- **Tests**
  - Added a new test to validate the acquisition and incrementation of CLOB pair IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->