### PR TITLE
[TRA-509] skip vault order calculation if market price is 0

### DIFF
--- a/protocol/x/vault/keeper/orders_test.go
+++ b/protocol/x/vault/keeper/orders_test.go
@@ -818,6 +818,21 @@ func TestGetVaultClobOrders(t *testing.T) {
 			perpetual:                  constants.BtcUsd_0DefaultFunding_10AtomicResolution,
 			expectedErr:                vaulttypes.ErrNonPositiveEquity,
 		},
+		"Error - Market price is zero": {
+			vaultParams:                vaulttypes.DefaultParams(),
+			vaultId:                    constants.Vault_Clob0,
+			vaultAssetQuoteQuantums:    big.NewInt(1_000_000_000), // 1,000 USDC
+			vaultInventoryBaseQuantums: big.NewInt(0),
+			clobPair:                   constants.ClobPair_Btc,
+			marketParam:                constants.TestMarketParams[0],
+			marketPrice: pricestypes.MarketPrice{
+				Id:       0,
+				Exponent: -5,
+				Price:    0,
+			},
+			perpetual:   constants.BtcUsd_0DefaultFunding_10AtomicResolution,
+			expectedErr: vaulttypes.ErrZeroMarketPrice,
+		},
 	}
 
 	for name, tc := range tests {

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -85,4 +85,9 @@ var (
 		16,
 		"TotalShares does not match sum of OwnerShares",
 	)
+	ErrZeroMarketPrice = errorsmod.Register(
+		ModuleName,
+		17,
+		"MarketPrice is zero",
+	)
 )


### PR DESCRIPTION
### Changelist
skip vault order calculation if market price is 0

### Test Plan
unit tests
- verified that the added unit test panics without the logic introduced in this PR

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new error handling mechanism for scenarios when the market price is zero, improving the reliability of vault order processing.
  - Added a specific error variable `ErrZeroMarketPrice` for better diagnostics related to market pricing issues.

- **Bug Fixes**
  - Enhanced the test suite with a case to verify correct handling of a zero market price, ensuring robust error responses in edge scenarios.

- **Documentation**
  - Improved comments for clarity on mathematical operations and error handling, aiding in understanding the code logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->