### PR TITLE
Fix ordering of begin/end blocker to match rc2.

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1205,15 +1205,13 @@ func New(
 		perpetualsmoduletypes.ModuleName,
 		statsmoduletypes.ModuleName,
 		satypes.ModuleName,
-		// should be before clob EndBlocker so that vault order cancels are
-		// processed before any vault order expirations (handled by clob)
-		vaultmoduletypes.ModuleName,
 		clobmoduletypes.ModuleName,
 		vestmoduletypes.ModuleName,
 		rewardsmoduletypes.ModuleName,
 		sendingmoduletypes.ModuleName,
 		govplusmoduletypes.ModuleName,
 		delaymsgmoduletypes.ModuleName,
+		vaultmoduletypes.ModuleName,
 	)
 
 	app.ModuleManager.SetOrderPrepareCheckStaters(
@@ -1246,6 +1244,9 @@ func New(
 		perpetualsmoduletypes.ModuleName,
 		statsmoduletypes.ModuleName,
 		satypes.ModuleName,
+		// should be before clob EndBlocker so that vault order cancels are
+		// processed before any vault order expirations (handled by clob)
+		vaultmoduletypes.ModuleName,
 		clobmoduletypes.ModuleName,
 		sendingmoduletypes.ModuleName,
 		vestmoduletypes.ModuleName,
@@ -1253,7 +1254,6 @@ func New(
 		epochsmoduletypes.ModuleName,
 		govplusmoduletypes.ModuleName,
 		delaymsgmoduletypes.ModuleName,
-		vaultmoduletypes.ModuleName,
 		authz.ModuleName,                // No-op.
 		blocktimemoduletypes.ModuleName, // Must be last
 	)


### PR DESCRIPTION
### Changelist
There was a typo in the previous PR #1910 that incorrectly changed the ordering in `BeginBlocker` and `EndBlocker`.

### Test Plan
Checked against rc2.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
