### PR TITLE
Update mainnet and testnet images for v6.0.0 development

### DIFF
--- a/protocol/testing/mainnet/mainnet.sh
+++ b/protocol/testing/mainnet/mainnet.sh
@@ -9,7 +9,7 @@ CHAIN_ID="dydx-mainnet-1"
 
 # Define the mapping from version to URL
 declare -A version_to_url
-# version_to_url["v5.1.0"]="https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv5.1.0-dev4/dydxprotocold-v5.1.0-dev4-linux-amd64.tar.gz"
+version_to_url["v5.2.0"]="https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv5.2.0/dydxprotocold-v5.2.0-linux-amd64.tar.gz"
 
 # Define dependencies for this script.
 # `jq` and `dasel` are used to manipulate json and yaml files respectively.

--- a/protocol/testing/mainnet/vars.sh
+++ b/protocol/testing/mainnet/vars.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-CURRENT_VERSION_DIR="v5.1.0"
+CURRENT_VERSION_DIR="v6.0.0"
 
 # Full node home directories will be set up for indices 0 to LAST_FULL_NODE_INDEX
 LAST_FULL_NODE_INDEX=5

--- a/protocol/testing/testnet/testnet.sh
+++ b/protocol/testing/testnet/testnet.sh
@@ -10,7 +10,7 @@ CHAIN_ID="dydx-testnet-1"
 
 # Define the mapping from version to URL
 declare -A version_to_url
-version_to_url["v5.1.0"]="https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv5.1.1/dydxprotocold-v5.1.1-linux-amd64.tar.gz"
+version_to_url["v5.2.0"]="https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv5.2.0/dydxprotocold-v5.2.0-linux-amd64.tar.gz"
 
 # Define dependencies for this script.
 # `jq` and `dasel` are used to manipulate json and yaml files respectively.

--- a/protocol/testing/testnet/vars.sh
+++ b/protocol/testing/testnet/vars.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-CURRENT_VERSION_DIR="v5.2.0"
+CURRENT_VERSION_DIR="v6.0.0"
 
 # Full node home directories will be set up for indices 0 to LAST_FULL_NODE_INDEX
 LAST_FULL_NODE_INDEX=2


### PR DESCRIPTION
### Changelist
Images include previous version v5.2.0 and current commit as v6.0.0

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version mappings to reference new software versions (v5.2.0 and v6.0.0), ensuring access to the latest features and improvements.
  
- **Bug Fixes**
	- Improved versioning structure to maintain compatibility with the latest software releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->