### PR TITLE
vault query does not error on non-existent clob pair

### DIFF
--- a/protocol/x/vault/keeper/grpc_query_vault.go
+++ b/protocol/x/vault/keeper/grpc_query_vault.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	"context"
-	"fmt"
+	"math/big"
 
 	"cosmossdk.io/store/prefix"
 	"google.golang.org/grpc/codes"
@@ -42,12 +42,12 @@ func (k Keeper) Vault(
 	}
 
 	// Get vault inventory.
+	inventory := big.NewInt(0)
 	clobPair, exists := k.clobKeeper.GetClobPair(ctx, clobtypes.ClobPairId(vaultId.Number))
-	if !exists {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("clob pair %d doesn't exist", vaultId.Number))
+	if exists {
+		perpId := clobPair.Metadata.(*clobtypes.ClobPair_PerpetualClobMetadata).PerpetualClobMetadata.PerpetualId
+		inventory = k.GetVaultInventoryInPerpetual(ctx, vaultId, perpId)
 	}
-	perpId := clobPair.Metadata.(*clobtypes.ClobPair_PerpetualClobMetadata).PerpetualClobMetadata.PerpetualId
-	inventory := k.GetVaultInventoryInPerpetual(ctx, vaultId, perpId)
 
 	// Get vault quoting params.
 	quotingParams := k.GetVaultQuotingParams(ctx, vaultId)

--- a/protocol/x/vault/keeper/grpc_query_vault_test.go
+++ b/protocol/x/vault/keeper/grpc_query_vault_test.go
@@ -62,6 +62,22 @@ func TestVault(t *testing.T) {
 			totalShares:    big.NewInt(300),
 			expectedEquity: big.NewInt(-300),
 		},
+		"Success: non-existent clob pair": {
+			req: &vaulttypes.QueryVaultRequest{
+				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
+				Number: 7777,
+			},
+			vaultId: vaulttypes.VaultId{
+				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,
+				Number: 7777,
+			},
+			asset:          big.NewInt(100),
+			perpId:         0,
+			inventory:      big.NewInt(0),
+			totalShares:    big.NewInt(300),
+			quotingParams:  &constants.QuotingParams,
+			expectedEquity: big.NewInt(100),
+		},
 		"Error: query non-existent vault": {
 			req: &vaulttypes.QueryVaultRequest{
 				Type:   vaulttypes.VaultType_VAULT_TYPE_CLOB,


### PR DESCRIPTION
### Changelist
instead of returning error when clob pair doesn't exist, vault query simply returns inventory as `0`

### Test Plan
unit tests
localnet testing

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved logic for vault inventory retrieval, ensuring inventory is fetched only when a valid `clobPair` exists.
  
- **Bug Fixes**
  - Enhanced error handling by preventing unnecessary inventory retrieval calls when the `clobPair` does not exist.

- **Tests**
  - Added a new test case to validate behavior when querying a non-existent vault, strengthening the overall test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->