### PR TITLE
Store stateful order expirations individually in state

### DIFF
--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -61,7 +61,7 @@ func EndBlocker(
 	keeper.PruneStateFillAmountsForShortTermOrders(ctx)
 
 	// Prune expired stateful orders completely from state.
-	expiredStatefulOrderIds := keeper.RemoveExpiredStatefulOrdersTimeSlices(ctx, ctx.BlockTime())
+	expiredStatefulOrderIds := keeper.RemoveExpiredStatefulOrders(ctx, ctx.BlockTime())
 	for _, orderId := range expiredStatefulOrderIds {
 		// Remove the order fill amount from state.
 		keeper.RemoveOrderFillAmount(ctx, orderId)

--- a/protocol/x/clob/abci_test.go
+++ b/protocol/x/clob/abci_test.go
@@ -82,7 +82,7 @@ func TestEndBlocker_Failure(t *testing.T) {
 				expiredOrder := constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20
 
 				ks.ClobKeeper.SetLongTermOrderPlacement(ctx, expiredOrder, blockHeight)
-				ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+				ks.ClobKeeper.AddStatefulOrderIdExpiration(
 					ctx,
 					expiredOrder.MustGetUnixGoodTilBlockTime(),
 					expiredOrder.OrderId,
@@ -246,7 +246,7 @@ func TestEndBlocker_Success(t *testing.T) {
 				}
 				for _, order := range orders {
 					ks.ClobKeeper.SetLongTermOrderPlacement(ctx, order, 0)
-					ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+					ks.ClobKeeper.AddStatefulOrderIdExpiration(
 						ctx,
 						order.MustGetUnixGoodTilBlockTime(),
 						order.OrderId,
@@ -289,9 +289,9 @@ func TestEndBlocker_Success(t *testing.T) {
 			},
 			expectedProcessProposerMatchesEvents: types.ProcessProposerMatchesEvents{
 				ExpiredStatefulOrderIds: []types.OrderId{
+					constants.ConditionalOrder_Alice_Num0_Id1_Clob0_Buy15_Price25_GTBT15_StopLoss25.OrderId,
 					constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15_StopLoss20.OrderId,
 					constants.ConditionalOrder_Alice_Num0_Id0_Clob1_Buy5_Price10_GTBT15_TakeProfit20.OrderId,
-					constants.ConditionalOrder_Alice_Num0_Id1_Clob0_Buy15_Price25_GTBT15_StopLoss25.OrderId,
 				},
 				BlockHeight: blockHeight,
 			},
@@ -477,7 +477,7 @@ func TestEndBlocker_Success(t *testing.T) {
 					constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10,
 					blockHeight,
 				)
-				ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+				ks.ClobKeeper.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10.OrderId,
@@ -493,7 +493,7 @@ func TestEndBlocker_Success(t *testing.T) {
 					constants.LongTermOrder_Bob_Num0_Id1_Clob0_Buy45_Price10_GTBT10,
 					blockHeight,
 				)
-				ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+				ks.ClobKeeper.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Bob_Num0_Id1_Clob0_Buy45_Price10_GTBT10.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Bob_Num0_Id1_Clob0_Buy45_Price10_GTBT10.OrderId,
@@ -519,7 +519,7 @@ func TestEndBlocker_Success(t *testing.T) {
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 					blockHeight,
 				)
-				ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+				ks.ClobKeeper.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.OrderId,
@@ -549,8 +549,8 @@ func TestEndBlocker_Success(t *testing.T) {
 			},
 			expectedProcessProposerMatchesEvents: types.ProcessProposerMatchesEvents{
 				ExpiredStatefulOrderIds: []types.OrderId{
-					constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10.OrderId,
 					constants.LongTermOrder_Bob_Num0_Id1_Clob0_Buy45_Price10_GTBT10.OrderId,
+					constants.LongTermOrder_Bob_Num0_Id0_Clob0_Buy25_Price30_GTBT10.OrderId,
 				},
 				BlockHeight:               blockHeight,
 				OrderIdsFilledInLastBlock: []types.OrderId{orderIdThree},
@@ -808,7 +808,7 @@ func TestEndBlocker_Success(t *testing.T) {
 			}
 
 			for time, expected := range tc.expectedStatefulOrderTimeSlice {
-				actual := ks.ClobKeeper.GetStatefulOrdersTimeSlice(ctx, time)
+				actual := ks.ClobKeeper.GetStatefulOrderIdExpirations(ctx, time)
 				require.Equal(t, expected, actual)
 			}
 

--- a/protocol/x/clob/e2e/app_test.go
+++ b/protocol/x/clob/e2e/app_test.go
@@ -364,7 +364,7 @@ func TestHydrationInPreBlocker(t *testing.T) {
 		constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10,
 		1,
 	)
-	tApp.App.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+	tApp.App.ClobKeeper.AddStatefulOrderIdExpiration(
 		tApp.App.NewUncachedContext(false, tmproto.Header{}),
 		time.Unix(50, 0),
 		constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10.OrderId,
@@ -440,7 +440,7 @@ func TestHydrationWithMatchPreBlocker(t *testing.T) {
 		constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10,
 		1,
 	)
-	tApp.App.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+	tApp.App.ClobKeeper.AddStatefulOrderIdExpiration(
 		tApp.App.NewUncachedContext(false, tmproto.Header{}),
 		time.Unix(10, 0),
 		constants.LongTermOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10.OrderId,
@@ -452,7 +452,7 @@ func TestHydrationWithMatchPreBlocker(t *testing.T) {
 		constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10,
 		1,
 	)
-	tApp.App.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+	tApp.App.ClobKeeper.AddStatefulOrderIdExpiration(
 		tApp.App.NewUncachedContext(false, tmproto.Header{}),
 		time.Unix(10, 0),
 		constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell1BTC_Price50000_GTBT10.OrderId,

--- a/protocol/x/clob/e2e/long_term_orders_test.go
+++ b/protocol/x/clob/e2e/long_term_orders_test.go
@@ -1779,7 +1779,7 @@ func TestRegression_InvalidTimeInForce(t *testing.T) {
 				LongTermPlaceOrder_Bob_Num0_Id0_Clob0_Sell1_Price50000_GTB20.Order,
 				1,
 			)
-			tApp.App.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+			tApp.App.ClobKeeper.AddStatefulOrderIdExpiration(
 				tApp.App.NewUncachedContext(true, tmproto.Header{}),
 				time.Unix(5, 0),
 				LongTermPlaceOrder_Bob_Num0_Id0_Clob0_Sell1_Price50000_GTB20.Order.OrderId,

--- a/protocol/x/clob/keeper/clob_pair_test.go
+++ b/protocol/x/clob/keeper/clob_pair_test.go
@@ -663,7 +663,7 @@ func TestUpdateClobPair_FinalSettlement(t *testing.T) {
 	}
 	for _, order := range statefulOrders {
 		ks.ClobKeeper.SetLongTermOrderPlacement(ks.Ctx, order, 5)
-		ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+		ks.ClobKeeper.AddStatefulOrderIdExpiration(
 			ks.Ctx,
 			order.MustGetUnixGoodTilBlockTime(),
 			order.GetOrderId(),

--- a/protocol/x/clob/keeper/msg_server_cancel_orders_test.go
+++ b/protocol/x/clob/keeper/msg_server_cancel_orders_test.go
@@ -226,7 +226,7 @@ func TestCancelOrder_Success(t *testing.T) {
 
 			// Add stateful order placement to state
 			ks.ClobKeeper.SetLongTermOrderPlacement(ctx, tc.StatefulOrderPlacement, 1)
-			ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+			ks.ClobKeeper.AddStatefulOrderIdExpiration(
 				ctx,
 				tc.StatefulOrderPlacement.MustGetUnixGoodTilBlockTime(),
 				tc.StatefulOrderPlacement.GetOrderId(),

--- a/protocol/x/clob/keeper/msg_server_place_order_test.go
+++ b/protocol/x/clob/keeper/msg_server_place_order_test.go
@@ -206,7 +206,7 @@ func TestPlaceOrder_Error(t *testing.T) {
 
 			for _, order := range tc.StatefulOrders {
 				ks.ClobKeeper.SetLongTermOrderPlacement(ctx, order, 5)
-				ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+				ks.ClobKeeper.AddStatefulOrderIdExpiration(
 					ctx,
 					order.MustGetUnixGoodTilBlockTime(),
 					order.GetOrderId(),

--- a/protocol/x/clob/keeper/order_cancellation_test.go
+++ b/protocol/x/clob/keeper/order_cancellation_test.go
@@ -146,7 +146,7 @@ func TestCancelOrder_KeeperForwardsErrorsFromMemclob(t *testing.T) {
 
 	longTermOrder := constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15
 	ks.ClobKeeper.SetLongTermOrderPlacement(ctx.WithIsCheckTx(false), longTermOrder, 15)
-	ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+	ks.ClobKeeper.AddStatefulOrderIdExpiration(
 		ctx,
 		longTermOrder.MustGetUnixGoodTilBlockTime(),
 		longTermOrder.GetOrderId(),
@@ -257,7 +257,7 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 					5,
 				)
-				k.MustAddOrderToStatefulOrdersTimeSlice(
+				k.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetOrderId(),
@@ -286,7 +286,7 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 					5,
 				)
-				k.MustAddOrderToStatefulOrdersTimeSlice(
+				k.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetOrderId(),
@@ -307,7 +307,7 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 					5,
 				)
-				k.MustAddOrderToStatefulOrdersTimeSlice(
+				k.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetOrderId(),
@@ -327,7 +327,7 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 					5,
 				)
-				k.MustAddOrderToStatefulOrdersTimeSlice(
+				k.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetOrderId(),
@@ -348,7 +348,7 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 					5,
 				)
-				k.MustAddOrderToStatefulOrdersTimeSlice(
+				k.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetOrderId(),
@@ -368,7 +368,7 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 					5,
 				)
-				k.MustAddOrderToStatefulOrdersTimeSlice(
+				k.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetOrderId(),
@@ -388,7 +388,7 @@ func TestPerformOrderCancellationStatefulValidation(t *testing.T) {
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15,
 					5,
 				)
-				k.MustAddOrderToStatefulOrdersTimeSlice(
+				k.AddStatefulOrderIdExpiration(
 					ctx,
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.MustGetUnixGoodTilBlockTime(),
 					constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT15.GetOrderId(),

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -398,7 +398,7 @@ func (k Keeper) PlaceStatefulOrder(
 	if lib.IsDeliverTxMode(ctx) {
 		// Write the stateful order to state and the memstore.
 		k.SetLongTermOrderPlacement(ctx, order, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
-		k.MustAddOrderToStatefulOrdersTimeSlice(
+		k.AddStatefulOrderIdExpiration(
 			ctx,
 			order.MustGetUnixGoodTilBlockTime(),
 			order.GetOrderId(),

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -860,7 +860,7 @@ func TestAddPreexistingStatefulOrder(t *testing.T) {
 			for _, order := range tc.existingOrders {
 				if order.IsStatefulOrder() {
 					ks.ClobKeeper.SetLongTermOrderPlacement(ctx, order, blockHeight)
-					ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+					ks.ClobKeeper.AddStatefulOrderIdExpiration(
 						ctx,
 						order.MustGetUnixGoodTilBlockTime(),
 						order.GetOrderId(),
@@ -881,7 +881,7 @@ func TestAddPreexistingStatefulOrder(t *testing.T) {
 			// by the time PlaceOrder was called, as PlaceOrder is called in PrepareCheckState for stateful orders.
 			if tc.order.IsStatefulOrder() {
 				ks.ClobKeeper.SetLongTermOrderPlacement(ctx, tc.order, blockHeight)
-				ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+				ks.ClobKeeper.AddStatefulOrderIdExpiration(
 					ctx,
 					tc.order.MustGetUnixGoodTilBlockTime(),
 					tc.order.GetOrderId(),
@@ -903,7 +903,7 @@ func TestAddPreexistingStatefulOrder(t *testing.T) {
 			// Verify test expectations.
 			require.ErrorIs(t, err, tc.expectedErr)
 			statefulOrderPlacement, _ := ks.ClobKeeper.GetLongTermOrderPlacement(ctx, tc.order.OrderId)
-			statefulOrderIds := ks.ClobKeeper.GetStatefulOrdersTimeSlice(ctx, tc.order.MustGetUnixGoodTilBlockTime())
+			statefulOrderIds := ks.ClobKeeper.GetStatefulOrderIdExpirations(ctx, tc.order.MustGetUnixGoodTilBlockTime())
 			if err == nil {
 				require.Equal(t, tc.expectedOrderStatus, orderStatus)
 				require.Equal(t, tc.expectedFilledSize, orderSizeOptimisticallyFilledFromMatching)

--- a/protocol/x/clob/keeper/process_operations_test.go
+++ b/protocol/x/clob/keeper/process_operations_test.go
@@ -2471,7 +2471,7 @@ func setupProcessProposerOperationsTestCase(
 		require.Falsef(t, exists, "Duplicate pre-existing stateful order (%+v)", order)
 		seenOrderIds[order.GetOrderId()] = struct{}{}
 		ks.ClobKeeper.SetLongTermOrderPlacement(ctx, order, blockHeight)
-		ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+		ks.ClobKeeper.AddStatefulOrderIdExpiration(
 			ctx,
 			order.MustGetUnixGoodTilBlockTime(),
 			order.OrderId,
@@ -2483,7 +2483,7 @@ func setupProcessProposerOperationsTestCase(
 		require.Falsef(t, exists, "Duplicate pre-existing stateful order (%+v)", order)
 		seenOrderIds[order.GetOrderId()] = struct{}{}
 		ks.ClobKeeper.SetLongTermOrderPlacement(ctx, order, blockHeight)
-		ks.ClobKeeper.MustAddOrderToStatefulOrdersTimeSlice(
+		ks.ClobKeeper.AddStatefulOrderIdExpiration(
 			ctx,
 			order.MustGetUnixGoodTilBlockTime(),
 			order.OrderId,

--- a/protocol/x/clob/keeper/process_proposer_matches_events_test.go
+++ b/protocol/x/clob/keeper/process_proposer_matches_events_test.go
@@ -197,16 +197,18 @@ func TestOrderedOrderIdList(t *testing.T) {
 		},
 	}
 
-	for _, orderId := range orderIds {
-		ks.ClobKeeper.AppendOrderedOrderId(ks.Ctx, prefixKey, indexKey, orderId)
-	}
-	require.Equal(t, orderIds, ks.ClobKeeper.GetOrderIds(ks.Ctx, prefixKey))
+	memStore := ks.Ctx.KVStore(ks.MemKey)
 
-	ks.ClobKeeper.ResetOrderedOrderIds(ks.Ctx, prefixKey, indexKey)
 	for _, orderId := range orderIds {
-		ks.ClobKeeper.AppendOrderedOrderId(ks.Ctx, prefixKey, indexKey, orderId)
+		ks.ClobKeeper.AppendOrderedOrderId(ks.Ctx, memStore, prefixKey, indexKey, orderId)
 	}
-	require.Equal(t, orderIds, ks.ClobKeeper.GetOrderIds(ks.Ctx, prefixKey))
+	require.Equal(t, orderIds, ks.ClobKeeper.GetOrderIds(ks.Ctx, memStore, prefixKey))
+
+	ks.ClobKeeper.ResetOrderedOrderIds(ks.Ctx, memStore, prefixKey, indexKey)
+	for _, orderId := range orderIds {
+		ks.ClobKeeper.AppendOrderedOrderId(ks.Ctx, memStore, prefixKey, indexKey, orderId)
+	}
+	require.Equal(t, orderIds, ks.ClobKeeper.GetOrderIds(ks.Ctx, memStore, prefixKey))
 }
 
 func TestUnorderedOrderIdList(t *testing.T) {
@@ -236,14 +238,16 @@ func TestUnorderedOrderIdList(t *testing.T) {
 		},
 	}
 
-	for _, orderId := range orderIds {
-		ks.ClobKeeper.SetUnorderedOrderId(ks.Ctx, prefixKey, orderId)
-	}
-	require.Equal(t, orderIds, ks.ClobKeeper.GetOrderIds(ks.Ctx, prefixKey))
+	memStore := ks.Ctx.KVStore(ks.MemKey)
 
-	ks.ClobKeeper.ResetOrderedOrderIds(ks.Ctx, prefixKey, indexKey)
 	for _, orderId := range orderIds {
-		ks.ClobKeeper.SetUnorderedOrderId(ks.Ctx, prefixKey, orderId)
+		ks.ClobKeeper.SetUnorderedOrderId(ks.Ctx, memStore, prefixKey, orderId)
 	}
-	require.Equal(t, orderIds, ks.ClobKeeper.GetOrderIds(ks.Ctx, prefixKey))
+	require.Equal(t, orderIds, ks.ClobKeeper.GetOrderIds(ks.Ctx, memStore, prefixKey))
+
+	ks.ClobKeeper.ResetOrderedOrderIds(ks.Ctx, memStore, prefixKey, indexKey)
+	for _, orderId := range orderIds {
+		ks.ClobKeeper.SetUnorderedOrderId(ks.Ctx, memStore, prefixKey, orderId)
+	}
+	require.Equal(t, orderIds, ks.ClobKeeper.GetOrderIds(ks.Ctx, memStore, prefixKey))
 }

--- a/protocol/x/clob/keeper/stores.go
+++ b/protocol/x/clob/keeper/stores.go
@@ -78,15 +78,6 @@ func (k Keeper) GetTriggeredConditionalOrderPlacementStore(ctx sdk.Context) pref
 	)
 }
 
-// getStatefulOrdersTimeSliceStore fetches a state store used for creating,
-// reading, updating, and deleting a stateful order time slice from state.
-func (k Keeper) getStatefulOrdersTimeSliceStore(ctx sdk.Context) prefix.Store {
-	return prefix.NewStore(
-		ctx.KVStore(k.storeKey),
-		[]byte(types.StatefulOrdersTimeSlicePrefix),
-	)
-}
-
 // getTransientStore fetches a transient store used for reading and
 // updating the transient store.
 func (k Keeper) getTransientStore(ctx sdk.Context) storetypes.KVStore {

--- a/protocol/x/clob/types/clob_keeper.go
+++ b/protocol/x/clob/types/clob_keeper.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"math/big"
-	"time"
 
 	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -103,20 +102,9 @@ type ClobKeeper interface {
 		orderId OrderId,
 	)
 	RemoveOrderFillAmount(ctx sdk.Context, orderId OrderId)
-	MustAddOrderToStatefulOrdersTimeSlice(
-		ctx sdk.Context,
-		goodTilBlockTime time.Time,
-		orderId OrderId,
-	)
-	GetStatefulOrdersTimeSlice(ctx sdk.Context, goodTilBlockTime time.Time) (
-		orderIds []OrderId,
-	)
 	MustRemoveStatefulOrder(
 		ctx sdk.Context,
 		orderId OrderId,
-	)
-	RemoveExpiredStatefulOrdersTimeSlices(ctx sdk.Context, blockTime time.Time) (
-		expiredOrderIds []OrderId,
 	)
 	GetProcessProposerMatchesEvents(ctx sdk.Context) ProcessProposerMatchesEvents
 	MustSetProcessProposerMatchesEvents(

--- a/protocol/x/clob/types/keys.go
+++ b/protocol/x/clob/types/keys.go
@@ -53,9 +53,13 @@ const (
 	// key-per-order format.
 	LegacyBlockHeightToPotentiallyPrunableOrdersPrefix = "ExpHt:"
 
-	// StatefulOrdersTimeSlicePrefix is the key to retrieve a unique list of the stateful orders that
-	// expire at a given timestamp, sorted by order ID.
-	StatefulOrdersTimeSlicePrefix = "ExpTm:"
+	// Deprecated: LegacyStatefulOrdersTimeSlicePrefix is the key to retrieve a unique list of the stateful
+	// orders that expire at a given timestamp, sorted by order ID. Do not use.
+	LegacyStatefulOrdersTimeSlicePrefix = "ExpTm:"
+
+	// StatefulOrdersTimeSliceKeyPrefix is used to store orders that expire at a certain time.
+	// The specifier should be replaced with the time.
+	StatefulOrdersExpirationsKeyPrefix = "Exp/%s:"
 
 	// TriggeredConditionalOrderKeyPrefix is the key to retrieve an triggered conditional order and
 	// information about when it was triggered.

--- a/protocol/x/clob/types/keys_test.go
+++ b/protocol/x/clob/types/keys_test.go
@@ -25,7 +25,6 @@ func TestStateKeys(t *testing.T) {
 	require.Equal(t, "Clob:", types.ClobPairKeyPrefix)
 	require.Equal(t, "Fill:", types.OrderAmountFilledKeyPrefix)
 	require.Equal(t, "ExpHt:", types.LegacyBlockHeightToPotentiallyPrunableOrdersPrefix)
-	require.Equal(t, "ExpTm:", types.StatefulOrdersTimeSlicePrefix)
 }
 
 func TestStoreAndMemstoreKeys(t *testing.T) {

--- a/protocol/x/clob/types/mem_clob_keeper.go
+++ b/protocol/x/clob/types/mem_clob_keeper.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"math/big"
-	"time"
 
 	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -71,11 +70,6 @@ type MemClobKeeper interface {
 		ctx sdk.Context,
 		order Order,
 		blockHeight uint32,
-	)
-	MustAddOrderToStatefulOrdersTimeSlice(
-		ctx sdk.Context,
-		goodTilBlockTime time.Time,
-		orderId OrderId,
 	)
 	OffsetSubaccountPerpetualPosition(
 		ctx sdk.Context,


### PR DESCRIPTION
### Changelist
- Store these individually to prevent lots of serde when receiving many orders with the same GTT

### Test Plan
- Modified and added tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved stateful order management by renaming and restructuring functions.
  - Enhanced efficiency in removing expired stateful orders.

- **Tests**
  - Updated test cases to align with the new function names and signatures.

- **Chores**
  - Cleaned up deprecated function calls and unused imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->