### PR TITLE
set vault spread ppm to 30bps on testing envs

### DIFF
--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -1839,7 +1839,7 @@
         "order_size_pct_ppm": 100000,
         "skew_factor_ppm": 2000000,
         "spread_buffer_ppm": 1500,
-        "spread_min_ppm": 10000
+        "spread_min_ppm": 3000
       },
       "vaults": []
     },

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -1496,6 +1496,8 @@ function edit_genesis() {
 	update_ica_controller_params
 
 	# Vaults
+	# Set vault params.
+	dasel put -t int -f "$GENESIS" ".app_state.vault.params.spread_min_ppm" -v '3000'
 	# Set total shares and owner shares of each vault.
 	vault_idx=0
 	if [ -z "${INPUT_TEST_ACCOUNTS[0]}" ]; then


### PR DESCRIPTION
### Changelist
set vault spread ppm to 30bps on testing envs to mirror production spread

### Test Plan
localnet testing

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced vault parameter configuration by adding a minimum spread requirement during genesis setup.
- **Bug Fixes**
	- Adjusted the minimum spread value from 10000 to 3000 for improved operational efficiency and tighter spreads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->