### PR TITLE
return empty vault orders if clob pair does not exist or is in final settlement

### DIFF
--- a/protocol/x/vault/keeper/orders.go
+++ b/protocol/x/vault/keeper/orders.go
@@ -151,11 +151,8 @@ func (k Keeper) GetVaultClobOrders(
 ) (orders []*clobtypes.Order, err error) {
 	// Get clob pair, perpetual, market parameter, and market price that correspond to this vault.
 	clobPair, exists := k.clobKeeper.GetClobPair(ctx, clobtypes.ClobPairId(vaultId.Number))
-	if !exists {
-		return orders, errorsmod.Wrap(
-			types.ErrClobPairNotFound,
-			fmt.Sprintf("VaultId: %v", vaultId),
-		)
+	if !exists || clobPair.Status == clobtypes.ClobPair_STATUS_FINAL_SETTLEMENT {
+		return []*clobtypes.Order{}, nil
 	}
 	perpId := clobPair.Metadata.(*clobtypes.ClobPair_PerpetualClobMetadata).PerpetualClobMetadata.PerpetualId
 	perpetual, err := k.perpetualsKeeper.GetPerpetual(ctx, perpId)
@@ -349,11 +346,19 @@ func (k Keeper) GetVaultClobOrders(
 		}
 	}
 
-	orderIds, err := k.GetVaultClobOrderIds(ctx, vaultId)
-	if err != nil {
-		return orders, err
-	}
+	orderIds := k.GetVaultClobOrderIds(ctx, vaultId)
 	orders = make([]*clobtypes.Order, 2*quotingParams.Layers)
+	if len(orders) != len(orderIds) { // sanity check
+		return orders, errorsmod.Wrap(
+			types.ErrOrdersAndOrderIdsDiffLen,
+			fmt.Sprintf(
+				"VaultId: %v, len(Orders):%d, len(OrderIds):%d",
+				vaultId,
+				len(orders),
+				len(orderIds),
+			),
+		)
+	}
 	for i := uint32(0); i < quotingParams.Layers; i++ {
 		// Construct ask at this layer.
 		orders[2*i] = constructOrder(clobtypes.Order_SIDE_SELL, i, orderIds[2*i])
@@ -372,14 +377,7 @@ func (k Keeper) GetVaultClobOrders(
 func (k Keeper) GetVaultClobOrderIds(
 	ctx sdk.Context,
 	vaultId types.VaultId,
-) (orderIds []*clobtypes.OrderId, err error) {
-	clobPair, exists := k.clobKeeper.GetClobPair(ctx, clobtypes.ClobPairId(vaultId.Number))
-	if !exists {
-		return orderIds, errorsmod.Wrap(
-			types.ErrClobPairNotFound,
-			fmt.Sprintf("VaultId: %v", vaultId),
-		)
-	}
+) (orderIds []*clobtypes.OrderId) {
 	vault := vaultId.ToSubaccountId()
 	constructOrderId := func(
 		side clobtypes.Order_Side,
@@ -389,7 +387,7 @@ func (k Keeper) GetVaultClobOrderIds(
 			SubaccountId: *vault,
 			ClientId:     types.GetVaultClobOrderClientId(side, uint8(layer)),
 			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
-			ClobPairId:   clobPair.Id,
+			ClobPairId:   clobtypes.ClobPairId(vaultId.Number).ToUint32(),
 		}
 	}
 
@@ -403,7 +401,7 @@ func (k Keeper) GetVaultClobOrderIds(
 		orderIds[2*i+1] = constructOrderId(clobtypes.Order_SIDE_BUY, i)
 	}
 
-	return orderIds, nil
+	return orderIds
 }
 
 // PlaceVaultClobOrder places a vault CLOB order internal to the protocol, skipping various

--- a/protocol/x/vault/keeper/orders_test.go
+++ b/protocol/x/vault/keeper/orders_test.go
@@ -304,12 +304,11 @@ func TestRefreshVaultClobOrders(t *testing.T) {
 			},
 			ordersShouldRefresh: true,
 		},
-		"Error - Vault for non-existent Clob Pair 4321": {
+		"Success - Vault for non-existent Clob Pair 4321": {
 			vaultId: vaulttypes.VaultId{
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
 				Number: 4321,
 			},
-			expectedErr: vaulttypes.ErrClobPairNotFound,
 		},
 	}
 
@@ -397,8 +396,7 @@ func TestRefreshVaultClobOrders(t *testing.T) {
 				require.Equal(t, expectedClientIds, mostRecentClientIds)
 			}
 			// Get canonical and flipped client IDs of this vault's orders.
-			orderIds, err := tApp.App.VaultKeeper.GetVaultClobOrderIds(ctx, tc.vaultId)
-			require.NoError(t, err)
+			orderIds := tApp.App.VaultKeeper.GetVaultClobOrderIds(ctx, tc.vaultId)
 			canonicalClientIds := make([]uint32, len(orderIds))
 			flippedClientIds := make([]uint32, len(orderIds))
 			for i, orderId := range orderIds {
@@ -788,14 +786,36 @@ func TestGetVaultClobOrders(t *testing.T) {
 			// order size is 0.
 			expectedOrderQuantums: []uint64{},
 		},
-		"Error - Clob Pair doesn't exist": {
+		"Success - Clob Pair doesn't exist, Empty orders": {
+			vaultQuotingParams:    vaulttypes.DefaultQuotingParams(),
+			vaultId:               constants.Vault_Clob0,
+			clobPair:              constants.ClobPair_Eth,
+			marketParam:           constants.TestMarketParams[1],
+			marketPrice:           constants.TestMarketPrices[1],
+			perpetual:             constants.EthUsd_NoMarginRequirement,
+			expectedOrderSubticks: []uint64{},
+			expectedOrderQuantums: []uint64{},
+		},
+		"Success - Clob Pair in status final settlement, Empty orders": {
 			vaultQuotingParams: vaulttypes.DefaultQuotingParams(),
-			vaultId:            constants.Vault_Clob0,
-			clobPair:           constants.ClobPair_Eth,
-			marketParam:        constants.TestMarketParams[1],
-			marketPrice:        constants.TestMarketPrices[1],
-			perpetual:          constants.EthUsd_NoMarginRequirement,
-			expectedErr:        vaulttypes.ErrClobPairNotFound,
+			vaultId:            constants.Vault_Clob1,
+			clobPair: clobtypes.ClobPair{
+				Id: 1,
+				Metadata: &clobtypes.ClobPair_PerpetualClobMetadata{
+					PerpetualClobMetadata: &clobtypes.PerpetualClobMetadata{
+						PerpetualId: 1,
+					},
+				},
+				StepBaseQuantums:          1000,
+				SubticksPerTick:           1000,
+				QuantumConversionExponent: -9,
+				Status:                    clobtypes.ClobPair_STATUS_FINAL_SETTLEMENT,
+			},
+			marketParam:           constants.TestMarketParams[1],
+			marketPrice:           constants.TestMarketPrices[1],
+			perpetual:             constants.EthUsd_NoMarginRequirement,
+			expectedOrderSubticks: []uint64{},
+			expectedOrderQuantums: []uint64{},
 		},
 		"Error - Vault equity is zero": {
 			vaultQuotingParams:         vaulttypes.DefaultQuotingParams(),
@@ -993,13 +1013,12 @@ func TestGetVaultClobOrderIds(t *testing.T) {
 			vaultId: constants.Vault_Clob0,
 			layers:  0,
 		},
-		"Vault Clob 797 (non-existent clob pair), 2 layers": {
+		"Vault Clob 797, 2 layers": {
 			vaultId: vaulttypes.VaultId{
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
 				Number: 797,
 			},
-			layers:      2,
-			expectedErr: vaulttypes.ErrClobPairNotFound,
+			layers: 2,
 		},
 	}
 
@@ -1033,14 +1052,7 @@ func TestGetVaultClobOrderIds(t *testing.T) {
 			}
 
 			// Verify order IDs.
-			orderIds, err := k.GetVaultClobOrderIds(ctx, tc.vaultId)
-			if tc.expectedErr != nil {
-				require.ErrorContains(t, err, tc.expectedErr.Error())
-				require.Empty(t, orderIds)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, expectedOrderIds, orderIds)
-			}
+			require.Equal(t, expectedOrderIds, k.GetVaultClobOrderIds(ctx, tc.vaultId))
 		})
 	}
 }

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -10,84 +10,84 @@ var (
 		1,
 		"Shares are negative",
 	)
-	ErrClobPairNotFound = errorsmod.Register(
-		ModuleName,
-		2,
-		"ClobPair not found",
-	)
 	ErrMarketParamNotFound = errorsmod.Register(
 		ModuleName,
-		3,
+		2,
 		"MarketParam not found",
 	)
 	ErrInvalidDepositAmount = errorsmod.Register(
 		ModuleName,
-		4,
+		3,
 		"Deposit amount is invalid",
 	)
 	ErrNonPositiveEquity = errorsmod.Register(
 		ModuleName,
-		5,
+		4,
 		"Equity is non-positive",
 	)
 	ErrZeroDenominator = errorsmod.Register(
 		ModuleName,
-		6,
+		5,
 		"Denominator is zero",
 	)
 	ErrNilFraction = errorsmod.Register(
 		ModuleName,
-		7,
+		6,
 		"Fraction is nil",
 	)
 	ErrInvalidOrderSizePctPpm = errorsmod.Register(
 		ModuleName,
-		8,
+		7,
 		"OrderSizePctPpm must be strictly greater than 0",
 	)
 	ErrInvalidOrderExpirationSeconds = errorsmod.Register(
 		ModuleName,
-		9,
+		8,
 		"OrderExpirationSeconds must be strictly greater than 0",
 	)
 	ErrInvalidSpreadMinPpm = errorsmod.Register(
 		ModuleName,
-		10,
+		9,
 		"SpreadMinPpm must be strictly greater than 0",
 	)
 	ErrInvalidLayers = errorsmod.Register(
 		ModuleName,
-		11,
+		10,
 		"Layers must be less than or equal to MaxUint8",
 	)
 	ErrZeroSharesToMint = errorsmod.Register(
 		ModuleName,
-		12,
+		11,
 		"Cannot mint zero shares",
 	)
 	ErrInvalidActivationThresholdQuoteQuantums = errorsmod.Register(
 		ModuleName,
-		13,
+		12,
 		"ActivationThresholdQuoteQuantums must be non-negative",
 	)
 	ErrInvalidOrderSize = errorsmod.Register(
 		ModuleName,
-		14,
+		13,
 		"OrderSize is invalid",
 	)
 	ErrInvalidOwner = errorsmod.Register(
 		ModuleName,
-		15,
+		14,
 		"Owner is invalid",
 	)
 	ErrMismatchedTotalAndOwnerShares = errorsmod.Register(
 		ModuleName,
-		16,
+		15,
 		"TotalShares does not match sum of OwnerShares",
 	)
 	ErrZeroMarketPrice = errorsmod.Register(
 		ModuleName,
-		17,
+		16,
 		"MarketPrice is zero",
+	)
+	ErrOrdersAndOrderIdsDiffLen = errorsmod.Register(
+		ModuleName,
+		17,
+		"Orders and OrderIds must have the same length",
 	)
 )

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -10,84 +10,90 @@ var (
 		1,
 		"Shares are negative",
 	)
-	ErrMarketParamNotFound = errorsmod.Register(
+	// Deprecated since v6.x
+	ErrClobPairNotFound = errorsmod.Register(
 		ModuleName,
 		2,
+		"ClobPair not found",
+	)
+	ErrMarketParamNotFound = errorsmod.Register(
+		ModuleName,
+		3,
 		"MarketParam not found",
 	)
 	ErrInvalidDepositAmount = errorsmod.Register(
 		ModuleName,
-		3,
+		4,
 		"Deposit amount is invalid",
 	)
 	ErrNonPositiveEquity = errorsmod.Register(
 		ModuleName,
-		4,
+		5,
 		"Equity is non-positive",
 	)
 	ErrZeroDenominator = errorsmod.Register(
 		ModuleName,
-		5,
+		6,
 		"Denominator is zero",
 	)
 	ErrNilFraction = errorsmod.Register(
 		ModuleName,
-		6,
+		7,
 		"Fraction is nil",
 	)
 	ErrInvalidOrderSizePctPpm = errorsmod.Register(
 		ModuleName,
-		7,
+		8,
 		"OrderSizePctPpm must be strictly greater than 0",
 	)
 	ErrInvalidOrderExpirationSeconds = errorsmod.Register(
 		ModuleName,
-		8,
+		9,
 		"OrderExpirationSeconds must be strictly greater than 0",
 	)
 	ErrInvalidSpreadMinPpm = errorsmod.Register(
 		ModuleName,
-		9,
+		10,
 		"SpreadMinPpm must be strictly greater than 0",
 	)
 	ErrInvalidLayers = errorsmod.Register(
 		ModuleName,
-		10,
+		11,
 		"Layers must be less than or equal to MaxUint8",
 	)
 	ErrZeroSharesToMint = errorsmod.Register(
 		ModuleName,
-		11,
+		12,
 		"Cannot mint zero shares",
 	)
 	ErrInvalidActivationThresholdQuoteQuantums = errorsmod.Register(
 		ModuleName,
-		12,
+		13,
 		"ActivationThresholdQuoteQuantums must be non-negative",
 	)
 	ErrInvalidOrderSize = errorsmod.Register(
 		ModuleName,
-		13,
+		14,
 		"OrderSize is invalid",
 	)
 	ErrInvalidOwner = errorsmod.Register(
 		ModuleName,
-		14,
+		15,
 		"Owner is invalid",
 	)
 	ErrMismatchedTotalAndOwnerShares = errorsmod.Register(
 		ModuleName,
-		15,
+		16,
 		"TotalShares does not match sum of OwnerShares",
 	)
 	ErrZeroMarketPrice = errorsmod.Register(
 		ModuleName,
-		16,
+		17,
 		"MarketPrice is zero",
 	)
 	ErrOrdersAndOrderIdsDiffLen = errorsmod.Register(
 		ModuleName,
-		17,
+		18,
 		"Orders and OrderIds must have the same length",
 	)
 )


### PR DESCRIPTION
### Changelist
when clob pair doesn't exist or is in final settlement, return empty orders and `nil` error

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for Clob pairs, allowing for smoother processing when non-existent pairs are encountered.
	- Introduced additional sanity checks to validate order data integrity.

- **Bug Fixes**
	- Adjusted test scenarios to reflect successful handling of previously error-prone cases, leading to more robust functionality.

- **Chores**
	- Updated error registration logic for improved clarity and consistency in error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->