### PR TITLE
[CT-964] Send deleveraging events in grpc stream

### DIFF
--- a/protocol/x/clob/keeper/process_operations.go
+++ b/protocol/x/clob/keeper/process_operations.go
@@ -835,6 +835,22 @@ func (k Keeper) PersistMatchDeleveragingToState(
 				),
 			),
 		)
+		// if GRPC streaming is on, emit a generated clob match to stream.
+		if streamingManager := k.GetGrpcStreamingManager(); streamingManager.Enabled() {
+			streamOrderbookFill := types.StreamOrderbookFill{
+				ClobMatch: &types.ClobMatch{
+					Match: &types.ClobMatch_MatchPerpetualDeleveraging{
+						MatchPerpetualDeleveraging: matchDeleveraging,
+					},
+				},
+			}
+			k.SendOrderbookFillUpdates(
+				ctx,
+				[]types.StreamOrderbookFill{
+					streamOrderbookFill,
+				},
+			)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Changelist
Send deleveraging events in grpc stream

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled GRPC streaming for CLOB matches, allowing real-time updates if streaming is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->