### PR TITLE
add gov msg that sets vault quoting params

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/tx.rpc.msg.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/tx.rpc.msg.ts
@@ -1,6 +1,6 @@
 import { Rpc } from "../../helpers";
 import * as _m0 from "protobufjs/minimal";
-import { MsgDepositToVault, MsgDepositToVaultResponse, MsgUpdateDefaultQuotingParams, MsgUpdateDefaultQuotingParamsResponse } from "./tx";
+import { MsgDepositToVault, MsgDepositToVaultResponse, MsgUpdateDefaultQuotingParams, MsgUpdateDefaultQuotingParamsResponse, MsgSetVaultQuotingParams, MsgSetVaultQuotingParamsResponse } from "./tx";
 /** Msg defines the Msg service. */
 
 export interface Msg {
@@ -9,6 +9,9 @@ export interface Msg {
   /** UpdateDefaultQuotingParams updates the default quoting params in state. */
 
   updateDefaultQuotingParams(request: MsgUpdateDefaultQuotingParams): Promise<MsgUpdateDefaultQuotingParamsResponse>;
+  /** SetVaultQuotingParams sets the quoting parameters of a specific vault. */
+
+  setVaultQuotingParams(request: MsgSetVaultQuotingParams): Promise<MsgSetVaultQuotingParamsResponse>;
 }
 export class MsgClientImpl implements Msg {
   private readonly rpc: Rpc;
@@ -17,6 +20,7 @@ export class MsgClientImpl implements Msg {
     this.rpc = rpc;
     this.depositToVault = this.depositToVault.bind(this);
     this.updateDefaultQuotingParams = this.updateDefaultQuotingParams.bind(this);
+    this.setVaultQuotingParams = this.setVaultQuotingParams.bind(this);
   }
 
   depositToVault(request: MsgDepositToVault): Promise<MsgDepositToVaultResponse> {
@@ -29,6 +33,12 @@ export class MsgClientImpl implements Msg {
     const data = MsgUpdateDefaultQuotingParams.encode(request).finish();
     const promise = this.rpc.request("dydxprotocol.vault.Msg", "UpdateDefaultQuotingParams", data);
     return promise.then(data => MsgUpdateDefaultQuotingParamsResponse.decode(new _m0.Reader(data)));
+  }
+
+  setVaultQuotingParams(request: MsgSetVaultQuotingParams): Promise<MsgSetVaultQuotingParamsResponse> {
+    const data = MsgSetVaultQuotingParams.encode(request).finish();
+    const promise = this.rpc.request("dydxprotocol.vault.Msg", "SetVaultQuotingParams", data);
+    return promise.then(data => MsgSetVaultQuotingParamsResponse.decode(new _m0.Reader(data)));
   }
 
 }

--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/tx.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/tx.ts
@@ -73,6 +73,40 @@ export interface MsgUpdateDefaultQuotingParamsResponse {}
  */
 
 export interface MsgUpdateDefaultQuotingParamsResponseSDKType {}
+/** MsgSetVaultQuotingParams is the Msg/SetVaultQuotingParams request type. */
+
+export interface MsgSetVaultQuotingParams {
+  authority: string;
+  /** The vault to set quoting params of. */
+
+  vaultId?: VaultId;
+  /** The quoting parameters to set. Each field must be set. */
+
+  quotingParams?: QuotingParams;
+}
+/** MsgSetVaultQuotingParams is the Msg/SetVaultQuotingParams request type. */
+
+export interface MsgSetVaultQuotingParamsSDKType {
+  authority: string;
+  /** The vault to set quoting params of. */
+
+  vault_id?: VaultIdSDKType;
+  /** The quoting parameters to set. Each field must be set. */
+
+  quoting_params?: QuotingParamsSDKType;
+}
+/**
+ * MsgSetVaultQuotingParamsResponse is the Msg/SetVaultQuotingParams response
+ * type.
+ */
+
+export interface MsgSetVaultQuotingParamsResponse {}
+/**
+ * MsgSetVaultQuotingParamsResponse is the Msg/SetVaultQuotingParams response
+ * type.
+ */
+
+export interface MsgSetVaultQuotingParamsResponseSDKType {}
 
 function createBaseMsgDepositToVault(): MsgDepositToVault {
   return {
@@ -257,6 +291,105 @@ export const MsgUpdateDefaultQuotingParamsResponse = {
 
   fromPartial(_: DeepPartial<MsgUpdateDefaultQuotingParamsResponse>): MsgUpdateDefaultQuotingParamsResponse {
     const message = createBaseMsgUpdateDefaultQuotingParamsResponse();
+    return message;
+  }
+
+};
+
+function createBaseMsgSetVaultQuotingParams(): MsgSetVaultQuotingParams {
+  return {
+    authority: "",
+    vaultId: undefined,
+    quotingParams: undefined
+  };
+}
+
+export const MsgSetVaultQuotingParams = {
+  encode(message: MsgSetVaultQuotingParams, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.authority !== "") {
+      writer.uint32(10).string(message.authority);
+    }
+
+    if (message.vaultId !== undefined) {
+      VaultId.encode(message.vaultId, writer.uint32(18).fork()).ldelim();
+    }
+
+    if (message.quotingParams !== undefined) {
+      QuotingParams.encode(message.quotingParams, writer.uint32(26).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgSetVaultQuotingParams {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgSetVaultQuotingParams();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.authority = reader.string();
+          break;
+
+        case 2:
+          message.vaultId = VaultId.decode(reader, reader.uint32());
+          break;
+
+        case 3:
+          message.quotingParams = QuotingParams.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<MsgSetVaultQuotingParams>): MsgSetVaultQuotingParams {
+    const message = createBaseMsgSetVaultQuotingParams();
+    message.authority = object.authority ?? "";
+    message.vaultId = object.vaultId !== undefined && object.vaultId !== null ? VaultId.fromPartial(object.vaultId) : undefined;
+    message.quotingParams = object.quotingParams !== undefined && object.quotingParams !== null ? QuotingParams.fromPartial(object.quotingParams) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseMsgSetVaultQuotingParamsResponse(): MsgSetVaultQuotingParamsResponse {
+  return {};
+}
+
+export const MsgSetVaultQuotingParamsResponse = {
+  encode(_: MsgSetVaultQuotingParamsResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgSetVaultQuotingParamsResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgSetVaultQuotingParamsResponse();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(_: DeepPartial<MsgSetVaultQuotingParamsResponse>): MsgSetVaultQuotingParamsResponse {
+    const message = createBaseMsgSetVaultQuotingParamsResponse();
     return message;
   }
 

--- a/proto/dydxprotocol/vault/tx.proto
+++ b/proto/dydxprotocol/vault/tx.proto
@@ -18,6 +18,10 @@ service Msg {
   // UpdateDefaultQuotingParams updates the default quoting params in state.
   rpc UpdateDefaultQuotingParams(MsgUpdateDefaultQuotingParams)
       returns (MsgUpdateDefaultQuotingParamsResponse);
+
+  // SetVaultQuotingParams sets the quoting parameters of a specific vault.
+  rpc SetVaultQuotingParams(MsgSetVaultQuotingParams)
+      returns (MsgSetVaultQuotingParamsResponse);
 }
 
 // MsgDepositToVault deposits the specified asset from the subaccount to the
@@ -59,3 +63,20 @@ message MsgUpdateDefaultQuotingParams {
 // MsgUpdateDefaultQuotingParamsResponse is the Msg/UpdateDefaultQuotingParams
 // response type.
 message MsgUpdateDefaultQuotingParamsResponse {}
+
+// MsgSetVaultQuotingParams is the Msg/SetVaultQuotingParams request type.
+message MsgSetVaultQuotingParams {
+  // Authority is the address that controls the module.
+  option (cosmos.msg.v1.signer) = "authority";
+  string authority = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+
+  // The vault to set quoting params of.
+  VaultId vault_id = 2 [ (gogoproto.nullable) = false ];
+
+  // The quoting parameters to set. Each field must be set.
+  QuotingParams quoting_params = 3 [ (gogoproto.nullable) = false ];
+}
+
+// MsgSetVaultQuotingParamsResponse is the Msg/SetVaultQuotingParams response
+// type.
+message MsgSetVaultQuotingParamsResponse {}

--- a/protocol/app/msgs/all_msgs.go
+++ b/protocol/app/msgs/all_msgs.go
@@ -243,10 +243,10 @@ var (
 		// vault
 		"/dydxprotocol.vault.MsgDepositToVault":                     {},
 		"/dydxprotocol.vault.MsgDepositToVaultResponse":             {},
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams":         {},
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse": {},
 		"/dydxprotocol.vault.MsgSetVaultQuotingParams":              {},
 		"/dydxprotocol.vault.MsgSetVaultQuotingParamsResponse":      {},
+		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams":         {},
+		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse": {},
 
 		// vest
 		"/dydxprotocol.vest.MsgSetVestEntry":            {},

--- a/protocol/app/msgs/all_msgs.go
+++ b/protocol/app/msgs/all_msgs.go
@@ -245,6 +245,8 @@ var (
 		"/dydxprotocol.vault.MsgDepositToVaultResponse":             {},
 		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams":         {},
 		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse": {},
+		"/dydxprotocol.vault.MsgSetVaultQuotingParams":              {},
+		"/dydxprotocol.vault.MsgSetVaultQuotingParamsResponse":      {},
 
 		// vest
 		"/dydxprotocol.vest.MsgSetVestEntry":            {},

--- a/protocol/app/msgs/internal_msgs.go
+++ b/protocol/app/msgs/internal_msgs.go
@@ -188,6 +188,8 @@ var (
 		// vault
 		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams":         &vault.MsgUpdateDefaultQuotingParams{},
 		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse": nil,
+		"/dydxprotocol.vault.MsgSetVaultQuotingParams":              &vault.MsgSetVaultQuotingParams{},
+		"/dydxprotocol.vault.MsgSetVaultQuotingParamsResponse":      nil,
 
 		// vest
 		"/dydxprotocol.vest.MsgSetVestEntry":            &vest.MsgSetVestEntry{},

--- a/protocol/app/msgs/internal_msgs.go
+++ b/protocol/app/msgs/internal_msgs.go
@@ -186,10 +186,10 @@ var (
 		"/dydxprotocol.stats.MsgUpdateParamsResponse": nil,
 
 		// vault
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams":         &vault.MsgUpdateDefaultQuotingParams{},
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse": nil,
 		"/dydxprotocol.vault.MsgSetVaultQuotingParams":              &vault.MsgSetVaultQuotingParams{},
 		"/dydxprotocol.vault.MsgSetVaultQuotingParamsResponse":      nil,
+		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams":         &vault.MsgUpdateDefaultQuotingParams{},
+		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse": nil,
 
 		// vest
 		"/dydxprotocol.vest.MsgSetVestEntry":            &vest.MsgSetVestEntry{},

--- a/protocol/app/msgs/internal_msgs_test.go
+++ b/protocol/app/msgs/internal_msgs_test.go
@@ -146,6 +146,8 @@ func TestInternalMsgSamples_Gov_Key(t *testing.T) {
 		// vault
 		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams",
 		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse",
+		"/dydxprotocol.vault.MsgSetVaultQuotingParams",
+		"/dydxprotocol.vault.MsgSetVaultQuotingParamsResponse",
 
 		// vest
 		"/dydxprotocol.vest.MsgDeleteVestEntry",

--- a/protocol/app/msgs/internal_msgs_test.go
+++ b/protocol/app/msgs/internal_msgs_test.go
@@ -144,10 +144,10 @@ func TestInternalMsgSamples_Gov_Key(t *testing.T) {
 		"/dydxprotocol.stats.MsgUpdateParamsResponse",
 
 		// vault
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams",
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse",
 		"/dydxprotocol.vault.MsgSetVaultQuotingParams",
 		"/dydxprotocol.vault.MsgSetVaultQuotingParamsResponse",
+		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams",
+		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse",
 
 		// vest
 		"/dydxprotocol.vest.MsgDeleteVestEntry",

--- a/protocol/lib/ante/internal_msg.go
+++ b/protocol/lib/ante/internal_msg.go
@@ -126,8 +126,8 @@ func IsInternalMsg(msg sdk.Msg) bool {
 		*stats.MsgUpdateParams,
 
 		// vault
-		*vault.MsgUpdateDefaultQuotingParams,
 		*vault.MsgSetVaultQuotingParams,
+		*vault.MsgUpdateDefaultQuotingParams,
 
 		// vest
 		*vest.MsgDeleteVestEntry,

--- a/protocol/lib/ante/internal_msg.go
+++ b/protocol/lib/ante/internal_msg.go
@@ -127,6 +127,7 @@ func IsInternalMsg(msg sdk.Msg) bool {
 
 		// vault
 		*vault.MsgUpdateDefaultQuotingParams,
+		*vault.MsgSetVaultQuotingParams,
 
 		// vest
 		*vest.MsgDeleteVestEntry,

--- a/protocol/testutil/constants/vault.go
+++ b/protocol/testutil/constants/vault.go
@@ -20,4 +20,14 @@ var (
 		SubaccountId:  &Alice_Num0,
 		QuoteQuantums: dtypes.NewInt(100),
 	}
+
+	QuotingParams = types.QuotingParams{
+		Layers:                           3,
+		SpreadMinPpm:                     4_321,
+		SpreadBufferPpm:                  1_789,
+		SkewFactorPpm:                    767_323,
+		OrderSizePctPpm:                  234_567,
+		OrderExpirationSeconds:           111,
+		ActivationThresholdQuoteQuantums: dtypes.NewInt(9_876_543),
+	}
 )

--- a/protocol/x/vault/keeper/msg_server_set_vault_quoting_params.go
+++ b/protocol/x/vault/keeper/msg_server_set_vault_quoting_params.go
@@ -1,0 +1,40 @@
+package keeper
+
+import (
+	"context"
+
+	errorsmod "cosmossdk.io/errors"
+
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+)
+
+// SetVaultQuotingParams sets the quoting parameters of a specific vault.
+func (k msgServer) SetVaultQuotingParams(
+	goCtx context.Context,
+	msg *types.MsgSetVaultQuotingParams,
+) (*types.MsgSetVaultQuotingParamsResponse, error) {
+	// Check if authority is valid.
+	if !k.HasAuthority(msg.Authority) {
+		return nil, errorsmod.Wrapf(
+			govtypes.ErrInvalidSigner,
+			"invalid authority %s",
+			msg.Authority,
+		)
+	}
+
+	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
+
+	// Validate quoting parameters.
+	if err := msg.QuotingParams.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Set quoting parameters for specified vault.
+	if err := k.Keeper.SetVaultQuotingParams(ctx, msg.VaultId, msg.QuotingParams); err != nil {
+		return nil, err
+	}
+
+	return &types.MsgSetVaultQuotingParamsResponse{}, nil
+}

--- a/protocol/x/vault/keeper/msg_server_set_vault_quoting_params_test.go
+++ b/protocol/x/vault/keeper/msg_server_set_vault_quoting_params_test.go
@@ -1,0 +1,89 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
+
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgSetVaultQuotingParams(t *testing.T) {
+	tests := map[string]struct {
+		// Msg.
+		msg *types.MsgSetVaultQuotingParams
+		// Expected error
+		expectedErr string
+	}{
+		"Success - Vault Clob 0": {
+			msg: &types.MsgSetVaultQuotingParams{
+				Authority:     lib.GovModuleAddress.String(),
+				VaultId:       constants.Vault_Clob0,
+				QuotingParams: constants.QuotingParams,
+			},
+		},
+		"Success - Vault Clob 1": {
+			msg: &types.MsgSetVaultQuotingParams{
+				Authority:     lib.GovModuleAddress.String(),
+				VaultId:       constants.Vault_Clob1,
+				QuotingParams: constants.QuotingParams,
+			},
+		},
+		"Failure - Invalid Authority": {
+			msg: &types.MsgSetVaultQuotingParams{
+				Authority:     constants.AliceAccAddress.String(),
+				VaultId:       constants.Vault_Clob0,
+				QuotingParams: constants.QuotingParams,
+			},
+			expectedErr: "invalid authority",
+		},
+		"Failure - Vault Clob 0. Invalid Quoting Params": {
+			msg: &types.MsgSetVaultQuotingParams{
+				Authority: lib.GovModuleAddress.String(),
+				VaultId:   constants.Vault_Clob0,
+				QuotingParams: types.QuotingParams{
+					Layers:                           3,
+					SpreadMinPpm:                     4_000,
+					SpreadBufferPpm:                  2_000,
+					SkewFactorPpm:                    500_000,
+					OrderSizePctPpm:                  100_000,
+					OrderExpirationSeconds:           5,
+					ActivationThresholdQuoteQuantums: dtypes.NewInt(-1), // invalid
+				},
+			},
+			expectedErr: types.ErrInvalidActivationThresholdQuoteQuantums.Error(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).Build()
+			ctx := tApp.InitChain()
+			k := tApp.App.VaultKeeper
+			ms := keeper.NewMsgServerImpl(k)
+
+			_, err := ms.SetVaultQuotingParams(ctx, tc.msg)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				require.Equal(
+					t,
+					types.DefaultQuotingParams(),
+					k.GetVaultQuotingParams(ctx, tc.msg.VaultId),
+				)
+			} else {
+				require.NoError(t, err)
+				require.Equal(
+					t,
+					tc.msg.QuotingParams,
+					k.GetVaultQuotingParams(ctx, tc.msg.VaultId),
+				)
+			}
+		})
+	}
+}

--- a/protocol/x/vault/keeper/msg_server_set_vault_quoting_params_test.go
+++ b/protocol/x/vault/keeper/msg_server_set_vault_quoting_params_test.go
@@ -43,6 +43,14 @@ func TestMsgSetVaultQuotingParams(t *testing.T) {
 			},
 			expectedErr: "invalid authority",
 		},
+		"Failure - Empty Authority": {
+			msg: &types.MsgSetVaultQuotingParams{
+				Authority:     "",
+				VaultId:       constants.Vault_Clob0,
+				QuotingParams: constants.QuotingParams,
+			},
+			expectedErr: "invalid authority",
+		},
 		"Failure - Vault Clob 0. Invalid Quoting Params": {
 			msg: &types.MsgSetVaultQuotingParams{
 				Authority: lib.GovModuleAddress.String(),

--- a/protocol/x/vault/keeper/vault.go
+++ b/protocol/x/vault/keeper/vault.go
@@ -82,7 +82,10 @@ func (k Keeper) DecommissionNonPositiveEquityVaults(
 	}
 }
 
-// DecommissionVault decommissions a vault by deleting its total shares and owner shares.
+// DecommissionVault decommissions a vault by
+// 1. deleting its total shares and owner shares
+// 2. deleting its address from vault address store
+// 3. deleting its quoting params if any
 func (k Keeper) DecommissionVault(
 	ctx sdk.Context,
 	vaultId types.VaultId,
@@ -102,6 +105,10 @@ func (k Keeper) DecommissionVault(
 	// Delete from vault address store.
 	vaultAddressStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.VaultAddressKeyPrefix))
 	vaultAddressStore.Delete([]byte(vaultId.ToModuleAccountAddress()))
+
+	// Delete vault quoting params if any.
+	vaultQuotingParamsStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.QuotingParamsKeyPrefix))
+	vaultQuotingParamsStore.Delete(vaultId.ToStateKey())
 }
 
 // AddVaultToAddressStore adds a vault's address to the vault address store.

--- a/protocol/x/vault/keeper/vault_test.go
+++ b/protocol/x/vault/keeper/vault_test.go
@@ -160,26 +160,30 @@ func TestDecommissionVault(t *testing.T) {
 		totalSharesExists bool
 		// Owners.
 		owners []string
+		// Vault quoting params.
+		quotingParams *vaulttypes.QuotingParams
 	}{
-		"Total shares doesn't exist, no owners": {
+		"Total shares doesn't exist, no owners, default quoting params": {
 			vaultId: constants.Vault_Clob0,
 		},
-		"Total shares exists, no owners": {
+		"Total shares exists, no owners, default quoting params": {
 			vaultId:           constants.Vault_Clob0,
 			totalSharesExists: true,
 		},
-		"Total shares exists, one owner": {
+		"Total shares exists, one owner, non-default quoting params": {
 			vaultId:           constants.Vault_Clob1,
 			totalSharesExists: true,
 			owners:            []string{constants.Alice_Num0.Owner},
+			quotingParams:     &constants.QuotingParams,
 		},
-		"Total shares exists, two owners": {
+		"Total shares exists, two owners, non-default quoting params": {
 			vaultId:           constants.Vault_Clob1,
 			totalSharesExists: true,
 			owners: []string{
 				constants.Alice_Num0.Owner,
 				constants.Bob_Num0.Owner,
 			},
+			quotingParams: &constants.QuotingParams,
 		},
 	}
 	for name, tc := range tests {
@@ -210,6 +214,10 @@ func TestDecommissionVault(t *testing.T) {
 				)
 				require.NoError(t, err)
 			}
+			if tc.quotingParams != nil {
+				err := k.SetVaultQuotingParams(ctx, tc.vaultId, *tc.quotingParams)
+				require.NoError(t, err)
+			}
 
 			// Decommission vault.
 			k.DecommissionVault(ctx, tc.vaultId)
@@ -222,6 +230,12 @@ func TestDecommissionVault(t *testing.T) {
 				require.Equal(t, false, exists)
 			}
 			require.False(t, k.IsVault(ctx, tc.vaultId.ToModuleAccountAddress()))
+			// Check that vault quoting params are back to default.
+			require.Equal(
+				t,
+				k.GetDefaultQuotingParams(ctx),
+				k.GetVaultQuotingParams(ctx, tc.vaultId),
+			)
 		})
 	}
 }

--- a/protocol/x/vault/types/tx.pb.go
+++ b/protocol/x/vault/types/tx.pb.go
@@ -220,51 +220,157 @@ func (m *MsgUpdateDefaultQuotingParamsResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgUpdateDefaultQuotingParamsResponse proto.InternalMessageInfo
 
+// MsgSetVaultQuotingParams is the Msg/SetVaultQuotingParams request type.
+type MsgSetVaultQuotingParams struct {
+	Authority string `protobuf:"bytes,1,opt,name=authority,proto3" json:"authority,omitempty"`
+	// The vault to set quoting params of.
+	VaultId VaultId `protobuf:"bytes,2,opt,name=vault_id,json=vaultId,proto3" json:"vault_id"`
+	// The quoting parameters to set. Each field must be set.
+	QuotingParams QuotingParams `protobuf:"bytes,3,opt,name=quoting_params,json=quotingParams,proto3" json:"quoting_params"`
+}
+
+func (m *MsgSetVaultQuotingParams) Reset()         { *m = MsgSetVaultQuotingParams{} }
+func (m *MsgSetVaultQuotingParams) String() string { return proto.CompactTextString(m) }
+func (*MsgSetVaultQuotingParams) ProtoMessage()    {}
+func (*MsgSetVaultQuotingParams) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ced574c6017ce006, []int{4}
+}
+func (m *MsgSetVaultQuotingParams) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgSetVaultQuotingParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgSetVaultQuotingParams.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgSetVaultQuotingParams) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgSetVaultQuotingParams.Merge(m, src)
+}
+func (m *MsgSetVaultQuotingParams) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgSetVaultQuotingParams) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgSetVaultQuotingParams.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgSetVaultQuotingParams proto.InternalMessageInfo
+
+func (m *MsgSetVaultQuotingParams) GetAuthority() string {
+	if m != nil {
+		return m.Authority
+	}
+	return ""
+}
+
+func (m *MsgSetVaultQuotingParams) GetVaultId() VaultId {
+	if m != nil {
+		return m.VaultId
+	}
+	return VaultId{}
+}
+
+func (m *MsgSetVaultQuotingParams) GetQuotingParams() QuotingParams {
+	if m != nil {
+		return m.QuotingParams
+	}
+	return QuotingParams{}
+}
+
+// MsgSetVaultQuotingParamsResponse is the Msg/SetVaultQuotingParams response
+// type.
+type MsgSetVaultQuotingParamsResponse struct {
+}
+
+func (m *MsgSetVaultQuotingParamsResponse) Reset()         { *m = MsgSetVaultQuotingParamsResponse{} }
+func (m *MsgSetVaultQuotingParamsResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgSetVaultQuotingParamsResponse) ProtoMessage()    {}
+func (*MsgSetVaultQuotingParamsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ced574c6017ce006, []int{5}
+}
+func (m *MsgSetVaultQuotingParamsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgSetVaultQuotingParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgSetVaultQuotingParamsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgSetVaultQuotingParamsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgSetVaultQuotingParamsResponse.Merge(m, src)
+}
+func (m *MsgSetVaultQuotingParamsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgSetVaultQuotingParamsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgSetVaultQuotingParamsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgSetVaultQuotingParamsResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgDepositToVault)(nil), "dydxprotocol.vault.MsgDepositToVault")
 	proto.RegisterType((*MsgDepositToVaultResponse)(nil), "dydxprotocol.vault.MsgDepositToVaultResponse")
 	proto.RegisterType((*MsgUpdateDefaultQuotingParams)(nil), "dydxprotocol.vault.MsgUpdateDefaultQuotingParams")
 	proto.RegisterType((*MsgUpdateDefaultQuotingParamsResponse)(nil), "dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse")
+	proto.RegisterType((*MsgSetVaultQuotingParams)(nil), "dydxprotocol.vault.MsgSetVaultQuotingParams")
+	proto.RegisterType((*MsgSetVaultQuotingParamsResponse)(nil), "dydxprotocol.vault.MsgSetVaultQuotingParamsResponse")
 }
 
 func init() { proto.RegisterFile("dydxprotocol/vault/tx.proto", fileDescriptor_ced574c6017ce006) }
 
 var fileDescriptor_ced574c6017ce006 = []byte{
-	// 529 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xc1, 0x6e, 0xd3, 0x40,
-	0x10, 0x8d, 0x5b, 0x04, 0x74, 0x69, 0x23, 0xb1, 0x8a, 0x20, 0x75, 0x84, 0x53, 0x22, 0x15, 0x0a,
-	0x52, 0x6c, 0xb5, 0xa0, 0x22, 0x7a, 0x82, 0xa8, 0x07, 0x22, 0x14, 0x89, 0x38, 0xc0, 0x01, 0x09,
-	0x59, 0x1b, 0xef, 0xd6, 0xb1, 0x14, 0x7b, 0x1d, 0xef, 0x3a, 0x4a, 0x38, 0x72, 0xe4, 0xc4, 0x0f,
-	0xf0, 0x0f, 0x1c, 0xf8, 0x06, 0xd4, 0x63, 0xc5, 0x09, 0x71, 0xa8, 0x50, 0x72, 0xe0, 0x1f, 0x38,
-	0x21, 0xef, 0xda, 0x4d, 0x4c, 0xdc, 0x2a, 0xbd, 0x24, 0xb3, 0x33, 0xf3, 0x66, 0xe6, 0xbd, 0x19,
-	0x19, 0x54, 0xf0, 0x18, 0x8f, 0x82, 0x90, 0x72, 0x6a, 0xd3, 0xbe, 0x31, 0x44, 0x51, 0x9f, 0x1b,
-	0x7c, 0xa4, 0x0b, 0x0f, 0x84, 0xf3, 0x41, 0x5d, 0x04, 0xd5, 0x4d, 0x9b, 0x32, 0x8f, 0x32, 0x4b,
-	0xb8, 0x0d, 0xf9, 0x90, 0xe9, 0xea, 0x6d, 0xf9, 0x32, 0x3c, 0xe6, 0x18, 0xc3, 0xdd, 0xf8, 0x2f,
-	0x09, 0x3c, 0xc8, 0x34, 0x61, 0x51, 0x17, 0xd9, 0x36, 0x8d, 0x7c, 0xce, 0xe6, 0xec, 0x24, 0xb5,
-	0x9a, 0x33, 0x4f, 0x80, 0x42, 0xe4, 0xa5, 0x4d, 0xb4, 0x9c, 0x04, 0xf1, 0x9b, 0xc4, 0x4b, 0x0e,
-	0x75, 0xa8, 0x1c, 0x2e, 0xb6, 0xa4, 0xb7, 0xf6, 0x65, 0x05, 0xdc, 0x6c, 0x31, 0xe7, 0x90, 0x04,
-	0x94, 0xb9, 0xfc, 0x35, 0x7d, 0x1b, 0x23, 0xe0, 0x3e, 0xb8, 0x2e, 0xa0, 0x96, 0x8b, 0xcb, 0xca,
-	0x96, 0xb2, 0x73, 0x63, 0xaf, 0xa2, 0x2f, 0x52, 0xd6, 0x45, 0x72, 0x13, 0x9b, 0xd7, 0x86, 0xd2,
-	0x80, 0x2f, 0xc1, 0xc6, 0x6c, 0xf0, 0x18, 0xbc, 0x22, 0xc0, 0xf7, 0xb2, 0xe0, 0x39, 0x9e, 0x7a,
-	0xe7, 0xcc, 0x6e, 0x62, 0x73, 0x9d, 0xcd, 0xbd, 0x20, 0x05, 0xc5, 0x41, 0x44, 0x39, 0xb1, 0x06,
-	0x11, 0xf2, 0x79, 0xe4, 0xb1, 0xf2, 0xea, 0x96, 0xb2, 0xb3, 0xde, 0x78, 0x71, 0x7c, 0x5a, 0x2d,
-	0xfc, 0x3a, 0xad, 0x3e, 0x73, 0x5c, 0xde, 0x8b, 0xba, 0xba, 0x4d, 0x3d, 0x23, 0xcb, 0xfd, 0x71,
-	0xdd, 0xee, 0x21, 0xd7, 0x37, 0xce, 0x3c, 0x98, 0x8f, 0x03, 0xc2, 0xf4, 0x0e, 0x09, 0x5d, 0xd4,
-	0x77, 0x3f, 0xa0, 0x6e, 0x9f, 0x34, 0x7d, 0x6e, 0x6e, 0x88, 0xfa, 0xed, 0xa4, 0xfc, 0x01, 0xfc,
-	0xf8, 0xe7, 0xeb, 0xc3, 0x2c, 0x81, 0x5a, 0x05, 0x6c, 0x2e, 0xc8, 0x63, 0x12, 0x16, 0x50, 0x9f,
-	0x91, 0xda, 0x77, 0x05, 0xdc, 0x69, 0x31, 0xe7, 0x4d, 0x80, 0x11, 0x27, 0x87, 0xe4, 0x28, 0x0e,
-	0xb6, 0x23, 0xca, 0x5d, 0xdf, 0x79, 0x25, 0x56, 0x03, 0xf7, 0xc1, 0x1a, 0x8a, 0x78, 0x8f, 0x86,
-	0x2e, 0x1f, 0x0b, 0x25, 0xd7, 0x1a, 0xe5, 0x1f, 0xdf, 0xea, 0xa5, 0xe4, 0x3c, 0x9e, 0x63, 0x1c,
-	0x12, 0xc6, 0x3a, 0x3c, 0x74, 0x7d, 0xc7, 0x9c, 0xa5, 0xc2, 0xf7, 0xe0, 0x16, 0x96, 0xf5, 0xac,
-	0x81, 0x2c, 0x68, 0xc9, 0x65, 0x27, 0x8a, 0xde, 0xcd, 0x5b, 0x47, 0xa6, 0x75, 0xe3, 0x4a, 0x2c,
-	0x93, 0x59, 0xc2, 0x39, 0x63, 0x1d, 0x14, 0x63, 0xa6, 0xb3, 0x76, 0xb5, 0xfb, 0x60, 0xfb, 0x42,
-	0x1e, 0x29, 0xe3, 0xbd, 0xbf, 0x0a, 0x58, 0x6d, 0x31, 0x07, 0x1e, 0x81, 0xe2, 0x7f, 0x27, 0xb3,
-	0x9d, 0x37, 0xd1, 0x82, 0x74, 0x6a, 0x7d, 0xa9, 0xb4, 0xb4, 0x1f, 0xfc, 0xa4, 0x00, 0xf5, 0x02,
-	0x79, 0x77, 0xcf, 0xa9, 0x76, 0x3e, 0x44, 0x7d, 0x7a, 0x69, 0x48, 0x3a, 0x4c, 0xa3, 0x7d, 0x3c,
-	0xd1, 0x94, 0x93, 0x89, 0xa6, 0xfc, 0x9e, 0x68, 0xca, 0xe7, 0xa9, 0x56, 0x38, 0x99, 0x6a, 0x85,
-	0x9f, 0x53, 0xad, 0xf0, 0xee, 0xc9, 0xf2, 0xa7, 0x38, 0x4a, 0xbf, 0x25, 0xf1, 0x45, 0x76, 0xaf,
-	0x0a, 0xff, 0xa3, 0x7f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x6a, 0x66, 0x7c, 0x37, 0x6e, 0x04, 0x00,
-	0x00,
+	// 590 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0xcf, 0x8e, 0xd2, 0x40,
+	0x1c, 0xa6, 0x60, 0xd4, 0x1d, 0x17, 0x12, 0x1b, 0x54, 0xb6, 0xc4, 0x82, 0x24, 0xab, 0xab, 0x91,
+	0x36, 0xbb, 0x6e, 0xd6, 0xb8, 0xf1, 0xa0, 0x64, 0x0f, 0x12, 0x83, 0x91, 0xa2, 0x7b, 0x30, 0x31,
+	0xa4, 0x74, 0x66, 0x4b, 0x13, 0xe8, 0x94, 0xce, 0x94, 0x80, 0xde, 0x3c, 0x7a, 0xf2, 0x05, 0x7c,
+	0x07, 0x0f, 0x3e, 0x83, 0xd9, 0xe3, 0xc6, 0x93, 0xf1, 0xb0, 0x31, 0x70, 0xf0, 0xea, 0xcd, 0xab,
+	0xe9, 0x4c, 0x81, 0x56, 0x0a, 0x2e, 0x89, 0x17, 0xf8, 0xcd, 0xef, 0xff, 0xf7, 0xcd, 0xd7, 0x01,
+	0x79, 0x38, 0x84, 0x03, 0xc7, 0xc5, 0x14, 0x1b, 0xb8, 0xa3, 0xf6, 0x75, 0xaf, 0x43, 0x55, 0x3a,
+	0x50, 0x98, 0x47, 0x14, 0xc3, 0x41, 0x85, 0x05, 0xa5, 0x0d, 0x03, 0x93, 0x2e, 0x26, 0x4d, 0xe6,
+	0x56, 0xf9, 0x81, 0xa7, 0x4b, 0xd7, 0xf8, 0x49, 0xed, 0x12, 0x53, 0xed, 0x6f, 0xfb, 0x7f, 0x41,
+	0xe0, 0x76, 0x64, 0x08, 0xf1, 0x5a, 0xba, 0x61, 0x60, 0xcf, 0xa6, 0x24, 0x64, 0x07, 0xa9, 0x85,
+	0x98, 0x7d, 0x1c, 0xdd, 0xd5, 0xbb, 0x93, 0x21, 0x72, 0x4c, 0x02, 0xfb, 0x0d, 0xe2, 0x59, 0x13,
+	0x9b, 0x98, 0x2f, 0xe7, 0x5b, 0xdc, 0x5b, 0xfa, 0x98, 0x04, 0x97, 0x6b, 0xc4, 0x3c, 0x40, 0x0e,
+	0x26, 0x16, 0x7d, 0x81, 0x0f, 0xfd, 0x0a, 0x71, 0x0f, 0x5c, 0x64, 0xa5, 0x4d, 0x0b, 0xe6, 0x84,
+	0xa2, 0xb0, 0x75, 0x69, 0x27, 0xaf, 0xcc, 0x43, 0x56, 0x58, 0x72, 0x15, 0x6a, 0x17, 0xfa, 0xdc,
+	0x10, 0x9f, 0x82, 0xf4, 0x6c, 0x71, 0xbf, 0x38, 0xc9, 0x8a, 0x6f, 0x46, 0x8b, 0x43, 0x38, 0x95,
+	0xc6, 0xd4, 0xae, 0x42, 0x6d, 0x9d, 0x84, 0x4e, 0x22, 0x06, 0x99, 0x9e, 0x87, 0x29, 0x6a, 0xf6,
+	0x3c, 0xdd, 0xa6, 0x5e, 0x97, 0xe4, 0x52, 0x45, 0x61, 0x6b, 0xbd, 0xf2, 0xe4, 0xf8, 0xb4, 0x90,
+	0xf8, 0x7e, 0x5a, 0x78, 0x64, 0x5a, 0xb4, 0xed, 0xb5, 0x14, 0x03, 0x77, 0xd5, 0x28, 0xf6, 0xdd,
+	0xb2, 0xd1, 0xd6, 0x2d, 0x5b, 0x9d, 0x7a, 0x20, 0x1d, 0x3a, 0x88, 0x28, 0x0d, 0xe4, 0x5a, 0x7a,
+	0xc7, 0x7a, 0xa3, 0xb7, 0x3a, 0xa8, 0x6a, 0x53, 0x2d, 0xcd, 0xfa, 0xd7, 0x83, 0xf6, 0xfb, 0xe2,
+	0xbb, 0x9f, 0x9f, 0xee, 0x44, 0x01, 0x94, 0xf2, 0x60, 0x63, 0x8e, 0x1e, 0x0d, 0x11, 0x07, 0xdb,
+	0x04, 0x95, 0xbe, 0x08, 0xe0, 0x7a, 0x8d, 0x98, 0x2f, 0x1d, 0xa8, 0x53, 0x74, 0x80, 0x8e, 0xfc,
+	0x60, 0xdd, 0xc3, 0xd4, 0xb2, 0xcd, 0xe7, 0xec, 0x6a, 0xc4, 0x3d, 0xb0, 0xa6, 0x7b, 0xb4, 0x8d,
+	0x5d, 0x8b, 0x0e, 0x19, 0x93, 0x6b, 0x95, 0xdc, 0xd7, 0xcf, 0xe5, 0x6c, 0x20, 0x8f, 0xc7, 0x10,
+	0xba, 0x88, 0x90, 0x06, 0x75, 0x2d, 0xdb, 0xd4, 0x66, 0xa9, 0xe2, 0x6b, 0x70, 0x15, 0xf2, 0x7e,
+	0xcd, 0x1e, 0x6f, 0xd8, 0xe4, 0x97, 0x1d, 0x30, 0x7a, 0x23, 0xee, 0x3a, 0x22, 0xa3, 0x2b, 0xe7,
+	0x7c, 0x9a, 0xb4, 0x2c, 0x8c, 0x59, 0x6b, 0x3f, 0xe3, 0x23, 0x9d, 0x8d, 0x2b, 0xdd, 0x02, 0x9b,
+	0x4b, 0x71, 0x4c, 0x11, 0xff, 0x12, 0x40, 0xae, 0x46, 0xcc, 0x06, 0xa2, 0x87, 0xff, 0x0f, 0xec,
+	0xc3, 0x90, 0xda, 0x92, 0xff, 0x54, 0x5b, 0x00, 0x6c, 0xaa, 0xb9, 0x67, 0x5c, 0x26, 0x21, 0x8a,
+	0x52, 0xab, 0x51, 0x94, 0xee, 0x2d, 0xe5, 0xa6, 0x04, 0x8a, 0x8b, 0x10, 0x4f, 0x68, 0xd9, 0xf9,
+	0x9d, 0x04, 0xa9, 0x1a, 0x31, 0xc5, 0x23, 0x90, 0xf9, 0xeb, 0x4b, 0xda, 0x8c, 0xdb, 0x62, 0x4e,
+	0x51, 0x52, 0xf9, 0x4c, 0x69, 0x93, 0x79, 0xe2, 0x7b, 0x01, 0x48, 0x4b, 0x54, 0xb7, 0xbd, 0xa0,
+	0xdb, 0xe2, 0x12, 0xe9, 0xc1, 0xca, 0x25, 0xd3, 0x65, 0xde, 0x82, 0x2b, 0xf1, 0x7a, 0xb8, 0xbb,
+	0xa0, 0x67, 0x6c, 0xb6, 0xb4, 0xbb, 0x4a, 0xf6, 0x64, 0x78, 0xa5, 0x7e, 0x3c, 0x92, 0x85, 0x93,
+	0x91, 0x2c, 0xfc, 0x18, 0xc9, 0xc2, 0x87, 0xb1, 0x9c, 0x38, 0x19, 0xcb, 0x89, 0x6f, 0x63, 0x39,
+	0xf1, 0xea, 0xfe, 0xd9, 0x9f, 0x87, 0xc1, 0xe4, 0x7d, 0xf7, 0x5f, 0x89, 0xd6, 0x79, 0xe6, 0xbf,
+	0xf7, 0x27, 0x00, 0x00, 0xff, 0xff, 0x94, 0xff, 0xce, 0x08, 0x02, 0x06, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -283,6 +389,8 @@ type MsgClient interface {
 	DepositToVault(ctx context.Context, in *MsgDepositToVault, opts ...grpc.CallOption) (*MsgDepositToVaultResponse, error)
 	// UpdateDefaultQuotingParams updates the default quoting params in state.
 	UpdateDefaultQuotingParams(ctx context.Context, in *MsgUpdateDefaultQuotingParams, opts ...grpc.CallOption) (*MsgUpdateDefaultQuotingParamsResponse, error)
+	// SetVaultQuotingParams sets the quoting parameters of a specific vault.
+	SetVaultQuotingParams(ctx context.Context, in *MsgSetVaultQuotingParams, opts ...grpc.CallOption) (*MsgSetVaultQuotingParamsResponse, error)
 }
 
 type msgClient struct {
@@ -311,12 +419,23 @@ func (c *msgClient) UpdateDefaultQuotingParams(ctx context.Context, in *MsgUpdat
 	return out, nil
 }
 
+func (c *msgClient) SetVaultQuotingParams(ctx context.Context, in *MsgSetVaultQuotingParams, opts ...grpc.CallOption) (*MsgSetVaultQuotingParamsResponse, error) {
+	out := new(MsgSetVaultQuotingParamsResponse)
+	err := c.cc.Invoke(ctx, "/dydxprotocol.vault.Msg/SetVaultQuotingParams", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	// DepositToVault deposits funds into a vault.
 	DepositToVault(context.Context, *MsgDepositToVault) (*MsgDepositToVaultResponse, error)
 	// UpdateDefaultQuotingParams updates the default quoting params in state.
 	UpdateDefaultQuotingParams(context.Context, *MsgUpdateDefaultQuotingParams) (*MsgUpdateDefaultQuotingParamsResponse, error)
+	// SetVaultQuotingParams sets the quoting parameters of a specific vault.
+	SetVaultQuotingParams(context.Context, *MsgSetVaultQuotingParams) (*MsgSetVaultQuotingParamsResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -328,6 +447,9 @@ func (*UnimplementedMsgServer) DepositToVault(ctx context.Context, req *MsgDepos
 }
 func (*UnimplementedMsgServer) UpdateDefaultQuotingParams(ctx context.Context, req *MsgUpdateDefaultQuotingParams) (*MsgUpdateDefaultQuotingParamsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateDefaultQuotingParams not implemented")
+}
+func (*UnimplementedMsgServer) SetVaultQuotingParams(ctx context.Context, req *MsgSetVaultQuotingParams) (*MsgSetVaultQuotingParamsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetVaultQuotingParams not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -370,6 +492,24 @@ func _Msg_UpdateDefaultQuotingParams_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_SetVaultQuotingParams_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgSetVaultQuotingParams)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).SetVaultQuotingParams(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/dydxprotocol.vault.Msg/SetVaultQuotingParams",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).SetVaultQuotingParams(ctx, req.(*MsgSetVaultQuotingParams))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "dydxprotocol.vault.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -381,6 +521,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateDefaultQuotingParams",
 			Handler:    _Msg_UpdateDefaultQuotingParams_Handler,
+		},
+		{
+			MethodName: "SetVaultQuotingParams",
+			Handler:    _Msg_SetVaultQuotingParams_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -530,6 +674,79 @@ func (m *MsgUpdateDefaultQuotingParamsResponse) MarshalToSizedBuffer(dAtA []byte
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgSetVaultQuotingParams) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgSetVaultQuotingParams) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgSetVaultQuotingParams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.QuotingParams.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x1a
+	{
+		size, err := m.VaultId.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
+	if len(m.Authority) > 0 {
+		i -= len(m.Authority)
+		copy(dAtA[i:], m.Authority)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Authority)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgSetVaultQuotingParamsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgSetVaultQuotingParamsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgSetVaultQuotingParamsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -585,6 +802,32 @@ func (m *MsgUpdateDefaultQuotingParams) Size() (n int) {
 }
 
 func (m *MsgUpdateDefaultQuotingParamsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgSetVaultQuotingParams) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Authority)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.VaultId.Size()
+	n += 1 + l + sovTx(uint64(l))
+	l = m.QuotingParams.Size()
+	n += 1 + l + sovTx(uint64(l))
+	return n
+}
+
+func (m *MsgSetVaultQuotingParamsResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -946,6 +1189,204 @@ func (m *MsgUpdateDefaultQuotingParamsResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgUpdateDefaultQuotingParamsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgSetVaultQuotingParams) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgSetVaultQuotingParams: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgSetVaultQuotingParams: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Authority", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Authority = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VaultId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.VaultId.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field QuotingParams", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.QuotingParams.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgSetVaultQuotingParamsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgSetVaultQuotingParamsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgSetVaultQuotingParamsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
### Changelist
add gov msg that sets vault quoting params
- vault quoting params are cleaned up when a vault is decommissioned

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced new interfaces for managing liquidation and taker orders, enhancing order processing capabilities.
  - Added `setVaultQuotingParams` method to allow users to set quoting parameters for specific vaults.
  - Implemented structured types for vault quoting parameters, improving configuration flexibility.

- **Bug Fixes**
  - Improved validation and handling of quoting parameters in the vault management system.

- **Tests**
  - Added unit tests for `SetVaultQuotingParams` to ensure robust handling of quoting parameters.
  - Updated test cases for vault decommissioning to include quoting parameter verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->