### PR TITLE
[OTE-541] Add username/address search api

### DIFF
--- a/indexer/packages/postgres/src/index.ts
+++ b/indexer/packages/postgres/src/index.ts
@@ -40,6 +40,7 @@ export * as ComplianceTable from './stores/compliance-table';
 export * as ComplianceStatusTable from './stores/compliance-status-table';
 export * as TradingRewardTable from './stores/trading-reward-table';
 export * as TradingRewardAggregationTable from './stores/trading-reward-aggregation-table';
+export * as SubaccountUsernamesTable from './stores/subaccount-usernames-table';
 
 export * as perpetualMarketRefresher from './loops/perpetual-market-refresher';
 export * as assetRefresher from './loops/asset-refresher';

--- a/indexer/services/comlink/__tests__/controllers/api/v4/social-trading-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/social-trading-controller.test.ts
@@ -1,0 +1,79 @@
+import {
+  dbHelpers,
+  SubaccountTable,
+  testMocks,
+  SubaccountUsernamesTable,
+} from '@dydxprotocol-indexer/postgres';
+
+import { RequestMethod } from '../../../../src/types';
+import { sendRequest } from '../../../helpers/helpers';
+
+describe('social-trading-controller', () => {
+
+  beforeAll(async () => {
+    await dbHelpers.migrate();
+  });
+
+  beforeEach(async () => {
+    await testMocks.seedData();
+  });
+
+  afterAll(async () => {
+    await dbHelpers.teardown();
+  });
+
+  afterEach(async () => {
+    await dbHelpers.clearData();
+  });
+
+  it('successfuly fetches subaccount info by address', async () => {
+    const subaccounts = await SubaccountTable.findAll({}, [], { readReplica: true });
+    const subaccount = subaccounts[0];
+
+    const subaccountUsernames = await SubaccountUsernamesTable.create({
+      subaccountId: subaccount.id,
+      username: 'test_username',
+    });
+
+    const response = await sendRequest({
+      type: RequestMethod.GET,
+      path: `/v4/trader/search?searchParam=${subaccount.address}`,
+    });
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      result: {
+        address: subaccount.address,
+        subaccountNumber: subaccount.subaccountNumber,
+        username: subaccountUsernames.username,
+        subaccountId: subaccount.id,
+      },
+    });
+  });
+
+  it('successfuly fetches subaccount info by username', async () => {
+
+    const subaccounts = await SubaccountTable.findAll({}, [], { readReplica: true });
+    const subaccount = subaccounts[0];
+    const subaccountUsernames = await SubaccountUsernamesTable.create({
+      subaccountId: subaccount.id,
+      username: 'test_username',
+    });
+
+    const response = await sendRequest({
+      type: RequestMethod.GET,
+      path: `/v4/trader/search?searchParam=${subaccountUsernames.username}`,
+    });
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      result: {
+        address: subaccount.address,
+        subaccountNumber: subaccount.subaccountNumber,
+        username: subaccountUsernames.username,
+        subaccountId: subaccount.id,
+      },
+    });
+  });
+
+});

--- a/indexer/services/comlink/__tests__/controllers/api/v4/social-trading-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/social-trading-controller.test.ts
@@ -28,7 +28,7 @@ describe('social-trading-controller', () => {
   });
 
   it('successfuly fetches subaccount info by address', async () => {
-    const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll({}, [], {});
+    const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll({}, []);
     const subaccount: SubaccountFromDatabase = subaccounts[0];
 
     const subaccountUsernames: SubaccountUsernamesFromDatabase = await
@@ -55,7 +55,7 @@ describe('social-trading-controller', () => {
 
   it('successfuly fetches subaccount info by username', async () => {
 
-    const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll({}, [], {});
+    const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll({}, []);
     const subaccount: SubaccountFromDatabase = subaccounts[0];
     const subaccountUsernames: SubaccountUsernamesFromDatabase = await
     SubaccountUsernamesTable.create({

--- a/indexer/services/comlink/__tests__/controllers/api/v4/social-trading-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/social-trading-controller.test.ts
@@ -3,8 +3,10 @@ import {
   SubaccountTable,
   testMocks,
   SubaccountUsernamesTable,
+  SubaccountFromDatabase,
+  SubaccountUsernamesFromDatabase,
 } from '@dydxprotocol-indexer/postgres';
-
+import request from 'supertest';
 import { RequestMethod } from '../../../../src/types';
 import { sendRequest } from '../../../helpers/helpers';
 
@@ -26,15 +28,16 @@ describe('social-trading-controller', () => {
   });
 
   it('successfuly fetches subaccount info by address', async () => {
-    const subaccounts = await SubaccountTable.findAll({}, [], { readReplica: true });
-    const subaccount = subaccounts[0];
+    const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll({}, [], {});
+    const subaccount: SubaccountFromDatabase = subaccounts[0];
 
-    const subaccountUsernames = await SubaccountUsernamesTable.create({
+    const subaccountUsernames: SubaccountUsernamesFromDatabase = await
+    SubaccountUsernamesTable.create({
       subaccountId: subaccount.id,
       username: 'test_username',
     });
 
-    const response = await sendRequest({
+    const response: request.Response = await sendRequest({
       type: RequestMethod.GET,
       path: `/v4/trader/search?searchParam=${subaccount.address}`,
     });
@@ -52,14 +55,15 @@ describe('social-trading-controller', () => {
 
   it('successfuly fetches subaccount info by username', async () => {
 
-    const subaccounts = await SubaccountTable.findAll({}, [], { readReplica: true });
-    const subaccount = subaccounts[0];
-    const subaccountUsernames = await SubaccountUsernamesTable.create({
+    const subaccounts: SubaccountFromDatabase[] = await SubaccountTable.findAll({}, [], {});
+    const subaccount: SubaccountFromDatabase = subaccounts[0];
+    const subaccountUsernames: SubaccountUsernamesFromDatabase = await
+    SubaccountUsernamesTable.create({
       subaccountId: subaccount.id,
       username: 'test_username',
     });
 
-    const response = await sendRequest({
+    const response: request.Response = await sendRequest({
       type: RequestMethod.GET,
       path: `/v4/trader/search?searchParam=${subaccountUsernames.username}`,
     });

--- a/indexer/services/comlink/__tests__/controllers/api/v4/social-trading-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/social-trading-controller.test.ts
@@ -9,7 +9,6 @@ import { RequestMethod } from '../../../../src/types';
 import { sendRequest } from '../../../helpers/helpers';
 
 describe('social-trading-controller', () => {
-
   beforeAll(async () => {
     await dbHelpers.migrate();
   });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -2438,6 +2438,87 @@ fetch(`${baseURL}/perpetualPositions/parentSubaccountNumber?address=string&paren
 This operation does not require authentication
 </aside>
 
+## SearchTrader
+
+<a id="opIdSearchTrader"></a>
+
+> Code samples
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/trader/search', params={
+  'searchParam': 'string'
+}, headers = headers)
+
+print(r.json())
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+};
+
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/trader/search?searchParam=string`,
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+`GET /trader/search`
+
+### Parameters
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|searchParam|query|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "result": {
+    "address": "string",
+    "subaccountNumber": 0.1,
+    "subaccountId": "string",
+    "username": "string"
+  }
+}
+```
+
+### Responses
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Ok|[TraderSearchResponse](#schematradersearchresponse)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
 ## Get
 
 <a id="opIdGet"></a>
@@ -4682,6 +4763,57 @@ or
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |positions|[[PerpetualPositionResponseObject](#schemaperpetualpositionresponseobject)]|true|none|none|
+
+## TraderSearchResponseObject
+
+<a id="schematradersearchresponseobject"></a>
+<a id="schema_TraderSearchResponseObject"></a>
+<a id="tocStradersearchresponseobject"></a>
+<a id="tocstradersearchresponseobject"></a>
+
+```json
+{
+  "address": "string",
+  "subaccountNumber": 0.1,
+  "subaccountId": "string",
+  "username": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address|string|true|none|none|
+|subaccountNumber|number(double)|true|none|none|
+|subaccountId|string|true|none|none|
+|username|string|true|none|none|
+
+## TraderSearchResponse
+
+<a id="schematradersearchresponse"></a>
+<a id="schema_TraderSearchResponse"></a>
+<a id="tocStradersearchresponse"></a>
+<a id="tocstradersearchresponse"></a>
+
+```json
+{
+  "result": {
+    "address": "string",
+    "subaccountNumber": 0.1,
+    "subaccountId": "string",
+    "username": "string"
+  }
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|result|[TraderSearchResponseObject](#schematradersearchresponseobject)|false|none|none|
 
 ## SparklineResponseObject
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -1051,6 +1051,40 @@
         "type": "object",
         "additionalProperties": false
       },
+      "TraderSearchResponseObject": {
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "subaccountNumber": {
+            "type": "number",
+            "format": "double"
+          },
+          "subaccountId": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "address",
+          "subaccountNumber",
+          "subaccountId",
+          "username"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TraderSearchResponse": {
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/TraderSearchResponseObject"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
       "SparklineResponseObject": {
         "properties": {},
         "type": "object",
@@ -2606,6 +2640,34 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/IsoString"
+            }
+          }
+        ]
+      }
+    },
+    "/trader/search": {
+      "get": {
+        "operationId": "SearchTrader",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraderSearchResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "searchParam",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
         ]

--- a/indexer/services/comlink/src/controllers/api/index-v4.ts
+++ b/indexer/services/comlink/src/controllers/api/index-v4.ts
@@ -15,6 +15,7 @@ import OrderbooksController from './v4/orderbook-controller';
 import OrdersController from './v4/orders-controller';
 import PerpetualMarketController from './v4/perpetual-markets-controller';
 import PerpetualPositionsController from './v4/perpetual-positions-controller';
+import SocialTradingController from './v4/social-trading-controller';
 import SparklinesController from './v4/sparklines-controller';
 import TimeController from './v4/time-controller';
 import TradesController from './v4/trades-controller';
@@ -42,5 +43,6 @@ router.use('/trades', TradesController);
 router.use('/transfers', TransfersController);
 router.use('/screen', ComplianceController);
 router.use('/compliance', ComplianceV2Controller);
+router.use('/trader', SocialTradingController);
 
 export default router;

--- a/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
@@ -34,12 +34,11 @@ class SocialTradingController extends Controller {
     @Query() searchParam: string,
   ): Promise<TraderSearchResponse> {
     if (checkIfValidDydxAddress(searchParam)) {
-
       const subaccounts: SubaccountFromDatabase[] = await
       SubaccountTable.findAll({
         address: searchParam,
         subaccountNumber: 0,
-      }, [], {});
+      }, []);
       const subaccount: SubaccountFromDatabase = subaccounts[0];
 
       if (!subaccount) {
@@ -49,7 +48,7 @@ class SocialTradingController extends Controller {
       const subaccountUsernames: SubaccountUsernamesFromDatabase[] = await
       SubaccountUsernamesTable.findAll({
         subaccountId: [subaccount.id],
-      }, [], {});
+      }, []);
 
       return subaccountInfoToTraderSearchResponse(subaccount, subaccountUsernames[0]);
     }
@@ -60,14 +59,11 @@ class SocialTradingController extends Controller {
     if (!subaccountUsername) {
       throw new NotFoundError(`Subaccount not found:${searchParam}`);
     }
-
+    // subaccount search below cannot be undefined because of foreign key constraint
     const subaccount: SubaccountFromDatabase | undefined = await
     SubaccountTable.findById(subaccountUsername.subaccountId);
-    if (!subaccount) {
-      throw new NotFoundError(`Subaccount not found:${subaccountUsername.subaccountId}`);
-    }
 
-    return subaccountInfoToTraderSearchResponse(subaccount, subaccountUsername);
+    return subaccountInfoToTraderSearchResponse(subaccount!, subaccountUsername);
 
   }
 }

--- a/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
@@ -2,6 +2,7 @@ import { stats } from '@dydxprotocol-indexer/base';
 import {
   SubaccountFromDatabase,
   SubaccountTable,
+  SubaccountUsernamesFromDatabase,
   SubaccountUsernamesTable,
 } from '@dydxprotocol-indexer/postgres';
 import express from 'express';
@@ -34,7 +35,8 @@ class SocialTradingController extends Controller {
   ): Promise<TraderSearchResponse> {
     if (checkIfValidDydxAddress(searchParam)) {
 
-      const subaccounts = await SubaccountTable.findAll({
+      const subaccounts: SubaccountFromDatabase[] = await
+      SubaccountTable.findAll({
         address: searchParam,
         subaccountNumber: 0,
       }, [], {});
@@ -44,14 +46,16 @@ class SocialTradingController extends Controller {
         throw new NotFoundError(`Subaccount not found:${searchParam}`);
       }
 
-      const subaccountUsernames = await SubaccountUsernamesTable.findAll({
+      const subaccountUsernames: SubaccountUsernamesFromDatabase[] = await
+      SubaccountUsernamesTable.findAll({
         subaccountId: [subaccount.id],
       }, [], {});
 
       return subaccountInfoToTraderSearchResponse(subaccount, subaccountUsernames[0]);
     }
 
-    const subaccountUsername = await SubaccountUsernamesTable.findByUsername(searchParam);
+    const subaccountUsername: SubaccountUsernamesFromDatabase | undefined = await
+    SubaccountUsernamesTable.findByUsername(searchParam);
 
     if (!subaccountUsername) {
       throw new NotFoundError(`Subaccount not found:${searchParam}`);
@@ -84,7 +88,7 @@ router.get('/search',
     try {
       const { searchParam } = matchedData(req) as TraderSearchRequest;
       const controller: SocialTradingController = new SocialTradingController();
-      const response = await controller.searchTrader(searchParam);
+      const response: TraderSearchResponse = await controller.searchTrader(searchParam);
       return res.send(response);
     } catch (error) {
       return handleControllerError(

--- a/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
@@ -53,7 +53,6 @@ async function searchTrader(
 
     const subaccount = await SubaccountTable.findById(subaccountUsername.subaccountId);
     if (!subaccount) {
-      // throw nto found erroe with the subaccountId
       throw new NotFoundError(`Subaccount not found:${subaccountUsername.subaccountId}`);
     }
 

--- a/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
@@ -1,4 +1,6 @@
+import { stats } from '@dydxprotocol-indexer/base';
 import {
+  SubaccountFromDatabase,
   SubaccountTable,
   SubaccountUsernamesTable,
 } from '@dydxprotocol-indexer/postgres';
@@ -7,81 +9,97 @@ import {
   checkSchema,
   matchedData,
 } from 'express-validator';
+import {
+  Controller, Get, Query, Route,
+} from 'tsoa';
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import config from '../../../config';
 import { NotFoundError } from '../../../lib/errors';
-import { handleControllerError } from '../../../lib/helpers';
+import { handleControllerError, checkIfValidDydxAddress } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
-import { SubaccountInfoToTraderSearchResponse } from '../../../request-helpers/request-transformer';
+import { subaccountInfoToTraderSearchResponse } from '../../../request-helpers/request-transformer';
+import { TraderSearchRequest, TraderSearchResponse } from '../../../types';
 
 const router: express.Router = express.Router();
 const controllerName: string = 'social-trading-controller';
 
-function checkIfValidDydxAddress(address: string): boolean {
-  const pattern = /^dydx[0-9a-z]{39}$/;
-  return pattern.test(address);
-}
+@Route('trader')
+class SocialTradingController extends Controller {
+  @Get('/search')
+  async searchTrader(
+    @Query() searchParam: string,
+  ): Promise<TraderSearchResponse> {
+    if (checkIfValidDydxAddress(searchParam)) {
 
-async function searchTrader(
-  searchParam: string,
-) {
-  if (checkIfValidDydxAddress(searchParam)) {
+      const subaccounts = await SubaccountTable.findAll({
+        address: searchParam,
+        subaccountNumber: 0,
+      }, [], {});
+      const subaccount: SubaccountFromDatabase = subaccounts[0];
 
-    const subaccounts = await SubaccountTable.findAll({
-      address: searchParam,
-      subaccountNumber: 0,
-    }, [], { readReplica: true });
-    const subaccount = subaccounts[0];
+      if (!subaccount) {
+        throw new NotFoundError(`Subaccount not found:${searchParam}`);
+      }
 
-    if (!subaccount) {
-      throw new NotFoundError(`Subaccount not found:${searchParam}`);
+      const subaccountUsernames = await SubaccountUsernamesTable.findAll({
+        subaccountId: [subaccount.id],
+      }, [], {});
+
+      return subaccountInfoToTraderSearchResponse(subaccount, subaccountUsernames[0]);
     }
 
-    const subaccountUsernames = await SubaccountUsernamesTable.findAll({
-      subaccountId: [subaccount.id],
-    }, [], { readReplica: true });
-
-    return SubaccountInfoToTraderSearchResponse(subaccount, subaccountUsernames[0]);
-  } else {
     const subaccountUsername = await SubaccountUsernamesTable.findByUsername(searchParam);
 
     if (!subaccountUsername) {
       throw new NotFoundError(`Subaccount not found:${searchParam}`);
     }
 
-    const subaccount = await SubaccountTable.findById(subaccountUsername.subaccountId);
+    const subaccount: SubaccountFromDatabase | undefined = await
+    SubaccountTable.findById(subaccountUsername.subaccountId);
     if (!subaccount) {
       throw new NotFoundError(`Subaccount not found:${subaccountUsername.subaccountId}`);
     }
 
-    return SubaccountInfoToTraderSearchResponse(subaccount, subaccountUsername);
+    return subaccountInfoToTraderSearchResponse(subaccount, subaccountUsername);
+
   }
 }
 
-router.get('/search', rateLimiterMiddleware(getReqRateLimiter), ...checkSchema({
-  searchParam: {
-    in: 'query',
-    isString: true,
-    errorMessage: 'searchParam is required',
-  },
-}), handleValidationErrors,
-ExportResponseCodeStats({ controllerName }),
-async (req, res) => {
-  try {
-    const { searchParam } = matchedData(req);
-    const response = await searchTrader(searchParam);
-    return res.send(response);
-  } catch (error) {
-    return handleControllerError(
-      'SocialTradingController GET /',
-      'User search error',
-      error,
-      req,
-      res,
-    );
-  }
-});
+router.get('/search',
+  rateLimiterMiddleware(getReqRateLimiter),
+  ...checkSchema({
+    searchParam: {
+      in: 'query',
+      isString: true,
+      errorMessage: 'searchParam is required',
+    },
+  }),
+  handleValidationErrors,
+  ExportResponseCodeStats({ controllerName }),
+  async (req: express.Request, res: express.Response) => {
+    const start: number = Date.now();
+    try {
+      const { searchParam } = matchedData(req) as TraderSearchRequest;
+      const controller: SocialTradingController = new SocialTradingController();
+      const response = await controller.searchTrader(searchParam);
+      return res.send(response);
+    } catch (error) {
+      return handleControllerError(
+        'SocialTradingController GET /',
+        'User search error',
+        error,
+        req,
+        res,
+      );
+    } finally {
+      stats.timing(
+        `${config.SERVICE_NAME}.${controllerName}.search_trader.timing`,
+        Date.now() - start,
+      );
+    }
+  });
 
 export default router;

--- a/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
@@ -1,0 +1,88 @@
+import {
+  SubaccountTable,
+  SubaccountUsernamesTable,
+} from '@dydxprotocol-indexer/postgres';
+import express from 'express';
+import {
+  checkSchema,
+  matchedData,
+} from 'express-validator';
+
+import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { NotFoundError } from '../../../lib/errors';
+import { handleControllerError } from '../../../lib/helpers';
+import { rateLimiterMiddleware } from '../../../lib/rate-limit';
+import { handleValidationErrors } from '../../../request-helpers/error-handler';
+import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
+import { SubaccountInfoToTraderSearchResponse } from '../../../request-helpers/request-transformer';
+
+const router: express.Router = express.Router();
+const controllerName: string = 'social-trading-controller';
+
+function checkIfValidDydxAddress(address: string): boolean {
+  const pattern = /^dydx[0-9a-z]{39}$/;
+  return pattern.test(address);
+}
+
+async function searchTrader(
+  searchParam: string,
+) {
+  if (checkIfValidDydxAddress(searchParam)) {
+
+    const subaccounts = await SubaccountTable.findAll({
+      address: searchParam,
+      subaccountNumber: 0,
+    }, [], { readReplica: true });
+    const subaccount = subaccounts[0];
+
+    if (!subaccount) {
+      throw new NotFoundError(`Subaccount not found:${searchParam}`);
+    }
+
+    const subaccountUsernames = await SubaccountUsernamesTable.findAll({
+      subaccountId: [subaccount.id],
+    }, [], { readReplica: true });
+
+    return SubaccountInfoToTraderSearchResponse(subaccount, subaccountUsernames[0]);
+  } else {
+    const subaccountUsername = await SubaccountUsernamesTable.findByUsername(searchParam);
+
+    if (!subaccountUsername) {
+      throw new NotFoundError(`Subaccount not found:${searchParam}`);
+    }
+
+    const subaccount = await SubaccountTable.findById(subaccountUsername.subaccountId);
+    if (!subaccount) {
+      // throw nto found erroe with the subaccountId
+      throw new NotFoundError(`Subaccount not found:${subaccountUsername.subaccountId}`);
+    }
+
+    return SubaccountInfoToTraderSearchResponse(subaccount, subaccountUsername);
+  }
+}
+
+router.get('/search', rateLimiterMiddleware(getReqRateLimiter), ...checkSchema({
+  searchParam: {
+    in: 'query',
+    isString: true,
+    errorMessage: 'searchParam is required',
+  },
+}), handleValidationErrors,
+ExportResponseCodeStats({ controllerName }),
+async (req, res) => {
+  try {
+    const { searchParam } = matchedData(req);
+    const response = await searchTrader(searchParam);
+    return res.send(response);
+  } catch (error) {
+    return handleControllerError(
+      'SocialTradingController GET /',
+      'User search error',
+      error,
+      req,
+      res,
+    );
+  }
+});
+
+export default router;

--- a/indexer/services/comlink/src/lib/helpers.ts
+++ b/indexer/services/comlink/src/lib/helpers.ts
@@ -526,3 +526,8 @@ export function getChildSubaccountIds(address: string, parentSubaccountNum: numb
     (subaccountNumber: number): string => SubaccountTable.uuid(address, subaccountNumber),
   );
 }
+
+export function checkIfValidDydxAddress(address: string): boolean {
+  const pattern = /^dydx[0-9a-z]{39}$/;
+  return pattern.test(address);
+}

--- a/indexer/services/comlink/src/lib/helpers.ts
+++ b/indexer/services/comlink/src/lib/helpers.ts
@@ -528,6 +528,6 @@ export function getChildSubaccountIds(address: string, parentSubaccountNum: numb
 }
 
 export function checkIfValidDydxAddress(address: string): boolean {
-  const pattern = /^dydx[0-9a-z]{39}$/;
+  const pattern: RegExp = /^dydx[0-9a-z]{39}$/;
   return pattern.test(address);
 }

--- a/indexer/services/comlink/src/request-helpers/request-transformer.ts
+++ b/indexer/services/comlink/src/request-helpers/request-transformer.ts
@@ -20,6 +20,7 @@ import {
   PositionSide,
   protocolTranslations,
   SubaccountFromDatabase,
+  SubaccountUsernamesFromDatabase,
   SubaccountTable,
   TimeInForce,
   TradingRewardAggregationFromDatabase,
@@ -58,6 +59,7 @@ import {
   SubaccountResponseObject,
   TradeResponseObject,
   TransferResponseObject,
+  TraderSearchResponse,
 } from '../types';
 
 /**
@@ -304,6 +306,20 @@ export function pnlTicksToResponseObject(
     createdAt: pnlTicks.createdAt,
     blockHeight: pnlTicks.blockHeight,
     blockTime: pnlTicks.blockTime,
+  };
+}
+
+export function SubaccountInfoToTraderSearchResponse(
+  subaccount: SubaccountFromDatabase,
+  subaccountUsername: SubaccountUsernamesFromDatabase,
+): TraderSearchResponse {
+  return {
+    result: {
+      address: subaccount.address,
+      subaccountNumber: subaccount.subaccountNumber,
+      subaccountId: subaccount.id,
+      username: subaccountUsername.username,
+    },
   };
 }
 

--- a/indexer/services/comlink/src/request-helpers/request-transformer.ts
+++ b/indexer/services/comlink/src/request-helpers/request-transformer.ts
@@ -309,7 +309,7 @@ export function pnlTicksToResponseObject(
   };
 }
 
-export function SubaccountInfoToTraderSearchResponse(
+export function subaccountInfoToTraderSearchResponse(
   subaccount: SubaccountFromDatabase,
   subaccountUsername: SubaccountUsernamesFromDatabase,
 ): TraderSearchResponse {

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -623,3 +623,20 @@ export interface HistoricalBlockTradingReward {
   createdAt: IsoString,
   createdAtHeight: string,
 }
+
+/* ------- Social Trading Types ------- */
+
+export interface TraderSearchResponse {
+  result?: TraderSearchResponseObject
+}
+
+export interface TraderSearchRequest {
+  username: string,
+}
+
+export interface TraderSearchResponseObject {
+  address: string,
+  subaccountNumber: number,
+  subaccountId: string,
+  username: string,
+}

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -631,7 +631,7 @@ export interface TraderSearchResponse {
 }
 
 export interface TraderSearchRequest {
-  username: string,
+  searchParam: string,
 }
 
 export interface TraderSearchResponseObject {


### PR DESCRIPTION
### Changelist
- Adds api to get subaccount information using wallet address or subaccount username

### Test Plan
- Added unit test for fetching both by address and subaccount username


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced social trading functionality with the ability to search traders by Dydx address or username.
  
- **Tests**
  - Added tests for verifying subaccount information retrieval by address and username.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->