### PR TITLE
[OTE-626]: Add support for whitelisted addresses

### DIFF
--- a/indexer/packages/compliance/__tests__/geoblocking/restrict-countries.test.ts
+++ b/indexer/packages/compliance/__tests__/geoblocking/restrict-countries.test.ts
@@ -1,6 +1,7 @@
 import {
   isRestrictedCountryHeaders,
   CountryHeaders,
+  isWhitelistedAddress,
 } from '../../src/geoblocking/restrict-countries';
 import * as util from '../../src/geoblocking/util';
 import config from '../../src/config';
@@ -45,5 +46,19 @@ describe('isRestrictedCountryHeaders', () => {
 
   it('does reject empty headers', () => {
     expect(isRestrictedCountryHeaders({})).toEqual(true);
+  });
+});
+
+describe('isWhitelistedAddress', () => {
+  it('returns true if address is whitelisted', () => {
+    config.WHITELISTED_ADDRESSES = '0x123,0x456';
+
+    expect(isWhitelistedAddress('0x123')).toEqual(true);
+  });
+
+  it('returns false if address is not whitelisted', () => {
+    config.WHITELISTED_ADDRESSES = '0x123,0x456';
+
+    expect(isWhitelistedAddress('0x789')).toEqual(false);
   });
 });

--- a/indexer/packages/compliance/src/config.ts
+++ b/indexer/packages/compliance/src/config.ts
@@ -22,6 +22,11 @@ export const complianceConfigSchema = {
     default: '', // comma de-limited
   }),
 
+  // Whitelisted list of dydx addresses
+  WHITELISTED_ADDRESSES: parseString({
+    default: '', // comma de-limited
+  }),
+
   // Required environment variables.
   ELLIPTIC_API_KEY: parseString({ default: 'default_elliptic_api_key' }),
   ELLIPTIC_API_SECRET: parseString({ default: '' }),

--- a/indexer/packages/compliance/src/geoblocking/restrict-countries.ts
+++ b/indexer/packages/compliance/src/geoblocking/restrict-countries.ts
@@ -31,3 +31,7 @@ export function isRestrictedCountryHeaders(headers: CountryHeaders): boolean {
 
   return false;
 }
+
+export function isWhitelistedAddress(address: string): boolean {
+  return config.WHITELISTED_ADDRESSES.split(',').includes(address);
+}

--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
@@ -19,7 +19,7 @@ import { DateTime } from 'luxon';
 import { ComplianceAction } from '../../../../src/controllers/api/v4/compliance-v2-controller';
 import { ExtendedSecp256k1Signature, Secp256k1 } from '@cosmjs/crypto';
 import { getGeoComplianceReason } from '../../../../src/helpers/compliance/compliance-utils';
-import { isRestrictedCountryHeaders } from '@dydxprotocol-indexer/compliance';
+import { isRestrictedCountryHeaders, isWhitelistedAddress } from '@dydxprotocol-indexer/compliance';
 import { toBech32 } from '@cosmjs/encoding';
 
 jest.mock('@dydxprotocol-indexer/compliance');
@@ -60,8 +60,11 @@ describe('ComplianceV2Controller', () => {
   });
 
   describe('GET', () => {
+    let isWhitelistedAddressSpy: jest.SpyInstance;
+
     beforeEach(async () => {
       ipAddrMock.mockReturnValue(ipAddr);
+      isWhitelistedAddressSpy = isWhitelistedAddress as unknown as jest.Mock;
       await testMocks.seedData();
     });
 
@@ -158,6 +161,31 @@ describe('ComplianceV2Controller', () => {
         }));
       });
 
+    it('should return COMPLIANT for a restricted, dydx address with existing CLOSE_ONLY compliance status', async () => {
+      jest.spyOn(ComplianceControllerHelper.prototype, 'screen').mockImplementation(() => {
+        return Promise.resolve({
+          restricted: true,
+        });
+      });
+
+      const createdAt: string = DateTime.utc().minus({ days: 1 }).toISO();
+      await ComplianceStatusTable.create({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.CLOSE_ONLY,
+        createdAt,
+        updatedAt: createdAt,
+      });
+      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
+      expect(data).toHaveLength(1);
+
+      isWhitelistedAddressSpy.mockReturnValue(true);
+      const response: any = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/compliance/screen/${testConstants.defaultAddress}`,
+      });
+      expect(response.body.status).toEqual(ComplianceStatus.COMPLIANT);
+    });
+
     it('should return CLOSE_ONLY & not update for a restricted, dydx address with existing CLOSE_ONLY compliance status',
       async () => {
         jest.spyOn(ComplianceControllerHelper.prototype, 'screen').mockImplementation(() => {
@@ -190,7 +218,8 @@ describe('ComplianceV2Controller', () => {
           createdAt,
           updatedAt: createdAt,
         }));
-      });
+      },
+    );
 
     it('should return COMPLIANT for a non-restricted, dydx address', async () => {
       jest.spyOn(ComplianceControllerHelper.prototype, 'screen').mockImplementation(() => {
@@ -298,6 +327,7 @@ describe('ComplianceV2Controller', () => {
   describe('POST /geoblock', () => {
     let getGeoComplianceReasonSpy: jest.SpyInstance;
     let isRestrictedCountryHeadersSpy: jest.SpyInstance;
+    let isWhitelistedAddressSpy: jest.SpyInstance;
 
     const body: any = {
       address: testConstants.defaultAddress,
@@ -311,6 +341,7 @@ describe('ComplianceV2Controller', () => {
     beforeEach(async () => {
       getGeoComplianceReasonSpy = getGeoComplianceReason as unknown as jest.Mock;
       isRestrictedCountryHeadersSpy = isRestrictedCountryHeaders as unknown as jest.Mock;
+      isWhitelistedAddressSpy = isWhitelistedAddress as unknown as jest.Mock;
       ipAddrMock.mockReturnValue(ipAddr);
       await testMocks.seedData();
       jest.mock('@cosmjs/crypto', () => ({
@@ -390,6 +421,30 @@ describe('ComplianceV2Controller', () => {
 
       expect(response.status).toEqual(200);
       expect(response.body.status).toEqual(ComplianceStatus.COMPLIANT);
+    });
+
+    it('should return COMPLIANT from a restricted country when whitelisted', async () => {
+      (Secp256k1.verifySignature as jest.Mock).mockResolvedValueOnce(true);
+      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
+      isRestrictedCountryHeadersSpy.mockReturnValue(true);
+      await dbHelpers.clearData();
+
+      const data2: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
+      expect(data2).toHaveLength(0);
+
+      isWhitelistedAddressSpy.mockReturnValue(true);
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: '/v4/compliance/geoblock',
+        body,
+        expectedStatus: 200,
+      });
+
+      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
+      expect(data).toHaveLength(0);
+
+      expect(response.body.status).toEqual(ComplianceStatus.COMPLIANT);
+      expect(response.body.updatedAt).toBeDefined();
     });
 
     it('should set status to BLOCKED for CONNECT action from a restricted country with no existing compliance status and no wallet', async () => {

--- a/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
+++ b/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
@@ -3,6 +3,7 @@ import {
   isRestrictedCountryHeaders,
   INDEXER_GEOBLOCKED_PAYLOAD,
   INDEXER_COMPLIANCE_BLOCKED_PAYLOAD,
+  isWhitelistedAddress,
 } from '@dydxprotocol-indexer/compliance';
 import {
   ComplianceStatus,
@@ -40,6 +41,10 @@ export async function complianceAndGeoCheck(
   }
 
   const { address }: AddressRequest = matchedData(req) as AddressRequest;
+  if (isWhitelistedAddress(address)) {
+    return next();
+  }
+
   if (address !== undefined) {
     const updatedStatus: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll(
       { address: [address] },


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter for whitelisted addresses to enhance compliance checks.
	- Added a function to validate if an address is whitelisted, impacting geoblocking logic.
	- Enhanced compliance logic to allow whitelisted addresses to bypass certain restrictions.

- **Bug Fixes**
	- Improved test coverage for compliance status handling related to address whitelisting and geographical restrictions.

- **Tests**
	- Added new test cases to verify the functionality of the whitelisting feature across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->