### PR TITLE
[OTE-553] Fix early return during timestamp nonce check bug

### DIFF
--- a/protocol/app/ante/sigverify.go
+++ b/protocol/app/ante/sigverify.go
@@ -105,7 +105,6 @@ func (svd SigVerificationDecorator) AnteHandle(
 						1,
 						[]gometrics.Label{metrics.GetLabelForIntValue(metrics.ExecMode, int(ctx.ExecMode()))},
 					)
-					return ctx, nil
 				} else {
 					telemetry.IncrCounterWithLabels(
 						[]string{metrics.TimestampNonce, metrics.Invalid, metrics.Count},

--- a/protocol/app/ante/sigverify.go
+++ b/protocol/app/ante/sigverify.go
@@ -97,15 +97,7 @@ func (svd SigVerificationDecorator) AnteHandle(
 		// `GoodTilBlock` for replay protection.
 		if !skipSequenceValidation {
 			if accountpluskeeper.IsTimestampNonce(sig.Sequence) {
-				err = svd.akp.ProcessTimestampNonce(ctx, acc, sig.Sequence)
-
-				if err == nil {
-					telemetry.IncrCounterWithLabels(
-						[]string{metrics.TimestampNonce, metrics.Valid, metrics.Count},
-						1,
-						[]gometrics.Label{metrics.GetLabelForIntValue(metrics.ExecMode, int(ctx.ExecMode()))},
-					)
-				} else {
+				if err := svd.akp.ProcessTimestampNonce(ctx, acc, sig.Sequence); err != nil {
 					telemetry.IncrCounterWithLabels(
 						[]string{metrics.TimestampNonce, metrics.Invalid, metrics.Count},
 						1,
@@ -113,6 +105,11 @@ func (svd SigVerificationDecorator) AnteHandle(
 					)
 					return ctx, errorsmod.Wrapf(sdkerrors.ErrWrongSequence, err.Error())
 				}
+				telemetry.IncrCounterWithLabels(
+					[]string{metrics.TimestampNonce, metrics.Valid, metrics.Count},
+					1,
+					[]gometrics.Label{metrics.GetLabelForIntValue(metrics.ExecMode, int(ctx.ExecMode()))},
+				)
 			} else {
 				if sig.Sequence != acc.GetSequence() {
 					labels := make([]gometrics.Label, 0)

--- a/protocol/app/ante/sigverify_test.go
+++ b/protocol/app/ante/sigverify_test.go
@@ -330,6 +330,22 @@ func TestSigVerification(t *testing.T) {
 			"",
 			true,
 		},
+		{
+			"timestamp nonce invalid sigs",
+			testMsgs,
+			[]cryptotypes.PrivKey{priv1, priv2, priv3},
+			[]uint64{accs[0].GetAccountNumber(), accs[1].GetAccountNumber(), accs[2].GetAccountNumber()},
+			[]uint64{
+				testante.TestBlockTime + 5000, // ts > min(tsNonces)
+				testante.TestBlockTime + 5000,
+				testante.TestBlockTime + 5000,
+			},
+			!validSigs,
+			false,
+			true,
+			"",
+			true,
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced testing framework with a new test case for validating signature verification against invalid signatures and nonce conditions.

- **Bug Fixes**
	- Improved control flow in the signature verification process, allowing better error handling and state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->