### PR TITLE
Fix close not being called for iterators

### DIFF
--- a/protocol/x/clob/keeper/process_proposer_matches_events.go
+++ b/protocol/x/clob/keeper/process_proposer_matches_events.go
@@ -144,6 +144,7 @@ func (k Keeper) ResetOrderedOrderIds(
 ) {
 	prefixStore := prefix.NewStore(store, []byte(keyPrefix))
 	it := prefixStore.Iterator(nil, nil)
+	defer it.Close()
 	for ; it.Valid(); it.Next() {
 		prefixStore.Delete(it.Key())
 	}
@@ -153,6 +154,7 @@ func (k Keeper) ResetOrderedOrderIds(
 func (k Keeper) ResetUnorderedOrderIds(ctx sdk.Context, store storetypes.KVStore, keyPrefix string) {
 	prefixStore := prefix.NewStore(store, []byte(keyPrefix))
 	it := prefixStore.Iterator(nil, nil)
+	defer it.Close()
 	for ; it.Valid(); it.Next() {
 		prefixStore.Delete(it.Key())
 	}
@@ -186,6 +188,7 @@ func (k Keeper) GetOrderIds(
 	ret := []types.OrderId{}
 	prefixStore := prefix.NewStore(store, []byte(keyPrefix))
 	it := prefixStore.Iterator(nil, nil)
+	defer it.Close()
 	for ; it.Valid(); it.Next() {
 		var orderId types.OrderId
 		k.cdc.MustUnmarshal(it.Value(), &orderId)

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -230,6 +230,7 @@ func (k Keeper) RemoveExpiredStatefulOrders(ctx sdk.Context, blockTime time.Time
 			[]byte(fmt.Sprintf(types.StatefulOrdersExpirationsKeyPrefix, sdk.FormatTimeString(blockTime))),
 		),
 	)
+	defer it.Close()
 	for ; it.Valid(); it.Next() {
 		var orderId types.OrderId
 		k.cdc.MustUnmarshal(it.Value(), &orderId)


### PR DESCRIPTION
### Changelist
Title

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management by ensuring proper cleanup of iterators in order processing functions.
	- Enhanced stability and performance by closing iterators after use in the `RemoveExpiredStatefulOrders` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->