### PR TITLE
fix: reformat slinky provider names

### DIFF
--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -868,7 +868,7 @@
           "ADA/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -876,7 +876,7 @@
                 "off_chain_ticker": "ADAUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -884,11 +884,11 @@
                 "off_chain_ticker": "ADAUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "ADA-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -896,7 +896,7 @@
                 "off_chain_ticker": "ADA_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -904,11 +904,11 @@
                 "off_chain_ticker": "adausdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "ADAUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -916,7 +916,7 @@
                 "off_chain_ticker": "ADA-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -937,7 +937,7 @@
           "APE/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -945,11 +945,11 @@
                 "off_chain_ticker": "APEUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "APE-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -957,11 +957,11 @@
                 "off_chain_ticker": "APE_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "APEUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -969,7 +969,7 @@
                 "off_chain_ticker": "APE-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -990,7 +990,7 @@
           "APT/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -998,7 +998,7 @@
                 "off_chain_ticker": "APTUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1006,11 +1006,11 @@
                 "off_chain_ticker": "APTUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "APT-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1018,7 +1018,7 @@
                 "off_chain_ticker": "APT_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1026,7 +1026,7 @@
                 "off_chain_ticker": "aptusdt"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1034,7 +1034,7 @@
                 "off_chain_ticker": "APT-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1055,7 +1055,7 @@
           "ARB/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1063,7 +1063,7 @@
                 "off_chain_ticker": "ARBUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1071,11 +1071,11 @@
                 "off_chain_ticker": "ARBUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "ARB-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1083,7 +1083,7 @@
                 "off_chain_ticker": "ARB_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1091,7 +1091,7 @@
                 "off_chain_ticker": "arbusdt"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1099,7 +1099,7 @@
                 "off_chain_ticker": "ARB-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1120,7 +1120,7 @@
           "ATOM/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1128,7 +1128,7 @@
                 "off_chain_ticker": "ATOMUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1136,11 +1136,11 @@
                 "off_chain_ticker": "ATOMUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "ATOM-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1148,11 +1148,11 @@
                 "off_chain_ticker": "ATOM_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "ATOMUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1160,7 +1160,7 @@
                 "off_chain_ticker": "ATOM-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1181,7 +1181,7 @@
           "AVAX/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1189,7 +1189,7 @@
                 "off_chain_ticker": "AVAXUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1197,11 +1197,11 @@
                 "off_chain_ticker": "AVAXUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "AVAX-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1209,7 +1209,7 @@
                 "off_chain_ticker": "AVAX_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1217,11 +1217,11 @@
                 "off_chain_ticker": "avaxusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "AVAXUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1229,7 +1229,7 @@
                 "off_chain_ticker": "AVAX-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1250,7 +1250,7 @@
           "BCH/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1258,7 +1258,7 @@
                 "off_chain_ticker": "BCHUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1266,11 +1266,11 @@
                 "off_chain_ticker": "BCHUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "BCH-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1278,7 +1278,7 @@
                 "off_chain_ticker": "BCH_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1286,11 +1286,11 @@
                 "off_chain_ticker": "bchusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "BCHUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1298,7 +1298,7 @@
                 "off_chain_ticker": "BCH-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1319,11 +1319,11 @@
           "BLUR/USD": {
             "provider_configs": [
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "BLUR-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1331,11 +1331,11 @@
                 "off_chain_ticker": "BLUR_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "BLURUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1343,7 +1343,7 @@
                 "off_chain_ticker": "BLUR-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1364,7 +1364,7 @@
           "BTC/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1372,7 +1372,7 @@
                 "off_chain_ticker": "BTCUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1380,11 +1380,11 @@
                 "off_chain_ticker": "BTCUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "BTC-USD"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1392,11 +1392,11 @@
                 "off_chain_ticker": "btcusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "XXBTZUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1404,7 +1404,7 @@
                 "off_chain_ticker": "BTC-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1425,7 +1425,7 @@
           "COMP/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1433,11 +1433,11 @@
                 "off_chain_ticker": "COMPUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "COMP-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1445,11 +1445,11 @@
                 "off_chain_ticker": "COMP_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "COMPUSD"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1470,7 +1470,7 @@
           "CRV/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1478,11 +1478,11 @@
                 "off_chain_ticker": "CRVUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "CRV-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1490,11 +1490,11 @@
                 "off_chain_ticker": "CRV_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "CRVUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1502,7 +1502,7 @@
                 "off_chain_ticker": "CRV-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1523,7 +1523,7 @@
           "DOGE/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1531,7 +1531,7 @@
                 "off_chain_ticker": "DOGEUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1539,11 +1539,11 @@
                 "off_chain_ticker": "DOGEUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "DOGE-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1551,7 +1551,7 @@
                 "off_chain_ticker": "DOGE_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1559,11 +1559,11 @@
                 "off_chain_ticker": "dogeusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "XDGUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1571,7 +1571,7 @@
                 "off_chain_ticker": "DOGE-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1592,7 +1592,7 @@
           "DOT/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1600,7 +1600,7 @@
                 "off_chain_ticker": "DOTUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1608,11 +1608,11 @@
                 "off_chain_ticker": "DOTUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "DOT-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1620,11 +1620,11 @@
                 "off_chain_ticker": "DOT_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "DOTUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1632,7 +1632,7 @@
                 "off_chain_ticker": "DOT-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1653,7 +1653,7 @@
           "DYDX/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1661,7 +1661,7 @@
                 "off_chain_ticker": "DYDXUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1669,7 +1669,7 @@
                 "off_chain_ticker": "DYDXUSDT"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1677,7 +1677,7 @@
                 "off_chain_ticker": "DYDX_USDT"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1685,7 +1685,7 @@
                 "off_chain_ticker": "DYDX-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1706,7 +1706,7 @@
           "ETC/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1714,11 +1714,11 @@
                 "off_chain_ticker": "ETCUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "ETC-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1726,7 +1726,7 @@
                 "off_chain_ticker": "ETC_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1734,7 +1734,7 @@
                 "off_chain_ticker": "etcusdt"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1742,7 +1742,7 @@
                 "off_chain_ticker": "ETC-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1763,7 +1763,7 @@
           "ETH/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1771,7 +1771,7 @@
                 "off_chain_ticker": "ETHUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1779,11 +1779,11 @@
                 "off_chain_ticker": "ETHUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "ETH-USD"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1791,11 +1791,11 @@
                 "off_chain_ticker": "ethusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "XETHZUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1803,7 +1803,7 @@
                 "off_chain_ticker": "ETH-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1824,7 +1824,7 @@
           "FIL/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1832,11 +1832,11 @@
                 "off_chain_ticker": "FILUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "FIL-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1844,7 +1844,7 @@
                 "off_chain_ticker": "FIL_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1852,11 +1852,11 @@
                 "off_chain_ticker": "filusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "FILUSD"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1877,7 +1877,7 @@
           "LDO/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1885,15 +1885,15 @@
                 "off_chain_ticker": "LDOUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "LDO-USD"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "LDOUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1901,7 +1901,7 @@
                 "off_chain_ticker": "LDO-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1922,7 +1922,7 @@
           "LINK/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1930,7 +1930,7 @@
                 "off_chain_ticker": "LINKUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1938,15 +1938,15 @@
                 "off_chain_ticker": "LINKUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "LINK-USD"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "LINKUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1954,7 +1954,7 @@
                 "off_chain_ticker": "LINK-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1975,7 +1975,7 @@
           "LTC/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1983,7 +1983,7 @@
                 "off_chain_ticker": "LTCUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -1991,11 +1991,11 @@
                 "off_chain_ticker": "LTCUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "LTC-USD"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2003,11 +2003,11 @@
                 "off_chain_ticker": "ltcusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "XLTCZUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2015,7 +2015,7 @@
                 "off_chain_ticker": "LTC-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2036,7 +2036,7 @@
           "MATIC/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2044,7 +2044,7 @@
                 "off_chain_ticker": "MATICUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2052,11 +2052,11 @@
                 "off_chain_ticker": "MATICUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "MATIC-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2064,7 +2064,7 @@
                 "off_chain_ticker": "MATIC_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2072,11 +2072,11 @@
                 "off_chain_ticker": "maticusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "MATICUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2084,7 +2084,7 @@
                 "off_chain_ticker": "MATIC-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2105,7 +2105,7 @@
           "MKR/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2113,15 +2113,15 @@
                 "off_chain_ticker": "MKRUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "MKR-USD"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "MKRUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2129,7 +2129,7 @@
                 "off_chain_ticker": "MKR-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2150,7 +2150,7 @@
           "NEAR/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2158,11 +2158,11 @@
                 "off_chain_ticker": "NEARUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "NEAR-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2170,7 +2170,7 @@
                 "off_chain_ticker": "NEAR_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2178,7 +2178,7 @@
                 "off_chain_ticker": "nearusdt"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2186,7 +2186,7 @@
                 "off_chain_ticker": "NEAR-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2207,7 +2207,7 @@
           "OP/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2215,11 +2215,11 @@
                 "off_chain_ticker": "OPUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "OP-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2227,7 +2227,7 @@
                 "off_chain_ticker": "OP_USDT"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2235,7 +2235,7 @@
                 "off_chain_ticker": "OP-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2256,7 +2256,7 @@
           "PEPE/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2264,7 +2264,7 @@
                 "off_chain_ticker": "PEPEUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2272,7 +2272,7 @@
                 "off_chain_ticker": "PEPEUSDT"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2280,11 +2280,11 @@
                 "off_chain_ticker": "PEPE_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "PEPEUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2292,7 +2292,7 @@
                 "off_chain_ticker": "PEPE-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2313,7 +2313,7 @@
           "SEI/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2321,7 +2321,7 @@
                 "off_chain_ticker": "SEIUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2329,11 +2329,11 @@
                 "off_chain_ticker": "SEIUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "SEI-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2341,7 +2341,7 @@
                 "off_chain_ticker": "SEI_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2349,7 +2349,7 @@
                 "off_chain_ticker": "seiusdt"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2370,7 +2370,7 @@
           "SHIB/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2378,7 +2378,7 @@
                 "off_chain_ticker": "SHIBUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2386,11 +2386,11 @@
                 "off_chain_ticker": "SHIBUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "SHIB-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2398,11 +2398,11 @@
                 "off_chain_ticker": "SHIB_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "SHIBUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2410,7 +2410,7 @@
                 "off_chain_ticker": "SHIB-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2431,7 +2431,7 @@
           "SOL/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2439,7 +2439,7 @@
                 "off_chain_ticker": "SOLUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2447,11 +2447,11 @@
                 "off_chain_ticker": "SOLUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "SOL-USD"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2459,11 +2459,11 @@
                 "off_chain_ticker": "solusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "SOLUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2471,7 +2471,7 @@
                 "off_chain_ticker": "SOL-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2492,7 +2492,7 @@
           "SUI/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2500,7 +2500,7 @@
                 "off_chain_ticker": "SUIUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2508,11 +2508,11 @@
                 "off_chain_ticker": "SUIUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "SUI-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2520,7 +2520,7 @@
                 "off_chain_ticker": "SUI_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2528,7 +2528,7 @@
                 "off_chain_ticker": "suiusdt"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2536,7 +2536,7 @@
                 "off_chain_ticker": "SUI-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2574,7 +2574,7 @@
           "TRX/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2582,7 +2582,7 @@
                 "off_chain_ticker": "TRXUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2590,7 +2590,7 @@
                 "off_chain_ticker": "TRXUSDT"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2598,7 +2598,7 @@
                 "off_chain_ticker": "TRX_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2606,11 +2606,11 @@
                 "off_chain_ticker": "trxusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "TRXUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2618,7 +2618,7 @@
                 "off_chain_ticker": "TRX-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2639,7 +2639,7 @@
           "UNI/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2647,7 +2647,7 @@
                 "off_chain_ticker": "UNIUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2655,11 +2655,11 @@
                 "off_chain_ticker": "UNIUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "UNI-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2667,11 +2667,11 @@
                 "off_chain_ticker": "UNI_USDT"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "UNIUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2679,7 +2679,7 @@
                 "off_chain_ticker": "UNI-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2701,21 +2701,21 @@
             "provider_configs": [
               {
                 "invert": true,
-                "name": "Binance",
+                "name": "binance_ws",
                 "off_chain_ticker": "USDCUSDT"
               },
               {
                 "invert": true,
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "off_chain_ticker": "USDCUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "USDT-USD"
               },
               {
                 "invert": true,
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "ETH",
                   "Quote": "USD"
@@ -2723,12 +2723,12 @@
                 "off_chain_ticker": "ethusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "USDTZUSD"
               },
               {
                 "invert": true,
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "BTC",
                   "Quote": "USD"
@@ -2737,7 +2737,7 @@
               },
               {
                 "invert": true,
-                "name": "Okx",
+                "name": "okx_ws",
                 "off_chain_ticker": "USDC-USDT"
               }
             ],
@@ -2754,7 +2754,7 @@
           "WLD/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2762,7 +2762,7 @@
                 "off_chain_ticker": "WLDUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2770,7 +2770,7 @@
                 "off_chain_ticker": "WLDUSDT"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2778,7 +2778,7 @@
                 "off_chain_ticker": "WLD_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2786,7 +2786,7 @@
                 "off_chain_ticker": "wldusdt"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2794,7 +2794,7 @@
                 "off_chain_ticker": "WLD-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2815,7 +2815,7 @@
           "XLM/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2823,7 +2823,7 @@
                 "off_chain_ticker": "XLMUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2831,15 +2831,15 @@
                 "off_chain_ticker": "XLMUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "XLM-USD"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "XXLMZUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2847,7 +2847,7 @@
                 "off_chain_ticker": "XLM-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2868,7 +2868,7 @@
           "XRP/USD": {
             "provider_configs": [
               {
-                "name": "Binance",
+                "name": "binance_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2876,7 +2876,7 @@
                 "off_chain_ticker": "XRPUSDT"
               },
               {
-                "name": "Bybit",
+                "name": "bybit_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2884,11 +2884,11 @@
                 "off_chain_ticker": "XRPUSDT"
               },
               {
-                "name": "CoinbasePro",
+                "name": "coinbase_ws",
                 "off_chain_ticker": "XRP-USD"
               },
               {
-                "name": "Gate",
+                "name": "gate_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2896,7 +2896,7 @@
                 "off_chain_ticker": "XRP_USDT"
               },
               {
-                "name": "Huobi",
+                "name": "huobi_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2904,11 +2904,11 @@
                 "off_chain_ticker": "xrpusdt"
               },
               {
-                "name": "Kraken",
+                "name": "kraken_api",
                 "off_chain_ticker": "XXRPZUSD"
               },
               {
-                "name": "Kucoin",
+                "name": "kucoin_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -2916,7 +2916,7 @@
                 "off_chain_ticker": "XRP-USDT"
               },
               {
-                "name": "Okx",
+                "name": "okx_ws",
                 "normalize_by_pair": {
                   "Base": "USDT",
                   "Quote": "USD"
@@ -3932,7 +3932,7 @@
       ]
     }
   },
-  "app_version": "5.0.0-dev0-320-gcf745f40",
+  "app_version": "5.0.0-dev0-404-gf14f3950",
   "chain_id": "dydx-sample-1",
   "consensus": {
     "params": {

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -530,13 +530,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "BTCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "BTCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "BTC-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "btcusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "XXBTZUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "BTC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "BTC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "BTCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "BTCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "BTC-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "btcusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "XXBTZUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "BTC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BTC/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "BTC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: ETH-USD
@@ -551,14 +551,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "ETHUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "ETHUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "ETH-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "ethusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "XETHZUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "ETH-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "ETH-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "ETHUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "ETHUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "ETH-USD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "ethusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "XETHZUSD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "ETH-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETH/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "ETH-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
     # Marketmap: LINK-USD
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD' -v "{}"
@@ -572,12 +571,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "LINKUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "LINKUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "LINK-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "LINKUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "LINK-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "LINK-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "LINKUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "LINKUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "LINK-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "LINKUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "LINK-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LINK/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "LINK-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: MATIC-USD
@@ -592,14 +591,14 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "MATICUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "MATICUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "MATIC-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "MATIC_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "maticusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "MATICUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "MATIC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "MATIC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "MATICUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "MATICUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "MATIC-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "MATIC_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "maticusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "MATICUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "MATIC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MATIC/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "MATIC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: CRV-USD
@@ -614,13 +613,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "CRVUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "CRV-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "CRV_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "CRVUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "CRV-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "CRV-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "CRVUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "CRV-USD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "CRV_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "CRVUSD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "CRV-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.CRV/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "CRV-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
     # Marketmap: SOL-USD
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD' -v "{}"
@@ -634,13 +632,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "SOLUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "SOLUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "SOL-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "solusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "SOLUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "SOL-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "SOL-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "SOLUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "SOLUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "SOL-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "solusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "SOLUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "SOL-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SOL/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "SOL-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: ADA-USD
@@ -655,14 +653,14 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "ADAUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "ADAUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "ADA-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "ADA_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "adausdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "ADAUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "ADA-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "ADA-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "ADAUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "ADAUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "ADA-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "ADA_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "adausdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "ADAUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "ADA-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ADA/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "ADA-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: AVAX-USD
@@ -677,14 +675,14 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "AVAXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "AVAXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "AVAX-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "AVAX_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "avaxusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "AVAXUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "AVAX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "AVAX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "AVAXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "AVAXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "AVAX-USD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "AVAX_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "avaxusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "AVAXUSD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "AVAX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.AVAX/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "AVAX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: FIL-USD
@@ -699,12 +697,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "FILUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "FIL-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "FIL_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "filusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "FILUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "FIL-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "FILUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "FIL-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "FIL_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "filusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "FILUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.FIL/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "FIL-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: LTC-USD
@@ -719,13 +717,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "LTCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "LTCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "LTC-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "ltcusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "XLTCZUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "LTC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "LTC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "LTCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "LTCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "LTC-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "ltcusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "XLTCZUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "LTC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LTC/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "LTC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: DOGE-USD
@@ -740,14 +738,14 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "DOGEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "DOGEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "DOGE-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "DOGE_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "dogeusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "XDGUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "DOGE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "DOGE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "DOGEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "DOGEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "DOGE-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "DOGE_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "dogeusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "XDGUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "DOGE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOGE/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "DOGE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: ATOM-USD
@@ -762,13 +760,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "ATOMUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "ATOMUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "ATOM-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "ATOM_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "ATOMUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "ATOM-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "ATOM-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "ATOMUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "ATOMUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "ATOM-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "ATOM_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "ATOMUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "ATOM-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ATOM/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "ATOM-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: DOT-USD
@@ -783,13 +781,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "DOTUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "DOTUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "DOT-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "DOT_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "DOTUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "DOT-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "DOT-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "DOTUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "DOTUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "DOT-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "DOT_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "DOTUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "DOT-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DOT/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "DOT-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: UNI-USD
@@ -804,13 +802,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "UNIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "UNIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "UNI-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "UNI_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "UNIUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "UNI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "UNI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "UNIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "UNIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "UNI-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "UNI_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "UNIUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "UNI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.UNI/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "UNI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: BCH-USD
@@ -825,14 +823,14 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "BCHUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "BCHUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "BCH-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "BCH_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "bchusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "BCHUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "BCH-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "BCH-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "BCHUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "BCHUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "BCH-USD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "BCH_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "bchusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "BCHUSD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "BCH-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BCH/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "BCH-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: TRX-USD
@@ -847,13 +845,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "TRXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "TRXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "TRX_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "trxusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "TRXUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "TRX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "TRX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "TRXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "TRXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "TRX_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "trxusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "TRXUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "TRX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.TRX/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "TRX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: NEAR-USD
@@ -868,12 +866,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "NEARUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "NEAR-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "NEAR_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "nearusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "NEAR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "NEAR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "NEARUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "NEAR-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "NEAR_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "nearusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "NEAR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.NEAR/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "NEAR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: MKR-USD
@@ -888,11 +886,11 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "MKRUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "MKR-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "MKRUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "MKR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "MKR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "MKRUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "MKR-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "MKRUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "MKR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.MKR/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "MKR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: XLM-USD
@@ -907,12 +905,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "XLMUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "XLMUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "XLM-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "XXLMZUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "XLM-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "XLM-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "XLMUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "XLMUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "XLM-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "XXLMZUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "XLM-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XLM/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "XLM-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: ETC-USD
@@ -927,12 +925,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "ETCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "ETC-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "ETC_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "etcusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "ETC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "ETC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "ETCUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "ETC-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "ETC_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "etcusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "ETC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ETC/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "ETC-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: COMP-USD
@@ -947,11 +945,11 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "COMPUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "COMP-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "COMP_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "COMPUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "COMP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "COMPUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "COMP-USD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "COMP_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "COMPUSD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.COMP/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "COMP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: WLD-USD
@@ -966,12 +964,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "WLDUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "WLDUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "WLD_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "wldusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "WLD-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "WLD-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "WLDUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "WLDUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "WLD_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "wldusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "WLD-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.WLD/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "WLD-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: APE-USD
@@ -986,12 +984,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "APEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "APE-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "APE_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "APEUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "APE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "APE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "APEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "APE-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "APE_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "APEUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "APE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APE/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "APE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: APT-USD
@@ -1006,13 +1004,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "APTUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "APTUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "APT-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "APT_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "aptusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "APT-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "APT-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "APTUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "APTUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "APT-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "APT_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "aptusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "APT-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.APT/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "APT-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: ARB-USD
@@ -1027,13 +1025,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "ARBUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "ARBUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "ARB-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "ARB_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "arbusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "ARB-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "ARB-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "ARBUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "ARBUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "ARB-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "ARB_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "arbusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "ARB-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.ARB/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "ARB-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: BLUR-USD
@@ -1048,11 +1046,11 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "BLUR-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "BLUR_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "BLURUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "BLUR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "BLUR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "BLUR-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "BLUR_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "BLURUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "BLUR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BLUR/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "BLUR-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: LDO-USD
@@ -1067,11 +1065,11 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "LDOUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "LDO-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "LDOUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "LDO-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "LDO-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "LDOUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "LDO-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "LDOUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "LDO-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.LDO/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "LDO-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: OP-USD
@@ -1086,11 +1084,11 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "OPUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "OP-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "OP_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "OP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "OP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "OPUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "OP-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "OP_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "OP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.OP/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "OP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: PEPE-USD
@@ -1105,13 +1103,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "PEPEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "PEPEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "PEPE_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "PEPEUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "PEPE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "PEPE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "PEPEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "PEPEUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "PEPE_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "PEPEUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "PEPE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.PEPE/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "PEPE-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
     # Marketmap: SEI-USD
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD' -v "{}"
@@ -1125,13 +1122,12 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "SEIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "SEIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "SEI-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "SEI_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "seiusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "SEI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "SEIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "SEIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "SEI-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "SEI_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "seiusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SEI/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "SEI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
     # Marketmap: SHIB-USD
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD' -v "{}"
@@ -1145,14 +1141,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "SHIBUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "SHIBUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "SHIB-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "SHIB_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "SHIBUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "SHIB-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "SHIB-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "SHIBUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "SHIBUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "SHIB-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "SHIB_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "SHIBUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "SHIB-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SHIB/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "SHIB-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
     # Marketmap: SUI-USD
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD' -v "{}"
@@ -1166,14 +1161,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "SUIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "SUIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "SUI-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "SUI_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "suiusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "SUI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "SUI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "SUIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "SUIUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "SUI-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "SUI_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "suiusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "SUI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.SUI/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "SUI-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
     # Marketmap: XRP-USD
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD' -v "{}"
@@ -1187,14 +1181,14 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "XRPUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "XRPUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "XRP-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "XRP_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "xrpusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "XXRPZUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "XRP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "XRP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "XRPUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "XRPUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "XRP-USD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "XRP_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "xrpusdt", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "XXRPZUSD"}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "XRP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.XRP/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "XRP-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 
     # Marketmap: TEST-USD
@@ -1224,13 +1218,13 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "USDCUSDT", "invert": true}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "USDCUSDT", "invert": true}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "CoinbasePro", "off_chain_ticker": "USDT-USD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "Huobi", "off_chain_ticker": "ethusdt", "normalize_by_pair": {"Base": "ETH", "Quote": "USD"}, "invert": true}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "Kraken", "off_chain_ticker": "USDTZUSD"}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "BTC-USDT", "normalize_by_pair": {"Base": "BTC", "Quote": "USD"}, "invert": true}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "USDC-USDT", "invert": true}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "USDCUSDT", "invert": true}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "USDCUSDT", "invert": true}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "USDT-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "huobi_ws", "off_chain_ticker": "ethusdt", "normalize_by_pair": {"Base": "ETH", "Quote": "USD"}, "invert": true}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "USDTZUSD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "BTC-USDT", "normalize_by_pair": {"Base": "BTC", "Quote": "USD"}, "invert": true}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "USDC-USDT", "invert": true}'
 
 
     # Marketmap: DYDX-USD
@@ -1245,11 +1239,11 @@ function edit_genesis() {
     dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.ticker.min_provider_count' -v '3'
     dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.ticker.enabled' -v 'true'
 
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "Binance", "off_chain_ticker": "DYDXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "Bybit", "off_chain_ticker": "DYDXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "Gate", "off_chain_ticker": "DYDX_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "Kucoin", "off_chain_ticker": "DYDX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
-    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "Okx", "off_chain_ticker": "DYDX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "binance_ws", "off_chain_ticker": "DYDXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "DYDXUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "gate_ws", "off_chain_ticker": "DYDX_USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "DYDX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "DYDX-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}}'
 
 	# Update prices module.
 	# Market: BTC-USD


### PR DESCRIPTION
## In This PR
- I update all market-map provider configurations to reference the actual slinky provider names, as opposed to the old dydx provider names 
- The mapping between dydx provider names and slinky provider names can be found [here](https://github.com/skip-mev/slinky/blob/8729deac0431eb10f78c555dd0b9a63c81c3bac8/providers/apis/dydx/parse.go#L35)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standardized naming conventions for cryptocurrency exchange providers in the configuration file, enhancing clarity (e.g., "Binance" to "binance_ws").
  
- **Bug Fixes**
  - Updated application version to reflect improvements and fixes since the previous release (changed from "5.0.0-dev0-320-gcf745f40" to "5.0.0-dev0-404-gf14f3950").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->