### PR TITLE
Do not overwrite existing CLOSE_ONLY/BLOCKED compliance statuses

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/compliance-status-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/compliance-status-table.test.ts
@@ -98,7 +98,7 @@ describe('Compliance status store', () => {
 
     const complianceStatus: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll(
       {
-        status: ComplianceStatus.COMPLIANT,
+        status: [ComplianceStatus.COMPLIANT],
       },
       [],
       { readReplica: true },

--- a/indexer/packages/postgres/src/stores/compliance-status-table.ts
+++ b/indexer/packages/postgres/src/stores/compliance-status-table.ts
@@ -59,7 +59,7 @@ export async function findAll(
   }
 
   if (status !== undefined) {
-    baseQuery = baseQuery.where(ComplianceStatusColumns.status, status);
+    baseQuery = baseQuery.whereIn(ComplianceStatusColumns.status, status);
   }
 
   if (reason !== undefined) {

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -283,7 +283,7 @@ export interface ComplianceDataQueryConfig extends QueryConfig {
 
 export interface ComplianceStatusQueryConfig extends QueryConfig {
   [QueryableField.ADDRESS]?: string[];
-  [QueryableField.STATUS]?: string;
+  [QueryableField.STATUS]?: string[];
   [QueryableField.CREATED_BEFORE_OR_AT]?: string;
   [QueryableField.UPDATED_BEFORE_OR_AT]?: string;
   [QueryableField.REASON]?: string;

--- a/indexer/services/roundtable/__tests__/tasks/update-compliance-data.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/update-compliance-data.test.ts
@@ -260,25 +260,7 @@ describe('update-compliance-data', () => {
       updatedAt: createdAt,
     });
 
-    const riskScore: string = '85.00';
-    setupMockProvider(
-      mockProvider,
-      { [testConstants.defaultAddress]: { blocked: true, riskScore } },
-    );
-
     await updateComplianceDataTask(mockProvider);
-
-    const complianceData: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
-    expect(complianceData).toHaveLength(1);
-    expectUpdatedCompliance(
-      complianceData[0],
-      {
-        address: testConstants.defaultAddress,
-        blocked: true,
-        riskScore,
-      },
-      mockProvider.provider,
-    );
 
     const complianceStatusData: ComplianceStatusFromDatabase[] = await
     ComplianceStatusTable.findAll({}, [], {});
@@ -294,8 +276,8 @@ describe('update-compliance-data', () => {
       activeAddresses: 1,
       newAddresses: 0,
       oldAddresses: 0,
-      addressesScreened: 1,
-      upserted: 1,
+      addressesScreened: 0,
+      upserted: 0,
       statusUpserted: 0,
     },
     mockProvider.provider,

--- a/indexer/services/roundtable/__tests__/tasks/update-compliance-data.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/update-compliance-data.test.ts
@@ -249,6 +249,60 @@ describe('update-compliance-data', () => {
     expectTimingStats(mockProvider.provider);
   });
 
+  it('succeeds with an active address to update but doesnt update existing CLOSE_ONLY position', async () => {
+    // Seed database with compliance data older than the age threshold for active addresses
+    await setupComplianceData(config.MAX_ACTIVE_COMPLIANCE_DATA_AGE_SECONDS * 2);
+    const createdAt: string = DateTime.utc().minus({ days: 1 }).toISO();
+    await ComplianceStatusTable.create({
+      address: testConstants.defaultAddress,
+      status: ComplianceStatus.CLOSE_ONLY,
+      reason: ComplianceReason.US_GEO,
+      updatedAt: createdAt,
+    });
+
+    const riskScore: string = '85.00';
+    setupMockProvider(
+      mockProvider,
+      { [testConstants.defaultAddress]: { blocked: true, riskScore } },
+    );
+
+    await updateComplianceDataTask(mockProvider);
+
+    const complianceData: ComplianceDataFromDatabase[] = await ComplianceTable.findAll({}, [], {});
+    expect(complianceData).toHaveLength(1);
+    expectUpdatedCompliance(
+      complianceData[0],
+      {
+        address: testConstants.defaultAddress,
+        blocked: true,
+        riskScore,
+      },
+      mockProvider.provider,
+    );
+
+    const complianceStatusData: ComplianceStatusFromDatabase[] = await
+    ComplianceStatusTable.findAll({}, [], {});
+    expect(complianceStatusData).toHaveLength(1);
+    expect(complianceStatusData[0]).toEqual(expect.objectContaining({
+      address: testConstants.defaultAddress,
+      status: ComplianceStatus.CLOSE_ONLY,
+      reason: ComplianceReason.US_GEO,
+      updatedAt: createdAt,
+    }));
+
+    expectGaugeStats({
+      activeAddresses: 1,
+      newAddresses: 0,
+      oldAddresses: 0,
+      addressesScreened: 1,
+      upserted: 1,
+      statusUpserted: 0,
+    },
+    mockProvider.provider,
+    );
+    expectTimingStats(mockProvider.provider);
+  });
+
   it('succeeds with an active address to update, undefined risk-score', async () => {
     // Seed database with compliance data older than the age threshold for active addresses
     await setupComplianceData(config.MAX_ACTIVE_COMPLIANCE_DATA_AGE_SECONDS * 2);

--- a/indexer/services/roundtable/src/tasks/perform-compliance-status-transitions.ts
+++ b/indexer/services/roundtable/src/tasks/perform-compliance-status-transitions.ts
@@ -21,7 +21,7 @@ export default async function runTask(): Promise<void> {
   const staleCloseOnlyAddresses: ComplianceStatusFromDatabase[] = await
   ComplianceStatusTable.findAll(
     {
-      status: ComplianceStatus.CLOSE_ONLY,
+      status: [ComplianceStatus.CLOSE_ONLY],
       updatedBeforeOrAt: new Date(
         queryStart - CLOSE_ONLY_TO_BLOCKED_DAYS_IN_MS,
       ).toISOString(),

--- a/indexer/services/roundtable/src/tasks/update-compliance-data.ts
+++ b/indexer/services/roundtable/src/tasks/update-compliance-data.ts
@@ -174,12 +174,12 @@ export default async function runTask(
       },
       [],
     );
-    const closeOnlyAddresses: string[] = _.chain(closeOnlyAndBlockedStatuses)
+    const closeOnlyAndBlockedAddresses: string[] = _.chain(closeOnlyAndBlockedStatuses)
       .map(ComplianceDataColumns.address)
       .uniq()
       .value();
 
-    addressesToQuery = _.without(addressesToQuery, ...closeOnlyAddresses);
+    addressesToQuery = _.without(addressesToQuery, ...closeOnlyAndBlockedAddresses);
 
     // Get compliance data for addresses
     const startQueryProvider: number = Date.now();

--- a/indexer/services/roundtable/src/tasks/update-compliance-data.ts
+++ b/indexer/services/roundtable/src/tasks/update-compliance-data.ts
@@ -183,13 +183,12 @@ export default async function runTask(
       },
     );
 
-    const complianceStatus: ComplianceStatusFromDatabase[] = await
+    const closeOnlyStatuses: ComplianceStatusFromDatabase[] = await
     ComplianceStatusTable.findAll(
       { address: addressesToQuery, status: ComplianceStatus.CLOSE_ONLY },
       [],
     );
-    // get complianceStatus addresses
-    const complianceStatusAddresses: string[] = _.chain(complianceStatus)
+    const closeOnlyAddresses: string[] = _.chain(closeOnlyStatuses)
       .map(ComplianceDataColumns.address)
       .uniq()
       .value();
@@ -209,7 +208,7 @@ export default async function runTask(
           return acc;
         }, [])
       .filter((complianceStatusUpsertObject: ComplianceStatusUpsertObject) => {
-        return !complianceStatusAddresses.includes(complianceStatusUpsertObject.address);
+        return !closeOnlyAddresses.includes(complianceStatusUpsertObject.address);
       });
 
     stats.timing(

--- a/indexer/services/roundtable/src/tasks/update-compliance-data.ts
+++ b/indexer/services/roundtable/src/tasks/update-compliance-data.ts
@@ -185,7 +185,10 @@ export default async function runTask(
 
     const closeOnlyStatuses: ComplianceStatusFromDatabase[] = await
     ComplianceStatusTable.findAll(
-      { address: addressesToQuery, status: ComplianceStatus.CLOSE_ONLY },
+      {
+        address: addressesToQuery,
+        status: [ComplianceStatus.CLOSE_ONLY, ComplianceStatus.BLOCKED],
+      },
       [],
     );
     const closeOnlyAddresses: string[] = _.chain(closeOnlyStatuses)


### PR DESCRIPTION
### Changelist
Do not overwrite existing CLOSE_ONLY/BLOCKED compliance statuses

### Test Plan
Unit tested


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced more granular compliance status filtering, differentiating between statuses like "close only" and "blocked".

- **Bug Fixes**
    - Enhanced test cases to verify updates on active addresses without affecting existing "close only" positions.

- **Improvements**
    - Extended compliance status queries to support multiple status values, improving the flexibility of compliance data updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->