### PR TITLE
Remove revshare from pre-upgrade genesis.

### DIFF
--- a/protocol/testing/containertest/preupgrade_genesis.json
+++ b/protocol/testing/containertest/preupgrade_genesis.json
@@ -2178,7 +2178,6 @@
         }
       ]
     },
-    "revshare": {},
     "rewards": {
       "params": {
         "treasury_account": "rewards_treasury",


### PR DESCRIPTION
### Changelist
Pre-upgrade genesis shouldn't contain state for `revshare` which is a module instantiated in the version being upgraded to.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the `revshare` object from the configuration file, simplifying the JSON structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->