### PR TITLE
[OTE-531] feat(OE): Move PruneRateLimit from EndBlocker to PrepareCheckState

### DIFF
--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -125,9 +125,6 @@ func EndBlocker(
 		processProposerMatchesEvents,
 	)
 
-	// Prune any rate limiting information that is no longer relevant.
-	keeper.PruneRateLimits(ctx)
-
 	// Emit relevant metrics at the end of every block.
 	metrics.SetGauge(
 		metrics.InsuranceFundBalance,
@@ -145,6 +142,9 @@ func PrepareCheckState(
 		// Prepare check state is for the next block.
 		log.BlockHeight, ctx.BlockHeight()+1,
 	)
+
+	// Prune any rate limiting information that is no longer relevant.
+	keeper.PruneRateLimits(ctx)
 
 	// Get the events generated from processing the matches in the latest block.
 	processProposerMatchesEvents := keeper.GetProcessProposerMatchesEvents(ctx)


### PR DESCRIPTION
### Changelist
[Context](https://dydx-team.slack.com/archives/C078HSZUV6E/p1720470109330719)

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized rate limiting process by pruning information earlier in the state preparation phase to enhance performance and accuracy during match processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->