### PR TITLE
use RunCached in vault abci

### DIFF
--- a/protocol/x/vault/abci.go
+++ b/protocol/x/vault/abci.go
@@ -4,6 +4,7 @@ import (
 	"runtime/debug"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/abci"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/log"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/keeper"
 )
@@ -14,18 +15,17 @@ func BeginBlocker(
 ) {
 	// Panic is not expected in BeginBlocker, but we should recover instead of
 	// halting the chain.
-	defer func() {
-		if r := recover(); r != nil {
-			log.ErrorLog(
-				ctx,
-				"panic in vault BeginBlocker",
-				"stack",
-				string(debug.Stack()),
-			)
-		}
-	}()
-
-	keeper.DecommissionNonPositiveEquityVaults(ctx)
+	if err := abci.RunCached(ctx, func(ctx sdk.Context) error {
+		keeper.DecommissionNonPositiveEquityVaults(ctx)
+		return nil
+	}); err != nil {
+		log.ErrorLog(
+			ctx,
+			"panic in vault BeginBlocker",
+			"stack",
+			string(debug.Stack()),
+		)
+	}
 }
 
 func EndBlocker(
@@ -34,16 +34,15 @@ func EndBlocker(
 ) {
 	// Panic is not expected in EndBlocker, but we should recover instead of
 	// halting the chain.
-	defer func() {
-		if r := recover(); r != nil {
-			log.ErrorLog(
-				ctx,
-				"panic in vault EndBlocker",
-				"stack",
-				string(debug.Stack()),
-			)
-		}
-	}()
-
-	keeper.RefreshAllVaultOrders(ctx)
+	if err := abci.RunCached(ctx, func(ctx sdk.Context) error {
+		keeper.RefreshAllVaultOrders(ctx)
+		return nil
+	}); err != nil {
+		log.ErrorLog(
+			ctx,
+			"panic in vault EndBlocker",
+			"stack",
+			string(debug.Stack()),
+		)
+	}
 }


### PR DESCRIPTION
### Changelist
use RunCached in vault abci. Two purposes
1. recover from panic
2. use a cached context (changes are persisted if no panic)

### Test Plan
existing tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the vault module, enhancing the logging of errors during critical operations.
	- Streamlined error recovery process, ensuring consistent logging of issues related to non-positive equity vaults and vault order refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->