### PR TITLE
Full node streaming remove minimum for snapshot interval flag

### DIFF
--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -187,10 +187,6 @@ func (f *Flags) Validate() error {
 		}
 	}
 
-	if f.FullNodeStreamingSnapshotInterval > 0 && f.FullNodeStreamingSnapshotInterval < 50 {
-		return fmt.Errorf("full node streaming snapshot interval must be >= 50 blocks or zero")
-	}
-
 	return nil
 }
 

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -202,7 +202,7 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("full node streaming batch size must be positive number"),
 		},
-		"failure - full node streaming enabled with <= 49 snapshot interval": {
+		"success - full node streaming enabled with 20 snapshot interval": {
 			flags: flags.Flags{
 				NonValidatingFullNode:             true,
 				GrpcEnable:                        true,
@@ -210,19 +210,7 @@ func TestValidate(t *testing.T) {
 				GrpcStreamingFlushIntervalMs:      100,
 				GrpcStreamingMaxBatchSize:         2000,
 				GrpcStreamingMaxChannelBufferSize: 2000,
-				FullNodeStreamingSnapshotInterval: 49,
-			},
-			expectedErr: fmt.Errorf("full node streaming snapshot interval must be >= 50 blocks or zero"),
-		},
-		"success - full node streaming enabled with 50 snapshot interval": {
-			flags: flags.Flags{
-				NonValidatingFullNode:             true,
-				GrpcEnable:                        true,
-				GrpcStreamingEnabled:              true,
-				GrpcStreamingFlushIntervalMs:      100,
-				GrpcStreamingMaxBatchSize:         2000,
-				GrpcStreamingMaxChannelBufferSize: 2000,
-				FullNodeStreamingSnapshotInterval: 50,
+				FullNodeStreamingSnapshotInterval: 20,
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded configuration options for the `FullNodeStreamingSnapshotInterval`, allowing values below 50.
  
- **Bug Fixes**
  - Updated validation logic to remove restrictions on the `FullNodeStreamingSnapshotInterval`, enabling smoother setup of streaming snapshots. 

- **Tests**
  - Adjusted test cases to reflect the changes in validation, confirming that a snapshot interval of 20 is now valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->