### PR TITLE
perf: further reduce timeout propose to 1sec

### DIFF
--- a/protocol/cmd/dydxprotocold/cmd/root.go
+++ b/protocol/cmd/dydxprotocold/cmd/root.go
@@ -58,7 +58,7 @@ const (
 	flagIAVLCacheSize = "iavl-cache-size"
 
 	// TimeoutProposeOverride is the software override for the `timeout_propose` consensus parameter.
-	TimeoutProposeOverride = 1500 * time.Millisecond
+	TimeoutProposeOverride = 1 * time.Second
 )
 
 // NewRootCmd creates a new root command for `dydxprotocold`. It is called once in the main function.


### PR DESCRIPTION
### Changelist
Follow-up to https://github.com/dydxprotocol/v4-chain/pull/1751, which has reduced block time (when proposer is offline) from `5.5sec` -> `4sec`:

```
+--------------+--------------------------------+--------+----------------------+--------+--------+------------------------+-----------------------+------------------------------------------+
| Block Height |              Time              | Rounds | Delta Time (seconds) | # Txns | VE raw | ProposerOperations raw | UpdateMarketPrice raw |             Proposer Address             |
+--------------+--------------------------------+--------+----------------------+--------+--------+------------------------+-----------------------+------------------------------------------+
|   21185746   | 2024-07-25T20:23:49.960942863Z |   1    |       4.056136       |   5    | 12976  |          7608          |           88          | 4548C96CA12DF7BAEA97A4F2AB23E428116BB990 |
```

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased timeout duration for the proposal phase in the consensus mechanism to enhance processing time.
  
- **Bug Fixes**
	- Reduced occurrences of timeouts during proposal finalizations, improving overall system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->