### PR TITLE
Set fromBeginning to false by default

### DIFF
--- a/indexer/services/vulcan/src/config.ts
+++ b/indexer/services/vulcan/src/config.ts
@@ -21,7 +21,7 @@ export const configSchema = {
   ...redisConfigSchema,
 
   BATCH_PROCESSING_ENABLED: parseBoolean({ default: true }),
-  PROCESS_FROM_BEGINNING: parseBoolean({ default: true }),
+  PROCESS_FROM_BEGINNING: parseBoolean({ default: false }),
   KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS: parseNumber({
     default: 3_000,
   }),

--- a/indexer/services/vulcan/src/helpers/kafka/kafka-controller.ts
+++ b/indexer/services/vulcan/src/helpers/kafka/kafka-controller.ts
@@ -17,8 +17,11 @@ export async function connect(): Promise<void> {
   await consumer.subscribe({
     topic: KafkaTopics.TO_VULCAN,
     // https://kafka.js.org/docs/consuming#a-name-from-beginning-a-frombeginning
-    // Need to set fromBeginning to true, so when vulcan restarts, it will consume all messages
-    // rather than ignoring the messages in queue that were produced before ender was started.
+    // fromBeginning is by default set to false, so vulcan will only consume messages produced
+    // after vulcan was started. This config should almost never matter, because by Vulcan should
+    // read from the last read offset. fromBeginning will only matter if the offset is lost.
+    // In the case where the offset is lost, Vulcan should read from head because in 60 seconds all
+    // short term messages will expire and we can resend stateful orders through bazooka to Vulcan.
     fromBeginning: config.PROCESS_FROM_BEGINNING,
   });
 


### PR DESCRIPTION
### Changelist
Context: https://dydx-team.slack.com/archives/C03S57F735K/p1723746235234569

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the default behavior for batch processing to continue from the last known state instead of starting from the beginning.
  
- **Documentation**
	- Improved comments in the Kafka consumer code to clarify the implications of the `fromBeginning` configuration and its relevance to message consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->