### PR TITLE
perf: Emit blocktime as sample 

### DIFF
--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -49,6 +49,7 @@ const (
 	LiquidationsPercentFilledDistribution                          = "liquidations_percent_filled_distribution"
 	LiquidationsPlacePerpetualLiquidationQuoteQuantumsDistribution = "liquidations_place_perpetual_liquidation_quote_quantums_distribution"
 	RateLimitWithdrawalAmount                                      = "rate_limit_withdrawal_amount"
+	BlockTimeDistribution                                          = "block_time_dist"
 
 	// Measure Since
 	ClobOffsettingSubaccountPerpetualPosition         = "clob_offsetting_subaccount_perpetual_position"

--- a/protocol/x/blocktime/keeper/keeper.go
+++ b/protocol/x/blocktime/keeper/keeper.go
@@ -103,6 +103,15 @@ func (k Keeper) UpdateAllDowntimeInfo(ctx sdk.Context) {
 		metrics.BlockTimeMs,
 	)
 
+	metrics.AddSampleWithLabels(
+		metrics.BlockTimeDistribution,
+		float32(delta.Milliseconds()),
+		metrics.GetLabelForStringValue(
+			metrics.Proposer,
+			sdk.ConsAddress(ctx.BlockHeader().ProposerAddress).String(),
+		),
+	)
+
 	allInfo := k.GetAllDowntimeInfo(ctx)
 
 	for _, info := range allInfo.Infos {


### PR DESCRIPTION
### Changelist
Emit block time as sample so we could graph by quantile (e.g. p50 for median)

### Test Plan
Tested on branch `td/v5.x-oe` running on `dev3`. Example [graph](https://app.datadoghq.com/dashboard/25s-bg4-rfr?fromUser=false&fullscreen_end_ts=1721143077000&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1721142616752&fullscreen_widget=3656051188985576&refresh_mode=paused&tile_focus=7899691207155956&tpl_var_env%5B0%5D=dev3&view=spans&from_ts=1721142616752&to_ts=1721143077000&live=false) 

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
