### PR TITLE
Enforce uniqueness of timestamp nonce

### DIFF
--- a/protocol/lib/collections.go
+++ b/protocol/lib/collections.go
@@ -152,3 +152,13 @@ func MergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
 	}
 	return combinedMap
 }
+
+// Check if slice contains a particular value
+func SliceContains[T comparable](list []T, value T) bool {
+	for _, v := range list {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}

--- a/protocol/lib/collections_test.go
+++ b/protocol/lib/collections_test.go
@@ -471,3 +471,15 @@ func TestMergeAllMapsWithDistinctKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestSliceContains(t *testing.T) {
+	require.True(
+		t,
+		lib.SliceContains([]uint32{1, 2}, 1),
+	)
+
+	require.False(
+		t,
+		lib.SliceContains([]uint32{1, 2}, 3),
+	)
+}

--- a/protocol/x/accountplus/keeper/timestampnonce.go
+++ b/protocol/x/accountplus/keeper/timestampnonce.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
 	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
 )
@@ -81,7 +82,7 @@ func AttemptTimestampNonceUpdate(
 	}
 
 	// Must be unique
-	if contains(tsNonceDetails.TimestampNonces, tsNonce) {
+	if lib.SliceContains(tsNonceDetails.TimestampNonces, tsNonce) {
 		return false
 	}
 
@@ -119,13 +120,4 @@ func isLargerThanSmallestValue(value uint64, values []uint64) (bool, int) {
 	} else {
 		return false, minIndex
 	}
-}
-
-func contains[T comparable](list []T, value T) bool {
-	for _, v := range list {
-		if v == value {
-			return true
-		}
-	}
-	return false
 }

--- a/protocol/x/accountplus/keeper/timestampnonce.go
+++ b/protocol/x/accountplus/keeper/timestampnonce.go
@@ -80,6 +80,11 @@ func AttemptTimestampNonceUpdate(
 		return false
 	}
 
+	// Must be unique
+	if contains(tsNonceDetails.TimestampNonces, tsNonce) {
+		return false
+	}
+
 	if len(tsNonceDetails.TimestampNonces) < MaxTimestampNonceArrSize {
 		tsNonceDetails.TimestampNonces = append(tsNonceDetails.TimestampNonces, tsNonce)
 		return true
@@ -114,4 +119,13 @@ func isLargerThanSmallestValue(value uint64, values []uint64) (bool, int) {
 	} else {
 		return false, minIndex
 	}
+}
+
+func contains[T comparable](list []T, value T) bool {
+	for _, v := range list {
+		if v == value {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### Changelist
Add check for uniqueness of ts nonce

### Test Plan
1. existing and new unit test passed
2. ran chain locally and performed following test
```
get current time
submit transaction with seq=above time
wait for block to be committed and reset cache by restarting container
submit prev transaction  
```
Second tx failed with error code 32 as intended (https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go)


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Implemented a uniqueness check for timestamp nonces during updates, ensuring no duplicates are added.

- **Bug Fixes**
	- Enhanced rejection logic for non-unique timestamp nonces, preventing erroneous updates.

- **Tests**
	- Improved clarity and specificity of existing test cases.
	- Added tests to validate the rejection of duplicate timestamp nonces.
	- Introduced a new test for verifying slice membership with the `SliceContains` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->