### PR TITLE
Stop creating client.toml in container tests

### DIFF
--- a/protocol/testing/containertest/node.go
+++ b/protocol/testing/containertest/node.go
@@ -9,7 +9,6 @@ import (
 
 	comethttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -121,15 +120,10 @@ func (n *Node) getContextForBroadcastTx(signer string) (*client.Context, *pflag.
 		return nil, nil, err
 	}
 
-	initClientCtx, err := config.ReadFromClientConfig(initClientCtx)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	// NB: In `cmd/dydxprotocol/root.go` this step is done before ReadFromClientConfig, but here we choose to
 	// do it second because ReadPersistentCommandFlags sets the node address we configured in flags.
 	// If we were to do it in reverse, ReadFromClientConfig would overwrite the node address.
-	initClientCtx, err = client.ReadPersistentCommandFlags(initClientCtx, flags)
+	initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, flags)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Changelist
An unnecessary client.toml file is created by container tests. 

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the initialization sequence of the client context to better preserve node address settings.
  
- **Refactor**
	- Streamlined the client context initialization logic for enhanced clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->