### PR TITLE
[OTE-664] Change docker-compose to new syntax

### DIFF
--- a/.github/workflows/protocol-benchmark.yml
+++ b/.github/workflows/protocol-benchmark.yml
@@ -28,6 +28,9 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.22
+      - name: Prune Docker system to free up space
+        run: |
+          docker system prune -a --volumes -f
       - name: Run Benchmarks
         run: make benchmark | tee ./benchmark_output.txt
       - name: Download previous benchmark data

--- a/.github/workflows/protocol-test.yml
+++ b/.github/workflows/protocol-test.yml
@@ -105,6 +105,9 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.22
+      - name: Prune Docker system to free up space
+        run: |
+          docker system prune -a --volumes -f
       - name: start localnet
         run: |
           DOCKER_BUILDKIT=1 make localnet-startd

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -365,12 +365,12 @@ localnet-init:
 localnet-compose-up:
 	@echo "Launching localnet at commit ${GIT_COMMIT_HASH}"
 	@docker build . -t local:dydxprotocol -f testing/testnet-local/Dockerfile --no-cache
-	@docker-compose -f docker-compose.yml up --force-recreate $(ARGS)
+	@docker compose -f docker-compose.yml up --force-recreate $(ARGS)
 
 localnet-compose-upd:
 	@echo "Launching localnet at commit ${GIT_COMMIT_HASH}"
 	@docker build . -t local:dydxprotocol -f testing/testnet-local/Dockerfile --no-cache
-	@docker-compose -f docker-compose.yml up --force-recreate -d $(ARGS)
+	@docker compose -f docker-compose.yml up --force-recreate -d $(ARGS)
 
 build-e2etest-image:
 	@echo "Build e2e test image at commit ${GIT_COMMIT_HASH}"
@@ -383,10 +383,10 @@ e2etest-build-image: localnet-init build-e2etest-image
 
 # Continue the localnet with the same chain state.
 localnet-continue:
-	@docker-compose -f docker-compose.yml up $(ARGS)
+	@docker compose -f docker-compose.yml up $(ARGS)
 
 localnet-stop:
-	@docker-compose -f docker-compose.yml down
+	@docker compose -f docker-compose.yml down
 
 .PHONY: all build-linux install format lint \
 	go-mod-cache draw-deps clean build build-contract-tests-hooks \


### PR DESCRIPTION
### Changelist
changed docker-compose to docker compose in makefile

github deprecated v1 docker (https://github.com/actions/runner-images/issues/9557) so `docker-compose` is no longer recognized during github auto reviews -> liveness test failing

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the Makefile to use `docker compose` commands for local network management, enhancing clarity and maintainability.
	- Added a new step in the GitHub Actions workflow to prune the Docker system before running benchmarks, optimizing disk space usage.
	- Introduced a similar step in the GitHub Actions workflow for tests, ensuring efficient Docker resource management during CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->