### PR TITLE
add panic recovering to vault abci methods

### DIFF
--- a/protocol/x/vault/abci.go
+++ b/protocol/x/vault/abci.go
@@ -1,7 +1,10 @@
 package vault
 
 import (
+	"runtime/debug"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/log"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/keeper"
 )
 
@@ -9,6 +12,19 @@ func BeginBlocker(
 	ctx sdk.Context,
 	keeper *keeper.Keeper,
 ) {
+	// Panic is not expected in BeginBlocker, but we should recover instead of
+	// halting the chain.
+	defer func() {
+		if r := recover(); r != nil {
+			log.ErrorLog(
+				ctx,
+				"panic in vault BeginBlocker",
+				"stack",
+				string(debug.Stack()),
+			)
+		}
+	}()
+
 	keeper.DecommissionNonPositiveEquityVaults(ctx)
 }
 
@@ -16,5 +32,18 @@ func EndBlocker(
 	ctx sdk.Context,
 	keeper *keeper.Keeper,
 ) {
+	// Panic is not expected in EndBlocker, but we should recover instead of
+	// halting the chain.
+	defer func() {
+		if r := recover(); r != nil {
+			log.ErrorLog(
+				ctx,
+				"panic in vault EndBlocker",
+				"stack",
+				string(debug.Stack()),
+			)
+		}
+	}()
+
 	keeper.RefreshAllVaultOrders(ctx)
 }


### PR DESCRIPTION
### Changelist
add panic recovering to x/vault abci methods just to be safe

### Test Plan
local testing by intentionally adding a panic and making sure correct error is logged and chain resumes

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved system stability by adding error recovery handling to prevent chain halting in case of a panic.
  - Enhanced logging to capture and debug panics with stack traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->