### PR TITLE
add handling to deal with infinite loops in id acquisition

### DIFF
--- a/protocol/x/clob/keeper/clob_pair.go
+++ b/protocol/x/clob/keeper/clob_pair.go
@@ -717,12 +717,19 @@ func (k Keeper) SetNextClobPairID(ctx sdk.Context, nextID uint32) {
 func (k Keeper) AcquireNextClobPairID(ctx sdk.Context) uint32 {
 	nextID := k.GetNextClobPairID(ctx)
 	// if clob pair id already exists, increment until we find one that doesn't
+	maxAttempts, attempts := 1000, 0
 	for {
 		_, found := k.GetClobPair(ctx, types.ClobPairId(nextID))
 		if !found {
 			break
 		}
 		nextID++
+
+		// panic if we've tried too many times and are stuck in a loop
+		attempts++
+		if attempts >= maxAttempts {
+			panic("Exceeded maximum attempts to find a unique clob pair id")
+		}
 	}
 
 	k.SetNextClobPairID(ctx, nextID+1)

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1537,12 +1537,19 @@ func (k Keeper) SetNextPerpetualID(ctx sdk.Context, nextID uint32) {
 func (k Keeper) AcquireNextPerpetualID(ctx sdk.Context) uint32 {
 	nextID := k.GetNextPerpetualID(ctx)
 	// if perpetual id already exists, increment until we find one that doesn't
+	maxAttempts, attempts := 1000, 0
 	for {
 		_, err := k.GetPerpetual(ctx, nextID)
 		if err != nil && errorsmod.IsOf(err, types.ErrPerpetualDoesNotExist) {
 			break
 		}
 		nextID++
+
+		// panic if we've tried too many times and are stuck in a loop
+		attempts++
+		if attempts >= maxAttempts {
+			panic("Exceeded maximum attempts to find a unique perpetual id")
+		}
 	}
 
 	k.SetNextPerpetualID(ctx, nextID+1)

--- a/protocol/x/prices/keeper/market.go
+++ b/protocol/x/prices/keeper/market.go
@@ -138,12 +138,19 @@ func (k Keeper) SetNextMarketID(ctx sdk.Context, nextID uint32) {
 func (k Keeper) AcquireNextMarketID(ctx sdk.Context) uint32 {
 	nextID := k.GetNextMarketID(ctx)
 	// if market id already exists, increment until we find one that doesn't
+	maxAttempts, attempts := 1000, 0
 	for {
 		_, exists := k.GetMarketParam(ctx, nextID)
 		if !exists {
 			break
 		}
 		nextID++
+
+		// panic if we've tried too many times and are stuck in a loop
+		attempts++
+		if attempts >= maxAttempts {
+			panic("Exceeded maximum attempts to find a unique market id")
+		}
 	}
 
 	k.SetNextMarketID(ctx, nextID+1)


### PR DESCRIPTION
### Changelist
In each ID generation, we loop over ids to find the next unique id. This should never fail but in the event that something is very wrong we don't want to be stuck in an infinite loop.
Put a max number of attempts on this loop to mitigate this

### Test Plan


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented safeguards to prevent infinite loops when generating unique IDs in various functions related to clob pairs, perpetuals, and markets.
  - Added a maximum attempts threshold to ensure system stability and prevent potential hang-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->