### PR TITLE
Change kafka producer client config

### DIFF
--- a/protocol/indexer/flags.go
+++ b/protocol/indexer/flags.go
@@ -16,12 +16,13 @@ type IndexerFlags struct {
 
 // List of default values
 const (
-	DefaultMaxRetries = 3
+	DefaultMaxRetries = 20
 )
 
 // List of CLI flags
 const (
-	FlagKafkaConnStr         = "indexer-kafka-conn-str"
+	FlagKafkaConnStr = "indexer-kafka-conn-str"
+	// max retry should be set so that max retry * retry backoff > Zookeeper session.timeout + some buffer
 	FlagKafkaMaxRetry        = "indexer-kafka-max-retry"
 	FlagSendOffchainData     = "indexer-send-offchain-data"
 	MsgSenderInstanceForTest = "msgsender-instance-for-test"

--- a/protocol/indexer/msgsender/msgsender_kafka.go
+++ b/protocol/indexer/msgsender/msgsender_kafka.go
@@ -43,7 +43,10 @@ func NewIndexerMessageSenderKafka(
 	config.Producer.Return.Errors = true
 	config.Producer.Return.Successes = true
 	config.Producer.Retry.Max = indexerFlags.MaxRetries
+	// max retry should be set so that max retry * retry backoff > Zookeeper session.timeout + some buffer
+	config.Producer.Retry.Backoff = 1000 * time.Millisecond
 	config.Producer.MaxMessageBytes = 4194304 // 4MB
+	config.Producer.RequiredAcks = sarama.WaitForAll
 	// Use the JVM compatible parititoner to match `kafkajs` which is used in the indexer services.
 	config.Producer.Partitioner = kafkautil.NewJVMCompatiblePartitioner
 	producer, err := sarama.NewAsyncProducer(indexerFlags.KafkaAddrs, config)


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the maximum retry attempts for operations from 3 to 20, enhancing system robustness.
	- Introduced new configuration parameters for the Kafka message sender to improve message delivery reliability: `Retry.Backoff` set to 1000 ms and `RequiredAcks` set to `sarama.WaitForAll`.

- **Bug Fixes**
	- Adjusted retry logic to ensure smoother handling of operations without premature failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->