### PR TITLE
Add post only crosses maker order as first class order status field

### DIFF
--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -1755,8 +1755,8 @@ func (m *MemClobPriceTimePriority) mustPerformTakerOrderMatching(
 		}
 
 		// If a valid match has been generated but the taker order is a post only order,
-		// end the matching loop. Because of this, post-only orders can cause at most 1
-		// undercollateralized maker orders to be removed from the book.
+		// end the matching loop. Because of this, post-only orders can cause
+		// undercollateralized maker orders to be removed from the book up to the first valid match.
 		if takerOrderCrossesMakerOrder &&
 			!newTakerOrder.IsLiquidation() &&
 			newTakerOrder.MustGetOrder().TimeInForce == types.Order_TIME_IN_FORCE_POST_ONLY {

--- a/protocol/x/clob/memclob/memclob_place_order_test.go
+++ b/protocol/x/clob/memclob/memclob_place_order_test.go
@@ -2834,14 +2834,11 @@ func TestPlaceOrder_PostOnly(t *testing.T) {
 				},
 			},
 			expectedRemainingAsks: []OrderWithRemainingSize{},
+			// Second order is not collat check'd since the first order generates a valid
+			// match, so the matching loop ends.
 			expectedCollatCheck: []expectedMatch{
 				{
 					makerOrder:      &constants.Order_Bob_Num0_Id11_Clob1_Buy5_Price40_GTB32,
-					takerOrder:      &constants.Order_Alice_Num1_Id1_Clob1_Sell10_Price15_GTB20_PO,
-					matchedQuantums: 5,
-				},
-				{
-					makerOrder:      &constants.Order_Bob_Num0_Id4_Clob1_Buy20_Price35_GTB22,
 					takerOrder:      &constants.Order_Alice_Num1_Id1_Clob1_Sell10_Price15_GTB20_PO,
 					matchedQuantums: 5,
 				},

--- a/protocol/x/clob/types/orderbook.go
+++ b/protocol/x/clob/types/orderbook.go
@@ -136,6 +136,9 @@ const (
 	// with either multiple positions in isolated perpetuals or both an isolated and a cross perpetual
 	// position.
 	ViolatesIsolatedSubaccountConstraints
+	// PostOnlyWouldCrossMakerOrder indicates that matching the post only taker order would cross the
+	// orderbook, and was therefore canceled.
+	PostOnlyWouldCrossMakerOrder
 )
 
 // String returns a string representation of this `OrderStatus` enum.


### PR DESCRIPTION
Adds post only taker order crosses maker order as first class citizen in `takerOrderStatus`.

Note this following pr has the following consequences:
- Previously, the post only taker orders would go through the whole matching loop and match the whole size before failing at the end and reverting state.
- Now, the post only taker order will break out of the matching loop upon the first valid match
- Can cause other undercollateralized maker orders to be removed from the book, up to the first valid match.

- The hierarchy of orders is changed. Post only orders are triggered over ReduceOnlyResize

I aimed to preserve functionality down the call stack [here](https://github.com/dydxprotocol/v4-chain/blob/main/protocol/x/clob/memclob/memclob.go#L523-L567) in PlaceOrder since the error takes priority over all taker order statuses,

Testing is needed to ensure behavior is correct. Need to double check indexer emissions are correct. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved handling of post-only orders to prevent them from crossing maker orders, enhancing order matching logic.
	- Introduced a new order status, `PostOnlyWouldCrossMakerOrder`, for clearer order management scenarios.

- **Bug Fixes**
	- Resolved issues in order cancellation logic related to post-only orders, ensuring better compliance with trading rules. 

- **Tests**
	- Streamlined test cases for order matching, enhancing clarity and focus on expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->