### PR TITLE
Remove info log for `TimeoutPropose` override

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -68,17 +67,12 @@ func NewRootCmd(
 	option *RootCmdOption,
 	homeDir string,
 ) *cobra.Command {
-	logger := log.NewLogger(os.Stdout)
 	return NewRootCmdWithInterceptors(
 		option,
 		homeDir,
 		func(serverCtxPtr *server.Context) {
 			// Provide an override for `timeout_propose`. This value should be consistent across the network
 			// for synchrony, and should never be tweaked by individual validators in practice.
-			logger.Info(fmt.Sprintf(
-				"Overriding [consensus.timeout_propose] from %v to software constant: %v",
-				serverCtxPtr.Config.Consensus.TimeoutPropose,
-				TimeoutProposeOverride))
 			serverCtxPtr.Config.Consensus.TimeoutPropose = TimeoutProposeOverride
 		},
 		func(s string, appConfig *DydxAppConfig) (string, *DydxAppConfig) {


### PR DESCRIPTION
### Changelist
Remove noisy INFO log for `TimeoutPropose` override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed unnecessary `fmt` package import.
  - Eliminated redundant logging related to `consensus.timeout_propose` in command initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->