### PR TITLE
rely on vault params store to iterate through vaults instead of total shares store

### DIFF
--- a/protocol/app/upgrades/v6.0.0/upgrade.go
+++ b/protocol/app/upgrades/v6.0.0/upgrade.go
@@ -123,7 +123,7 @@ func initVaultDefaultQuotingParams(
 	oldParams := vaultKeeper.UnsafeGetParams(ctx)
 	if err := vaultKeeper.SetDefaultQuotingParams(
 		ctx,
-		&vaulttypes.QuotingParams{
+		vaulttypes.QuotingParams{
 			Layers:                           oldParams.Layers,
 			SpreadMinPpm:                     oldParams.SpreadMinPpm,
 			SpreadBufferPpm:                  oldParams.SpreadBufferPpm,

--- a/protocol/testutil/constants/vault.go
+++ b/protocol/testutil/constants/vault.go
@@ -14,6 +14,10 @@ var (
 		Type:   types.VaultType_VAULT_TYPE_CLOB,
 		Number: 1,
 	}
+	Vault_Clob7 = types.VaultId{
+		Type:   types.VaultType_VAULT_TYPE_CLOB,
+		Number: 7,
+	}
 
 	MsgDepositToVault_Clob0_Alice0_100 = &types.MsgDepositToVault{
 		VaultId:       &Vault_Clob0,

--- a/protocol/x/vault/genesis.go
+++ b/protocol/x/vault/genesis.go
@@ -11,7 +11,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	k.InitializeForGenesis(ctx)
 
 	// Set default quoting params.
-	if err := k.SetDefaultQuotingParams(ctx, &genState.DefaultQuotingParams); err != nil {
+	if err := k.SetDefaultQuotingParams(ctx, genState.DefaultQuotingParams); err != nil {
 		panic(err)
 	}
 	// For each vault:

--- a/protocol/x/vault/keeper/msg_server_update_default_quoting_params.go
+++ b/protocol/x/vault/keeper/msg_server_update_default_quoting_params.go
@@ -24,7 +24,7 @@ func (k msgServer) UpdateDefaultQuotingParams(
 	}
 
 	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
-	if err := k.SetDefaultQuotingParams(ctx, &msg.DefaultQuotingParams); err != nil {
+	if err := k.SetDefaultQuotingParams(ctx, msg.DefaultQuotingParams); err != nil {
 		return nil, err
 	}
 

--- a/protocol/x/vault/keeper/orders.go
+++ b/protocol/x/vault/keeper/orders.go
@@ -38,13 +38,11 @@ func (k Keeper) RefreshAllVaultOrders(ctx sdk.Context) {
 		}
 		// TODO (TRA-547): implement close-only mode.
 
-		// Use default quoting params if no custom ones.
+		// Skip if vault has no perpetual positions and strictly less than `activation_threshold_quote_quantums` USDC.
 		if vaultParams.QuotingParams == nil {
 			defaultQuotingParams := k.GetDefaultQuotingParams(ctx)
 			vaultParams.QuotingParams = &defaultQuotingParams
 		}
-
-		// Skip if vault has no perpetual positions and strictly less than `activation_threshold_quote_quantums` USDC.
 		vault := k.subaccountsKeeper.GetSubaccount(ctx, *vaultId.ToSubaccountId())
 		if vault.PerpetualPositions == nil || len(vault.PerpetualPositions) == 0 {
 			if vault.GetUsdcPosition().Cmp(vaultParams.QuotingParams.ActivationThresholdQuoteQuantums.BigInt()) == -1 {

--- a/protocol/x/vault/keeper/params.go
+++ b/protocol/x/vault/keeper/params.go
@@ -23,14 +23,14 @@ func (k Keeper) GetDefaultQuotingParams(
 // Returns an error if validation fails.
 func (k Keeper) SetDefaultQuotingParams(
 	ctx sdk.Context,
-	params *types.QuotingParams,
+	params types.QuotingParams,
 ) error {
 	if err := params.Validate(); err != nil {
 		return err
 	}
 
 	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshal(params)
+	b := k.cdc.MustMarshal(&params)
 	store.Set([]byte(types.DefaultQuotingParamsKey), b)
 
 	return nil

--- a/protocol/x/vault/keeper/params.go
+++ b/protocol/x/vault/keeper/params.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"cosmossdk.io/store/prefix"
+	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
@@ -70,6 +71,12 @@ func (k Keeper) SetVaultParams(
 	store.Set(vaultId.ToStateKey(), b)
 
 	return nil
+}
+
+// getVaultParamsIterator returns an iterator over all VaultParams.
+func (k Keeper) getVaultParamsIterator(ctx sdk.Context) storetypes.Iterator {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.VaultParamsKeyPrefix))
+	return storetypes.KVStorePrefixIterator(store, []byte{})
 }
 
 // GetVaultQuotingParams returns quoting parameters for a given vault, which is

--- a/protocol/x/vault/keeper/params_test.go
+++ b/protocol/x/vault/keeper/params_test.go
@@ -20,7 +20,7 @@ func TestGetSetDefaultQuotingParams(t *testing.T) {
 	require.Equal(t, types.DefaultQuotingParams(), params)
 
 	// Set new params and get.
-	newParams := &types.QuotingParams{
+	newParams := types.QuotingParams{
 		Layers:                           3,
 		SpreadMinPpm:                     4_000,
 		SpreadBufferPpm:                  2_000,
@@ -31,10 +31,10 @@ func TestGetSetDefaultQuotingParams(t *testing.T) {
 	}
 	err := k.SetDefaultQuotingParams(ctx, newParams)
 	require.NoError(t, err)
-	require.Equal(t, *newParams, k.GetDefaultQuotingParams(ctx))
+	require.Equal(t, newParams, k.GetDefaultQuotingParams(ctx))
 
 	// Set invalid params and get.
-	invalidParams := &types.QuotingParams{
+	invalidParams := types.QuotingParams{
 		Layers:                           3,
 		SpreadMinPpm:                     4_000,
 		SpreadBufferPpm:                  2_000,
@@ -45,7 +45,7 @@ func TestGetSetDefaultQuotingParams(t *testing.T) {
 	}
 	err = k.SetDefaultQuotingParams(ctx, invalidParams)
 	require.Error(t, err)
-	require.Equal(t, *newParams, k.GetDefaultQuotingParams(ctx))
+	require.Equal(t, newParams, k.GetDefaultQuotingParams(ctx))
 }
 
 func TestGetSetVaultParams(t *testing.T) {

--- a/protocol/x/vault/keeper/shares.go
+++ b/protocol/x/vault/keeper/shares.go
@@ -48,13 +48,6 @@ func (k Keeper) SetTotalShares(
 	return nil
 }
 
-// getTotalSharesIterator returns an iterator over all TotalShares.
-func (k Keeper) getTotalSharesIterator(ctx sdk.Context) storetypes.Iterator {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.TotalSharesKeyPrefix))
-
-	return storetypes.KVStorePrefixIterator(store, []byte{})
-}
-
 // GetOwnerShares gets owner shares for an owner in a vault.
 func (k Keeper) GetOwnerShares(
 	ctx sdk.Context,

--- a/protocol/x/vault/keeper/vault_test.go
+++ b/protocol/x/vault/keeper/vault_test.go
@@ -63,7 +63,7 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 			},
 			decommissioned: []bool{
 				false,
-				true, // this vault should be decommissioned.
+				true, // decommissioned as vault has 0 equity and is deactivated.
 			},
 		},
 		"Decommission two vaults": {
@@ -85,7 +85,7 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 			decommissioned: []bool{
 				true,
 				true,
-				false,
+				false, // not decommissioned (even though equity is negative) bc status is not deactivated.
 			},
 		},
 	}

--- a/protocol/x/vault/keeper/vault_test.go
+++ b/protocol/x/vault/keeper/vault_test.go
@@ -21,8 +21,8 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 		/* --- Setup --- */
 		// Vault IDs.
 		vaultIds []vaulttypes.VaultId
-		// Total shares of above vaults.
-		totalShares []*big.Int
+		// Statuses of above vaults.
+		statuses []vaulttypes.VaultStatus
 		// Equities of above vaults.
 		equities []*big.Int
 
@@ -35,9 +35,9 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 				constants.Vault_Clob0,
 				constants.Vault_Clob1,
 			},
-			totalShares: []*big.Int{
-				big.NewInt(7),
-				big.NewInt(7),
+			statuses: []vaulttypes.VaultStatus{
+				vaulttypes.VaultStatus_VAULT_STATUS_QUOTING,
+				vaulttypes.VaultStatus_VAULT_STATUS_DEACTIVATED,
 			},
 			equities: []*big.Int{
 				big.NewInt(1),
@@ -53,9 +53,9 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 				constants.Vault_Clob0,
 				constants.Vault_Clob1,
 			},
-			totalShares: []*big.Int{
-				big.NewInt(7),
-				big.NewInt(7),
+			statuses: []vaulttypes.VaultStatus{
+				vaulttypes.VaultStatus_VAULT_STATUS_STAND_BY,
+				vaulttypes.VaultStatus_VAULT_STATUS_DEACTIVATED,
 			},
 			equities: []*big.Int{
 				big.NewInt(1),
@@ -70,18 +70,22 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 			vaultIds: []vaulttypes.VaultId{
 				constants.Vault_Clob0,
 				constants.Vault_Clob1,
+				constants.Vault_Clob7,
 			},
-			totalShares: []*big.Int{
-				big.NewInt(7),
-				big.NewInt(7),
+			statuses: []vaulttypes.VaultStatus{
+				vaulttypes.VaultStatus_VAULT_STATUS_DEACTIVATED,
+				vaulttypes.VaultStatus_VAULT_STATUS_DEACTIVATED,
+				vaulttypes.VaultStatus_VAULT_STATUS_CLOSE_ONLY,
 			},
 			equities: []*big.Int{
 				big.NewInt(0),
+				big.NewInt(-1),
 				big.NewInt(-1),
 			},
 			decommissioned: []bool{
 				true,
 				true,
+				false,
 			},
 		},
 	}
@@ -120,11 +124,11 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 
 			// Set total shares and owner shares for all vaults.
 			testOwner := constants.Alice_Num0.Owner
-			for i, vaultId := range tc.vaultIds {
+			for _, vaultId := range tc.vaultIds {
 				err := k.SetTotalShares(
 					ctx,
 					vaultId,
-					vaulttypes.BigIntToNumShares(tc.totalShares[i]),
+					vaulttypes.BigIntToNumShares(big.NewInt(7)),
 				)
 				require.NoError(t, err)
 				err = k.SetOwnerShares(
@@ -136,16 +140,40 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			// Set statuses of vaults and add to vault address store.
+			for i, vaultId := range tc.vaultIds {
+				err := k.SetVaultParams(
+					ctx,
+					vaultId,
+					vaulttypes.VaultParams{
+						Status: tc.statuses[i],
+					},
+				)
+				require.NoError(t, err)
+				k.AddVaultToAddressStore(ctx, vaultId)
+			}
+
 			// Decommission all vaults.
 			k.DecommissionNonPositiveEquityVaults(ctx)
 
-			// Check that total shares and owner shares are deleted for decommissioned
-			// vaults and not deleted for non-decommissioned vaults.
+			// Check that below are deleted for decommissioned vaults only:
+			// - total shares
+			// - owner shares
+			// - vault params
+			// - vault address (from vault address store)
 			for i, decommissioned := range tc.decommissioned {
 				_, exists := k.GetTotalShares(ctx, tc.vaultIds[i])
 				require.Equal(t, !decommissioned, exists)
 				_, exists = k.GetOwnerShares(ctx, tc.vaultIds[i], testOwner)
 				require.Equal(t, !decommissioned, exists)
+
+				_, exists = k.GetVaultParams(ctx, tc.vaultIds[i])
+				require.Equal(t, !decommissioned, exists)
+				require.Equal(
+					t,
+					!decommissioned,
+					k.IsVault(ctx, tc.vaultIds[i].ToModuleAccountAddress()),
+				)
 			}
 		})
 	}

--- a/protocol/x/vault/types/types.go
+++ b/protocol/x/vault/types/types.go
@@ -13,11 +13,6 @@ type VaultKeeper interface {
 		ctx sdk.Context,
 		vaultId VaultId,
 	) (orders []*clobtypes.Order, err error)
-	GetVaultClobOrderClientId(
-		ctx sdk.Context,
-		side clobtypes.Order_Side,
-		layer uint8,
-	) uint32
 	RefreshAllVaultOrders(ctx sdk.Context)
 	RefreshVaultClobOrders(
 		ctx sdk.Context,


### PR DESCRIPTION
### Changelist
iterate through vault params store instead of total shares store

### Test Plan
unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new vault identifier, `Vault_Clob7`, enhancing vault management options.
	- Added a function to iterate over vault parameters, improving access to vault details.

- **Bug Fixes**
	- Updated vault order refreshing logic to prevent orders under specific conditions, enhancing operational integrity.

- **Tests**
	- Revised test cases to focus on vault statuses instead of total shares, aligning tests with current operational logic.

- **Chores**
	- Removed unused method for accessing total shares, simplifying the Keeper interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->