### PR TITLE
[OTE-727] Add stub endpoint for affiliates/referral_code

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/affiliates-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/affiliates-controller.test.ts
@@ -1,0 +1,20 @@
+import { RequestMethod } from '../../../../src/types';
+import request from 'supertest';
+import { sendRequest } from '../../../helpers/helpers';
+
+describe('test-controller#V4', () => {
+  describe('GET /referral_code', () => {
+    it('should return referral code for a valid address string', async () => {
+      const address = 'some_address';
+      const response: request.Response = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/affiliates/referral_code?address=${address}`,
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        referralCode: 'TempCode123',
+      });
+    });
+  });
+});

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -431,6 +431,82 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
 This operation does not require authentication
 </aside>
 
+## GetReferralCode
+
+<a id="opIdGetReferralCode"></a>
+
+> Code samples
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/affiliates/referral_code', params={
+  'address': 'string'
+}, headers = headers)
+
+print(r.json())
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+};
+
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/affiliates/referral_code?address=string`,
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+`GET /affiliates/referral_code`
+
+### Parameters
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|address|query|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "referralCode": "string"
+}
+```
+
+### Responses
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Ok|[AffiliateReferralCodeResponse](#schemaaffiliatereferralcoderesponse)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
 ## GetAssetPositions
 
 <a id="opIdGetAssetPositions"></a>
@@ -3741,6 +3817,26 @@ This operation does not require authentication
 |equity|string|true|none|none|
 |freeCollateral|string|true|none|none|
 |childSubaccounts|[[SubaccountResponseObject](#schemasubaccountresponseobject)]|true|none|none|
+
+## AffiliateReferralCodeResponse
+
+<a id="schemaaffiliatereferralcoderesponse"></a>
+<a id="schema_AffiliateReferralCodeResponse"></a>
+<a id="tocSaffiliatereferralcoderesponse"></a>
+<a id="tocsaffiliatereferralcoderesponse"></a>
+
+```json
+{
+  "referralCode": "string"
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|referralCode|string¦null|true|none|none|
 
 ## AssetPositionResponse
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -240,6 +240,19 @@
         "type": "object",
         "additionalProperties": false
       },
+      "AffiliateReferralCodeResponse": {
+        "properties": {
+          "referralCode": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "referralCode"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
       "AssetPositionResponse": {
         "properties": {
           "positions": {
@@ -1515,6 +1528,34 @@
             "schema": {
               "format": "double",
               "type": "number"
+            }
+          }
+        ]
+      }
+    },
+    "/affiliates/referral_code": {
+      "get": {
+        "operationId": "GetReferralCode",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateReferralCodeResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
         ]

--- a/indexer/services/comlink/src/controllers/api/index-v4.ts
+++ b/indexer/services/comlink/src/controllers/api/index-v4.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import AddressesController from './v4/addresses-controller';
+import AffiliatesController from './v4/affiliates-controller';
 import AssetPositionsController from './v4/asset-positions-controller';
 import CandlesController from './v4/candles-controller';
 import ComplianceController from './v4/compliance-controller';
@@ -26,6 +27,7 @@ import VaultController from './v4/vault-controller';
 
 const router: express.Router = express.Router();
 router.use('/addresses', AddressesController);
+router.use('/affiliates', AffiliatesController);
 router.use('/assetPositions', AssetPositionsController);
 router.use('/candles', CandlesController);
 router.use('/fills', FillsController);

--- a/indexer/services/comlink/src/controllers/api/v4/affiliates-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/affiliates-controller.ts
@@ -1,0 +1,71 @@
+import { stats } from '@dydxprotocol-indexer/base';
+import express from 'express';
+import { checkSchema, matchedData } from 'express-validator';
+import {
+  Controller, Get, Query, Route,
+} from 'tsoa';
+
+import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import config from '../../../config';
+import { handleControllerError } from '../../../lib/helpers';
+import { rateLimiterMiddleware } from '../../../lib/rate-limit';
+import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
+import { AffiliateReferralCodeRequest, AffiliateReferralCodeResponse } from '../../../types';
+
+const router: express.Router = express.Router();
+const controllerName: string = 'affiliates-controller';
+
+@Route('affiliates')
+class AffiliatesController extends Controller {
+  @Get('/referral_code')
+  async getReferralCode(
+    @Query() address: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+  ): Promise<AffiliateReferralCodeResponse> {
+    // TODO: OTE-731 replace apit stubs with real logic
+    // simulate a delay
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    return {
+      referralCode: 'TempCode123',
+    };
+  }
+}
+
+router.get(
+  '/referral_code',
+  rateLimiterMiddleware(getReqRateLimiter),
+  ...checkSchema({
+    address: {
+      in: ['query'],
+      isString: true,
+      errorMessage: 'address must be a valid string',
+    },
+  }),
+  ExportResponseCodeStats({ controllerName }),
+  async (req: express.Request, res: express.Response) => {
+    const start: number = Date.now();
+    const {
+      address,
+    }: AffiliateReferralCodeRequest = matchedData(req) as AffiliateReferralCodeRequest;
+
+    try {
+      const controller: AffiliatesController = new AffiliatesController();
+      const response: AffiliateReferralCodeResponse = await controller.getReferralCode(address);
+      return res.send(response);
+    } catch (error) {
+      return handleControllerError(
+        'AffiliatesController GET /referral_code',
+        'Affiliates referral code error',
+        error,
+        req,
+        res,
+      );
+    } finally {
+      stats.timing(
+        `${config.SERVICE_NAME}.${controllerName}.get_referral_code.timing`,
+        Date.now() - start,
+      );
+    }
+  },
+);
+
+export default router;

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -666,3 +666,32 @@ export interface VaultPosition {
 export interface MegavaultPositionResponse {
   positions: VaultPosition[];
 }
+
+/* ------- Affiliates Types ------- */
+export interface AffiliateReferralCodeRequest{
+  address: string
+}
+
+export interface AffiliateReferralCodeResponse {
+  referralCode: string | null,
+}
+
+export interface AffiliateAddressResponse {
+  address: string | null,
+}
+
+export interface AffiliateSnapshotResponse {
+  affiliateList: AffiliateSnapshotResponseObject[],
+  total: number,
+  currentOffset: number
+}
+
+export interface AffiliateSnapshotResponseObject {
+  affiliateAddress: string,
+  affiliateEarnings: number,
+  affiliateReferralCode: string,
+  affiliateReferredTrades: number,
+  affiliateTotalReferredFees: number,
+  affiliateReferredUsers: number,
+  affiliateReferredNetProtocolEarnings: number
+}


### PR DESCRIPTION
### Changelist
Start of affiliates api work. First create a single stub, with more to follow.

### Test Plan
unit test
tested api stub against local indexer 

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint `GET /affiliates/referral_code` for retrieving referral codes based on an address.
  - Added detailed API documentation for the new endpoint, including request handling and response structure.
  - Implemented a controller to manage requests related to affiliate referral codes with validation and error handling.

- **Bug Fixes**
  - Enhanced request validation and error handling for the referral code retrieval process.

- **Documentation**
  - Updated API documentation with examples and response formats for the new referral code endpoint.

- **Tests**
  - Added unit tests for the new `affiliates-controller` API endpoint to ensure proper functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->