### PR TITLE
skip liquidation task loop if last committed block height is the same

### DIFF
--- a/protocol/daemons/liquidation/client/grpc_helper_test.go
+++ b/protocol/daemons/liquidation/client/grpc_helper_test.go
@@ -590,7 +590,11 @@ func TestSendLiquidatableSubaccountIds(t *testing.T) {
 				tc.subaccountOpenPositionInfo,
 				1000,
 			)
-			require.Equal(t, tc.expectedError, err)
+			if tc.expectedError != nil {
+				require.ErrorContains(t, err, tc.expectedError.Error())
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/protocol/daemons/liquidation/client/sub_task_runner.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner.go
@@ -60,6 +60,8 @@ func (s *SubTaskRunnerImpl) RunLiquidationDaemonTaskLoop(
 		return nil
 	}
 
+	s.lastLoopBlockHeight = lastCommittedBlockHeight
+
 	// 1. Fetch all information needed to calculate total net collateral and margin requirements.
 	subaccounts,
 		perpInfos,

--- a/protocol/daemons/liquidation/client/sub_task_runner.go
+++ b/protocol/daemons/liquidation/client/sub_task_runner.go
@@ -52,6 +52,8 @@ func (s *SubTaskRunnerImpl) RunLiquidationDaemonTaskLoop(
 		return err
 	}
 
+	// Skip the loop if no new block has been committed.
+	// Note that lastLoopBlockHeight is initialized to 0, so the first loop will always run.
 	if lastCommittedBlockHeight == s.lastLoopBlockHeight {
 		daemonClient.logger.Info(
 			"Skipping liquidation daemon task loop as no new block has been committed",
@@ -60,6 +62,7 @@ func (s *SubTaskRunnerImpl) RunLiquidationDaemonTaskLoop(
 		return nil
 	}
 
+	// Update the last loop block height.
 	s.lastLoopBlockHeight = lastCommittedBlockHeight
 
 	// 1. Fetch all information needed to calculate total net collateral and margin requirements.


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Enhanced error handling in test cases for more precise validation of expected errors.
  
- **New Features**
	- Improved efficiency of the liquidation daemon task loop by preventing unnecessary processing when no new blocks are committed.
	- Added state management capabilities to track the last processed block height within the task loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->