### PR TITLE
[TRA-481] change vault order skewing to non-linear

### DIFF
--- a/protocol/x/vault/keeper/orders.go
+++ b/protocol/x/vault/keeper/orders.go
@@ -150,13 +150,24 @@ func (k Keeper) RefreshVaultClobOrders(ctx sdk.Context, vaultId types.VaultId) (
 // GetVaultClobOrders returns a list of long term orders for a given CLOB vault.
 // Let n be number of layers, then the function returns orders at [a_0, b_0, a_1, b_1, ..., a_{n-1}, b_{n-1}]
 // where a_i and b_i are the ask price and bid price at i-th layer. To compute a_i and b_i:
-// - a_i = oraclePrice * (1 + skew_i) * (1 + spread)^{i+1}
-// - b_i = oraclePrice * (1 + skew_i) / (1 + spread)^{i+1}
-// - skew_i = -leverage_i * spread * skew_factor
+// - a_i = oraclePrice * (1 + ask_spread_i)
+// - b_i = oraclePrice * (1 - bid_spread_i)
+//
+// - ask_spread_i = (1 + skew_i) * spread
+// - bid_spread_i = (1 - skew_i) * spread
+//
+// - skew_i is computed differently based on order side and leverage_i:
+//   - ask, leverage_i < 0: (skew_factor * leverage_i - 1)^2 - 1
+//   - bid, leverage_i < 0: -skew_factor * leverage_i
+//   - ask, leverage_i >= 0: -skew_factor * leverage_i
+//   - bid, leverage_i >= 0: -((skew_factor * leverage_i + 1)^2 - 1)
+//
 // - leverage_i = leverage +/- i * order_size_pct\ (- for ask and + for bid)
 // - leverage = open notional / equity
+//
 // - spread = max(spread_min, spread_buffer + min_price_change)
-// and size of each order is calculated as `order_size * equity / oraclePrice`.
+//
+// size of each order is calculated as `order_size_pct * equity / oraclePrice`.
 func (k Keeper) GetVaultClobOrders(
 	ctx sdk.Context,
 	vaultId types.VaultId,
@@ -269,51 +280,66 @@ func (k Keeper) GetVaultClobOrders(
 	) *clobtypes.Order {
 		// Ask: leverage_i = leverage - i * order_size_pct
 		// Bid: leverage_i = leverage + i * order_size_pct
-		// skew_i = -leverage_i * spread * skew_factor
 		leveragePpmI := lib.BigU(layer)
 		leveragePpmI.Mul(leveragePpmI, orderSizePctPpm)
 		if side == clobtypes.Order_SIDE_SELL {
 			leveragePpmI.Neg(leveragePpmI)
 		}
 		leveragePpmI.Add(leveragePpmI, leveragePpm)
-		skewPpmI := leveragePpmI.
-			Mul(leveragePpmI, spreadPpm).
-			Mul(leveragePpmI, skewFactorPpm).
-			Quo(leveragePpmI, lib.BigIntOneMillion()).
-			Quo(leveragePpmI, lib.BigIntOneMillion()).
-			Neg(leveragePpmI)
 
-		// spread_i = spread * (layer+1)
-		// negated for buys
-		spreadPpmI := lib.BigU(layer + 1)
-		spreadPpmI.Mul(spreadPpmI, spreadPpm)
-		if side == clobtypes.Order_SIDE_BUY {
-			spreadPpmI.Neg(spreadPpmI)
+		// Calculate skew.
+		skewPpmI := lib.BigMulPpm(leveragePpmI, skewFactorPpm, true)
+		if leveragePpm.Sign() < 0 {
+			if side == clobtypes.Order_SIDE_SELL {
+				// ask when short: skew_i = (skew_factor * leverage_i - 1)^2 - 1
+				skewPpmI.Sub(skewPpmI, lib.BigIntOneMillion())
+				skewPpmI = lib.BigMulPpm(skewPpmI, skewPpmI, true)
+				skewPpmI.Sub(skewPpmI, lib.BigIntOneMillion())
+			} else {
+				// bid when short: skew_i = -skew_factor * leverage_i
+				skewPpmI.Neg(skewPpmI)
+			}
+		} else {
+			if side == clobtypes.Order_SIDE_SELL {
+				// ask when long: skew_i = -skew_factor * leverage_i
+				skewPpmI.Neg(skewPpmI)
+			} else {
+				// bid when long: skew_i = -((skew_factor * leverage_i + 1)^2 - 1)
+				skewPpmI.Add(skewPpmI, lib.BigIntOneMillion())
+				skewPpmI = lib.BigMulPpm(skewPpmI, skewPpmI, true)
+				skewPpmI.Sub(skewPpmI, lib.BigIntOneMillion())
+				skewPpmI.Neg(skewPpmI)
+			}
 		}
 
-		// price = oracleprice * (1 + skew_i + spread_i)
-		// price <= oracleprice for buys
-		// price >= oracleprice for sells
-		spreadSkewPpm := new(big.Int).Add(spreadPpmI, skewPpmI)
-		if side == clobtypes.Order_SIDE_SELL && spreadSkewPpm.Sign() < 0 {
-			spreadSkewPpm.SetUint64(0)
-		} else if side == clobtypes.Order_SIDE_BUY && spreadSkewPpm.Sign() > 0 {
-			spreadSkewPpm.SetUint64(0)
+		// Calculate skewed spread.
+		skewedSpreadPpmI := lib.BigIntOneMillion()
+		if side == clobtypes.Order_SIDE_SELL {
+			skewedSpreadPpmI.Add(skewedSpreadPpmI, skewPpmI)
+		} else {
+			skewedSpreadPpmI.Sub(skewPpmI, skewedSpreadPpmI)
 		}
-		spreadSkewPpm.Add(spreadSkewPpm, lib.BigIntOneMillion())
-		orderSubticksNum := lib.BigMulPpm(
+		// To maintain precision, delay division by 1 million until after multiplying skewed spread with oracle price.
+		skewedSpreadPpmI.Mul(skewedSpreadPpmI, spreadPpm)
+		skewedSpreadPpmI.Add(skewedSpreadPpmI, lib.BigIntOneTrillion())
+
+		// Determine order subticks.
+		subticks := lib.BigMulPpm(
 			oracleSubticks.Num(),
-			spreadSkewPpm,
+			skewedSpreadPpmI,
+			side == clobtypes.Order_SIDE_SELL,
+		)
+		if side == clobtypes.Order_SIDE_SELL {
+			subticks = lib.BigDivCeil(subticks, oracleSubticks.Denom())
+		} else {
+			subticks = new(big.Int).Quo(subticks, oracleSubticks.Denom())
+		}
+		subticks = lib.BigMulPpm( // delayed division by 1 million (rounding up) as noted above.
+			subticks,
+			big.NewInt(1),
 			side == clobtypes.Order_SIDE_SELL,
 		)
 
-		// Determine the subticks.
-		var subticks *big.Int
-		if side == clobtypes.Order_SIDE_SELL {
-			subticks = lib.BigDivCeil(orderSubticksNum, oracleSubticks.Denom())
-		} else {
-			subticks = new(big.Int).Quo(orderSubticksNum, oracleSubticks.Denom())
-		}
 		// Bound subticks between the minimum and maximum subticks.
 		subticksPerTick := lib.BigU(clobPair.SubticksPerTick)
 		subticks = lib.BigIntRoundToMultiple(

--- a/protocol/x/vault/keeper/orders.go
+++ b/protocol/x/vault/keeper/orders.go
@@ -329,16 +329,13 @@ func (k Keeper) GetVaultClobOrders(
 			skewedSpreadPpmI,
 			side == clobtypes.Order_SIDE_SELL,
 		)
+		divisor := lib.BigIntOneMillion() // delayed division by 1 million as noted above.
+		divisor.Mul(divisor, oracleSubticks.Denom())
 		if side == clobtypes.Order_SIDE_SELL {
-			subticks = lib.BigDivCeil(subticks, oracleSubticks.Denom())
+			subticks = lib.BigDivCeil(subticks, divisor)
 		} else {
-			subticks = new(big.Int).Quo(subticks, oracleSubticks.Denom())
+			subticks = new(big.Int).Quo(subticks, divisor)
 		}
-		subticks = lib.BigMulPpm( // delayed division by 1 million (rounding up) as noted above.
-			subticks,
-			big.NewInt(1),
-			side == clobtypes.Order_SIDE_SELL,
-		)
 
 		// Bound subticks between the minimum and maximum subticks.
 		subticksPerTick := lib.BigU(clobPair.SubticksPerTick)

--- a/protocol/x/vault/keeper/orders_test.go
+++ b/protocol/x/vault/keeper/orders_test.go
@@ -344,7 +344,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 		expectedOrderQuantums []uint64
 		expectedErr           error
 	}{
-		"Success - Get orders from Vault for Clob Pair 0": {
+		"Success - Vault Clob 0, 2 layers, leverage 0, doesn't cross oracle price": {
 			vaultParams: vaulttypes.Params{
 				Layers:                           2,       // 2 layers
 				SpreadMinPpm:                     3_123,   // 31.23 bps
@@ -369,10 +369,15 @@ func TestGetVaultClobOrders(t *testing.T) {
 			// 1. spread = max(spread_min, spread_buffer + min_price_change)
 			// 2. leverage = open_notional / equity
 			// 3. leverage_i = leverage +/- i * order_size_pct (- for ask and + for bid)
-			// 4. skew_i = -leverage_i * spread * skew_factor
-			// 5. a_i = max(oracle_price * (1 + skew_i + spread * {i+1}), oracle_price)
-			//    b_i = min(oracle_price * (1 + skew_i - spread * {i+1}), oracle_price)
-			// 6. subticks needs to be a multiple of subticks_per_tick (round up for asks, round down for bids)
+			// 4. skew_i
+			//    * for ask when long / bid when short: -skew_factor * leverage_i
+			//    * for ask when short: (skew_factor * leverage_i - 1)^2 - 1
+			//    * for bid when long: -((skew_factor * leverage_i + 1)^2 - 1)
+			// 5. ask_spread_i = (1 + skew_i) * spread
+			//    bid_spread_i = (1 - skew_i) * spread
+			// 6. a_i = oraclePrice * (1 + ask_spread_i)
+			//    b_i = oraclePrice * (1 - bid_spread_i)
+			// 7. subticks needs to be a multiple of subticks_per_tick (round up for asks, round down for bids)
 			// To calculate size of each order
 			// 1. `order_size_pct_ppm * equity / oracle_price`.
 			expectedOrderSubticks: []uint64{
@@ -381,19 +386,28 @@ func TestGetVaultClobOrders(t *testing.T) {
 				// leverage = 0 / 1_000 = 0
 				// oracleSubticks = 5_000_000_000 * 10^(-5 - (-8) + (-10) - (-6)) = 5e8
 				// leverage_0 = leverage = 0
-				// skew_0 = -0 * 3_123 * 0.554321 = 0
-				// a_0 = 5e5 * (1 + 0 + 0.003123*1) = 501_561.5 = 501_565 (rounded up to 5)
+				// skew_0_ask = -0.554321 * 0 = 0
+				// ask_spread_0 = (1 + 0) * 0.003123 = 0.003123
+				// a_0 = 5e5 * (1 + 0.003123) = 501_561.5 = 501_565 (rounded up to 5)
 				501_565,
-				// b_0 = 5e5 * (1 + 0 - 0.003123*1) = 498_438.5 = 498435 (rounded down to 5)
+				// skew_0_bid = -((0.554321 * 0 + 1)^2 - 1) = 0
+				// bid_spread_0 = (1 - 0) * 0.003123 = 0.003123
+				// b_0 = 5e5 * (1 - 0.003123) = 498_438.5 = 498435 (rounded down to 5)
 				498_435,
 				// leverage_1 = leverage - 0.1 = -0.1
 				// skew_1 = 0.1 * 0.003123 * 0.554321 ~= 0.000173
-				// a_1 = 5e5 * (1 + 0.000173 + 0.003123*2) = 503209.5 ~= 503_210 (rounded up to 5)
-				503_210,
+				// a_1 = 5e5 * (1 + 0.0554321 + 0.003123*2) = 503209.5 ~= 503_210 (rounded up to 5)
+				// skew_1_ask = -0.554321 * -0.1 = 0.0554321
+				// ask_spread_1 = (1 + 0.0554321) * 0.003123 = 0.003296114448 ~= 0.003297 (rounded up to 6 decimcal places)
+				// a_1 = 5e5 * (1 + 0.003296114448) = 501_648.057224 ~= 501_650 (rounded up to 5)
+				501_650,
 				// leverage_1 = leverage + 0.1 = 0.1
 				// skew_1 = -0.1 * 0.003123 * 0.554321 = -0.000173
 				// b_2 = 5e5 * (1 - 0.000173 - 0.003123*2) = 496790.5 ~= 496_790 (rounded down to 5)
-				496_790,
+				// skew_1_bid = -((0.554321 * 0.1 + 1)^2 - 1) = -0.1139369177
+				// bid_spread_1 = (1 - -0.1139369177) * 0.003123 = 0.003478824994
+				// b_1 = 5e5 * (1 - 0.003478824994) = 498_260.587503 ~= 498_260 (rounded down to 5)
+				498_260,
 			},
 			// order_size = 10% * $1_000 / $50 = 2
 			// order_size_base_quantums = 2 * 10^10 = 20_000_000_000
@@ -404,7 +418,87 @@ func TestGetVaultClobOrders(t *testing.T) {
 				20_000_000_000,
 			},
 		},
-		"Success - Get orders from Vault for Clob Pair 1, bids bounded by oracle price.": {
+		"Success - Vault Clob 1, 3 layers, leverage -0.6, doesn't cross oracle price": {
+			vaultParams: vaulttypes.Params{
+				Layers:                           3,         // 3 layers
+				SpreadMinPpm:                     7_654,     // 76.54 bps
+				SpreadBufferPpm:                  2_900,     // 29 bps
+				SkewFactorPpm:                    1_234_000, // 1.234
+				OrderSizePctPpm:                  100_000,   // 10%
+				OrderExpirationSeconds:           4,         // 4 seconds
+				ActivationThresholdQuoteQuantums: dtypes.NewInt(1_000_000_000),
+			},
+			vaultId:                    constants.Vault_Clob1,
+			vaultAssetQuoteQuantums:    big.NewInt(2_000_000_000), // 2,000 USDC
+			vaultInventoryBaseQuantums: big.NewInt(-250_000_000),  // -0.25 ETH
+			clobPair:                   constants.ClobPair_Eth,
+			marketParam:                constants.TestMarketParams[1],
+			marketPrice:                constants.TestMarketPrices[1],
+			perpetual:                  constants.EthUsd_0DefaultFunding_9AtomicResolution,
+			// To calculate order subticks:
+			// 1. spread = max(spread_min, spread_buffer + min_price_change)
+			// 2. leverage = open_notional / equity
+			// 3. leverage_i = leverage +/- i * order_size_pct (- for ask and + for bid)
+			// 4. skew_i
+			//    * for ask when long / bid when short: -skew_factor * leverage_i
+			//    * for ask when short: (skew_factor * leverage_i - 1)^2 - 1
+			//    * for bid when long: -((skew_factor * leverage_i + 1)^2 - 1)
+			// 5. ask_spread_i = (1 + skew_i) * spread
+			//    bid_spread_i = (1 - skew_i) * spread
+			// 6. a_i = oraclePrice * (1 + ask_spread_i)
+			//    b_i = oraclePrice * (1 - bid_spread_i)
+			// 7. subticks needs to be a multiple of subticks_per_tick (round up for asks, round down for bids)
+			// To calculate size of each order
+			// 1. `order_size_pct_ppm * equity / oracle_price`.
+			expectedOrderSubticks: []uint64{
+				// spreadPpm = max(7_654, 2_900 + 50) = 7_654
+				// spread = 0.007654
+				// open_notional = -250_000_000 * 10^-9 * 3_000 * 10^6 = -750_000_000
+				// leverage = -750_000_000 / (2_000_000_000 - 750_000_000) = -0.6
+				// oracleSubticks = 3_000_000_000 * 10^(-6 - (-9) + (-9) - (-6)) = 3e9
+				// leverage_0 = leverage - 0 * 0.1 = -0.6
+				// skew_ask_0 = (1.234 * -0.6 - 1)^2 - 1 = 2.02899216
+				// ask_spread_0 = (1 + 2.02899216) * 0.007654 = 0.02318390599
+				// a_0 = 3e9 * (1 + 0.02318390599) = 3_069_551_717.97 ~= 3_069_552_000 (round up to 1000)
+				3_069_552_000,
+				// skew_bid_0 = -1.234 * -0.6 = 0.7404
+				// bid_spread_0 = (1 - 0.7404) * 0.007654 = 0.0019869784
+				// b_0 = 3e9 * (1 - 0.0019869784) = 2_994_039_064.8 ~= 2_994_039_000 (round down to 1000)
+				2_994_039_000,
+				// leverage_1 = leverage - 1 * 0.1 = -0.7
+				// skew_ask_1 = (1.234 * -0.7 - 1)^2 - 1 = 2.47375044
+				// ask_spread_1 = (1 + 2.47375044) * 0.007654 = 0.02658808587
+				// a_1 = 3e9 * (1 + 0.02658808587) = 3_079_764_257.61 ~= 3_079_765_000 (round up to 1000)
+				3_079_765_000,
+				// leverage_1 = leverage + 1 * 0.1 = -0.5
+				// skew_bid_1 = -1.234 * -0.5 = 0.617
+				// bid_spread_1 = (1 - 0.617) * 0.007654 = 0.002931482
+				// b_1 = 3e9 * (1 - 0.002931482) = 2_991_205_554 ~= 2_991_205_000 (round down to 1000)
+				2_991_205_000,
+				// leverage_2 = leverage - 2 * 0.1 = -0.8
+				// skew_ask_2 = (1.234 * -0.8 - 1)^2 - 1 = 2.94896384
+				// ask_spread_2 = (1 + 2.94896384) * 0.007654 = 0.03022536923
+				// a_2 = 3e9 * (1 + 0.03022536923) = 3_090_676_107.69 ~= 3_090_677_000 (round up to 1000)
+				3_090_677_000,
+				// leverage_2 = leverage + 2 * 0.1 = -0.4
+				// skew_bid_2 = -1.234 * -0.4 = 0.4936
+				// bid_spread_2 = (1 - 0.4936) * 0.007654 = 0.0038759856
+				// b_2 = 3e9 * (1 - 0.0038759856) = 2_988_372_043.2 ~= 2_988_372_000 (round down to 1000)
+				2_988_372_000,
+			},
+			// order_size = 10% * 1250 / 3000 ~= 0.04166666667
+			// order_size_base_quantums = 0.04166666667e9 ~= 41_666_667
+			// round down to nearest multiple of step_base_quantums=1_000.
+			expectedOrderQuantums: []uint64{
+				41_666_000,
+				41_666_000,
+				41_666_000,
+				41_666_000,
+				41_666_000,
+				41_666_000,
+			},
+		},
+		"Success - Vault Clob 1, 3 layers, leverage -3, crosses oracle price": {
 			vaultParams: vaulttypes.Params{
 				Layers:                           3,       // 3 layers
 				SpreadMinPpm:                     3_000,   // 30 bps
@@ -425,10 +519,15 @@ func TestGetVaultClobOrders(t *testing.T) {
 			// 1. spread = max(spread_min, spread_buffer + min_price_change)
 			// 2. leverage = open_notional / equity
 			// 3. leverage_i = leverage +/- i * order_size_pct (- for ask and + for bid)
-			// 4. skew_i = -leverage_i * spread * skew_factor
-			// 5. a_i = max(oracle_price * (1 + skew_i + spread*{i+1}), oracle_price)
-			//    b_i = min(oracle_price * (1 + skew_i - spread*{i+1}), oracle_price)
-			// 6. subticks needs to be a multiple of subticks_per_tick (round up for asks, round down for bids)
+			// 4. skew_i
+			//    * for ask when long / bid when short: -skew_factor * leverage_i
+			//    * for ask when short: (skew_factor * leverage_i - 1)^2 - 1
+			//    * for bid when long: -((skew_factor * leverage_i + 1)^2 - 1)
+			// 5. ask_spread_i = (1 + skew_i) * spread
+			//    bid_spread_i = (1 - skew_i) * spread
+			// 6. a_i = oraclePrice * (1 + ask_spread_i)
+			//    b_i = oraclePrice * (1 - bid_spread_i)
+			// 7. subticks needs to be a multiple of subticks_per_tick (round up for asks, round down for bids)
 			// To calculate size of each order
 			// 1. `order_size_pct_ppm * equity / oracle_price`.
 			expectedOrderSubticks: []uint64{
@@ -438,33 +537,34 @@ func TestGetVaultClobOrders(t *testing.T) {
 				// leverage = -1_500_000_000 / (2_000_000_000 - 1_500_000_000) = -3
 				// oracleSubticks = 3_000_000_000 * 10^(-6 - (-9) + (-9) - (-6)) = 3e9
 				// leverage_0 = leverage - 0 * 0.2 = -3
-				// skew_0 = 3 * 0.00855 * 0.9
-				// a_0 = 3e9 * (1 + skew_0 + 0.00855*1) = 3_094_905_000
-				// a_0 = max(a_0, oracle_price) = 3_094_905_000
-				3_094_905_000,
-				// b_0 = 3e9 * (1 + skew_0 - 0.00855*1) = 3_043_605_000
-				// b_0 = min(b_0, oracle_price) = 3e9 (bound)
-				3_000_000_000,
+				// skew_ask_0 = (0.9 * -3 - 1)^2 - 1 = 12.69
+				// ask_spread_0 = (1 + 12.69) * 0.00855 = 0.1170495
+				// a_0 = 3e9 * (1 + 0.1170495) = 3_351_148_500 ~= 3_351_149_000 (round up to 1000)
+				3_351_149_000,
+				// skew_bid_0 = -0.9 * -3 = 2.7
+				// bid_spread_0 = (1 - 2.7) * 0.00855 = -0.014535
+				// b_0 = 3e9 * (1 - -0.014535) = 3_043_605_000
+				3_043_605_000,
 				// leverage_1 = leverage - 1 * 0.2
-				// skew_1 = -leverage_1 * 0.00855 * 0.9
-				// a_1 = 3e9 * (1 + skew_1 + 0.00855*2) = 3_125_172_000
-				// a_1 = max(a_1, oracle_price) = 3_125_172_000
-				3_125_172_000,
+				// skew_ask_1 = (0.9 * -3.2 - 1)^2 - 1 = 14.0544
+				// ask_spread_1 = (1 + 14.0544) * 0.00855 = 0.12871512
+				// a_1 = 3e9 * (1 + 0.12871512) = 3_386_145_360 ~= 3_386_146_000 (round up to 1000)
+				3_386_146_000,
 				// leverage_1 = leverage + 1 * 0.2
-				// skew_1 = -leverage_1 * 0.00855 * 0.9
-				// b_1 = 3e9 * (1 + skew_1 - 0.00855*2) = 3_013_338_000
-				// b_1 = min(b_1, oracle_price) = 3e9 (bound)
-				3_000_000_000,
+				// skew_bid_1 = -0.9 * -2.8 = 2.52
+				// bid_spread_1 = (1 - 2.52) * 0.00855 = -0.012996
+				// b_1 = 3e9 * (1 - -0.012996) = 3_038_988_000
+				3_038_988_000,
 				// leverage_2 = leverage - 2 * 0.2
-				// skew_2 = -leverage_2 * 0.00855 * 0.9
-				// a_2 = 3e9 * (1 + skew_2 + 0.00855*3) = 3_155_439_000
-				// a_2 = max(a_2, oracle_price) = 3_155_439_000
-				3_155_439_000,
+				// skew_ask_2 = (0.9 * -3.4 - 1)^2 - 1 = 15.4836
+				// ask_spread_2 = (1 + 15.4836) * 0.00855 = 0.14093478
+				// a_2 = 3e9 * (1 + 0.14093478) = 3_422_804_340 ~= 3_422_805_000 (round up to 1000)
+				3_422_805_000,
 				// leverage_2 = leverage + 2 * 0.2
-				// skew_2 = -leverage_2 * 0.00855 * 0.9
-				// b_2 = 3e9 * (1 + skew_2 - 0.00855*3) = 2_983_071_000
-				// b_2 = min(b_2, oracle_price) = 2_983_071_000
-				2_983_071_000,
+				// skew_bid_2 = -0.9 * -2.6 = 2.34
+				// bid_spread_2 = (1 - 2.34) * 0.00855 = -0.011457
+				// b_2 = 3e9 * (1 - -0.011457) = 3_034_371_000
+				3_034_371_000,
 			},
 			// order_size = 20% * 500 / 3000 ~= 0.0333333333
 			// order_size_base_quantums = 0.0333333333e9 ~= 33_333_333.33
@@ -478,7 +578,7 @@ func TestGetVaultClobOrders(t *testing.T) {
 				33_333_000,
 			},
 		},
-		"Success - Get orders from Vault for Clob Pair 1, asks bounded by oracle price.": {
+		"Success - Vault Clob 1, 2 layers, leverage 3, crosses oracle price": {
 			vaultParams: vaulttypes.Params{
 				Layers:                           2,         // 2 layers
 				SpreadMinPpm:                     3_000,     // 30 bps
@@ -499,10 +599,15 @@ func TestGetVaultClobOrders(t *testing.T) {
 			// 1. spread = max(spread_min, spread_buffer + min_price_change)
 			// 2. leverage = open_notional / equity
 			// 3. leverage_i = leverage +/- i * order_size_pct (- for ask and + for bid)
-			// 4. skew_i = -leverage_i * spread * skew_factor
-			// 5. a_i = max(oracle_price * (1 + skew_i + spread*{i+1}), oracle_price)
-			//    b_i = min(oracle_price * (1 + skew_i - spread*{i+1}), oracle_price)
-			// 6. subticks needs to be a multiple of subticks_per_tick (round up for asks, round down for bids)
+			// 4. skew_i
+			//    * for ask when long / bid when short: -skew_factor * leverage_i
+			//    * for ask when short: (skew_factor * leverage_i - 1)^2 - 1
+			//    * for bid when long: -((skew_factor * leverage_i + 1)^2 - 1)
+			// 5. ask_spread_i = (1 + skew_i) * spread
+			//    bid_spread_i = (1 - skew_i) * spread
+			// 6. a_i = oraclePrice * (1 + ask_spread_i)
+			//    b_i = oraclePrice * (1 - bid_spread_i)
+			// 7. subticks needs to be a multiple of subticks_per_tick (round up for asks, round down for bids)
 			// To calculate size of each order
 			// 1. `order_size_pct_ppm * equity / oracle_price`.
 			expectedOrderSubticks: []uint64{
@@ -512,23 +617,24 @@ func TestGetVaultClobOrders(t *testing.T) {
 				// leverage = 3_000_000_000 / (-2_000_000_000 + 3_000_000_000) = 3
 				// oracleSubticks = 3_000_000_000 * 10^(-6 - (-9) + (-9) - (-6)) = 3e9
 				// leverage_0 = leverage - 0 * 1 = 3
-				// skew_0 = -3 * 0.003 * 0.5
-				// a_0 = 3e9 * (1 + skew_0 + 0.003*1) = 2_995_500_000
-				// a_0 = max(a_0, oracle_price) = 3e9 (bound)
-				3_000_000_000,
-				// b_0 = 3e9 * (1 + skew_0 - 0.003*1) = 2_977_500_000
-				// b_0 = min(b_0, oracle_price) = 2_977_500_000
-				2_977_500_000,
+				// skew_ask_0 = -0.5 * 3 = -1.5
+				// ask_spread_0 = (1 + -1.5) * 0.003 = -0.0015
+				// a_0 = 3e9 * (1 + -0.0015) = 2_995_500_000
+				2_995_500_000,
+				// skew_bid_0 = -((0.5 * 3 + 1)^2 - 1) = -5.25
+				// bid_spread_0 = (1 - -5.25) * 0.003 = 0.01875
+				// b_0 = 3e9 * (1 - 0.01875) = 2_943_750_000
+				2_943_750_000,
 				// leverage_1 = leverage - 1 * 1 = 2
-				// skew_1 = -2 * 0.003 * .5
-				// a_1 = 3e9 * (1 + skew_1 + 0.003*2) = 3_009_000_000
-				// a_1 = max(a_1, oracle_price) = 3_009_000_000
-				3_009_000_000,
+				// skew_ask_1 = -0.5 * 2 = -1
+				// ask_spread_1 = (1 + -1) * 0.003 = 0
+				// a_1 = 3e9 * (1 + 0) = 3_000_000_000
+				3_000_000_000,
 				// leverage_1 = leverage + 1 * 1 = 4
-				// skew_1 = -4 * 0.003 * .5
-				// b_1 = 3e9 * (1 + skew_1 - 0.003*2) = 2_964_000_000
-				// b_1 = min(b_1, oracle_price) = 2_964_000_000
-				2_964_000_000,
+				// skew_bid_1 = -((0.5 * 4 + 1)^2 - 1) = -8
+				// bid_spread_1 = (1 - -8) * 0.003 = 0.027
+				// b_1 = 3e9 * (1 - 0.027) = 2_919_000_000
+				2_919_000_000,
 			},
 			// order_size = 100% * 1000 / 3000 ~= 0.333333333
 			// order_size_base_quantums = 0.333333333e9 ~= 333_333_333.33


### PR DESCRIPTION
### Changelist
implement vaults phase 2 skewing

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced order calculation logic using refined formulas for better precision.
  - Adjusted order size determination to improve accuracy and performance.

- **Bug Fixes**
  - Corrected the computation of skew factors based on order side and leverage, ensuring better alignment with market conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->