### PR TITLE
Full Node Streaming default port 9092

### DIFF
--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -73,7 +73,7 @@ const (
 	DefaultGrpcStreamingMaxBatchSize         = 2000
 	DefaultGrpcStreamingMaxChannelBufferSize = 2000
 	DefaultWebsocketStreamingEnabled         = false
-	DefaultWebsocketStreamingPort            = 9091
+	DefaultWebsocketStreamingPort            = 9092
 	DefaultFullNodeStreamingSnapshotInterval = 0
 
 	DefaultVEOracleEnabled            = true
@@ -140,7 +140,7 @@ func AddFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().Uint16(
 		WebsocketStreamingPort,
 		DefaultWebsocketStreamingPort,
-		"Port for websocket full node streaming connections",
+		"Port for websocket full node streaming connections. Defaults to 9092.",
 	)
 	cmd.Flags().Bool(
 		VEOracleEnabled,

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -269,7 +269,7 @@ func TestGetFlagValuesFromOptions(t *testing.T) {
 			expectedGrpcStreamingBatchSize:            2000,
 			expectedGrpcStreamingMaxChannelBufferSize: 2000,
 			expectedWebsocketEnabled:                  false,
-			expectedWebsocketPort:                     9091,
+			expectedWebsocketPort:                     9092,
 			expectedFullNodeStreamingSnapshotInterval: 0,
 			expectedOptimisticExecutionEnabled:        false,
 		},

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     ports:
       - "26657:26657"
       - "9090:9090"
-      - "9091:9091"
+      - "9092:9092" # full node streaming
       - "1317:1317"
 
   dydxprotocold1:


### PR DESCRIPTION
Localnet build uses 9091 for prometheus (PR #1452 )