### PR TITLE
[CT-1002] functions to move collateral in and out of perpetual positions

### DIFF
--- a/protocol/testutil/perpetuals/perpetuals.go
+++ b/protocol/testutil/perpetuals/perpetuals.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	pricetypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
 type PerpetualModifierOption func(cp *perptypes.Perpetual)
@@ -130,5 +131,38 @@ func SetUpDefaultPerpOIsForTest(
 				),
 			)
 		}
+	}
+}
+
+func CreatePerpInfo(
+	id uint32,
+	atomicResolution int32,
+	price uint64,
+	priceExponent int32,
+) perptypes.PerpInfo {
+	return perptypes.PerpInfo{
+		Perpetual: perptypes.Perpetual{
+			Params: perptypes.PerpetualParams{
+				Id:               id,
+				Ticker:           "test ticker",
+				MarketId:         id,
+				AtomicResolution: atomicResolution,
+				LiquidityTier:    id,
+			},
+			FundingIndex: dtypes.NewInt(0),
+			OpenInterest: dtypes.NewInt(0),
+		},
+		Price: pricetypes.MarketPrice{
+			Id:       id,
+			Exponent: priceExponent,
+			Price:    price,
+		},
+		LiquidityTier: perptypes.LiquidityTier{
+			Id:                     id,
+			InitialMarginPpm:       100_000,
+			MaintenanceFractionPpm: 500_000,
+			OpenInterestLowerCap:   0,
+			OpenInterestUpperCap:   0,
+		},
 	}
 }

--- a/protocol/x/subaccounts/keeper/margining.go
+++ b/protocol/x/subaccounts/keeper/margining.go
@@ -1,0 +1,230 @@
+package keeper
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+	perplib "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/lib"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	salib "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+)
+
+// GetMarginedUpdates calculates the quote balance updates needed
+// for the given settled updates.
+func GetMarginedUpdates(
+	settledUpdates []types.SettledUpdate,
+	perpInfos perptypes.PerpInfos,
+) (
+	marginedUpdates []types.SettledUpdate,
+) {
+	marginedUpdates = make([]types.SettledUpdate, len(settledUpdates))
+
+	for i, update := range settledUpdates {
+		marginedUpdates[i] = getMarginedUpdate(update, perpInfos)
+	}
+
+	return marginedUpdates
+}
+
+// GetMarginedUpdate calculates the quote balance updates needed
+// for the given settled updates.
+func getMarginedUpdate(
+	update types.SettledUpdate,
+	perpInfos perptypes.PerpInfos,
+) (
+	marginedUpdate types.SettledUpdate,
+) {
+	marginedAssetUpdates := update.GetAssetUpdates()
+	marginedPerpetualUpdates := update.GetPerpetualUpdates()
+
+	// Calculate the updated subaccount.
+	updatedSubaccount := salib.CalculateUpdatedSubaccount(update, perpInfos)
+	updatedPositionMap := make(map[uint32]*types.PerpetualPosition)
+	for _, pos := range updatedSubaccount.PerpetualPositions {
+		updatedPositionMap[pos.PerpetualId] = pos
+	}
+
+	// For each of the updated positions, check if the position is margined and
+	// if we need to move any collateral.
+	rebalancingNeeded := false
+	for _, u := range update.PerpetualUpdates {
+		pos := updatedPositionMap[u.PerpetualId]
+		if pos == nil {
+			continue
+		}
+
+		// case 1: the position is fully closed, but there is still some collateral left.
+		// move the remaining collateral to the main quote balance.
+		if pos.Quantums.Sign() == 0 {
+			moveCollateralToPosition(
+				marginedAssetUpdates,
+				marginedPerpetualUpdates,
+				u.PerpetualId,
+				// Negate the quote balance to move it to the main quote balance.
+				new(big.Int).Neg(pos.GetQuoteBalance()),
+			)
+			continue
+		}
+
+		perpInfo := perpInfos.MustGet(pos.PerpetualId)
+		risk := perplib.GetNetCollateralAndMarginRequirements(
+			perpInfo.Perpetual,
+			perpInfo.Price,
+			perpInfo.LiquidityTier,
+			pos.GetBigQuantums(),
+			pos.GetQuoteBalance(),
+		)
+
+		// case 2: the position is undercollateralized w.r.t. the maintenance margin requirement.
+		// In this case, we need to rebalance the collateral across all positions.
+		if !risk.IsMaintenanceCollateralized() {
+			rebalancingNeeded = true
+		}
+	}
+
+	// Deal with undercollateralized positions if needed.
+	if rebalancingNeeded {
+		rebalanceCollateralAcrossPositions(
+			update.SettledSubaccount,
+			marginedAssetUpdates,
+			marginedPerpetualUpdates,
+			perpInfos,
+		)
+	}
+
+	r := types.SettledUpdate{
+		SettledSubaccount: update.SettledSubaccount,
+	}
+	if len(marginedAssetUpdates) > 0 {
+		r.AssetUpdates = lib.MapToSortedSlice[lib.Sortable[uint32]](marginedAssetUpdates)
+	}
+	if len(marginedPerpetualUpdates) > 0 {
+		r.PerpetualUpdates = lib.MapToSortedSlice[lib.Sortable[uint32]](marginedPerpetualUpdates)
+	}
+	return r
+}
+
+// rebalanceCollateralAcrossPositions rebalances the collateral across all positions
+// by first withdrawing as much as possible from the other positions without going below
+// their maintenance margin requirements, and then moving collateral to the undercollateralized
+// positions.
+func rebalanceCollateralAcrossPositions(
+	subaccount types.Subaccount,
+	assetUpdates map[uint32]types.AssetUpdate,
+	perpetualUpdates map[uint32]types.PerpetualUpdate,
+	perpInfos perptypes.PerpInfos,
+) {
+	// Withdraw as much as possible from the other positions without going below
+	// their maintenance margin requirements.
+	withdrawCollateralFromPerpetualPositions(
+		subaccount,
+		assetUpdates,
+		perpetualUpdates,
+		perpInfos,
+	)
+
+	// Calculate the updated subaccount after withdrawing collateral.
+	updatedSubaccount := salib.CalculateUpdatedSubaccount(
+		types.SettledUpdate{
+			SettledSubaccount: subaccount,
+			AssetUpdates:      lib.MapToSortedSlice[lib.Sortable[uint32]](assetUpdates),
+			PerpetualUpdates:  lib.MapToSortedSlice[lib.Sortable[uint32]](perpetualUpdates),
+		},
+		perpInfos,
+	)
+	mainQuoteBalance := updatedSubaccount.GetUsdcPosition()
+
+	for _, pos := range updatedSubaccount.PerpetualPositions {
+		perpInfo := perpInfos.MustGet(pos.PerpetualId)
+		risk := perplib.GetNetCollateralAndMarginRequirements(
+			perpInfo.Perpetual,
+			perpInfo.Price,
+			perpInfo.LiquidityTier,
+			pos.GetBigQuantums(),
+			pos.GetQuoteBalance(),
+		)
+
+		// Move collateral to the position if it is undercollateralized.
+		if !risk.IsMaintenanceCollateralized() {
+			collateralNeeded := new(big.Int).Sub(risk.MMR, risk.NC)
+			collateralToTransfer := lib.BigMin(collateralNeeded, mainQuoteBalance)
+			fmt.Println("collateralToTransfer: ", collateralToTransfer.String())
+
+			moveCollateralToPosition(assetUpdates, perpetualUpdates, pos.PerpetualId, collateralToTransfer)
+			mainQuoteBalance.Sub(mainQuoteBalance, collateralToTransfer)
+		}
+	}
+}
+
+// withdrawCollateralFromPerpetualPositions withdraws all extra collateral from all perpetual positions
+// associated with the given subaccount.
+// Withdraw as much as possible without going below the maintenance margin.
+func withdrawCollateralFromPerpetualPositions(
+	subaccount types.Subaccount,
+	assetUpdates map[uint32]types.AssetUpdate,
+	perpetualUpdates map[uint32]types.PerpetualUpdate,
+	perpInfos perptypes.PerpInfos,
+) {
+	for _, pos := range subaccount.PerpetualPositions {
+		perpInfo := perpInfos.MustGet(pos.PerpetualId)
+		risk := perplib.GetNetCollateralAndMarginRequirements(
+			perpInfo.Perpetual,
+			perpInfo.Price,
+			perpInfo.LiquidityTier,
+			pos.GetBigQuantums(),
+			pos.GetQuoteBalance(),
+		)
+
+		// Calculate the amount of extra collateral that can be withdrawn.
+		// Withdraw as much as possible without going below the maintenance margin.
+		extraCollateral := new(big.Int).Sub(risk.NC, risk.MMR)
+
+		if extraCollateral.Sign() > 0 {
+			moveCollateralToPosition(
+				assetUpdates,
+				perpetualUpdates,
+				pos.PerpetualId,
+				// Negate the quote balance to move it to the main quote balance.
+				new(big.Int).Neg(extraCollateral),
+			)
+		}
+	}
+}
+
+func moveCollateralToPosition(
+	assetUpdates map[uint32]types.AssetUpdate,
+	perpetualUpdates map[uint32]types.PerpetualUpdate,
+	perpetualId uint32,
+	collateral *big.Int,
+) {
+	if collateral.Sign() == 0 {
+		return
+	}
+
+	usdcAssetUpdate, ok := assetUpdates[assettypes.AssetUsdc.Id]
+	if !ok {
+		usdcAssetUpdate = types.AssetUpdate{
+			AssetId:          assettypes.AssetUsdc.Id,
+			BigQuantumsDelta: new(big.Int),
+		}
+		assetUpdates[assettypes.AssetUsdc.Id] = usdcAssetUpdate
+	}
+	usdcAssetUpdate.BigQuantumsDelta.Sub(usdcAssetUpdate.BigQuantumsDelta, collateral)
+
+	perpetualUpdate, ok := perpetualUpdates[perpetualId]
+	if !ok {
+		perpetualUpdate = types.PerpetualUpdate{
+			PerpetualId:          perpetualId,
+			BigQuantumsDelta:     new(big.Int),
+			BigQuoteBalanceDelta: new(big.Int),
+		}
+		perpetualUpdates[perpetualId] = perpetualUpdate
+	}
+	perpetualUpdate.BigQuoteBalanceDelta.Add(
+		perpetualUpdate.BigQuoteBalanceDelta,
+		collateral,
+	)
+}

--- a/protocol/x/subaccounts/keeper/margining_test.go
+++ b/protocol/x/subaccounts/keeper/margining_test.go
@@ -122,6 +122,13 @@ func TestGetMarginedUpdates(t *testing.T) {
 						big.NewInt(0),
 						big.NewInt(2_500_000_000-50_000_000_000),
 					),
+					testutil.CreateSinglePerpetualPosition(
+						1,
+						big.NewInt(1_000_000_000), // 1 ETH
+						big.NewInt(0),
+						// Extra collateral in ETH position.
+						big.NewInt(10_000_000_000),
+					),
 				},
 			},
 			perpetualUpdates: []types.PerpetualUpdate{

--- a/protocol/x/subaccounts/keeper/margining_test.go
+++ b/protocol/x/subaccounts/keeper/margining_test.go
@@ -1,0 +1,225 @@
+package keeper_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	perp_testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
+	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/util"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMarginedUpdates(t *testing.T) {
+	perpInfos := perptypes.PerpInfos{
+		0: perp_testutil.CreatePerpInfo(
+			0,
+			constants.BtcUsd_100PercentMarginRequirement.Params.AtomicResolution,
+			constants.FiveBillion,
+			constants.BtcUsdExponent,
+		),
+		1: perp_testutil.CreatePerpInfo(
+			1,
+			constants.EthUsd_100PercentMarginRequirement.Params.AtomicResolution,
+			constants.ThreeBillion,
+			constants.EthUsdExponent,
+		),
+	}
+
+	tests := map[string]struct {
+		subaccount       types.Subaccount
+		assetUpdates     []types.AssetUpdate
+		perpetualUpdates []types.PerpetualUpdate
+
+		expectedAssetUpdates     []types.AssetUpdate
+		expectedPerpetualUpdates []types.PerpetualUpdate
+	}{
+		"perpetual position is collateralized - no collateral updates": {
+			subaccount: types.Subaccount{
+				Id: &constants.Alice_Num0,
+				AssetPositions: []*types.AssetPosition{
+					&constants.Usdc_Asset_10_000,
+				},
+				PerpetualPositions: []*types.PerpetualPosition{
+					testutil.CreateSinglePerpetualPosition(
+						0,
+						big.NewInt(100_000_000), // 1 BTC
+						big.NewInt(0),
+						// $10,000, enough to cover 2 BTC total.
+						big.NewInt(5_000_000_000-50_000_000_000),
+					),
+				},
+			},
+			perpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:          0,
+					BigQuantumsDelta:     big.NewInt(100_000_000),
+					BigQuoteBalanceDelta: big.NewInt(-50_000_000_000),
+				},
+			},
+			expectedPerpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:          0,
+					BigQuantumsDelta:     big.NewInt(100_000_000),
+					BigQuoteBalanceDelta: big.NewInt(-50_000_000_000),
+				},
+			},
+		},
+		`perpetual position is fully closed - remaining collateral moved back
+		to main quote balance`: {
+			subaccount: types.Subaccount{
+				Id: &constants.Alice_Num0,
+				AssetPositions: []*types.AssetPosition{
+					&constants.Usdc_Asset_10_000,
+				},
+				PerpetualPositions: []*types.PerpetualPosition{
+					testutil.CreateSinglePerpetualPosition(
+						0,
+						big.NewInt(100_000_000), // 1 BTC
+						big.NewInt(0),
+						big.NewInt(10_000_000_000-50_000_000_000),
+					),
+				},
+			},
+			perpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:      0,
+					BigQuantumsDelta: big.NewInt(-100_000_000),
+					// Position is closed at $50,000.
+					BigQuoteBalanceDelta: big.NewInt(50_000_000_000),
+				},
+			},
+			expectedAssetUpdates: []types.AssetUpdate{
+				{
+					AssetId: 0,
+					// net $10,000 is moved back to the main quote balance.
+					BigQuantumsDelta: big.NewInt(10_000_000_000),
+				},
+			},
+			expectedPerpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:      0,
+					BigQuantumsDelta: big.NewInt(-100_000_000),
+					// net $10,000 is moved back to the main quote balance.
+					BigQuoteBalanceDelta: big.NewInt(40_000_000_000),
+				},
+			},
+		},
+		`new perpetual position is under-collateralized - main quote balance has enough collateral
+		for the new position`: {
+			subaccount: types.Subaccount{
+				Id: &constants.Alice_Num0,
+				AssetPositions: []*types.AssetPosition{
+					&constants.Usdc_Asset_10_000,
+				},
+				PerpetualPositions: []*types.PerpetualPosition{
+					testutil.CreateSinglePerpetualPosition(
+						0,
+						big.NewInt(100_000_000), // 1 BTC
+						big.NewInt(0),
+						big.NewInt(2_500_000_000-50_000_000_000),
+					),
+				},
+			},
+			perpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:          0,
+					BigQuantumsDelta:     big.NewInt(100_000_000),
+					BigQuoteBalanceDelta: big.NewInt(-50_000_000_000),
+				},
+			},
+			expectedAssetUpdates: []types.AssetUpdate{
+				{
+					AssetId: 0,
+					// $2,500 is moved to the new position.
+					BigQuantumsDelta: big.NewInt(-2_500_000_000),
+				},
+			},
+			expectedPerpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:      0,
+					BigQuantumsDelta: big.NewInt(100_000_000),
+					// $2,500 is moved to the new position.
+					BigQuoteBalanceDelta: big.NewInt(-50_000_000_000 + 2_500_000_000),
+				},
+			},
+		},
+		`new perpetual position is under-collateralized - main quote balance does not have enough collateral
+		for the new position and rebalancing is needed`: {
+			subaccount: types.Subaccount{
+				Id: &constants.Alice_Num0,
+				PerpetualPositions: []*types.PerpetualPosition{
+					testutil.CreateSinglePerpetualPosition(
+						0,
+						big.NewInt(100_000_000), // 1 BTC
+						big.NewInt(0),
+						big.NewInt(2_500_000_000-50_000_000_000),
+					),
+					testutil.CreateSinglePerpetualPosition(
+						1,
+						big.NewInt(1_000_000_000), // 1 ETH
+						big.NewInt(0),
+						// Extra collateral in ETH position.
+						// NC = $10,000 + $3,000 = $13,000
+						// MMR = $150
+						// Free collateral = $13,000 - $150 = $12,850
+						big.NewInt(10_000_000_000),
+					),
+				},
+			},
+			perpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:          0,
+					BigQuantumsDelta:     big.NewInt(100_000_000),
+					BigQuoteBalanceDelta: big.NewInt(-50_000_000_000),
+				},
+			},
+			expectedAssetUpdates: []types.AssetUpdate{
+				{
+					AssetId:          0,
+					BigQuantumsDelta: big.NewInt(12_850_000_000 - 2_500_000_000),
+				},
+			},
+			expectedPerpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:      0,
+					BigQuantumsDelta: big.NewInt(100_000_000),
+					// $2,500 is moved to the new position.
+					BigQuoteBalanceDelta: big.NewInt(-50_000_000_000 + 2_500_000_000),
+				},
+				{
+					PerpetualId:      1,
+					BigQuantumsDelta: big.NewInt(0),
+					// $12,850 is moved out of the position.
+					BigQuoteBalanceDelta: big.NewInt(-12_850_000_000),
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualUpdates := keeper.GetMarginedUpdates(
+				[]types.SettledUpdate{
+					{
+						SettledSubaccount: tc.subaccount,
+						AssetUpdates:      tc.assetUpdates,
+						PerpetualUpdates:  tc.perpetualUpdates,
+					},
+				}, perpInfos)
+			require.Equal(t, tc.subaccount, actualUpdates[0].SettledSubaccount)
+			require.Equal(t, tc.expectedAssetUpdates, actualUpdates[0].AssetUpdates)
+
+			actualPerpetualUpdates := actualUpdates[0].PerpetualUpdates
+			require.Equal(t, len(tc.expectedPerpetualUpdates), len(actualPerpetualUpdates))
+			for i, expectedUpdate := range tc.expectedPerpetualUpdates {
+				require.Equal(t, expectedUpdate.PerpetualId, actualPerpetualUpdates[i].PerpetualId)
+				require.Equal(t, expectedUpdate.GetBigQuantums(), actualPerpetualUpdates[i].GetBigQuantums())
+				require.Equal(t, expectedUpdate.GetBigQuoteBalance(), actualPerpetualUpdates[i].GetBigQuoteBalance())
+			}
+		})
+	}
+}

--- a/protocol/x/subaccounts/lib/updates.go
+++ b/protocol/x/subaccounts/lib/updates.go
@@ -287,11 +287,16 @@ func CalculateUpdatedPerpetualPositions(
 			// Update existing position.
 			quantums := pos.GetBigQuantums()
 			quantums.Add(quantums, update.GetBigQuantums())
-			if quantums.BitLen() == 0 {
+
+			quoteBalance := pos.GetQuoteBalance()
+			quoteBalance.Add(quoteBalance, update.GetBigQuoteBalance())
+
+			if quantums.BitLen() == 0 && quoteBalance.BitLen() == 0 {
 				// The position is now closed.
 				delete(positionsMap, update.PerpetualId)
 			} else {
 				pos.Quantums = dtypes.NewIntFromBigInt(quantums)
+				pos.QuoteBalance = dtypes.NewIntFromBigInt(quoteBalance)
 			}
 		} else {
 			// Create a new position.
@@ -299,7 +304,7 @@ func CalculateUpdatedPerpetualPositions(
 			positionsMap[update.PerpetualId] = &types.PerpetualPosition{
 				PerpetualId:  update.PerpetualId,
 				Quantums:     dtypes.NewIntFromBigInt(update.GetBigQuantums()),
-				QuoteBalance: dtypes.ZeroInt(),
+				QuoteBalance: dtypes.NewIntFromBigInt(update.GetBigQuoteBalance()),
 				FundingIndex: perpInfo.Perpetual.FundingIndex,
 			}
 		}

--- a/protocol/x/subaccounts/lib/updates_test.go
+++ b/protocol/x/subaccounts/lib/updates_test.go
@@ -4,11 +4,10 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/margin"
+	perp_testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
 	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/util"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
-	pricetypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
@@ -129,7 +128,7 @@ func TestGetRiskForSubaccount(t *testing.T) {
 				AssetPositions: testutil.CreateUsdcAssetPositions(big.NewInt(100)),
 			},
 			perpInfos: perptypes.PerpInfos{
-				1: createPerpInfo(1, -6, 100, 0),
+				1: perp_testutil.CreatePerpInfo(1, -6, 100, 0),
 			},
 			expectedRisk: margin.Risk{
 				NC:  big.NewInt(100*100 + 100),
@@ -148,8 +147,8 @@ func TestGetRiskForSubaccount(t *testing.T) {
 				AssetPositions: testutil.CreateUsdcAssetPositions(big.NewInt(110)),
 			},
 			perpInfos: perptypes.PerpInfos{
-				1: createPerpInfo(1, -6, 100, 0),
-				2: createPerpInfo(2, -6, 200, 0),
+				1: perp_testutil.CreatePerpInfo(1, -6, 100, 0),
+				2: perp_testutil.CreatePerpInfo(2, -6, 200, 0),
 			},
 			expectedRisk: margin.Risk{
 				NC:  big.NewInt((100*100 + 100) + (-25*200 + 10)),
@@ -186,37 +185,4 @@ func TestGetRiskForSubaccount_Panic(t *testing.T) {
 	require.Panics(t, func() {
 		_, _ = lib.GetRiskForSubaccount(subaccount, emptyPerpInfos)
 	})
-}
-
-func createPerpInfo(
-	id uint32,
-	atomicResolution int32,
-	price uint64,
-	priceExponent int32,
-) perptypes.PerpInfo {
-	return perptypes.PerpInfo{
-		Perpetual: perptypes.Perpetual{
-			Params: perptypes.PerpetualParams{
-				Id:               id,
-				Ticker:           "test ticker",
-				MarketId:         id,
-				AtomicResolution: atomicResolution,
-				LiquidityTier:    id,
-			},
-			FundingIndex: dtypes.NewInt(0),
-			OpenInterest: dtypes.NewInt(0),
-		},
-		Price: pricetypes.MarketPrice{
-			Id:       id,
-			Exponent: priceExponent,
-			Price:    price,
-		},
-		LiquidityTier: perptypes.LiquidityTier{
-			Id:                     id,
-			InitialMarginPpm:       100_000,
-			MaintenanceFractionPpm: 500_000,
-			OpenInterestLowerCap:   0,
-			OpenInterestUpperCap:   0,
-		},
-	}
 }

--- a/protocol/x/subaccounts/types/position_size.go
+++ b/protocol/x/subaccounts/types/position_size.go
@@ -124,6 +124,13 @@ func (pu PerpetualUpdate) GetBigQuantums() *big.Int {
 	return pu.BigQuantumsDelta
 }
 
+func (pu PerpetualUpdate) GetBigQuoteBalance() *big.Int {
+	if pu.BigQuoteBalanceDelta == nil {
+		return new(big.Int)
+	}
+	return pu.BigQuoteBalanceDelta
+}
+
 func (pu PerpetualUpdate) GetId() uint32 {
 	return pu.PerpetualId
 }

--- a/protocol/x/subaccounts/types/settled_update.go
+++ b/protocol/x/subaccounts/types/settled_update.go
@@ -12,3 +12,19 @@ type SettledUpdate struct {
 	// A list of changes to make to any `PerpetualPositions` in the `Subaccount`.
 	PerpetualUpdates []PerpetualUpdate
 }
+
+func (u *SettledUpdate) GetAssetUpdates() map[uint32]AssetUpdate {
+	updates := make(map[uint32]AssetUpdate)
+	for _, update := range u.AssetUpdates {
+		updates[update.AssetId] = update.DeepCopy()
+	}
+	return updates
+}
+
+func (u *SettledUpdate) GetPerpetualUpdates() map[uint32]PerpetualUpdate {
+	updates := make(map[uint32]PerpetualUpdate)
+	for _, update := range u.PerpetualUpdates {
+		updates[update.PerpetualId] = update.DeepCopy()
+	}
+	return updates
+}

--- a/protocol/x/subaccounts/types/update.go
+++ b/protocol/x/subaccounts/types/update.go
@@ -92,12 +92,34 @@ type AssetUpdate struct {
 	BigQuantumsDelta *big.Int
 }
 
+func (u *AssetUpdate) DeepCopy() AssetUpdate {
+	return AssetUpdate{
+		AssetId:          u.AssetId,
+		BigQuantumsDelta: new(big.Int).Set(u.BigQuantumsDelta),
+	}
+}
+
 type PerpetualUpdate struct {
 	// The `Id` of the `Perpetual` for which the `PerpetualPosition` is for.
 	PerpetualId uint32
 	// The signed change in the `Quantums` of the `PerpetualPosition`
 	// represented in base quantums.
 	BigQuantumsDelta *big.Int
+	// The signed change in the `QuoteBalance` of the `PerpetualPosition`.
+	BigQuoteBalanceDelta *big.Int
+}
+
+func (u *PerpetualUpdate) DeepCopy() PerpetualUpdate {
+	r := PerpetualUpdate{
+		PerpetualId:          u.PerpetualId,
+		BigQuantumsDelta:     new(big.Int).Set(u.BigQuantumsDelta),
+		BigQuoteBalanceDelta: new(big.Int),
+	}
+
+	if u.BigQuoteBalanceDelta != nil {
+		r.BigQuoteBalanceDelta.Set(u.BigQuoteBalanceDelta)
+	}
+	return r
 }
 
 type UpdateType uint


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new methods to manage perpetual market and collateral rebalancing across subaccounts.
  - Added functionality to handle quote balance updates for settled positions.

- **Enhancements**
  - Improved calculation of perpetual positions by including quantum and quote balance.

- **Refactor**
  - Replaced local function calls with utility functions to standardize perpetual market setup.

- **Testing**
  - Updated test files to align with new utility function for creating perpetual information.

- **Documentation**
  - Added and updated methods to improve clarity and functionality of asset and perpetual updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->