### PR TITLE
fix updatedAt in /geoblock response

### DIFF
--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -280,7 +280,7 @@ router.post(
       const response = {
         status: complianceStatusFromDatabase!.status,
         reason: complianceStatusFromDatabase!.reason,
-        updatedAt,
+        updatedAt: complianceStatusFromDatabase!.updatedAt,
       };
 
       return res.send(response);


### PR DESCRIPTION
### Changelist
fix updatedAt in POST /geoblock response to be from db

### Test Plan
Unit tested

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added test cases to verify behavior for `CONNECT` action from restricted countries and `INVALID_SURVEY` action updates.

- **Bug Fixes**
  - Ensured the `updatedAt` field in responses correctly reflects the database value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->