### PR TITLE
[TRA-504] flip vault order client IDs on order expiration/fill

### DIFF
--- a/protocol/x/vault/keeper/orders_test.go
+++ b/protocol/x/vault/keeper/orders_test.go
@@ -6,11 +6,10 @@ import (
 	"time"
 
 	"github.com/cometbft/cometbft/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
-	"github.com/dydxprotocol/v4-chain/protocol/indexer"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
-	"github.com/dydxprotocol/v4-chain/protocol/indexer/msgsender"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	testtx "github.com/dydxprotocol/v4-chain/protocol/testutil/tx"
@@ -114,14 +113,8 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Enable testapp's indexer event manager
-			msgSender := msgsender.NewIndexerMessageSenderInMemoryCollector()
-			appOpts := map[string]interface{}{
-				indexer.MsgSenderInstanceForTest: msgSender,
-			}
-
 			// Initialize tApp.
-			tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				// Initialize each vault with enough quote quantums to be actively quoting.
 				testapp.UpdateGenesisDocWithAppStateForModule(
@@ -210,23 +203,99 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 	}
 }
 
-// TODO (TRA-498): verify placement and replacement indexer events in this test instead of the one above.
 func TestRefreshVaultClobOrders(t *testing.T) {
 	tests := map[string]struct {
 		/* --- Setup --- */
 		// Vault ID.
-		vaultId vaulttypes.VaultId
+		vaultId      vaulttypes.VaultId
+		advanceBlock func(ctx sdk.Context, tApp *testapp.TestApp) sdk.Context
 
 		/* --- Expectations --- */
-		expectedErr error
+		ordersShouldRefresh bool
+		expectedErr         error
 	}{
-		"Success - Refresh Orders from Vault for Clob Pair 0": {
+		"Success - Orders do not refresh": {
 			vaultId: constants.Vault_Clob0,
+			advanceBlock: func(ctx sdk.Context, tApp *testapp.TestApp) sdk.Context {
+				return tApp.AdvanceToBlock(
+					uint32(tApp.GetBlockHeight())+1,
+					testapp.AdvanceToBlockOptions{
+						BlockTime: ctx.BlockTime().Add(time.Second),
+					},
+				)
+			},
+			ordersShouldRefresh: false,
 		},
-		"Success - Refresh Orders from Vault for Clob Pair 1": {
-			vaultId: constants.Vault_Clob1,
+		"Success - Orders refresh due to expiration": {
+			vaultId: constants.Vault_Clob0,
+			advanceBlock: func(ctx sdk.Context, tApp *testapp.TestApp) sdk.Context {
+				return tApp.AdvanceToBlock(
+					uint32(tApp.GetBlockHeight())+5,
+					testapp.AdvanceToBlockOptions{
+						BlockTime: ctx.BlockTime().Add(
+							time.Second * time.Duration(vaulttypes.DefaultParams().OrderExpirationSeconds),
+						),
+					},
+				)
+			},
+			ordersShouldRefresh: true,
 		},
-		"Error - Refresh Orders from Vault for Clob Pair 4321 (non-existent clob pair)": {
+		"Success - Orders refresh due to price updates": {
+			vaultId: constants.Vault_Clob0,
+			advanceBlock: func(ctx sdk.Context, tApp *testapp.TestApp) sdk.Context {
+				marketPrice, err := tApp.App.PricesKeeper.GetMarketPrice(ctx, constants.Vault_Clob0.Number)
+				require.NoError(t, err)
+				msgUpdateMarketPrices := &pricestypes.MsgUpdateMarketPrices{
+					MarketPriceUpdates: []*pricestypes.MsgUpdateMarketPrices_MarketPrice{
+						{
+							MarketId: constants.Vault_Clob0.Number,
+							Price:    marketPrice.Price * 2,
+						},
+					},
+				}
+				return tApp.AdvanceToBlock(
+					uint32(tApp.GetBlockHeight())+1,
+					testapp.AdvanceToBlockOptions{
+						BlockTime: ctx.BlockTime().Add(time.Second),
+						DeliverTxsOverride: [][]byte{
+							testtx.MustGetTxBytes(msgUpdateMarketPrices),
+						},
+					},
+				)
+			},
+			ordersShouldRefresh: true,
+		},
+		"Success - Orders refresh due to order size increase": {
+			vaultId: constants.Vault_Clob0,
+			advanceBlock: func(ctx sdk.Context, tApp *testapp.TestApp) sdk.Context {
+				msgDepositToVault := vaulttypes.MsgDepositToVault{
+					VaultId:       &constants.Vault_Clob0,
+					SubaccountId:  &(constants.Alice_Num0),
+					QuoteQuantums: dtypes.NewInt(87_654_321),
+				}
+				CheckTx_MsgDepositToVault := testapp.MustMakeCheckTx(
+					ctx,
+					tApp.App,
+					testapp.MustMakeCheckTxOptions{
+						AccAddressForSigning: constants.Alice_Num0.Owner,
+						Gas:                  constants.TestGasLimit,
+						FeeAmt:               constants.TestFeeCoins_5Cents,
+					},
+					&msgDepositToVault,
+				)
+				checkTxResp := tApp.CheckTx(CheckTx_MsgDepositToVault)
+				require.Conditionf(t, checkTxResp.IsOK, "Expected CheckTx to succeed. Response: %+v", checkTxResp)
+
+				return tApp.AdvanceToBlock(
+					uint32(tApp.GetBlockHeight())+1,
+					testapp.AdvanceToBlockOptions{
+						BlockTime: ctx.BlockTime().Add(time.Second * 2),
+					},
+				)
+			},
+			ordersShouldRefresh: true,
+		},
+		"Error - Vault for non-existent Clob Pair 4321": {
 			vaultId: vaulttypes.VaultId{
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
 				Number: 4321,
@@ -238,12 +307,8 @@ func TestRefreshVaultClobOrders(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Initialize tApp.
-			msgSender := msgsender.NewIndexerMessageSenderInMemoryCollector()
-			appOpts := map[string]interface{}{
-				indexer.MsgSenderInstanceForTest: msgSender,
-			}
 			params := vaulttypes.DefaultParams()
-			tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				testapp.UpdateGenesisDocWithAppStateForModule(
 					&genesis,
@@ -252,13 +317,13 @@ func TestRefreshVaultClobOrders(t *testing.T) {
 							{
 								VaultId: &tc.vaultId,
 								TotalShares: &vaulttypes.NumShares{
-									NumShares: dtypes.NewInt(10),
+									NumShares: dtypes.NewInt(100),
 								},
 								OwnerShares: []*vaulttypes.OwnerShare{
 									{
 										Owner: constants.AliceAccAddress.String(),
 										Shares: &vaulttypes.NumShares{
-											NumShares: dtypes.NewInt(10),
+											NumShares: dtypes.NewInt(100),
 										},
 									},
 								},
@@ -303,17 +368,24 @@ func TestRefreshVaultClobOrders(t *testing.T) {
 				return
 			}
 
-			// Helper function that verifies that most recent client IDs are up-to-date with vault orders.
-			verifyMostRecentClientIds := func(expectedClientIds []uint32) {
-				// Verify that most recent client IDs are as expected.
-				mostRecentClientIds := tApp.App.VaultKeeper.GetMostRecentClientIds(ctx, tc.vaultId)
-				require.Equal(t, expectedClientIds, mostRecentClientIds)
+			// Helper function that verifies that vault orders are as expected.
+			verifyVaultOrders := func(expectedGTBT uint32, expectedClientIds []uint32) {
+				allStatefulOrders := tApp.App.ClobKeeper.GetAllStatefulOrders(ctx)
+				// Verify that number of vault orders is `layers * 2`.
+				require.Len(t, allStatefulOrders, int(params.Layers*2))
+				// Verify that GTBT of orders is as expected.
+				for _, order := range allStatefulOrders {
+					require.Equal(t, expectedGTBT, order.GetGoodTilBlockTime())
+				}
 
 				// Verify that stateful order IDs have expected client IDs.
-				allStatefulOrders := tApp.App.ClobKeeper.GetAllStatefulOrders(ctx)
 				for i, order := range allStatefulOrders {
 					require.Equal(t, expectedClientIds[i], order.OrderId.ClientId)
 				}
+
+				// Verify that most recent client IDs are as expected.
+				mostRecentClientIds := tApp.App.VaultKeeper.GetMostRecentClientIds(ctx, tc.vaultId)
+				require.Equal(t, expectedClientIds, mostRecentClientIds)
 			}
 			// Get canonical and flipped client IDs of this vault's orders.
 			orderIds, err := tApp.App.VaultKeeper.GetVaultClobOrderIds(ctx, tc.vaultId)
@@ -328,110 +400,28 @@ func TestRefreshVaultClobOrders(t *testing.T) {
 			// Vault should place its initial orders (client IDs should be canonical).
 			initialOrders := tApp.App.ClobKeeper.GetAllStatefulOrders(ctx)
 			require.Len(t, initialOrders, int(params.Layers*2))
-			verifyMostRecentClientIds(canonicalClientIds)
-
-			// Advance a few blocks with no price updates / order matches and vault should not refresh its orders.
-			msgSender.Clear()
-			ctx = tApp.AdvanceToBlock(uint32(tApp.GetBlockHeight())+12, testapp.AdvanceToBlockOptions{})
-			require.Equal(
-				t,
-				initialOrders,
-				tApp.App.ClobKeeper.GetAllStatefulOrders(ctx),
+			verifyVaultOrders(
+				uint32(ctx.BlockTime().Unix())+params.OrderExpirationSeconds,
+				canonicalClientIds,
 			)
-			verifyMostRecentClientIds(canonicalClientIds)
 
-			// Advance to next block with price updates and vault should replace its old orders with new ones (client IDs should be flipped).
-			msgSender.Clear()
-			marketPrice, err := tApp.App.PricesKeeper.GetMarketPrice(ctx, tc.vaultId.Number)
-			require.NoError(t, err)
-			msgUpdateMarketPrices := &pricestypes.MsgUpdateMarketPrices{
-				MarketPriceUpdates: []*pricestypes.MsgUpdateMarketPrices_MarketPrice{
-					{
-						MarketId: tc.vaultId.Number,
-						Price:    marketPrice.Price * 2,
-					},
-				},
-			}
-			ctx = tApp.AdvanceToBlock(
-				uint32(tApp.GetBlockHeight())+1,
-				testapp.AdvanceToBlockOptions{
-					DeliverTxsOverride: [][]byte{
-						testtx.MustGetTxBytes(msgUpdateMarketPrices),
-					},
-				},
-			)
-			newOrders := tApp.App.ClobKeeper.GetAllStatefulOrders(ctx)
-			require.Len(t, newOrders, int(params.Layers*2))
-			verifyMostRecentClientIds(flippedClientIds)
-			for _, newOrder := range newOrders {
-				require.Equal(
-					t,
+			if tc.ordersShouldRefresh {
+				ctx = tc.advanceBlock(ctx, tApp)
+				verifyVaultOrders(
 					uint32(ctx.BlockTime().Unix())+params.OrderExpirationSeconds,
-					newOrder.GetGoodTilBlockTime(),
+					flippedClientIds, // Client IDs should be flipped.
 				)
-			}
-
-			advanceToBlockWhereOrdersExpire := func(expectedClientIds []uint32) {
-				ctx = tApp.AdvanceToBlock(
-					uint32(tApp.GetBlockHeight())+1,
-					testapp.AdvanceToBlockOptions{
-						BlockTime: ctx.BlockTime().Add(
-							time.Second * time.Duration(params.OrderExpirationSeconds+1),
-						),
-					},
-				)
-				newOrders = tApp.App.ClobKeeper.GetAllStatefulOrders(ctx)
-				require.Len(t, newOrders, int(params.Layers*2))
-				verifyMostRecentClientIds(expectedClientIds)
-				for _, newOrder := range newOrders {
-					require.Equal(
-						t,
-						uint32(ctx.BlockTime().Unix())+params.OrderExpirationSeconds,
-						newOrder.GetGoodTilBlockTime(),
-					)
-				}
-			}
-			// Advance to next block where vault orders have expired and vault should place new orders (client IDs should be back to canonical).
-			advanceToBlockWhereOrdersExpire(canonicalClientIds)
-			// Advance to next block where vault orders have expired and vault should place new orders (client IDs should be flipped).
-			advanceToBlockWhereOrdersExpire(flippedClientIds)
-			// Advance to next block where vault orders have expired and vault should place new orders (client IDs should be back to canonical).
-			advanceToBlockWhereOrdersExpire(canonicalClientIds)
-
-			// Advance to next block where vault should replace its orders to update their sizes (client IDs should be flipped).
-			// Deposit to vault to increase its equity, resulting in a larger order size.
-			// TODO (TRA-500): add scenario of filled orders.
-			msgDepositToVault := vaulttypes.MsgDepositToVault{
-				VaultId:       &(tc.vaultId),
-				SubaccountId:  &(constants.Alice_Num0),
-				QuoteQuantums: params.ActivationThresholdQuoteQuantums,
-			}
-			CheckTx_MsgDepositToVault := testapp.MustMakeCheckTx(
-				ctx,
-				tApp.App,
-				testapp.MustMakeCheckTxOptions{
-					AccAddressForSigning: constants.Alice_Num0.Owner,
-					Gas:                  constants.TestGasLimit,
-					FeeAmt:               constants.TestFeeCoins_5Cents,
-				},
-				&msgDepositToVault,
-			)
-			checkTxResp := tApp.CheckTx(CheckTx_MsgDepositToVault)
-			require.Conditionf(t, checkTxResp.IsOK, "Expected CheckTx to succeed. Response: %+v", checkTxResp)
-
-			ctx = tApp.AdvanceToBlock(
-				uint32(tApp.GetBlockHeight())+1,
-				testapp.AdvanceToBlockOptions{
-					BlockTime: ctx.BlockTime().Add(time.Second),
-				},
-			)
-			newOrders = tApp.App.ClobKeeper.GetAllStatefulOrders(ctx)
-			verifyMostRecentClientIds(flippedClientIds)
-			for _, newOrder := range newOrders {
-				require.Equal(
-					t,
+				ctx = tc.advanceBlock(ctx, tApp)
+				verifyVaultOrders(
 					uint32(ctx.BlockTime().Unix())+params.OrderExpirationSeconds,
-					newOrder.GetGoodTilBlockTime(),
+					canonicalClientIds, // Client IDs should be back to canonical.
+				)
+			} else {
+				oldBlockTime := uint32(ctx.BlockTime().Unix())
+				ctx = tc.advanceBlock(ctx, tApp)
+				verifyVaultOrders(
+					oldBlockTime+params.OrderExpirationSeconds,
+					canonicalClientIds,
 				)
 			}
 		})

--- a/protocol/x/vault/keeper/orders_test.go
+++ b/protocol/x/vault/keeper/orders_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/msgsender"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	testtx "github.com/dydxprotocol/v4-chain/protocol/testutil/tx"
@@ -113,8 +115,14 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			// Enable testapp's indexer event manager
+			msgSender := msgsender.NewIndexerMessageSenderInMemoryCollector()
+			appOpts := map[string]interface{}{
+				indexer.MsgSenderInstanceForTest: msgSender,
+			}
+
 			// Initialize tApp.
-			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			tApp := testapp.NewTestAppBuilder(t).WithAppOptions(appOpts).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
 				genesis = testapp.DefaultGenesis()
 				// Initialize each vault with enough quote quantums to be actively quoting.
 				testapp.UpdateGenesisDocWithAppStateForModule(


### PR DESCRIPTION
### Changelist
flip vault order client IDs on order expiration/fill
- see reason in code comment

### Test Plan
unit / integration test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of expired and fully filled orders to prevent conflicts with existing orders.
  - Updated logic for order placements to address issues with order expiration and full fills.

- **Tests**
  - Enhanced test coverage for verifying client IDs, order placements, and order refreshing within the vault.
  - Included additional checks for price changes and order replacements upon expiration.

- **Refactor**
  - Updated function signatures for better clarity and reliability in handling various order scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->