### PR TITLE
Reduce voting period to 2min for devnets

### DIFF
--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -91,10 +91,10 @@ function edit_genesis() {
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_deposit.[0].denom' -v "$NATIVE_TOKEN"
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.expedited_min_deposit.[0].denom' -v "$NATIVE_TOKEN"
 	# reduced deposit period
-	dasel put -t string -f "$GENESIS" '.app_state.gov.params.max_deposit_period' -v '300s'
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.max_deposit_period' -v '120s'
 	# reduced voting period
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.expedited_voting_period' -v '60s'
-	dasel put -t string -f "$GENESIS" '.app_state.gov.params.voting_period' -v '300s'
+	dasel put -t string -f "$GENESIS" '.app_state.gov.params.voting_period' -v '120s'
 	# set initial deposit ratio to prevent spamming
 	dasel put -t string -f "$GENESIS" '.app_state.gov.params.min_initial_deposit_ratio' -v '0.20000' # 20%
 	# setting to 1 disables cancelling proposals


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Reduced the maximum deposit period from 300 seconds to 120 seconds for quicker governance cycles.
	- Shortened the voting period to enhance decision-making speed, now set at 60 seconds. 

These changes will allow users to experience a more responsive governance process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->