### PR TITLE
add megavault module account

### DIFF
--- a/protocol/app/module_accounts.go
+++ b/protocol/app/module_accounts.go
@@ -13,6 +13,7 @@ import (
 	perpetualsmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	rewardsmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	vaultmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 	vestmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
 	marketmapmoduletypes "github.com/skip-mev/slinky/x/marketmap/types"
 
@@ -52,6 +53,8 @@ var (
 		vestmoduletypes.CommunityVesterAccountName: nil,
 		// Slinky marketmap module permissions.
 		marketmapmoduletypes.ModuleName: nil,
+		// Megavault account holds funds for vaults.
+		vaultmoduletypes.MegavaultAccountName: nil,
 	}
 	// Blocked module accounts which cannot receive external funds.
 	// By default, all non-custom modules (except for gov) are blocked. This prevents

--- a/protocol/app/module_accounts_test.go
+++ b/protocol/app/module_accounts_test.go
@@ -1,8 +1,9 @@
 package app_test
 
 import (
-	marketmapmoduletypes "github.com/skip-mev/slinky/x/marketmap/types"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -15,8 +16,9 @@ import (
 	perpetualsmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	rewardsmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/rewards/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	vaultmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 	vestmoduletypes "github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
-	"github.com/stretchr/testify/require"
+	marketmapmoduletypes "github.com/skip-mev/slinky/x/marketmap/types"
 )
 
 func TestModuleAccountsToAddresses(t *testing.T) {
@@ -36,6 +38,7 @@ func TestModuleAccountsToAddresses(t *testing.T) {
 		vestmoduletypes.CommunityVesterAccountName:   "dydx1wxje320an3karyc6mjw4zghs300dmrjkwn7xtk",
 		icatypes.ModuleName:                          "dydx1vlthgax23ca9syk7xgaz347xmf4nunefw3cnv8",
 		marketmapmoduletypes.ModuleName:              "dydx16j3d86dww8p2rzdlqsv7wle98cxzjxw6gjjyzn",
+		vaultmoduletypes.MegavaultAccountName:        "dydx18tkxrnrkqc2t0lr3zxr5g6a4hdvqksylxqje4r",
 	}
 
 	require.True(t, len(expectedModuleAccToAddresses) == len(app.GetMaccPerms()),
@@ -76,6 +79,7 @@ func TestMaccPerms(t *testing.T) {
 		"community_treasury":     nil,
 		"community_vester":       nil,
 		"marketmap":              nil,
+		"megavault":              nil,
 	}
 	require.Equal(t, expectedMaccPerms, maccPerms, "default macc perms list does not match expected")
 }
@@ -97,6 +101,7 @@ func TestModuleAccountAddrs(t *testing.T) {
 		"dydx15ztc7xy42tn2ukkc0qjthkucw9ac63pgp70urn": true, // x/vest.communityTreasury
 		"dydx1wxje320an3karyc6mjw4zghs300dmrjkwn7xtk": true, // x/vest.communityVester
 		"dydx16j3d86dww8p2rzdlqsv7wle98cxzjxw6gjjyzn": true, // x/marketmap
+		"dydx18tkxrnrkqc2t0lr3zxr5g6a4hdvqksylxqje4r": true, // x/vault.megavault
 	}
 
 	require.Equal(t, expectedModuleAccAddresses, app.ModuleAccountAddrs())

--- a/protocol/x/vault/types/keys.go
+++ b/protocol/x/vault/types/keys.go
@@ -33,3 +33,9 @@ const (
 	// MostRecentClientIdsStore: vaultId VaultId -> clientIds []uint32
 	MostRecentClientIdsKeyPrefix = "MostRecentClientIds:"
 )
+
+// Module accounts
+const (
+	// MegavaultAccountName defines the root string for megavault module account.
+	MegavaultAccountName = "megavault"
+)

--- a/protocol/x/vault/types/keys_test.go
+++ b/protocol/x/vault/types/keys_test.go
@@ -15,3 +15,7 @@ func TestModuleKeys(t *testing.T) {
 func TestStateKeys(t *testing.T) {
 	require.Equal(t, "TotalShares:", types.TotalSharesKeyPrefix)
 }
+
+func TestModuleAccountKeys(t *testing.T) {
+	require.Equal(t, "megavault", types.MegavaultAccountName)
+}


### PR DESCRIPTION
### Changelist
add megavault module account

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced module functionality to recognize and manage vault accounts, including the introduction of `MegavaultAccountName`.
	- Added support for vault-related account mappings within the application.

- **Bug Fixes**
	- Improved test coverage by including assertions for the `MegavaultAccountName`, ensuring its correctness.

- **Documentation**
	- Updated test structure for better clarity and validation of new functionalities related to vault management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->