### PR TITLE
Change fromBeginning to a flag

### DIFF
--- a/indexer/services/vulcan/src/config.ts
+++ b/indexer/services/vulcan/src/config.ts
@@ -21,6 +21,7 @@ export const configSchema = {
   ...redisConfigSchema,
 
   BATCH_PROCESSING_ENABLED: parseBoolean({ default: true }),
+  PROCESS_FROM_BEGINNING: parseBoolean({ default: true }),
   KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS: parseNumber({
     default: 3_000,
   }),

--- a/indexer/services/vulcan/src/helpers/kafka/kafka-controller.ts
+++ b/indexer/services/vulcan/src/helpers/kafka/kafka-controller.ts
@@ -19,7 +19,7 @@ export async function connect(): Promise<void> {
     // https://kafka.js.org/docs/consuming#a-name-from-beginning-a-frombeginning
     // Need to set fromBeginning to true, so when vulcan restarts, it will consume all messages
     // rather than ignoring the messages in queue that were produced before ender was started.
-    fromBeginning: true,
+    fromBeginning: config.PROCESS_FROM_BEGINNING,
   });
 
   if (config.BATCH_PROCESSING_ENABLED) {


### PR DESCRIPTION
### Changelist
Change fromBeginning to a flag

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option, `PROCESS_FROM_BEGINNING`, allowing users to control batch processing behavior dynamically.
- **Improvements**
	- Enhanced message consumption flexibility by allowing the use of the `PROCESS_FROM_BEGINNING` configuration in the message consumption logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->