### PR TITLE
[TRA-530] When changing market pair name, validate that new pair exists in the market map

### DIFF
--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -50,10 +50,7 @@ func (k Keeper) ModifyMarketParam(
 		}
 	}
 	if _, err := k.MarketMapKeeper.GetMarket(ctx, updatedMarketParam.Pair); err != nil {
-		return types.MarketParam{}, errorsmod.Wrapf(
-			types.ErrTickerNotFoundInMarketMap,
-			updatedMarketParam.Pair,
-		)
+		return types.MarketParam{}, errorsmod.Wrapf(types.ErrTickerNotFoundInMarketMap, updatedMarketParam.Pair)
 	}
 
 	// Store the modified market param.

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -49,8 +49,11 @@ func (k Keeper) ModifyMarketParam(
 			return types.MarketParam{}, errorsmod.Wrapf(types.ErrMarketParamPairAlreadyExists, updatedMarketParam.Pair)
 		}
 	}
-	if _, err := k.GetMarketPrice(ctx, updatedMarketParam.Id); err != nil {
-		return types.MarketParam{}, errorsmod.Wrapf(types.ErrMarketPriceDoesNotExist, updatedMarketParam.Pair)
+	if _, err := k.MarketMapKeeper.GetMarket(ctx, updatedMarketParam.Pair); err != nil {
+		return types.MarketParam{}, errorsmod.Wrapf(
+			types.ErrTickerNotFoundInMarketMap,
+			updatedMarketParam.Pair,
+		)
 	}
 
 	// Store the modified market param.

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -49,6 +49,9 @@ func (k Keeper) ModifyMarketParam(
 			return types.MarketParam{}, errorsmod.Wrapf(types.ErrMarketParamPairAlreadyExists, updatedMarketParam.Pair)
 		}
 	}
+	if _, err := k.GetMarketPrice(ctx, updatedMarketParam.Id); err != nil {
+		return types.MarketParam{}, errorsmod.Wrapf(types.ErrMarketPriceDoesNotExist, updatedMarketParam.Pair)
+	}
 
 	// Store the modified market param.
 	marketParamStore := k.getMarketParamStore(ctx)

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -49,8 +49,14 @@ func (k Keeper) ModifyMarketParam(
 			return types.MarketParam{}, errorsmod.Wrapf(types.ErrMarketParamPairAlreadyExists, updatedMarketParam.Pair)
 		}
 	}
-	if _, err := k.MarketMapKeeper.GetMarket(ctx, updatedMarketParam.Pair); err != nil {
-		return types.MarketParam{}, errorsmod.Wrapf(types.ErrTickerNotFoundInMarketMap, updatedMarketParam.Pair)
+
+	// Validate that modified market param has a corresponding ticker in MarketMap
+	cp, err := slinky.MarketPairToCurrencyPair(updatedMarketParam.Pair)
+	if err != nil {
+		return types.MarketParam{}, errorsmod.Wrapf(types.ErrMarketPairConversionFailed, updatedMarketParam.Pair)
+	}
+	if _, err := k.MarketMapKeeper.GetMarket(ctx, cp.String()); err != nil {
+		return types.MarketParam{}, errorsmod.Wrapf(types.ErrTickerNotFoundInMarketMap, cp.String())
 	}
 
 	// Store the modified market param.

--- a/protocol/x/prices/keeper/market_param.go
+++ b/protocol/x/prices/keeper/market_param.go
@@ -70,12 +70,7 @@ func (k Keeper) ModifyMarketParam(
 		k.currencyPairIDCache.Remove(uint64(existingParam.Id))
 
 		// add the new cache entry
-		cp, err := slinky.MarketPairToCurrencyPair(updatedMarketParam.Pair)
-		if err == nil {
-			k.currencyPairIDCache.AddCurrencyPair(uint64(updatedMarketParam.Id), cp.String())
-		} else {
-			k.Logger(ctx).Error("failed to add currency pair to cache", "pair", updatedMarketParam.Pair)
-		}
+		k.currencyPairIDCache.AddCurrencyPair(uint64(updatedMarketParam.Id), cp.String())
 	}
 
 	// Generate indexer event.

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -79,16 +79,19 @@ func TestModifyMarketParamUpdatesCache(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, uint64(id), cpID)
 
-	// create new ticker in MarketMap for newParam (new ticker must exist in MarketMap before MarketParam.Pair can be updated)
+	// create new ticker in MarketMap for newParam
+	// (new ticker must exist in MarketMap before MarketParam.Pair can be updated)
 	newParam := oldParam
 	newParam.Pair = "bar-foo"
-	keepertest.CreateMarketsInMarketMapFromParams(t, ctx, keeper.MarketMapKeeper.(*marketmapkeeper.Keeper), []types.MarketParam{newParam})
+	keepertest.CreateMarketsInMarketMapFromParams(
+		t,
+		ctx,
+		keeper.MarketMapKeeper.(*marketmapkeeper.Keeper),
+		[]types.MarketParam{newParam},
+	)
 
 	// modify the market param
-	newParam, err = keeper.ModifyMarketParam(
-		ctx,
-		newParam,
-	)
+	newParam, err = keeper.ModifyMarketParam(ctx, newParam)
 	require.NoError(t, err)
 
 	// check that the existing entry does not exist

--- a/protocol/x/prices/keeper/market_param_test.go
+++ b/protocol/x/prices/keeper/market_param_test.go
@@ -21,7 +21,6 @@ func TestModifyMarketParam(t *testing.T) {
 	mockTimeProvider.On("Now").Return(constants.TimeT)
 	ctx = ctx.WithTxBytes(constants.TestTxBytes)
 	items := keepertest.CreateNMarkets(t, ctx, keeper, 10)
-
 	for i, item := range items {
 		// Modify each field arbitrarily and
 		// verify the fields were modified in state
@@ -62,8 +61,7 @@ func TestModifyMarketParamUpdatesCache(t *testing.T) {
 		MinPriceChangePpm:  uint32(50),
 		ExchangeConfigJson: `{"id":"1"}`,
 	}
-
-	oldMp, err := keepertest.CreateTestMarket(t, ctx, keeper, oldParam, types.MarketPrice{
+	mp, err := keepertest.CreateTestMarket(t, ctx, keeper, oldParam, types.MarketPrice{
 		Id:       id,
 		Exponent: -8,
 		Price:    1,
@@ -71,7 +69,7 @@ func TestModifyMarketParamUpdatesCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// check that the existing entry exists
-	cp, err := slinky.MarketPairToCurrencyPair(oldMp.Pair)
+	cp, err := slinky.MarketPairToCurrencyPair(mp.Pair)
 	require.NoError(t, err)
 
 	// check that the existing entry exists


### PR DESCRIPTION
### Changelist
* When changing market pair name, validate that new pair exists in the market map

### Test Plan
* Updated tests in `market_param_test.go`:
   * Changed "valid" tests to enforce that new pair ticker exists in MarketMap
   * Added new "error" test to ensure the correct error is fired upon failure

### Author/Reviewer Checklist
- [] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for modifying market parameters, ensuring only valid market parameters are processed.
	- Improved error handling when updating market parameters related to tickers.

- **Bug Fixes**
	- Expanded test cases for error handling in market parameter modifications to cover scenarios where the ticker is absent in the MarketMap.

- **Tests**
	- Updated test cases to ensure robustness in the modification and error handling of market parameters, including new scenarios for invalid pairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->