### PR TITLE
add megavault total shares query cli

### DIFF
--- a/protocol/x/vault/client/cli/query.go
+++ b/protocol/x/vault/client/cli/query.go
@@ -26,6 +26,7 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 	cmd.AddCommand(CmdQueryParams())
 	cmd.AddCommand(CmdQueryVault())
 	cmd.AddCommand(CmdQueryListVault())
+	cmd.AddCommand(CmdQueryTotalShares())
 	cmd.AddCommand(CmdQueryListOwnerShares())
 
 	return cmd
@@ -123,6 +124,30 @@ func CmdQueryListVault() *cobra.Command {
 	}
 
 	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdQueryTotalShares() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "total-shares",
+		Short: "get total shares of megavault",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.MegavaultTotalShares(
+				context.Background(),
+				&types.QueryMegavaultTotalSharesRequest{},
+			)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd


### PR DESCRIPTION
### Changelist
add `total-shares` query cli

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command, `total-shares`, allowing users to query the total shares of the megavault via the command-line interface.
	- Enhanced user experience by integrating this command into the existing command structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->