### PR TITLE
Add subaccount id as kafka key for subaccount messages

### DIFF
--- a/indexer/services/ender/__tests__/lib/kafka-publisher.test.ts
+++ b/indexer/services/ender/__tests__/lib/kafka-publisher.test.ts
@@ -27,6 +27,7 @@ import { AnnotatedSubaccountMessage, ConsolidatedKafkaEvent, SingleTradeMessage 
 import { KafkaPublisher } from '../../src/lib/kafka-publisher';
 import {
   defaultDateTime,
+  defaultSubaccountId,
   defaultSubaccountMessage,
   defaultTradeContent,
   defaultTradeKafkaEvent,
@@ -69,6 +70,9 @@ describe('kafka-publisher', () => {
     expect(producerSendMock).toHaveBeenCalledWith({
       topic: subaccountKafkaEvent.topic,
       messages: [{
+        key: Buffer.from(Uint8Array.from(
+          IndexerSubaccountId.encode(defaultSubaccountId).finish(),
+        )),
         value: Buffer.from(SubaccountMessage.encode(subaccountKafkaEvent.message).finish()),
       }],
     });
@@ -420,6 +424,10 @@ describe('kafka-publisher', () => {
         topic: KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS,
         messages: _.map(expectedMsgs, (message: SubaccountMessage) => {
           return {
+            key: message.subaccountId !== undefined
+              ? Buffer.from(Uint8Array.from(
+                IndexerSubaccountId.encode(message.subaccountId).finish(),
+              )) : undefined,
             value: Buffer.from(Uint8Array.from(SubaccountMessage.encode(message).finish())),
           };
         }),

--- a/indexer/services/ender/src/lib/kafka-publisher.ts
+++ b/indexer/services/ender/src/lib/kafka-publisher.ts
@@ -10,6 +10,7 @@ import { FillSubaccountMessageContents, TradeMessageContents } from '@dydxprotoc
 import {
   BlockHeightMessage,
   CandleMessage,
+  IndexerSubaccountId,
   MarketMessage,
   OffChainUpdateV1,
   SubaccountMessage,
@@ -220,10 +221,15 @@ export class KafkaPublisher {
 
     if (this.subaccountMessages.length > 0) {
       this.aggregateFillEventsForSubaccountMessages();
+
       allTopicKafkaMessages.push({
         topic: KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS,
         messages: _.map(this.subaccountMessages, (message: SubaccountMessage) => {
           return {
+            key: message.subaccountId !== undefined
+              ? Buffer.from(Uint8Array.from(
+                IndexerSubaccountId.encode(message.subaccountId).finish(),
+              )) : undefined,
             value: Buffer.from(Uint8Array.from(SubaccountMessage.encode(message).finish())),
           };
         }),

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -17,6 +17,7 @@ import {
 import { getOrderIdHash, isStatefulOrder, ORDER_FLAG_SHORT_TERM } from '@dydxprotocol-indexer/v4-proto-parser';
 import {
   IndexerOrder,
+  IndexerSubaccountId,
   OffChainUpdateV1,
   OrderPlaceV1,
   OrderPlaceV1_OrderPlacementStatus,
@@ -116,6 +117,9 @@ export class OrderPlaceHandler extends Handler {
         await this.sendCachedOrderUpdate(orderUuid, headers);
       }
       const subaccountMessage: Message = {
+        key: Buffer.from(Uint8Array.from(
+          IndexerSubaccountId.encode(redisOrder.order!.orderId!.subaccountId!).finish(),
+        )),
         value: createSubaccountWebsocketMessage(
           redisOrder,
           dbOrder,

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -34,6 +34,7 @@ import {
 import {
   OffChainUpdateV1,
   IndexerOrder,
+  IndexerSubaccountId,
   OrderRemoveV1,
   OrderRemovalReason,
   OrderRemoveV1_OrderRemovalStatus,
@@ -220,6 +221,9 @@ export class OrderRemoveHandler extends Handler {
     }
 
     const subaccountMessage: Message = {
+      key: Buffer.from(Uint8Array.from(
+        IndexerSubaccountId.encode(orderRemove.removedOrderId!.subaccountId!).finish(),
+      )),
       value: this.createSubaccountWebsocketMessageFromPostgresOrder(
         order,
         orderRemove,
@@ -282,6 +286,9 @@ export class OrderRemoveHandler extends Handler {
           this.generateTimingStatsOptions('find_order'),
         );
         const subaccountMessage: Message = {
+          key: Buffer.from(Uint8Array.from(
+            IndexerSubaccountId.encode(orderRemove.removedOrderId!.subaccountId!).finish(),
+          )),
           value: this.createSubaccountWebsocketMessageFromOrderRemoveMessage(
             canceledOrder,
             orderRemove,
@@ -321,6 +328,9 @@ export class OrderRemoveHandler extends Handler {
     }
 
     const subaccountMessage: Message = {
+      key: Buffer.from(Uint8Array.from(
+        IndexerSubaccountId.encode(orderRemove.removedOrderId!.subaccountId!).finish(),
+      )),
       value: this.createSubaccountWebsocketMessageFromRemoveOrderResult(
         removeOrderResult,
         canceledOrder,


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced message handling by integrating subaccount identifiers in the Kafka messaging system.
	- Improved order processing with structured messages that include encoded subaccount IDs for order placement and removal.

- **Bug Fixes**
	- Resolved issues related to the clarity and integrity of order-related messages through proper subaccount ID encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->