### PR TITLE
update subaccountId to address

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -139,6 +139,11 @@ export const defaultWallet2: WalletCreateObject = {
   totalTradingRewards: denomToHumanReadableConversion(1),
 };
 
+export const defaultWallet3: WalletCreateObject = {
+  address: defaultAddress2,
+  totalTradingRewards: denomToHumanReadableConversion(0),
+};
+
 // ============== Assets ==============
 
 export const defaultAsset: AssetCreateObject = {

--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -65,6 +65,7 @@ export const createdHeight: string = '2';
 export const invalidTicker: string = 'INVALID-INVALID';
 export const dydxChain: string = 'dydx';
 export const defaultAddress: string = 'dydx1n88uc38xhjgxzw9nwre4ep2c8ga4fjxc565lnf';
+export const defaultAddress2: string = 'dydx1n88uc38xhjgxzw9nwre4ep2c8ga4fjxc575lnf';
 export const blockedAddress: string = 'dydx1f9k5qldwmqrnwy8hcgp4fw6heuvszt35egvtx2';
 
 // ============== Subaccounts ==============
@@ -860,7 +861,7 @@ export const duplicatedSubaccountUsername: SubaccountUsernamesCreateObject = {
 // ============== Leaderboard pnl Data ==============
 
 export const defaultLeaderboardPnlOneDay: LeaderboardPnlCreateObject = {
-  subaccountId: defaultSubaccountId,
+  address: defaultAddress,
   timeSpan: 'ONE_DAY',
   pnl: '10000',
   currentEquity: '1000',
@@ -868,7 +869,7 @@ export const defaultLeaderboardPnlOneDay: LeaderboardPnlCreateObject = {
 };
 
 export const defaultLeaderboardPnl2OneDay: LeaderboardPnlCreateObject = {
-  subaccountId: defaultSubaccountId2,
+  address: defaultAddress2,
   timeSpan: 'ONE_DAY',
   pnl: '100',
   currentEquity: '10000',
@@ -876,7 +877,7 @@ export const defaultLeaderboardPnl2OneDay: LeaderboardPnlCreateObject = {
 };
 
 export const defaultLeaderboardPnl1AllTime: LeaderboardPnlCreateObject = {
-  subaccountId: defaultSubaccountId,
+  address: defaultAddress,
   timeSpan: 'ALL_TIME',
   pnl: '10000',
   currentEquity: '1000',
@@ -884,7 +885,7 @@ export const defaultLeaderboardPnl1AllTime: LeaderboardPnlCreateObject = {
 };
 
 export const defaultLeaderboardPnlOneDayToUpsert: LeaderboardPnlCreateObject = {
-  subaccountId: defaultSubaccountId,
+  address: defaultAddress,
   timeSpan: 'ONE_DAY',
   pnl: '100000',
   currentEquity: '1000',

--- a/indexer/packages/postgres/__tests__/stores/leaderboard-pnl-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/leaderboard-pnl-table.test.ts
@@ -45,7 +45,7 @@ describe('LeaderboardPnl store', () => {
     expect(leaderboardPnls.length).toEqual(3);
   });
 
-  it('Successfully finds LeaderboardPnl with subaccountId and timespan', async () => {
+  it('Successfully finds LeaderboardPnl with address and timespan', async () => {
     await Promise.all([
       LeaderboardPnlTable.create(defaultLeaderboardPnlOneDay),
       LeaderboardPnlTable.create(defaultLeaderboardPnl2OneDay),
@@ -54,7 +54,7 @@ describe('LeaderboardPnl store', () => {
 
     const leaderboardPnl: LeaderboardPnlFromDatabase[] = await LeaderboardPnlTable.findAll(
       {
-        subaccountId: [defaultLeaderboardPnlOneDay.subaccountId],
+        address: [defaultLeaderboardPnlOneDay.address],
         timeSpan: [defaultLeaderboardPnlOneDay.timeSpan],
       },
       [],

--- a/indexer/packages/postgres/__tests__/stores/leaderboard-pnl-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/leaderboard-pnl-table.test.ts
@@ -6,12 +6,15 @@ import {
   defaultLeaderboardPnlOneDay,
   defaultLeaderboardPnl1AllTime,
   defaultLeaderboardPnlOneDayToUpsert,
+  defaultWallet3,
 } from '../helpers/constants';
 import { seedData } from '../helpers/mock-generators';
+import { WalletTable } from '../../src';
 
 describe('LeaderboardPnl store', () => {
   beforeEach(async () => {
     await seedData();
+    await WalletTable.create(defaultWallet3);
   });
 
   beforeAll(async () => {

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240717160024_create_leaderboard_pnl_table.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240717160024_create_leaderboard_pnl_table.ts
@@ -2,7 +2,7 @@ import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.createTable('leaderboard_pnl', (table) => {
-    table.string('address').notNullable();
+    table.string('address').notNullable().references('address').inTable('wallets');
     table.enum(
       'timeSpan',
       [

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240717160024_create_leaderboard_pnl_table.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240717160024_create_leaderboard_pnl_table.ts
@@ -2,7 +2,7 @@ import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.createTable('leaderboard_pnl', (table) => {
-    table.uuid('subaccountId').notNullable().references('id').inTable('subaccounts');
+    table.string('address').notNullable();
     table.enum(
       'timeSpan',
       [
@@ -16,7 +16,7 @@ export async function up(knex: Knex): Promise<void> {
     table.string('pnl').notNullable();
     table.string('currentEquity').notNullable();
     table.integer('rank').notNullable();
-    table.primary(['subaccountId', 'timeSpan']);
+    table.primary(['address', 'timeSpan']);
   });
 }
 

--- a/indexer/packages/postgres/src/models/leaderboard-pnl-model.ts
+++ b/indexer/packages/postgres/src/models/leaderboard-pnl-model.ts
@@ -1,3 +1,7 @@
+import path from 'path';
+
+import { Model } from 'objection';
+
 import { NumericPattern } from '../lib/validators';
 import UpsertQueryBuilder from '../query-builders/upsert';
 import BaseModel from './base-model';
@@ -12,7 +16,16 @@ export default class LeaderboardPnlModel extends BaseModel {
     return ['address', 'timeSpan'];
   }
 
-  static relationMappings = {};
+  static relationMappings = {
+    wallets: {
+      relation: Model.BelongsToOneRelation,
+      modelClass: path.join(__dirname, 'wallet-model'),
+      join: {
+        from: 'leaderboard_pnl.address',
+        to: 'wallets.address',
+      },
+    },
+  };
 
   static get jsonSchema() {
     return {

--- a/indexer/packages/postgres/src/models/leaderboard-pnl-model.ts
+++ b/indexer/packages/postgres/src/models/leaderboard-pnl-model.ts
@@ -13,32 +13,23 @@ export default class LeaderboardPnlModel extends BaseModel {
   }
 
   static get idColumn() {
-    return ['subaccountId', 'timeSpan'];
+    return ['address', 'timeSpan'];
   }
 
-  static relationMappings = {
-    subaccount: {
-      relation: Model.BelongsToOneRelation,
-      modelClass: path.join(__dirname, 'subaccount-model'),
-      join: {
-        from: 'leaderboard_pnl.subaccountId',
-        to: 'subaccounts.id',
-      },
-    },
-  };
+  static relationMappings = {};
 
   static get jsonSchema() {
     return {
       type: 'object',
       required: [
-        'subaccountId',
+        'address',
         'timeSpan',
         'pnl',
         'currentEquity',
         'rank',
       ],
       properties: {
-        subaccountId: { type: 'string' },
+        address: { type: 'string' },
         timeSpan: { type: 'string' },
         pnl: { type: 'string', pattern: NumericPattern },
         currentEquity: { type: 'string', pattern: NumericPattern },
@@ -47,7 +38,7 @@ export default class LeaderboardPnlModel extends BaseModel {
     };
   }
 
-  subaccountId!: string;
+  address!: string;
 
   timeSpan!: string;
 

--- a/indexer/packages/postgres/src/models/leaderboard-pnl-model.ts
+++ b/indexer/packages/postgres/src/models/leaderboard-pnl-model.ts
@@ -1,7 +1,3 @@
-import path from 'path';
-
-import { Model } from 'objection';
-
 import { NumericPattern } from '../lib/validators';
 import UpsertQueryBuilder from '../query-builders/upsert';
 import BaseModel from './base-model';

--- a/indexer/packages/postgres/src/stores/leaderboard-pnl-table.ts
+++ b/indexer/packages/postgres/src/stores/leaderboard-pnl-table.ts
@@ -26,7 +26,7 @@ import {
 
 export async function findAll(
   {
-    subaccountId,
+    address,
     timeSpan,
     rank,
     limit,
@@ -36,7 +36,7 @@ export async function findAll(
 ): Promise<LeaderboardPnlFromDatabase[]> {
   verifyAllRequiredFields(
     {
-      subaccountId,
+      address,
       timeSpan,
       rank,
       limit,
@@ -49,8 +49,8 @@ export async function findAll(
     options,
   );
 
-  if (subaccountId) {
-    baseQuery = baseQuery.whereIn(LeaderboardPnlColumns.subaccountId, subaccountId);
+  if (address) {
+    baseQuery = baseQuery.whereIn(LeaderboardPnlColumns.address, address);
   }
 
   if (timeSpan) {
@@ -124,7 +124,7 @@ export async function bulkUpsert(
       LeaderboardPnlColumns.rank,
     ],
     stringColumns: [
-      LeaderboardPnlColumns.subaccountId,
+      LeaderboardPnlColumns.address,
       LeaderboardPnlColumns.timeSpan,
       LeaderboardPnlColumns.currentEquity,
       LeaderboardPnlColumns.pnl,
@@ -135,7 +135,7 @@ export async function bulkUpsert(
     table: LeaderboardPnlModel.tableName,
     objectRows: rows,
     columns,
-    uniqueIdentifiers: [LeaderboardPnlColumns.subaccountId, LeaderboardPnlColumns.timeSpan],
+    uniqueIdentifiers: [LeaderboardPnlColumns.address, LeaderboardPnlColumns.timeSpan],
   });
 
   const transaction: Knex.Transaction | undefined = Transaction.get(options.txId);

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -261,7 +261,7 @@ export interface SubaccountUsernamesFromDatabase {
 }
 
 export interface LeaderboardPnlFromDatabase {
-  subaccountId: string;
+  address: string;
   timeSpan: string;
   pnl: string;
   currentEquity: string;

--- a/indexer/packages/postgres/src/types/leaderboard-pnl-types.ts
+++ b/indexer/packages/postgres/src/types/leaderboard-pnl-types.ts
@@ -1,7 +1,7 @@
 /* ------- LEADERBOARD PNL TYPES ------- */
 
 export interface LeaderboardPnlCreateObject {
-  subaccountId: string;
+  address: string;
   pnl: string;
   timeSpan: string;
   currentEquity: string;
@@ -9,7 +9,7 @@ export interface LeaderboardPnlCreateObject {
 }
 
 export enum LeaderboardPnlColumns {
-  subaccountId = 'subaccountId',
+  address = 'address',
   timeSpan = 'timeSpan',
   pnl = 'pnl',
   currentEquity = 'currentEquity',

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -317,7 +317,7 @@ export interface TradingRewardAggregationQueryConfig extends QueryConfig {
 }
 
 export interface LeaderboardPnlQueryConfig extends QueryConfig {
-  [QueryableField.SUBACCOUNT_ID]?: string[];
+  [QueryableField.ADDRESS]?: string[];
   [QueryableField.TIMESPAN]?: string[];
   [QueryableField.RANK]?: number[];
 }


### PR DESCRIPTION
### Changelist
- Fixes erroneous column in leaderboard table which should have been address

### Test Plan
updated tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Replaced all instances of `subaccountId` with `address` in leaderboard data, ensuring correct user identification.

- **Tests**
  - Updated test cases to align with the new `address` property.

This update enhances data consistency and integrity by using a more accurate identifier for leaderboard entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->