### PR TITLE
Revert "Increase default rebalance timeout"

### DIFF
--- a/indexer/packages/kafka/src/config.ts
+++ b/indexer/packages/kafka/src/config.ts
@@ -20,7 +20,7 @@ export const kafkaConfigSchema = {
   }),
   KAFKA_CONNECTION_TIMEOUT_MS: parseInteger({ default: 5_000 }),
   KAFKA_SESSION_TIMEOUT_MS: parseInteger({ default: 60_000 }),
-  KAFKA_REBALANCE_TIMEOUT_MS: parseInteger({ default: 120_000 }),
+  KAFKA_REBALANCE_TIMEOUT_MS: parseInteger({ default: 50_000 }),
   KAFKA_HEARTBEAT_INTERVAL_MS: parseInteger({ default: 5_000 }),
   KAFKA_CONCURRENT_PARTITIONS: parseInteger({ default: 1 }),
   // If true, consumers will have unique group ids, and SERVICE_NAME will be a common prefix for


### PR DESCRIPTION
Reverts dydxprotocol/v4-chain#2077

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Optimized Kafka consumer group management by reducing the rebalance timeout duration from 120 seconds to 50 seconds, potentially enhancing responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->