### PR TITLE
Disable leaderboard pnl roundtable jobs

### DIFF
--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -52,11 +52,11 @@ export const configSchema = {
   LOOPS_ENABLED_AGGREGATE_TRADING_REWARDS_WEEKLY: parseBoolean({ default: true }),
   LOOPS_ENABLED_AGGREGATE_TRADING_REWARDS_MONTHLY: parseBoolean({ default: true }),
   LOOPS_ENABLED_SUBACCOUNT_USERNAME_GENERATOR: parseBoolean({ default: true }),
-  LOOPS_ENABLED_LEADERBOARD_PNL_ALL_TIME: parseBoolean({ default: true }),
-  LOOPS_ENABLED_LEADERBOARD_PNL_DAILY: parseBoolean({ default: true }),
-  LOOPS_ENABLED_LEADERBOARD_PNL_WEEKLY: parseBoolean({ default: true }),
-  LOOPS_ENABLED_LEADERBOARD_PNL_MONTHLY: parseBoolean({ default: true }),
-  LOOPS_ENABLED_LEADERBOARD_PNL_YEARLY: parseBoolean({ default: true }),
+  LOOPS_ENABLED_LEADERBOARD_PNL_ALL_TIME: parseBoolean({ default: false }),
+  LOOPS_ENABLED_LEADERBOARD_PNL_DAILY: parseBoolean({ default: false }),
+  LOOPS_ENABLED_LEADERBOARD_PNL_WEEKLY: parseBoolean({ default: false }),
+  LOOPS_ENABLED_LEADERBOARD_PNL_MONTHLY: parseBoolean({ default: false }),
+  LOOPS_ENABLED_LEADERBOARD_PNL_YEARLY: parseBoolean({ default: false }),
 
   // Loop Timing
   LOOPS_INTERVAL_MS_MARKET_UPDATER: parseInteger({


### PR DESCRIPTION
### Changelist
Update roundtable to temporarily disable leaderboard pnl jobs

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Leaderboard profit and loss tracking features are now disabled by default, requiring users to enable them explicitly if desired.
  
- **Bug Fixes**
	- Adjusted default settings for various leaderboard-related configurations to improve user experience and system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->