### PR TITLE
[OTE-539] Add subaccounts username table

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -47,6 +47,7 @@ import {
   PnlTicksCreateObject,
   PositionSide,
   SubaccountCreateObject,
+  SubaccountUsernamesCreateObject,
   TendermintEventCreateObject,
   TimeInForce,
   TradingRewardAggregationCreateObject,
@@ -838,3 +839,19 @@ export const defaultTradingRewardAggregationId: string = TradingRewardAggregatio
   defaultTradingRewardAggregation.period,
   defaultTradingRewardAggregation.startedAtHeight,
 );
+
+// ============== Subaccount Usernames ==============
+export const defaultSubaccountUsername: SubaccountUsernamesCreateObject = {
+  username: 'LyingRaisin32',
+  subaccountId: defaultSubaccountId,
+};
+
+export const defaultSubaccountUsername2: SubaccountUsernamesCreateObject = {
+  username: 'LyingRaisin33',
+  subaccountId: defaultSubaccountId2,
+};
+
+export const duplicatedSubaccountUsername: SubaccountUsernamesCreateObject = {
+  username: 'LyingRaisin32',
+  subaccountId: defaultSubaccountId3,
+};

--- a/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
@@ -64,4 +64,8 @@ describe('SubaccountUsernames store', () => {
     await SubaccountUsernamesTable.create(defaultSubaccountUsername);
     await expect(SubaccountUsernamesTable.create(duplicatedSubaccountUsername)).rejects.toThrow();
   });
+
+  it('Creation of row without subaccountId fails', async () => {
+    await expect(SubaccountUsernamesTable.create({ ...defaultSubaccountUsername, subaccountId: '' })).rejects.toThrow();
+  });
 });

--- a/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
@@ -1,0 +1,67 @@
+import { SubaccountUsernamesFromDatabase } from '../../src/types';
+import * as SubaccountUsernamesTable from '../../src/stores/subaccount-usernames-table';
+import { clearData, migrate, teardown } from '../../src/helpers/db-helpers';
+import {
+  defaultSubaccountUsername,
+  defaultSubaccountUsername2,
+  duplicatedSubaccountUsername,
+} from '../helpers/constants';
+import { seedData } from '../helpers/mock-generators';
+
+describe('SubaccountUsernames store', () => {
+  beforeEach(async () => {
+    await seedData();
+  });
+
+  beforeAll(async () => {
+    await migrate();
+  });
+
+  afterEach(async () => {
+    await clearData();
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  it('Successfully creates a SubaccountUsername', async () => {
+    await SubaccountUsernamesTable.create(defaultSubaccountUsername);
+  });
+
+  it('Successfully finds all SubaccountUsernames', async () => {
+    await Promise.all([
+      SubaccountUsernamesTable.create(defaultSubaccountUsername),
+      SubaccountUsernamesTable.create(defaultSubaccountUsername2),
+    ]);
+
+    const subaccountUsernames:
+    SubaccountUsernamesFromDatabase[] = await SubaccountUsernamesTable.findAll(
+      {},
+      [],
+      { readReplica: true },
+    );
+
+    expect(subaccountUsernames.length).toEqual(2);
+    expect(subaccountUsernames[0]).toEqual(expect.objectContaining(defaultSubaccountUsername));
+    expect(subaccountUsernames[1]).toEqual(expect.objectContaining(defaultSubaccountUsername2));
+  });
+
+  it('Successfully finds SubaccountUsername with subaccountId', async () => {
+    await Promise.all([
+      SubaccountUsernamesTable.create(defaultSubaccountUsername),
+      SubaccountUsernamesTable.create(defaultSubaccountUsername2),
+    ]);
+
+    const subaccountUsername:
+    SubaccountUsernamesFromDatabase | undefined = await SubaccountUsernamesTable.findByUsername(
+      defaultSubaccountUsername.username,
+    );
+    expect(subaccountUsername).toEqual(expect.objectContaining(defaultSubaccountUsername));
+  });
+
+  it('Duplicate SubaccountUsername creation fails', async () => {
+    await SubaccountUsernamesTable.create(defaultSubaccountUsername);
+    await expect(SubaccountUsernamesTable.create(duplicatedSubaccountUsername)).rejects.toThrow();
+  });
+});

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240715155120_subaccount_usernames.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240715155120_subaccount_usernames.ts
@@ -2,10 +2,10 @@ import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('subaccount_usernames', (table) => {
-    // username should be unique across the table
-    table.string('username').notNullable().unique();
+    // username is primary key and is unique across the table
+    table.string('username').notNullable().primary();
     // subaccounts is a foreign key to the subaccounts table subaccounts.id
-    table.uuid('subaccountId').notNullable().primary().references('id').inTable('subaccounts');
+    table.uuid('subaccountId').notNullable().references('id').inTable('subaccounts');
   });
 }
 

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240715155120_subaccount_usernames.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240715155120_subaccount_usernames.ts
@@ -4,7 +4,8 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('subaccount_usernames', (table) => {
     // username should be unique across the table
     table.string('username').notNullable().unique();
-    table.string('subaccountId').notNullable().primary();
+    // subaccounts is a foreign key to the subaccounts table subaccounts.id
+    table.uuid('subaccountId').notNullable().primary().references('id').inTable('subaccounts');
   });
 }
 

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240715155120_subaccount_usernames.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240715155120_subaccount_usernames.ts
@@ -1,0 +1,13 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('subaccount_usernames', (table) => {
+    // username should be unique across the table
+    table.string('username').notNullable().unique();
+    table.string('subaccountId').notNullable().primary();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('subaccount_usernames');
+}

--- a/indexer/packages/postgres/src/helpers/db-helpers.ts
+++ b/indexer/packages/postgres/src/helpers/db-helpers.ts
@@ -8,6 +8,7 @@ import { rawQuery } from './stores-helpers';
 const layer2Tables = [
   'perpetual_positions',
   'fills',
+  'subaccount_usernames',
 ];
 
 const layer1Tables = [

--- a/indexer/packages/postgres/src/index.ts
+++ b/indexer/packages/postgres/src/index.ts
@@ -16,6 +16,7 @@ export { default as PerpetualPositionModel } from './models/perpetual-position-m
 export { default as TransferModel } from './models/transfer-model';
 export { default as TradingRewardModel } from './models/trading-reward-model';
 export { default as TradingRewardAggregationModel } from './models/trading-reward-aggregation-model';
+export { default as SubaccountUsernamesModel } from './models/subaccount-usernames-model';
 
 export * as AssetTable from './stores/asset-table';
 export * as AssetPositionTable from './stores/asset-position-table';

--- a/indexer/packages/postgres/src/models/subaccount-usernames-model.ts
+++ b/indexer/packages/postgres/src/models/subaccount-usernames-model.ts
@@ -1,0 +1,42 @@
+import path from 'path';
+
+import { Model } from 'objection';
+
+export default class SubaccountUsernames extends Model {
+
+  static get tableName() {
+    return 'subaccount_usernames';
+  }
+
+  static get idColumn() {
+    return 'subaccountId';
+  }
+
+  static relationMappings = {
+    subaccount: {
+      relation: Model.BelongsToOneRelation,
+      modelClass: path.join(__dirname, 'subaccount-model'),
+      join: {
+        from: 'subaccount_usernames.subaccountId',
+        to: 'subaccounts.id',
+      },
+    },
+  };
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: [
+        'username',
+        'subaccountId'],
+      properties: {
+        username: { type: 'string' },
+        subaccountId: { type: 'string' },
+      },
+    };
+  }
+
+  username!: string;
+
+  subaccountId!: string;
+}

--- a/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
@@ -42,11 +42,11 @@ export async function findAll(
   );
 
   if (username) {
-    baseQuery = baseQuery.where(SubaccountUsernamesColumns.username, username);
+    baseQuery = baseQuery.whereIn(SubaccountUsernamesColumns.username, username);
   }
 
   if (subaccountId) {
-    baseQuery = baseQuery.where(SubaccountUsernamesColumns.subaccountId, subaccountId);
+    baseQuery = baseQuery.whereIn(SubaccountUsernamesColumns.subaccountId, subaccountId);
   }
 
   if (options.orderBy !== undefined) {

--- a/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
@@ -1,0 +1,94 @@
+import { QueryBuilder } from 'objection';
+
+import { DEFAULT_POSTGRES_OPTIONS } from '../constants';
+import {
+  verifyAllRequiredFields,
+  setupBaseQuery,
+} from '../helpers/stores-helpers';
+import Transaction from '../helpers/transaction';
+import SubaccountUsernamesModel from '../models/subaccount-usernames-model';
+import {
+  QueryConfig,
+  SubaccountUsernamesFromDatabase,
+  SubaccountUsernamesQueryConfig,
+  SubaccountUsernamesColumns,
+  SubaccountUsernamesCreateObject,
+  Options,
+  Ordering,
+  QueryableField,
+} from '../types';
+
+export async function findAll(
+  {
+    username,
+    subaccountId,
+    limit,
+  }: SubaccountUsernamesQueryConfig,
+  requiredFields: QueryableField[],
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
+): Promise<SubaccountUsernamesFromDatabase[]> {
+  verifyAllRequiredFields(
+    {
+      username,
+      subaccountId,
+      limit,
+    } as QueryConfig,
+    requiredFields,
+  );
+
+  let baseQuery: QueryBuilder<SubaccountUsernamesModel> = setupBaseQuery<SubaccountUsernamesModel>(
+    SubaccountUsernamesModel,
+    options,
+  );
+
+  if (username) {
+    baseQuery = baseQuery.where(SubaccountUsernamesColumns.username, username);
+  }
+
+  if (subaccountId) {
+    baseQuery = baseQuery.where(SubaccountUsernamesColumns.subaccountId, subaccountId);
+  }
+
+  if (options.orderBy !== undefined) {
+    for (const [column, order] of options.orderBy) {
+      baseQuery = baseQuery.orderBy(
+        column,
+        order,
+      );
+    }
+  } else {
+    baseQuery = baseQuery.orderBy(
+      SubaccountUsernamesColumns.username,
+      Ordering.ASC,
+    );
+  }
+
+  if (limit) {
+    baseQuery = baseQuery.limit(limit);
+  }
+
+  return baseQuery.returning('*');
+}
+
+export async function create(
+  subaccountUsernameToCreate: SubaccountUsernamesCreateObject,
+  options: Options = { txId: undefined },
+): Promise<SubaccountUsernamesFromDatabase> {
+  return SubaccountUsernamesModel.query(
+    Transaction.get(options.txId),
+  ).insert({
+    ...subaccountUsernameToCreate,
+  }).returning('*');
+}
+
+export async function findByUsername(
+  username: string,
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
+): Promise<SubaccountUsernamesFromDatabase | undefined> {
+  const baseQuery:
+  QueryBuilder<SubaccountUsernamesModel> = setupBaseQuery<SubaccountUsernamesModel>(
+    SubaccountUsernamesModel,
+    options,
+  );
+  return (await baseQuery).find((subaccountUsername) => subaccountUsername.username === username);
+}

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -255,6 +255,11 @@ export interface TradingRewardAggregationFromDatabase {
   amount: string;
 }
 
+export interface SubaccountUsernamesFromDatabase {
+  username: string;
+  subaccountId: string;
+}
+
 export type SubaccountAssetNetTransferMap = { [subaccountId: string]:
 { [assetId: string]: string } };
 export type SubaccountToPerpetualPositionsMap = { [subaccountId: string]:

--- a/indexer/packages/postgres/src/types/index.ts
+++ b/indexer/packages/postgres/src/types/index.ts
@@ -26,4 +26,5 @@ export * from './compliance-status-types';
 export * from './trading-reward-types';
 export * from './trading-reward-aggregation-types';
 export * from './pagination-types';
+export * from './subaccount-usernames-types';
 export { PositionSide } from './position-types';

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -102,8 +102,8 @@ export interface SubaccountQueryConfig extends QueryConfig {
 }
 
 export interface SubaccountUsernamesQueryConfig extends QueryConfig {
-  [QueryableField.USERNAME]?: string;
-  [QueryableField.SUBACCOUNT_ID]?: string;
+  [QueryableField.USERNAME]?: string[];
+  [QueryableField.SUBACCOUNT_ID]?: string[];
 }
 
 export interface WalletQueryConfig extends QueryConfig {

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -85,6 +85,7 @@ export enum QueryableField {
   STARTED_AT_BEFORE_OR_AT = 'startedAtBeforeOrAt',
   STARTED_AT_HEIGHT_BEFORE_OR_AT = 'startedAtHeightBeforeOrAt',
   REASON = 'reason',
+  USERNAME = 'username',
 }
 
 export interface QueryConfig {
@@ -98,6 +99,11 @@ export interface SubaccountQueryConfig extends QueryConfig {
   [QueryableField.SUBACCOUNT_NUMBER]?: number;
   [QueryableField.UPDATED_BEFORE_OR_AT]?: string;
   [QueryableField.UPDATED_ON_OR_AFTER]?: string;
+}
+
+export interface SubaccountUsernamesQueryConfig extends QueryConfig {
+  [QueryableField.USERNAME]?: string;
+  [QueryableField.SUBACCOUNT_ID]?: string;
 }
 
 export interface WalletQueryConfig extends QueryConfig {

--- a/indexer/packages/postgres/src/types/subaccount-usernames-types.ts
+++ b/indexer/packages/postgres/src/types/subaccount-usernames-types.ts
@@ -1,0 +1,11 @@
+/* ------- SUBACCOUNT USERNAME TYPES ------- */
+
+export interface SubaccountUsernamesCreateObject {
+  username: string,
+  subaccountId: string,
+}
+
+export enum SubaccountUsernamesColumns {
+  username = 'username',
+  subaccountId = 'subaccountId',
+}


### PR DESCRIPTION
### Changelist
- Adds subaccounts username table

### Test Plan
- Adds unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for managing subaccount usernames in the database.
  - Added functions to find all subaccount usernames, create new subaccount usernames, and find a username by its value.

- **Improvements**
  - Updated query configurations to support querying by username and subaccount ID.
  - Enhanced `QueryableField` enum to include `USERNAME`.

- **Documentation**
  - Improved type definitions and function signatures for better clarity and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->