### PR TITLE
[OTE-542] add index for subaccount id in pnl ticks table

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240717142808_pnl_ticks_subaccount_id_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240717142808_pnl_ticks_subaccount_id_index.ts
@@ -1,0 +1,17 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "pnl_ticks_subaccountid_index" ON "pnl_ticks" ("subaccountId");
+      `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+        DROP INDEX CONCURRENTLY IF EXISTS "pnl_ticks_subaccountid_index";
+      `);
+}
+
+export const config = {
+  transaction: false,
+};

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240717142808_pnl_ticks_subaccount_id_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240717142808_pnl_ticks_subaccount_id_index.ts
@@ -2,14 +2,14 @@ import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS "pnl_ticks_subaccountid_index" ON "pnl_ticks" ("subaccountId");
-      `);
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "pnl_ticks_subaccountid_index" ON "pnl_ticks" ("subaccountId");
+    `);
 }
 
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
-        DROP INDEX CONCURRENTLY IF EXISTS "pnl_ticks_subaccountid_index";
-      `);
+    DROP INDEX CONCURRENTLY IF EXISTS "pnl_ticks_subaccountid_index";
+    `);
 }
 
 export const config = {


### PR DESCRIPTION
### Changelist
Adds index for subaccount id in pnl ticks table

### Test Plan
Manually checked in postgres

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved database performance by adding an index on the "subaccountId" column of the "pnl_ticks" table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->