### PR TITLE
[TRA-523] Switch localnet to use dydx_migration_api marketmap provider

### DIFF
--- a/protocol/contrib/slinky/oracle.json
+++ b/protocol/contrib/slinky/oracle.json
@@ -1,0 +1,26 @@
+{
+    "providers": {
+      "dydx_migration_api": {
+        "name": "dydx_migration_api",
+        "api": {
+          "enabled": true,
+          "timeout": 20000000000,
+          "interval": 10000000000,
+          "reconnectTimeout": 2000000000,
+          "maxQueries": 1,
+          "atomic": true,
+          "endpoints": [
+            {
+              "url": "http://dydxprotocold0:1317"
+            },
+            {
+              "url": "dydxprotocold0:9090"
+            }
+          ],
+          "batchSize": 0,
+          "name": "dydx_migration_api"
+        },
+        "type": "market_map_provider"
+      }
+    }
+}

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -113,11 +113,13 @@ services:
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
   slinky0:
-    image: ghcr.io/skip-mev/slinky-sidecar:v1.0.1
+    image: ghcr.io/skip-mev/slinky-sidecar:v1.0.5
     entrypoint: >
-      sh -c "slinky --marketmap-provider dydx_api --market-map-endpoint http://dydxprotocold0:1317 --update-market-config-path /etc/market.json --log-std-out-level error"
+      sh -c "slinky --marketmap-provider dydx_migration_api --oracle-config /etc/slinky/oracle.json --log-std-out-level error"
     environment:
       - SLINKY_CONFIG_PROVIDERS_RAYDIUM_API_API_ENDPOINTS_0_URL=${RAYDIUM_URL}
+    volumes:
+      - ./contrib/slinky:/etc/slinky
     ports:
       - "8080:8080"
       - "8002:8002" # metrics


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configuration for the dYdX migration API, enhancing system interaction and market mapping operations.
  - Updated service entrypoint to use the new market map provider, potentially improving data interaction.

- **Bug Fixes**
  - Updated Docker image to the latest version, likely including important fixes and enhancements.

- **Chores**
  - Added volume mapping for better access to configuration files and resources within the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->