### PR TITLE
Update main-net node setup.

### DIFF
--- a/protocol/testing/mainnet/mainnet.sh
+++ b/protocol/testing/mainnet/mainnet.sh
@@ -46,14 +46,14 @@ set_cosmovisor_binary_permissions() {
 
 create_full_nodes() {
 	# Create directories for full-nodes to use.
-	for i in $(seq 1 $LAST_FULL_NODE_INDEX); do
+	for i in $(seq 0 $LAST_FULL_NODE_INDEX); do
 		FULL_NODE_HOME_DIR="$HOME/chain/.full-node-$i"
 		FULL_NODE_CONFIG_DIR="$FULL_NODE_HOME_DIR/config"
 		dydxprotocold init "full-node" -o --chain-id=$CHAIN_ID --home "$FULL_NODE_HOME_DIR"
 	done
 
 	# Copy the genesis file to the full-node directories.
-	for i in $(seq 1 $LAST_FULL_NODE_INDEX); do
+	for i in $(seq 0 $LAST_FULL_NODE_INDEX); do
 		FULL_NODE_HOME_DIR="$HOME/chain/.full-node-$i"
 		FULL_NODE_CONFIG_DIR="$FULL_NODE_HOME_DIR/config"
 
@@ -61,7 +61,7 @@ create_full_nodes() {
 	done
 
 	# Set up CosmosVisor for full-nodes.
-	for i in $(seq 1 $LAST_FULL_NODE_INDEX); do
+	for i in $(seq 0 $LAST_FULL_NODE_INDEX); do
 		FULL_NODE_HOME_DIR="$HOME/chain/.full-node-$i"
 		# DAEMON_NAME is the name of the binary.
 		export DAEMON_NAME=dydxprotocold

--- a/protocol/testing/mainnet/start.sh
+++ b/protocol/testing/mainnet/start.sh
@@ -9,7 +9,7 @@ set -eo pipefail
 source "./vars.sh"
 
 # Set up CosmosVisor for full-nodes.
-for i in $(seq 1 $LAST_FULL_NODE_INDEX); do
+for i in $(seq 0 $LAST_FULL_NODE_INDEX); do
 	FULL_NODE_HOME_DIR="$HOME/chain/.full-node-$i"
 	# Copy binaries for `cosmovisor` from the docker image into the home directory.
 	# Work-around to ensure docker volume contains the same binaries as the git repo.


### PR DESCRIPTION
### Changelist
Fix typo for the generation of full-node indices for the startup / setup scripts. Indices should start from 0 not 1.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated node initialization scripts to include full node at index 0, enhancing the setup process.
  
- **Bug Fixes**
	- Corrected indexing issues in node directory creation, ensuring all nodes are properly configured from index 0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->