### PR TITLE
[OTE-540] Add roundtable task to generate usernames

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
@@ -1,5 +1,6 @@
 import { SubaccountUsernamesFromDatabase } from '../../src/types';
 import * as SubaccountUsernamesTable from '../../src/stores/subaccount-usernames-table';
+import * as SubaccountsTable from '../../src/stores/subaccount-table';
 import { clearData, migrate, teardown } from '../../src/helpers/db-helpers';
 import {
   defaultSubaccountUsername,
@@ -67,5 +68,15 @@ describe('SubaccountUsernames store', () => {
 
   it('Creation of row without subaccountId fails', async () => {
     await expect(SubaccountUsernamesTable.create({ ...defaultSubaccountUsername, subaccountId: '' })).rejects.toThrow();
+  });
+
+  it('Get subaccount ids which arent in the subaccount usernames table', async () => {
+    const subaccounts = await SubaccountsTable.findAll({
+      subaccountNumber: 0,
+    }, [], { readReplica: true });
+    const subaccountLength = subaccounts.length;
+    await SubaccountUsernamesTable.create(defaultSubaccountUsername);
+    const subaccountIds = await SubaccountUsernamesTable.getSubaccountsWithoutUsernames();
+    expect(subaccountIds.length).toEqual(subaccountLength - 1);
   });
 });

--- a/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
@@ -1,4 +1,4 @@
-import { SubaccountUsernamesFromDatabase, SubaccountsWithoutUsernamesResult } from '../../src/types';
+import { SubaccountFromDatabase, SubaccountUsernamesFromDatabase, SubaccountsWithoutUsernamesResult } from '../../src/types';
 import * as SubaccountUsernamesTable from '../../src/stores/subaccount-usernames-table';
 import * as SubaccountsTable from '../../src/stores/subaccount-table';
 import { clearData, migrate, teardown } from '../../src/helpers/db-helpers';
@@ -40,7 +40,7 @@ describe('SubaccountUsernames store', () => {
     SubaccountUsernamesFromDatabase[] = await SubaccountUsernamesTable.findAll(
       {},
       [],
-      { readReplica: true },
+      {},
     );
 
     expect(subaccountUsernames.length).toEqual(2);
@@ -71,9 +71,9 @@ describe('SubaccountUsernames store', () => {
   });
 
   it('Get subaccount ids which arent in the subaccount usernames table', async () => {
-    const subaccounts = await SubaccountsTable.findAll({
+    const subaccounts: SubaccountFromDatabase[] = await SubaccountsTable.findAll({
       subaccountNumber: 0,
-    }, [], { readReplica: true });
+    }, [], {});
     const subaccountLength = subaccounts.length;
     await SubaccountUsernamesTable.create(defaultSubaccountUsername);
     const subaccountIds: SubaccountsWithoutUsernamesResult[] = await

--- a/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/subaccount-usernames-table.test.ts
@@ -1,4 +1,4 @@
-import { SubaccountUsernamesFromDatabase } from '../../src/types';
+import { SubaccountUsernamesFromDatabase, SubaccountsWithoutUsernamesResult } from '../../src/types';
 import * as SubaccountUsernamesTable from '../../src/stores/subaccount-usernames-table';
 import * as SubaccountsTable from '../../src/stores/subaccount-table';
 import { clearData, migrate, teardown } from '../../src/helpers/db-helpers';
@@ -76,7 +76,8 @@ describe('SubaccountUsernames store', () => {
     }, [], { readReplica: true });
     const subaccountLength = subaccounts.length;
     await SubaccountUsernamesTable.create(defaultSubaccountUsername);
-    const subaccountIds = await SubaccountUsernamesTable.getSubaccountsWithoutUsernames();
+    const subaccountIds: SubaccountsWithoutUsernamesResult[] = await
+    SubaccountUsernamesTable.getSubaccountsWithoutUsernames();
     expect(subaccountIds.length).toEqual(subaccountLength - 1);
   });
 });

--- a/indexer/packages/postgres/src/index.ts
+++ b/indexer/packages/postgres/src/index.ts
@@ -40,6 +40,7 @@ export * as ComplianceTable from './stores/compliance-table';
 export * as ComplianceStatusTable from './stores/compliance-status-table';
 export * as TradingRewardTable from './stores/trading-reward-table';
 export * as TradingRewardAggregationTable from './stores/trading-reward-aggregation-table';
+export * as SubaccountUsernamesTable from './stores/subaccount-usernames-table';
 
 export * as perpetualMarketRefresher from './loops/perpetual-market-refresher';
 export * as assetRefresher from './loops/asset-refresher';

--- a/indexer/packages/postgres/src/stores/subaccount-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-table.ts
@@ -59,7 +59,6 @@ export async function findAll(
     SubaccountModel,
     options,
   );
-
   if (id) {
     baseQuery = baseQuery.whereIn(SubaccountColumns.id, id);
   }
@@ -68,7 +67,7 @@ export async function findAll(
     baseQuery = baseQuery.where(SubaccountColumns.address, address);
   }
 
-  if (subaccountNumber) {
+  if (subaccountNumber !== undefined) {
     baseQuery = baseQuery.where(SubaccountColumns.subaccountNumber, subaccountNumber);
   }
 

--- a/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
@@ -95,8 +95,9 @@ export async function findByUsername(
   return (await baseQuery).find((subaccountUsername) => subaccountUsername.username === username);
 }
 
-export async function getSubaccountsWithoutUsernames():
-Promise<SubaccountsWithoutUsernamesResult[]> {
+export async function getSubaccountsWithoutUsernames(
+  options: Options = DEFAULT_POSTGRES_OPTIONS):
+  Promise<SubaccountsWithoutUsernamesResult[]> {
   const queryString: string = `
     SELECT id as "subaccountId"
     FROM subaccounts
@@ -108,7 +109,7 @@ Promise<SubaccountsWithoutUsernamesResult[]> {
 
   const result: {
     rows: SubaccountsWithoutUsernamesResult[],
-  } = await rawQuery(queryString, DEFAULT_POSTGRES_OPTIONS);
+  } = await rawQuery(queryString, options);
 
   return result.rows;
 }

--- a/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
@@ -95,8 +95,8 @@ export async function findByUsername(
   return (await baseQuery).find((subaccountUsername) => subaccountUsername.username === username);
 }
 
-export async function getSubaccountsWithoutUsernames(
-) : Promise<SubaccountsWithoutUsernamesResult[]> {
+export async function getSubaccountsWithoutUsernames():
+Promise<SubaccountsWithoutUsernamesResult[]> {
   const queryString: string = `
     SELECT id as "subaccountId"
     FROM subaccounts

--- a/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-usernames-table.ts
@@ -4,6 +4,7 @@ import { DEFAULT_POSTGRES_OPTIONS } from '../constants';
 import {
   verifyAllRequiredFields,
   setupBaseQuery,
+  rawQuery,
 } from '../helpers/stores-helpers';
 import Transaction from '../helpers/transaction';
 import SubaccountUsernamesModel from '../models/subaccount-usernames-model';
@@ -13,6 +14,7 @@ import {
   SubaccountUsernamesQueryConfig,
   SubaccountUsernamesColumns,
   SubaccountUsernamesCreateObject,
+  SubaccountsWithoutUsernamesResult,
   Options,
   Ordering,
   QueryableField,
@@ -91,4 +93,22 @@ export async function findByUsername(
     options,
   );
   return (await baseQuery).find((subaccountUsername) => subaccountUsername.username === username);
+}
+
+export async function getSubaccountsWithoutUsernames(
+) : Promise<SubaccountsWithoutUsernamesResult[]> {
+  const queryString: string = `
+    SELECT id as "subaccountId"
+    FROM subaccounts
+    WHERE id NOT IN (
+      SELECT "subaccountId" FROM subaccount_usernames
+    )
+    AND subaccounts."subaccountNumber"=0
+  `;
+
+  const result: {
+    rows: SubaccountsWithoutUsernamesResult[],
+  } = await rawQuery(queryString, DEFAULT_POSTGRES_OPTIONS);
+
+  return result.rows;
 }

--- a/indexer/packages/postgres/src/types/subaccount-usernames-types.ts
+++ b/indexer/packages/postgres/src/types/subaccount-usernames-types.ts
@@ -9,3 +9,7 @@ export enum SubaccountUsernamesColumns {
   username = 'username',
   subaccountId = 'subaccountId',
 }
+
+export interface SubaccountsWithoutUsernamesResult {
+  subaccountId: string
+}

--- a/indexer/pnpm-lock.yaml
+++ b/indexer/pnpm-lock.yaml
@@ -182,7 +182,6 @@ importers:
       pg: ^8.7.3
       ts-node: ^10.8.2
       typescript: ^4.7.4
-      unique-username-generator: ^1.3.0
       uuid: ^8.3.2
     dependencies:
       '@dydxprotocol-indexer/base': link:../base
@@ -199,7 +198,6 @@ importers:
       objection-unique: 1.2.2_objection@2.2.18
       pg: 8.7.3
       ts-node: 10.8.2_2dd5d46eecda2aef953638919121af58
-      unique-username-generator: 1.3.0
       uuid: 8.3.2
     devDependencies:
       '@dydxprotocol-indexer/dev': link:../dev
@@ -10003,7 +10001,7 @@ packages:
       pretty-format: 28.1.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.8.2_2dd5d46eecda2aef953638919121af58
+      ts-node: 10.8.2_2ee97d30e4a239eb38d57e3751ee8d16
     transitivePeerDependencies:
       - supports-color
 
@@ -13146,7 +13144,6 @@ packages:
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: true
 
   /ts-node/10.8.2_4ea55324100c26d4019c6e6bcc89fac6:
     resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}

--- a/indexer/pnpm-lock.yaml
+++ b/indexer/pnpm-lock.yaml
@@ -182,6 +182,7 @@ importers:
       pg: ^8.7.3
       ts-node: ^10.8.2
       typescript: ^4.7.4
+      unique-username-generator: ^1.3.0
       uuid: ^8.3.2
     dependencies:
       '@dydxprotocol-indexer/base': link:../base
@@ -198,6 +199,7 @@ importers:
       objection-unique: 1.2.2_objection@2.2.18
       pg: 8.7.3
       ts-node: 10.8.2_2dd5d46eecda2aef953638919121af58
+      unique-username-generator: 1.3.0
       uuid: 8.3.2
     devDependencies:
       '@dydxprotocol-indexer/dev': link:../dev
@@ -622,6 +624,7 @@ importers:
       ts-node: ^10.8.2
       tsconfig-paths: ^4.0.0
       typescript: ^4.7.4
+      unique-username-generator: ^1.3.0
       uuid: ^8.3.2
     dependencies:
       '@dydxprotocol-indexer/base': link:../../packages/base
@@ -639,6 +642,7 @@ importers:
       lodash: 4.17.21
       luxon: 3.0.1
       redis: 2.8.0
+      unique-username-generator: 1.3.0
       uuid: 8.3.2
     devDependencies:
       '@dydxprotocol-indexer/dev': link:../../packages/dev
@@ -13339,6 +13343,10 @@ packages:
       get-value: 2.0.6
       is-extendable: 0.1.1
       set-value: 2.0.1
+    dev: false
+
+  /unique-username-generator/1.3.0:
+    resolution: {integrity: sha512-oPs+Jq9UlXmcrpzrpYvWOWVUVLkJ0/x8zM66ikWEBe1l/hBqXS5fofsDvdScLIlPtqQKlu8/Y91b6T2XtIFubQ==}
     dev: false
 
   /universalify/2.0.0:

--- a/indexer/services/roundtable/__tests__/tasks/subaccount-username-generator.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/subaccount-username-generator.test.ts
@@ -1,0 +1,47 @@
+import {
+  SubaccountUsernamesTable,
+  SubaccountTable,
+  QueryableField,
+
+  testMocks,
+  dbHelpers,
+} from '@dydxprotocol-indexer/postgres';
+import subaccountUsernameGenerator from '../../src/tasks/subaccount-username-generator';
+
+describe('subaccount-username-generator', () => {
+  beforeAll(async () => {
+    await dbHelpers.migrate();
+    await dbHelpers.clearData();
+  });
+
+  beforeEach(async () => {
+    await testMocks.seedData();
+  });
+
+  afterAll(async () => {
+    await dbHelpers.teardown();
+    jest.resetAllMocks();
+  });
+
+  afterEach(async () => {
+    await dbHelpers.clearData();
+    jest.clearAllMocks();
+  });
+
+  it('Successfully creates a username for all subaccount', async () => {
+    const subaccounts = await SubaccountTable.findAll({
+      subaccountNumber: 0,
+    }, [QueryableField.SUBACCOUNT_NUMBER], {});
+
+    const subaccountsLength = subaccounts.length;
+    const subaccountsWithUsernames = await SubaccountUsernamesTable.findAll(
+      {}, [], { readReplica: true });
+    expect(subaccountsWithUsernames.length).toEqual(0);
+
+    await subaccountUsernameGenerator();
+    const subaccountsWithUsernamesAfter = await SubaccountUsernamesTable.findAll(
+      {}, [], { readReplica: true });
+
+    expect(subaccountsWithUsernamesAfter.length).toEqual(subaccountsLength);
+  });
+});

--- a/indexer/services/roundtable/__tests__/tasks/subaccount-username-generator.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/subaccount-username-generator.test.ts
@@ -5,6 +5,8 @@ import {
 
   testMocks,
   dbHelpers,
+  SubaccountUsernamesFromDatabase,
+  SubaccountFromDatabase,
 } from '@dydxprotocol-indexer/postgres';
 import subaccountUsernameGenerator from '../../src/tasks/subaccount-username-generator';
 
@@ -29,18 +31,21 @@ describe('subaccount-username-generator', () => {
   });
 
   it('Successfully creates a username for all subaccount', async () => {
-    const subaccounts = await SubaccountTable.findAll({
+    const subaccounts: SubaccountFromDatabase[] = await
+    SubaccountTable.findAll({
       subaccountNumber: 0,
     }, [QueryableField.SUBACCOUNT_NUMBER], {});
 
-    const subaccountsLength = subaccounts.length;
-    const subaccountsWithUsernames = await SubaccountUsernamesTable.findAll(
-      {}, [], { readReplica: true });
+    const subaccountsLength: number = subaccounts.length;
+    const subaccountsWithUsernames: SubaccountUsernamesFromDatabase[] = await
+    SubaccountUsernamesTable.findAll(
+      {}, [], {});
     expect(subaccountsWithUsernames.length).toEqual(0);
 
     await subaccountUsernameGenerator();
-    const subaccountsWithUsernamesAfter = await SubaccountUsernamesTable.findAll(
-      {}, [], { readReplica: true });
+    const subaccountsWithUsernamesAfter: SubaccountUsernamesFromDatabase[] = await
+    SubaccountUsernamesTable.findAll(
+      {}, [], {});
 
     expect(subaccountsWithUsernamesAfter.length).toEqual(subaccountsLength);
   });

--- a/indexer/services/roundtable/__tests__/tasks/update-compliance-data.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/update-compliance-data.test.ts
@@ -677,7 +677,6 @@ async function setupInitialSubaccounts(
 ): Promise<void> {
   const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll({
     address: testConstants.defaultAddress,
-    subaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
   }, [], {});
   await setupSubaccounts(deltaSeconds, _.map(subaccounts, 'id'));
 }

--- a/indexer/services/roundtable/package.json
+++ b/indexer/services/roundtable/package.json
@@ -31,6 +31,7 @@
     "lodash": "^4.17.21",
     "luxon": "^3.0.1",
     "redis": "2.8.0",
+    "unique-username-generator": "^1.3.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -171,6 +171,9 @@ export const configSchema = {
 
   // Uncross orderbook
   STALE_ORDERBOOK_LEVEL_THRESHOLD_SECONDS: parseInteger({ default: 10 }),
+
+  // Subaccount username generator
+  SUBACCOUNT_USERNAME_NUM_RANDOM_DIGITS: parseInteger({ default: 3 }),
 };
 
 export default parseSchema(configSchema);

--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -51,6 +51,7 @@ export const configSchema = {
   LOOPS_ENABLED_AGGREGATE_TRADING_REWARDS_DAILY: parseBoolean({ default: true }),
   LOOPS_ENABLED_AGGREGATE_TRADING_REWARDS_WEEKLY: parseBoolean({ default: true }),
   LOOPS_ENABLED_AGGREGATE_TRADING_REWARDS_MONTHLY: parseBoolean({ default: true }),
+  LOOPS_ENABLED_SUBACCOUNT_USERNAME_GENERATOR: parseBoolean({ default: true }),
 
   // Loop Timing
   LOOPS_INTERVAL_MS_MARKET_UPDATER: parseInteger({
@@ -100,6 +101,9 @@ export const configSchema = {
   }),
   LOOPS_INTERVAL_MS_PERFORM_COMPLIANCE_STATUS_TRANSITIONS: parseInteger({
     default: ONE_HOUR_IN_MILLISECONDS,
+  }),
+  LOOPS_INTERVAL_MS_SUBACCOUNT_USERNAME_GENERATOR: parseInteger({
+    default: THIRTY_SECONDS_IN_MILLISECONDS,
   }),
 
   // Start delay

--- a/indexer/services/roundtable/src/index.ts
+++ b/indexer/services/roundtable/src/index.ts
@@ -20,6 +20,7 @@ import performComplianceStatusTransitionsTask from './tasks/perform-compliance-s
 import pnlInstrumentationTask from './tasks/pnl-instrumentation';
 import removeExpiredOrdersTask from './tasks/remove-expired-orders';
 import removeOldOrderUpdatesTask from './tasks/remove-old-order-updates';
+import subaccountUsernameGeneratorTask from './tasks/subaccount-username-generator';
 import takeFastSyncSnapshotTask from './tasks/take-fast-sync-snapshot';
 import trackLag from './tasks/track-lag';
 import uncrossOrderbookTask from './tasks/uncross-orderbook';
@@ -189,6 +190,14 @@ async function start(): Promise<void> {
       aggregateTradingRewardsTasks(TradingRewardAggregationPeriod.MONTHLY),
       'aggregate_trading_rewards_monthly',
       config.LOOPS_INTERVAL_MS_AGGREGATE_TRADING_REWARDS,
+    );
+  }
+
+  if (config.LOOPS_ENABLED_SUBACCOUNT_USERNAME_GENERATOR) {
+    startLoop(
+      subaccountUsernameGeneratorTask,
+      'subaccount_username_generator',
+      config.LOOPS_INTERVAL_MS_SUBACCOUNT_USERNAME_GENERATOR,
     );
   }
 

--- a/indexer/services/roundtable/src/tasks/subaccount-username-generator.ts
+++ b/indexer/services/roundtable/src/tasks/subaccount-username-generator.ts
@@ -5,14 +5,14 @@ import {
 } from '@dydxprotocol-indexer/postgres';
 import { generateUsername } from 'unique-username-generator';
 
-const RANDOM_DIGITS = 3;
+import config from '../config';
 
 export default async function runTask(): Promise<void> {
   const subaccounts:
   SubaccountsWithoutUsernamesResult[] = await
   SubaccountUsernamesTable.getSubaccountsWithoutUsernames();
   for (const subaccount of subaccounts) {
-    const username: string = generateUsername('', RANDOM_DIGITS);
+    const username: string = generateUsername('', config.SUBACCOUNT_USERNAME_NUM_RANDOM_DIGITS);
     try {
       // if insert fails, try it in the next roundtable cycle
       // There are roughly 50 Billion possible usernames with 3 random digits

--- a/indexer/services/roundtable/src/tasks/subaccount-username-generator.ts
+++ b/indexer/services/roundtable/src/tasks/subaccount-username-generator.ts
@@ -1,0 +1,34 @@
+import { logger } from '@dydxprotocol-indexer/base';
+import {
+  SubaccountUsernamesTable,
+  SubaccountsWithoutUsernamesResult,
+} from '@dydxprotocol-indexer/postgres';
+import { generateUsername } from 'unique-username-generator';
+
+const RANDOM_DIGITS = 3;
+
+export default async function runTask(): Promise<void> {
+  const subaccounts:
+  SubaccountsWithoutUsernamesResult[] = await
+  SubaccountUsernamesTable.getSubaccountsWithoutUsernames();
+  for (const subaccount of subaccounts) {
+    const username: string = generateUsername('', RANDOM_DIGITS);
+    try {
+      // if insert fails, try it in the next roundtable cycle
+      // There are roughly 50 Billion possible usernames with 3 random digits
+      // so the chance of a collision is very low
+      await SubaccountUsernamesTable.create({
+        username,
+        subaccountId: subaccount.subaccountId,
+      });
+    } catch (e) {
+      logger.error({
+        at: 'subaccount-username-generator#runTask',
+        message: 'Failed to insert username for subaccount',
+        subaccountId: subaccount.subaccountId,
+        username,
+        error: e,
+      });
+    }
+  }
+}


### PR DESCRIPTION
### Changelist
- Adds rountable task to generate usernames
- Adds function in postgres to get subaccounts with subaccount number 0 without any usernames

### Test Plan
- Adds unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to generate unique usernames for subaccounts without existing usernames.
  - Added configuration settings for automatic subaccount username generation.

- **Tests**
  - Added test suite to verify the creation of usernames for subaccounts without usernames, ensuring accuracy and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->