### PR TITLE
[TRA-499] remove pagination from historical-pnl/parentSubaccountNumber endpt

### DIFF
--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1399,7 +1399,6 @@ fetch(`${baseURL}/historical-pnl/parentSubaccountNumber?address=string&parentSub
 |createdBeforeOrAt|query|[IsoString](#schemaisostring)|false|none|
 |createdOnOrAfterHeight|query|number(double)|false|none|
 |createdOnOrAfter|query|[IsoString](#schemaisostring)|false|none|
-|page|query|number(double)|false|none|
 
 > Example responses
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -2087,15 +2087,6 @@
             "schema": {
               "$ref": "#/components/schemas/IsoString"
             }
-          },
-          {
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "format": "double",
-              "type": "number"
-            }
           }
         ]
       }

--- a/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
@@ -110,7 +110,6 @@ class HistoricalPnlController extends Controller {
       @Query() createdBeforeOrAt?: IsoString,
       @Query() createdOnOrAfterHeight?: number,
       @Query() createdOnOrAfter?: IsoString,
-      @Query() page?: number,
   ): Promise<HistoricalPnlResponse> {
 
     const childSubaccountIds: string[] = getChildSubaccountIds(address, parentSubaccountNumber);
@@ -118,9 +117,6 @@ class HistoricalPnlController extends Controller {
     const [subaccounts,
       {
         results: pnlTicks,
-        limit: pageSize,
-        offset,
-        total,
       },
     ]: [
       SubaccountFromDatabase[],
@@ -144,7 +140,6 @@ class HistoricalPnlController extends Controller {
             ? createdOnOrAfterHeight.toString()
             : undefined,
           createdOnOrAfter,
-          page,
         },
         [QueryableField.LIMIT],
         {
@@ -185,9 +180,6 @@ class HistoricalPnlController extends Controller {
         (pnlTick: PnlTicksFromDatabase) => {
           return pnlTicksToResponseObject(pnlTick);
         }),
-      pageSize,
-      totalResults: total,
-      offset,
     };
   }
 }


### PR DESCRIPTION
### Changelist
remove pagination from historical-pnl/parentSubaccountNumber endpoint since its not applicable for this endpoint

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the `page` query parameter from API documentation and endpoints to address pagination inconsistencies.

- **Refactor**
  - Simplified API response by removing unnecessary pagination properties (`limit`, `offset`, `total`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->