### PR TITLE
[OTE-600] Emit metrics for geoblock endpoint

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
@@ -414,6 +414,11 @@ describe('ComplianceV2Controller', () => {
         reason: ComplianceReason.US_GEO,
       }));
 
+      expect(stats.increment).toHaveBeenCalledWith(`${config.SERVICE_NAME}.compliance-v2-controller.geo_block.compliance_status_changed.count`,
+        {
+          newStatus: ComplianceStatus.BLOCKED,
+        });
+
       expect(response.body.status).toEqual(ComplianceStatus.BLOCKED);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
       expect(response.body.updatedAt).toBeDefined();
@@ -441,6 +446,10 @@ describe('ComplianceV2Controller', () => {
         status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
         reason: ComplianceReason.US_GEO,
       }));
+      expect(stats.increment).toHaveBeenCalledWith(`${config.SERVICE_NAME}.compliance-v2-controller.geo_block.compliance_status_changed.count`,
+        {
+          newStatus: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
+        });
 
       expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
@@ -520,6 +529,11 @@ describe('ComplianceV2Controller', () => {
         expectedStatus: 200,
       });
 
+      expect(stats.increment).toHaveBeenCalledWith(`${config.SERVICE_NAME}.compliance-v2-controller.geo_block.compliance_status_changed.count`,
+        {
+          newStatus: ComplianceStatus.CLOSE_ONLY,
+        });
+
       const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
       expect(data).toHaveLength(1);
       expect(data[0]).toEqual(expect.objectContaining({
@@ -554,7 +568,6 @@ describe('ComplianceV2Controller', () => {
         },
         expectedStatus: 200,
       });
-
       const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
       expect(data).toHaveLength(1);
       expect(data[0]).toEqual(expect.objectContaining({
@@ -588,6 +601,10 @@ describe('ComplianceV2Controller', () => {
         },
         expectedStatus: 200,
       });
+      expect(stats.increment).toHaveBeenCalledWith(`${config.SERVICE_NAME}.compliance-v2-controller.geo_block.compliance_status_changed.count`,
+        {
+          newStatus: ComplianceStatus.CLOSE_ONLY,
+        });
 
       const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
       expect(data).toHaveLength(1);
@@ -621,6 +638,10 @@ describe('ComplianceV2Controller', () => {
         },
         expectedStatus: 200,
       });
+      expect(stats.increment).toHaveBeenCalledWith(`${config.SERVICE_NAME}.compliance-v2-controller.geo_block.compliance_status_changed.count`,
+        {
+          newStatus: ComplianceStatus.FIRST_STRIKE,
+        });
 
       const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
       expect(data).toHaveLength(1);
@@ -633,31 +654,6 @@ describe('ComplianceV2Controller', () => {
       expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
       expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
       expect(response.body.updatedAt).toBeDefined();
-    });
-
-    it('Stats being sent for the geoblock compliance', async () => {
-      await ComplianceStatusTable.create({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
-        reason: ComplianceReason.US_GEO,
-      });
-      (Secp256k1.verifySignature as jest.Mock).mockResolvedValueOnce(true);
-      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
-      isRestrictedCountryHeadersSpy.mockReturnValue(true);
-
-      await sendRequest({
-        type: RequestMethod.POST,
-        path: '/v4/compliance/geoblock',
-        body: {
-          ...body,
-          action: ComplianceAction.VALID_SURVEY,
-        },
-        expectedStatus: 200,
-      });
-      expect(stats.increment).toHaveBeenCalledWith(`${config.SERVICE_NAME}.compliance-v2-controller.geo_block.compliance_status_changed.count`,
-        {
-          newStatus: ComplianceStatus.FIRST_STRIKE,
-        });
     });
   });
 });

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -276,7 +276,7 @@ router.post(
         complianceStatus,
         updatedAt,
       );
-      if ( complianceStatus.length === 0 ||
+      if (complianceStatus.length === 0 ||
         complianceStatus[0] !== complianceStatusFromDatabase) {
         if (complianceStatusFromDatabase !== undefined &&
           complianceStatusFromDatabase.status !== ComplianceStatus.COMPLIANT

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -276,6 +276,17 @@ router.post(
         complianceStatus,
         updatedAt,
       );
+      if (complianceStatus[0] !== complianceStatusFromDatabase &&
+        complianceStatusFromDatabase !== undefined &&
+        complianceStatusFromDatabase.status !== ComplianceStatus.COMPLIANT
+      ) {
+        stats.increment(
+          `${config.SERVICE_NAME}.${controllerName}.geo_block.compliance_status_changed.count`,
+          {
+            newStatus: complianceStatusFromDatabase!.status,
+          },
+        );
+      }
 
       const response = {
         status: complianceStatusFromDatabase!.status,

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -276,16 +276,18 @@ router.post(
         complianceStatus,
         updatedAt,
       );
-      if (complianceStatus[0] !== complianceStatusFromDatabase &&
-        complianceStatusFromDatabase !== undefined &&
-        complianceStatusFromDatabase.status !== ComplianceStatus.COMPLIANT
-      ) {
-        stats.increment(
-          `${config.SERVICE_NAME}.${controllerName}.geo_block.compliance_status_changed.count`,
-          {
-            newStatus: complianceStatusFromDatabase!.status,
-          },
-        );
+      if ( complianceStatus.length === 0 ||
+        complianceStatus[0] !== complianceStatusFromDatabase) {
+        if (complianceStatusFromDatabase !== undefined &&
+          complianceStatusFromDatabase.status !== ComplianceStatus.COMPLIANT
+        ) {
+          stats.increment(
+            `${config.SERVICE_NAME}.${controllerName}.geo_block.compliance_status_changed.count`,
+            {
+              newStatus: complianceStatusFromDatabase!.status,
+            },
+          );
+        }
       }
 
       const response = {


### PR DESCRIPTION
### Changelist
Emit metric to track changes in state for geoblock endpoint 

### Test Plan
Added unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced compliance monitoring by tracking changes in compliance status and incrementing related statistics.
  
- **Tests**
	- Added a new test case to ensure correct statistics are captured during geoblock compliance status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->