### PR TITLE
[CT-1117] aggregate subaccount updates

### DIFF
--- a/protocol/streaming/full_node_streaming_manager.go
+++ b/protocol/streaming/full_node_streaming_manager.go
@@ -517,7 +517,9 @@ func (sm *FullNodeStreamingManagerImpl) SendSubaccountUpdates(
 	// Group subaccount updates by subaccount id.
 	streamUpdates := make([]clobtypes.StreamUpdate, 0)
 	subaccountIds := make([]*satypes.SubaccountId, 0)
-	for _, subaccountUpdate := range subaccountUpdates {
+	// Aggregate subaccount updates by subaccount id.
+	aggregatedSubaccounts := streaming_util.AggregateSubaccountUpdates(subaccountUpdates)
+	for _, subaccountUpdate := range aggregatedSubaccounts {
 		streamUpdate := clobtypes.StreamUpdate{
 			UpdateMessage: &clobtypes.StreamUpdate_SubaccountUpdate{
 				SubaccountUpdate: &subaccountUpdate,

--- a/protocol/streaming/util/util.go
+++ b/protocol/streaming/util/util.go
@@ -53,7 +53,10 @@ func AggregateSubaccountUpdates(subaccountUpdates []satypes.StreamSubaccountUpda
 }
 
 // Helper function to merge perpetual positions
-func mergePerpetualPositions(existing, updates []*satypes.SubaccountPerpetualPosition) []*satypes.SubaccountPerpetualPosition {
+func mergePerpetualPositions(
+	existing,
+	updates []*satypes.SubaccountPerpetualPosition,
+) []*satypes.SubaccountPerpetualPosition {
 	positionMap := make(map[uint32]*satypes.SubaccountPerpetualPosition)
 
 	for _, pos := range existing {

--- a/protocol/streaming/util/util.go
+++ b/protocol/streaming/util/util.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	ocutypes "github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
 // GetOffchainUpdatesV1 unmarshals messages in offchain updates to OffchainUpdateV1.
@@ -18,4 +19,92 @@ func GetOffchainUpdatesV1(offchainUpdates *clobtypes.OffchainUpdates) ([]ocutype
 		v1updates = append(v1updates, update)
 	}
 	return v1updates, nil
+}
+
+func AggregateSubaccountUpdates(subaccountUpdates []satypes.StreamSubaccountUpdate) []satypes.StreamSubaccountUpdate {
+	subaccounts := make(map[satypes.SubaccountId][]satypes.StreamSubaccountUpdate)
+
+	for _, update := range subaccountUpdates {
+		if update.SubaccountId == nil {
+			continue
+		}
+		subaccountId := *update.SubaccountId
+
+		if updates, exists := subaccounts[subaccountId]; exists {
+			lastUpdate := updates[len(updates)-1]
+
+			// If it's a snapshot, or the last update was a snapshot, just append
+			if update.Snapshot || lastUpdate.Snapshot {
+				subaccounts[subaccountId] = append(subaccounts[subaccountId], update)
+			} else {
+				// Merge with the last non-snapshot update
+				lastUpdate.UpdatedPerpetualPositions = mergePerpetualPositions(
+					lastUpdate.UpdatedPerpetualPositions, update.UpdatedPerpetualPositions)
+
+				lastUpdate.UpdatedAssetPositions = mergeAssetPositions(
+					lastUpdate.UpdatedAssetPositions, update.UpdatedAssetPositions)
+
+				subaccounts[subaccountId][len(subaccounts[subaccountId])-1] = lastUpdate
+			}
+		} else {
+			// First update for this subaccount, just append
+			subaccounts[subaccountId] = []satypes.StreamSubaccountUpdate{update}
+		}
+	}
+
+	// Convert the subaccounts map to a slice
+	aggregatedUpdates := make([]satypes.StreamSubaccountUpdate, 0, len(subaccounts))
+	for _, updates := range subaccounts {
+		aggregatedUpdates = append(aggregatedUpdates, updates...)
+	}
+
+	return aggregatedUpdates
+}
+
+// Helper function to merge perpetual positions
+func mergePerpetualPositions(existing, updates []*satypes.SubaccountPerpetualPosition) []*satypes.SubaccountPerpetualPosition {
+	positionMap := make(map[uint32]*satypes.SubaccountPerpetualPosition)
+
+	for _, pos := range existing {
+		positionMap[pos.PerpetualId] = pos
+	}
+
+	for _, update := range updates {
+		if existingPos, exists := positionMap[update.PerpetualId]; exists {
+			existingPos.Quantums = update.Quantums
+		} else {
+			positionMap[update.PerpetualId] = update
+		}
+	}
+
+	mergedPositions := make([]*satypes.SubaccountPerpetualPosition, 0, len(positionMap))
+	for _, pos := range positionMap {
+		mergedPositions = append(mergedPositions, pos)
+	}
+
+	return mergedPositions
+}
+
+// Helper function to merge asset positions
+func mergeAssetPositions(existing, updates []*satypes.SubaccountAssetPosition) []*satypes.SubaccountAssetPosition {
+	positionMap := make(map[uint32]*satypes.SubaccountAssetPosition)
+
+	for _, pos := range existing {
+		positionMap[pos.AssetId] = pos
+	}
+
+	for _, update := range updates {
+		if existingPos, exists := positionMap[update.AssetId]; exists {
+			existingPos.Quantums = update.Quantums
+		} else {
+			positionMap[update.AssetId] = update
+		}
+	}
+
+	mergedPositions := make([]*satypes.SubaccountAssetPosition, 0, len(positionMap))
+	for _, pos := range positionMap {
+		mergedPositions = append(mergedPositions, pos)
+	}
+
+	return mergedPositions
 }


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced handling of subaccount updates with improved aggregation logic.
	- Introduced new utility functions for efficient management of snapshot and non-snapshot updates.

- **Bug Fixes**
	- Improved efficiency and clarity in the processing of subaccount updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->