### PR TITLE
[OT-767] add two new rules to indexer eslint

### DIFF
--- a/indexer/packages/base/src/axios/errors.ts
+++ b/indexer/packages/base/src/axios/errors.ts
@@ -1,8 +1,8 @@
 import { WrappedError } from '../errors';
 
 export interface AxiosOriginalError extends Error {
-  isAxiosError: true;
-  toJSON(): Error;
+  isAxiosError: true,
+  toJSON(): Error,
 }
 
 export interface AxiosErrorResponse {

--- a/indexer/packages/base/src/config-util.ts
+++ b/indexer/packages/base/src/config-util.ts
@@ -48,10 +48,10 @@ interface ParseOptions<T> {
   // If `default` is present, then the environment variable will be optional and will default to the
   // value of `default` when unset. In particular, `default` may be null in which case the config
   // value will be null when the environment variable is not set.
-  default: T;
+  default: T,
 
   // Can be specified to ensure the default value is not used when running in a certain NODE_ENV.
-  requireInEnv?: NodeEnv[];
+  requireInEnv?: NodeEnv[],
 }
 
 const NODE_ENV = process.env.NODE_ENV;
@@ -229,10 +229,10 @@ export function parseSchema<T extends SchemaBase>(
 ): {
   [K in keyof T]: T[K] extends ParseFn<infer U> ? U : never;
 } & {
-  isDevelopment: () => boolean;
-  isStaging: () => boolean;
-  isProduction: () => boolean;
-  isTest: () => boolean;
+  isDevelopment: () => boolean,
+  isStaging: () => boolean,
+  isProduction: () => boolean,
+  isTest: () => boolean,
 } {
   const config = _.mapValues(schema, (parseFn: ParseFn<T>, varName: string) => {
     const fullVarName = prefix ? `${prefix}_${varName}` : varName;

--- a/indexer/packages/base/src/logger.ts
+++ b/indexer/packages/base/src/logger.ts
@@ -13,21 +13,21 @@ type UnusedLevels = 'warn' | 'help' | 'data' | 'prompt' | 'http' | 'verbose' | '
 
 // Enforce type constraints on the objects passed into Winston logging functions.
 interface LeveledLogMethod {
-  (infoObject: InfoObject): winston.Logger;
+  (infoObject: InfoObject): winston.Logger,
 }
 // Exclude the functions whose type we want to change from the base definition. This seems to be
 // enough (and the only way I've found) to trick TypeScript into accepting the modified LoggerExport
 // as a valid extension of the base winston.Logger type.
 type SyslogLevels = 'emerg' | 'alert' | 'crit' | 'error' | 'warning' | 'notice' | 'info' | 'debug';
 export interface LoggerExport extends Omit<winston.Logger, UnusedLevels | SyslogLevels> {
-  emerg: LeveledLogMethod;
-  alert: LeveledLogMethod;
-  crit: LeveledLogMethod;
-  error: LeveledLogMethod;
-  warning: LeveledLogMethod;
-  notice: LeveledLogMethod;
-  info: LeveledLogMethod;
-  debug: LeveledLogMethod;
+  emerg: LeveledLogMethod,
+  alert: LeveledLogMethod,
+  crit: LeveledLogMethod,
+  error: LeveledLogMethod,
+  warning: LeveledLogMethod,
+  notice: LeveledLogMethod,
+  info: LeveledLogMethod,
+  debug: LeveledLogMethod,
 }
 
 const logger: LoggerExport = winston.createLogger({

--- a/indexer/packages/base/src/types.ts
+++ b/indexer/packages/base/src/types.ts
@@ -21,8 +21,8 @@ export enum BugsnagReleaseStage {
 }
 
 export interface PagerDutyInfo {
-  message: {};
-  id?: string;
+  message: {},
+  id?: string,
 }
 
 // Enforce type constraints on the objects passed into Winston logging functions.

--- a/indexer/packages/dev/.eslintrc.js
+++ b/indexer/packages/dev/.eslintrc.js
@@ -62,6 +62,7 @@ module.exports = {
     ],
     'import/no-extraneous-dependencies': 'off',
     'import/prefer-default-export': 'off',
+    'key-spacing': ['error', { beforeColon: false, afterColon: true }],
     'max-classes-per-file': 'off',
     'no-await-in-loop': 'off',
     'no-continue': 'off',
@@ -139,6 +140,16 @@ module.exports = {
       'always',
       { exceptAfterSingleLine: true },
     ],
+    '@typescript-eslint/member-delimiter-style': ['error', {
+      multiline: {
+        delimiter: 'comma',
+        requireLast: true,
+      },
+      singleline: {
+        delimiter: 'comma',
+        requireLast: false,
+      },
+    }],
     '@typescript-eslint/naming-convention': ['error',
       {
         selector: 'variableLike',

--- a/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
@@ -201,7 +201,7 @@ describe('PnlTicks store', () => {
       maxBlockTime, count,
     }: {
       maxBlockTime: string,
-      count: number
+      count: number,
     } = await PnlTicksTable.findLatestProcessedBlocktimeAndCount();
 
     expect(maxBlockTime).toEqual(blockTime);
@@ -213,7 +213,7 @@ describe('PnlTicks store', () => {
       maxBlockTime, count,
     }: {
       maxBlockTime: string,
-      count: number
+      count: number,
     } = await PnlTicksTable.findLatestProcessedBlocktimeAndCount();
 
     expect(maxBlockTime).toEqual(ZERO_TIME_ISO_8601);
@@ -289,7 +289,7 @@ describe('PnlTicks store', () => {
     ]);
 
     const leaderboardRankedData: {
-      [accountId: string]: PnlTicksCreateObject
+      [accountId: string]: PnlTicksCreateObject,
     } = await PnlTicksTable.findMostRecentPnlTickForEachAccount(
       '3',
     );

--- a/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
+++ b/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
@@ -222,7 +222,7 @@ export async function findLatestProcessedBlocktimeAndCount(): Promise<{
   count: number,
 }> {
   const result: {
-    rows: [{ max: string, count: number }]
+    rows: [{ max: string, count: number }],
   } = await knexReadReplica.getConnection().raw(
     `
     WITH maxBlockTime AS (
@@ -253,12 +253,12 @@ export async function findLatestProcessedBlocktimeAndCount(): Promise<{
 export async function findMostRecentPnlTickForEachAccount(
   createdOnOrAfterHeight: string,
 ): Promise<{
-  [subaccountId: string]: PnlTicksCreateObject
+  [subaccountId: string]: PnlTicksCreateObject,
 }> {
   verifyAllInjectableVariables([createdOnOrAfterHeight]);
 
   const result: {
-    rows: PnlTicksFromDatabase[]
+    rows: PnlTicksFromDatabase[],
   } = await knexReadReplica.getConnection().raw(
     `
     SELECT DISTINCT ON ("subaccountId") *
@@ -331,7 +331,7 @@ async function getRankedPnlTicksForTimeSpan(
   const vaultAddressesString: string = vaultAddresses.map((address) => `'${address}'`).join(',');
   const intervalSqlString: string = convertTimespanToSQL(timeSpan);
   const result: {
-    rows: LeaderboardPnlCreateObject[]
+    rows: LeaderboardPnlCreateObject[],
   } = await knexReadReplica.getConnection().raw(
     `
     WITH latest_subaccount_pnl_x_days_ago AS (
@@ -410,7 +410,7 @@ async function getAllTimeRankedPnlTicks(): Promise<LeaderboardPnlCreateObject[]>
   const vaultAddresses: string[] = getVaultAddresses();
   const vaultAddressesString: string = vaultAddresses.map((address) => `'${address}'`).join(',');
   const result: {
-    rows: LeaderboardPnlCreateObject[]
+    rows: LeaderboardPnlCreateObject[],
   } = await knexReadReplica.getConnection().raw(
     `
     WITH latest_pnl as (

--- a/indexer/packages/postgres/src/stores/transfer-table.ts
+++ b/indexer/packages/postgres/src/stores/transfer-table.ts
@@ -41,9 +41,9 @@ export function uuid(
 }
 
 interface SubaccountAssetNetTransfer {
-  subaccountId: string;
-  assetId: string;
-  totalSize: string;
+  subaccountId: string,
+  assetId: string,
+  totalSize: string,
 }
 
 export async function findAll(
@@ -345,7 +345,7 @@ function convertToSubaccountAssetMap(
 }
 
 export interface AssetTransferMap {
-  [assetId: string]: Big;
+  [assetId: string]: Big,
 }
 
 export async function getNetTransfersBetweenBlockHeightsForSubaccount(
@@ -378,8 +378,8 @@ export async function getNetTransfersBetweenBlockHeightsForSubaccount(
 
   const result: {
     rows: {
-      assetId: string;
-      totalSize: string;
+      assetId: string,
+      totalSize: string,
     }[],
   } = await rawQuery(queryString, options);
   return _.mapValues(_.keyBy(result.rows, 'assetId'), (row: { assetId: string, totalSize: string }) => {

--- a/indexer/packages/postgres/src/types/block-types.ts
+++ b/indexer/packages/postgres/src/types/block-types.ts
@@ -3,8 +3,8 @@
 type IsoString = string;
 
 export interface BlockCreateObject {
-  blockHeight: string;
-  time: IsoString;
+  blockHeight: string,
+  time: IsoString,
 }
 
 export enum BlockColumns {

--- a/indexer/packages/postgres/src/types/candle-types.ts
+++ b/indexer/packages/postgres/src/types/candle-types.ts
@@ -1,33 +1,33 @@
 import { IsoString } from './utility-types';
 
 export interface CandleCreateObject {
-  startedAt: IsoString;
-  ticker: string;
-  resolution: CandleResolution;
-  low: string;
-  high: string;
-  open: string;
-  close: string;
-  baseTokenVolume: string;
-  usdVolume: string;
-  trades: number;
-  startingOpenInterest: string;
-  orderbookMidPriceOpen: string | undefined;
-  orderbookMidPriceClose: string | undefined;
+  startedAt: IsoString,
+  ticker: string,
+  resolution: CandleResolution,
+  low: string,
+  high: string,
+  open: string,
+  close: string,
+  baseTokenVolume: string,
+  usdVolume: string,
+  trades: number,
+  startingOpenInterest: string,
+  orderbookMidPriceOpen: string | undefined,
+  orderbookMidPriceClose: string | undefined,
 }
 
 export interface CandleUpdateObject {
-  id: string;
-  low?: string;
-  high?: string;
-  open?: string;
-  close?: string;
-  baseTokenVolume?: string;
-  usdVolume?: string;
-  trades?: number;
-  startingOpenInterest?: string;
-  orderbookMidPriceOpen?: string;
-  orderbookMidPriceClose?: string;
+  id: string,
+  low?: string,
+  high?: string,
+  open?: string,
+  close?: string,
+  baseTokenVolume?: string,
+  usdVolume?: string,
+  trades?: number,
+  startingOpenInterest?: string,
+  orderbookMidPriceOpen?: string,
+  orderbookMidPriceClose?: string,
 }
 
 export enum CandleResolution {

--- a/indexer/packages/postgres/src/types/compliance-data-types.ts
+++ b/indexer/packages/postgres/src/types/compliance-data-types.ts
@@ -7,21 +7,21 @@ export enum ComplianceProvider {
 }
 
 export interface ComplianceDataCreateObject {
-  address: string;
-  provider: string;
-  chain?: string;
-  blocked: boolean;
-  riskScore?: string;
-  updatedAt?: IsoString;
+  address: string,
+  provider: string,
+  chain?: string,
+  blocked: boolean,
+  riskScore?: string,
+  updatedAt?: IsoString,
 }
 
 export interface ComplianceDataUpdateObject {
-  address: string;
-  provider: string;
-  chain?: string;
-  blocked?: boolean;
-  riskScore?: string;
-  updatedAt?: IsoString;
+  address: string,
+  provider: string,
+  chain?: string,
+  blocked?: boolean,
+  riskScore?: string,
+  updatedAt?: IsoString,
 }
 
 export enum ComplianceDataColumns {

--- a/indexer/packages/postgres/src/types/compliance-status-types.ts
+++ b/indexer/packages/postgres/src/types/compliance-status-types.ts
@@ -20,26 +20,26 @@ export enum ComplianceStatus {
 }
 
 export interface ComplianceStatusCreateObject {
-  address: string;
-  status: ComplianceStatus;
-  reason?: ComplianceReason;
-  createdAt?: IsoString;
-  updatedAt?: IsoString;
+  address: string,
+  status: ComplianceStatus,
+  reason?: ComplianceReason,
+  createdAt?: IsoString,
+  updatedAt?: IsoString,
 }
 
 export interface ComplianceStatusUpsertObject {
-  address: string;
-  status: ComplianceStatus;
-  reason?: ComplianceReason;
-  updatedAt: IsoString;
+  address: string,
+  status: ComplianceStatus,
+  reason?: ComplianceReason,
+  updatedAt: IsoString,
 }
 
 export interface ComplianceStatusUpdateObject {
-  address: string;
-  status?: ComplianceStatus;
-  reason?: ComplianceReason | null;
-  createdAt?: IsoString;
-  updatedAt?: IsoString;
+  address: string,
+  status?: ComplianceStatus,
+  reason?: ComplianceReason | null,
+  createdAt?: IsoString,
+  updatedAt?: IsoString,
 }
 
 export enum ComplianceStatusColumns {

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -15,7 +15,7 @@ import { TradingRewardAggregationPeriod } from './trading-reward-aggregation-typ
 type IsoString = string;
 
 export interface IdBasedModelFromDatabase {
-  id: string;
+  id: string,
 }
 
 export interface SubaccountFromDatabase extends IdBasedModelFromDatabase {
@@ -31,99 +31,99 @@ export interface WalletFromDatabase {
 }
 
 export interface PerpetualPositionFromDatabase extends IdBasedModelFromDatabase {
-  id: string;
-  subaccountId: string;
-  perpetualId: string;
-  side: PositionSide;
-  status: PerpetualPositionStatus;
-  size: string;  // The size of the position. Positive for long, negative for short.
-  maxSize: string;
-  entryPrice: string;
-  exitPrice?: string;
-  sumOpen: string;
-  sumClose: string;
-  createdAt: IsoString;
-  closedAt?: IsoString;
-  createdAtHeight: string;
-  closedAtHeight?: string;
-  openEventId: Buffer;
-  closeEventId?: Buffer;
-  lastEventId: Buffer;
-  settledFunding: string;
+  id: string,
+  subaccountId: string,
+  perpetualId: string,
+  side: PositionSide,
+  status: PerpetualPositionStatus,
+  size: string,  // The size of the position. Positive for long, negative for short.
+  maxSize: string,
+  entryPrice: string,
+  exitPrice?: string,
+  sumOpen: string,
+  sumClose: string,
+  createdAt: IsoString,
+  closedAt?: IsoString,
+  createdAtHeight: string,
+  closedAtHeight?: string,
+  openEventId: Buffer,
+  closeEventId?: Buffer,
+  lastEventId: Buffer,
+  settledFunding: string,
 }
 
 export interface OrderFromDatabase extends IdBasedModelFromDatabase {
-  subaccountId: string;
-  clientId: string;
-  clobPairId: string;
-  side: OrderSide;
-  size: string;
-  totalFilled: string;
-  price: string;
-  type: OrderType;
-  status: OrderStatus;
-  timeInForce: TimeInForce;
-  reduceOnly: boolean;
-  orderFlags: string;
-  updatedAt: IsoString;
-  updatedAtHeight: string;
-  goodTilBlock?: string;
-  goodTilBlockTime?: string;
+  subaccountId: string,
+  clientId: string,
+  clobPairId: string,
+  side: OrderSide,
+  size: string,
+  totalFilled: string,
+  price: string,
+  type: OrderType,
+  status: OrderStatus,
+  timeInForce: TimeInForce,
+  reduceOnly: boolean,
+  orderFlags: string,
+  updatedAt: IsoString,
+  updatedAtHeight: string,
+  goodTilBlock?: string,
+  goodTilBlockTime?: string,
   // createdAtHeight is optional because short term orders do not have a createdAtHeight.
-  createdAtHeight?: string;
-  clientMetadata: string;
-  triggerPrice?: string;
+  createdAtHeight?: string,
+  clientMetadata: string,
+  triggerPrice?: string,
 }
 
 export interface PerpetualMarketFromDatabase {
-  id: string;
-  clobPairId: string;
-  ticker: string;
-  marketId: number;
-  status: PerpetualMarketStatus;
-  priceChange24H: string;
-  volume24H: string;
-  trades24H: number;
-  nextFundingRate: string;
-  openInterest: string;
-  quantumConversionExponent: number;
-  atomicResolution: number;
-  subticksPerTick: number;
-  stepBaseQuantums: number;
-  liquidityTierId: number;
-  marketType: PerpetualMarketType;
-  baseOpenInterest: string;
+  id: string,
+  clobPairId: string,
+  ticker: string,
+  marketId: number,
+  status: PerpetualMarketStatus,
+  priceChange24H: string,
+  volume24H: string,
+  trades24H: number,
+  nextFundingRate: string,
+  openInterest: string,
+  quantumConversionExponent: number,
+  atomicResolution: number,
+  subticksPerTick: number,
+  stepBaseQuantums: number,
+  liquidityTierId: number,
+  marketType: PerpetualMarketType,
+  baseOpenInterest: string,
 }
 
 export interface FillFromDatabase {
-  id: string;
-  subaccountId: string;
-  side: OrderSide;
-  liquidity: Liquidity;
-  type: FillType;
-  clobPairId: string;
-  size: string;
-  price: string;
-  quoteAmount: string;
-  eventId: Buffer;
-  transactionHash: string;
-  createdAt: IsoString;
-  createdAtHeight: string;
-  orderId?: string;
-  clientMetadata?: string;
-  fee: string;
+  id: string,
+  subaccountId: string,
+  side: OrderSide,
+  liquidity: Liquidity,
+  type: FillType,
+  clobPairId: string,
+  size: string,
+  price: string,
+  quoteAmount: string,
+  eventId: Buffer,
+  transactionHash: string,
+  createdAt: IsoString,
+  createdAtHeight: string,
+  orderId?: string,
+  clientMetadata?: string,
+  fee: string,
 }
 
 export interface BlockFromDatabase {
-  blockHeight: string;
-  time: IsoString;
+  blockHeight: string,
+  time: IsoString,
 }
 
 export interface TendermintEventFromDatabase {
-  id: Buffer;
-  blockHeight: string;
-  transactionIndex: number;
-  eventIndex: number;
+  id: Buffer,
+  blockHeight: string,
+  transactionIndex: number,
+  eventIndex: number,
 }
 
 export interface TransactionFromDatabase extends IdBasedModelFromDatabase {
@@ -134,146 +134,146 @@ export interface TransactionFromDatabase extends IdBasedModelFromDatabase {
 }
 
 export interface AssetFromDatabase {
-  id: string;
-  symbol: string;
-  atomicResolution: number;
-  hasMarket: boolean;
-  marketId?: number;
+  id: string,
+  symbol: string,
+  atomicResolution: number,
+  hasMarket: boolean,
+  marketId?: number,
 }
 
 export interface AssetPositionFromDatabase {
-  id: string;
-  assetId: string;
-  subaccountId: string;
-  size: string;
-  isLong: boolean;
+  id: string,
+  assetId: string,
+  subaccountId: string,
+  size: string,
+  isLong: boolean,
 }
 
 export interface TransferFromDatabase extends IdBasedModelFromDatabase {
-  senderSubaccountId?: string;
-  recipientSubaccountId?: string;
-  senderWalletAddress?: string;
-  recipientWalletAddress?: string;
-  assetId: string;
-  size: string;
-  eventId: Buffer;
-  transactionHash: string;
-  createdAt: IsoString;
-  createdAtHeight: string;
+  senderSubaccountId?: string,
+  recipientSubaccountId?: string,
+  senderWalletAddress?: string,
+  recipientWalletAddress?: string,
+  assetId: string,
+  size: string,
+  eventId: Buffer,
+  transactionHash: string,
+  createdAt: IsoString,
+  createdAtHeight: string,
 }
 
 export interface MarketFromDatabase {
-  id: number;
-  pair: string;
-  exponent: number;
-  minPriceChangePpm: number;
-  oraclePrice?: string;
+  id: number,
+  pair: string,
+  exponent: number,
+  minPriceChangePpm: number,
+  oraclePrice?: string,
 }
 
 export interface OraclePriceFromDatabase extends IdBasedModelFromDatabase {
-  marketId: number;
-  price: string;
-  effectiveAt: IsoString;
-  effectiveAtHeight: string;
+  marketId: number,
+  price: string,
+  effectiveAt: IsoString,
+  effectiveAtHeight: string,
 }
 
 export interface LiquidityTiersFromDatabase {
-  id: number;
-  name: string;
-  initialMarginPpm: string;
-  maintenanceFractionPpm: string;
-  openInterestLowerCap?: string;
-  openInterestUpperCap?: string;
+  id: number,
+  name: string,
+  initialMarginPpm: string,
+  maintenanceFractionPpm: string,
+  openInterestLowerCap?: string,
+  openInterestUpperCap?: string,
 }
 
 export interface CandleFromDatabase extends IdBasedModelFromDatabase {
-  startedAt: IsoString;
-  ticker: string;
-  resolution: CandleResolution;
-  low: string;
-  high: string;
-  open: string;
-  close: string;
-  baseTokenVolume: string;
-  usdVolume: string;
-  trades: number;
-  startingOpenInterest: string;
-  orderbookMidPriceOpen?: string | null;
-  orderbookMidPriceClose?: string | null;
+  startedAt: IsoString,
+  ticker: string,
+  resolution: CandleResolution,
+  low: string,
+  high: string,
+  open: string,
+  close: string,
+  baseTokenVolume: string,
+  usdVolume: string,
+  trades: number,
+  startingOpenInterest: string,
+  orderbookMidPriceOpen?: string | null,
+  orderbookMidPriceClose?: string | null,
 }
 
 export interface PnlTicksFromDatabase extends IdBasedModelFromDatabase {
-  subaccountId: string;
-  equity: string;
-  totalPnl: string;
-  netTransfers: string;
-  createdAt: IsoString;
-  blockHeight: string;
-  blockTime: IsoString;
+  subaccountId: string,
+  equity: string,
+  totalPnl: string,
+  netTransfers: string,
+  createdAt: IsoString,
+  blockHeight: string,
+  blockTime: IsoString,
 }
 
 export interface FundingIndexUpdatesFromDatabase extends IdBasedModelFromDatabase {
-  perpetualId: string;
-  eventId: Buffer;
-  rate: string;
-  oraclePrice: string;
-  fundingIndex: string;
-  effectiveAt: string;
-  effectiveAtHeight: string;
+  perpetualId: string,
+  eventId: Buffer,
+  rate: string,
+  oraclePrice: string,
+  fundingIndex: string,
+  effectiveAt: string,
+  effectiveAtHeight: string,
 }
 
 export interface ComplianceDataFromDatabase {
-  address: string;
-  chain?: string;
-  blocked: boolean;
-  riskScore?: string;
-  updatedAt: string;
+  address: string,
+  chain?: string,
+  blocked: boolean,
+  riskScore?: string,
+  updatedAt: string,
 }
 
 export interface ComplianceStatusFromDatabase {
-  address: string;
-  status: ComplianceStatus;
-  reason?: ComplianceReason;
-  createdAt: IsoString;
-  updatedAt: IsoString;
+  address: string,
+  status: ComplianceStatus,
+  reason?: ComplianceReason,
+  createdAt: IsoString,
+  updatedAt: IsoString,
 }
 
 export interface TradingRewardFromDatabase {
-  id: string;
-  address: string;
-  blockTime: IsoString;
-  blockHeight: string;
-  amount: string;
+  id: string,
+  address: string,
+  blockTime: IsoString,
+  blockHeight: string,
+  amount: string,
 }
 
 export interface TradingRewardAggregationFromDatabase {
-  id: string;
-  address: string;
-  startedAt: IsoString;
-  startedAtHeight: string;
-  endedAt?: IsoString;
-  endedAtHeight?: string;
-  period: TradingRewardAggregationPeriod;
-  amount: string;
+  id: string,
+  address: string,
+  startedAt: IsoString,
+  startedAtHeight: string,
+  endedAt?: IsoString,
+  endedAtHeight?: string,
+  period: TradingRewardAggregationPeriod,
+  amount: string,
 }
 
 export interface SubaccountUsernamesFromDatabase {
-  username: string;
-  subaccountId: string;
+  username: string,
+  subaccountId: string,
 }
 
 export interface LeaderboardPnlFromDatabase {
-  address: string;
-  timeSpan: string;
-  pnl: string;
-  currentEquity: string;
-  rank: number;
+  address: string,
+  timeSpan: string,
+  pnl: string,
+  currentEquity: string,
+  rank: number,
 }
 
 export type SubaccountAssetNetTransferMap = { [subaccountId: string]:
-{ [assetId: string]: string } };
+{ [assetId: string]: string }, };
 export type SubaccountToPerpetualPositionsMap = { [subaccountId: string]:
-{ [perpetualId: string]: PerpetualPositionFromDatabase } };
+{ [perpetualId: string]: PerpetualPositionFromDatabase }, };
 export type PerpetualPositionsMap = { [perpetualMarketId: string]: PerpetualPositionFromDatabase };
 export type PerpetualMarketsMap = { [perpetualMarketId: string]: PerpetualMarketFromDatabase };
 export type AssetsMap = { [assetId: string]: AssetFromDatabase };

--- a/indexer/packages/postgres/src/types/fill-types.ts
+++ b/indexer/packages/postgres/src/types/fill-types.ts
@@ -30,32 +30,32 @@ export enum FillType {
 }
 
 export interface FillCreateObject {
-  subaccountId: string;
-  side: OrderSide;
-  liquidity: Liquidity;
-  type: FillType;
-  clobPairId: string;
-  orderId?: string;
-  size: string;
-  price: string;
-  quoteAmount: string;
-  eventId: Buffer;
-  transactionHash: string;
-  createdAt: string;
-  createdAtHeight: string;
-  clientMetadata?: string;
-  fee: string;
+  subaccountId: string,
+  side: OrderSide,
+  liquidity: Liquidity,
+  type: FillType,
+  clobPairId: string,
+  orderId?: string,
+  size: string,
+  price: string,
+  quoteAmount: string,
+  eventId: Buffer,
+  transactionHash: string,
+  createdAt: string,
+  createdAtHeight: string,
+  clientMetadata?: string,
+  fee: string,
 }
 
 export interface FillUpdateObject {
-  id: string;
-  side?: OrderSide;
-  type?: FillType;
-  clobPairId?: string;
-  orderId?: string | null;
-  size?: string;
-  price?: string;
-  quoteAmount?: string;
+  id: string,
+  side?: OrderSide,
+  type?: FillType,
+  clobPairId?: string,
+  orderId?: string | null,
+  size?: string,
+  price?: string,
+  quoteAmount?: string,
 }
 
 export enum FillColumns {
@@ -78,27 +78,27 @@ export enum FillColumns {
 }
 
 export type CostOfFills = {
-  cost: number;
+  cost: number,
 };
 
 export interface OrderedFillsWithFundingIndices {
-  id: string;
-  subaccountId: string;
-  side: OrderSide;
-  size: string;
-  createdAtHeight: string;
-  fundingIndex: string;
-  lastFillId: string;
-  lastFillSide: OrderSide;
-  lastFillSize: string;
-  lastFillCreatedAtHeight: string;
-  lastFillFundingIndex: string;
+  id: string,
+  subaccountId: string,
+  side: OrderSide,
+  size: string,
+  createdAtHeight: string,
+  fundingIndex: string,
+  lastFillId: string,
+  lastFillSide: OrderSide,
+  lastFillSize: string,
+  lastFillCreatedAtHeight: string,
+  lastFillFundingIndex: string,
 }
 
 export interface OpenSizeWithFundingIndex {
-  clobPairId: string;
-  openSize: string;
-  lastFillHeight: string;
-  fundingIndex: string;
-  fundingIndexHeight: string;
+  clobPairId: string,
+  openSize: string,
+  lastFillHeight: string,
+  fundingIndex: string,
+  fundingIndexHeight: string,
 }

--- a/indexer/packages/postgres/src/types/leaderboard-pnl-types.ts
+++ b/indexer/packages/postgres/src/types/leaderboard-pnl-types.ts
@@ -1,11 +1,11 @@
 /* ------- LEADERBOARD PNL TYPES ------- */
 
 export interface LeaderboardPnlCreateObject {
-  address: string;
-  pnl: string;
-  timeSpan: string;
-  currentEquity: string;
-  rank: number;
+  address: string,
+  pnl: string,
+  timeSpan: string,
+  currentEquity: string,
+  rank: number,
 }
 
 export enum LeaderboardPnlColumns {

--- a/indexer/packages/postgres/src/types/market-types.ts
+++ b/indexer/packages/postgres/src/types/market-types.ts
@@ -12,7 +12,7 @@ export interface MarketUpdateObject {
   id: number,
   pair?: string,
   minPriceChangePpm?: number,
-  oraclePrice?: string;
+  oraclePrice?: string,
 }
 
 export enum MarketColumns {

--- a/indexer/packages/postgres/src/types/order-types.ts
+++ b/indexer/packages/postgres/src/types/order-types.ts
@@ -43,46 +43,46 @@ export enum TimeInForce {
 }
 
 export interface OrderCreateObject {
-  subaccountId: string;
-  clientId: string;
-  clobPairId: string;
-  side: OrderSide;
-  size: string;
-  totalFilled: string;
-  price: string;
-  type: OrderType;
-  status: OrderStatus;
-  timeInForce: TimeInForce;
-  reduceOnly: boolean;
-  orderFlags: string;
-  updatedAt: IsoString;
-  updatedAtHeight: string;
-  goodTilBlock?: string;
-  goodTilBlockTime?: string;
+  subaccountId: string,
+  clientId: string,
+  clobPairId: string,
+  side: OrderSide,
+  size: string,
+  totalFilled: string,
+  price: string,
+  type: OrderType,
+  status: OrderStatus,
+  timeInForce: TimeInForce,
+  reduceOnly: boolean,
+  orderFlags: string,
+  updatedAt: IsoString,
+  updatedAtHeight: string,
+  goodTilBlock?: string,
+  goodTilBlockTime?: string,
   // createdAtHeight is optional because short term orders do not have a createdAtHeight.
-  createdAtHeight?: string;
-  clientMetadata: string;
+  createdAtHeight?: string,
+  clientMetadata: string,
   triggerPrice?: string,
 }
 
 export interface OrderUpdateObject {
-  id: string;
-  clobPairId?: string;
-  side?: OrderSide;
-  size?: string;
-  totalFilled?: string;
-  price?: string;
-  type?: OrderType;
-  status?: OrderStatus;
-  timeInForce?: TimeInForce;
-  reduceOnly?: boolean;
-  orderFlags?: string;
-  updatedAt?: IsoString;
-  updatedAtHeight?: string;
-  goodTilBlock?: string | null;
-  goodTilBlockTime?: string | null;
-  clientMetadata?: string;
-  triggerPrice?: string;
+  id: string,
+  clobPairId?: string,
+  side?: OrderSide,
+  size?: string,
+  totalFilled?: string,
+  price?: string,
+  type?: OrderType,
+  status?: OrderStatus,
+  timeInForce?: TimeInForce,
+  reduceOnly?: boolean,
+  orderFlags?: string,
+  updatedAt?: IsoString,
+  updatedAtHeight?: string,
+  goodTilBlock?: string | null,
+  goodTilBlockTime?: string | null,
+  clientMetadata?: string,
+  triggerPrice?: string,
 }
 
 export enum OrderColumns {

--- a/indexer/packages/postgres/src/types/pagination-types.ts
+++ b/indexer/packages/postgres/src/types/pagination-types.ts
@@ -1,6 +1,6 @@
 export interface PaginationFromDatabase<T> {
-  results: T[];
+  results: T[],
   total?: number,
   offset?: number,
-  limit?: number
+  limit?: number,
 }

--- a/indexer/packages/postgres/src/types/perpetual-market-types.ts
+++ b/indexer/packages/postgres/src/types/perpetual-market-types.ts
@@ -1,41 +1,41 @@
 /* ------- PERPETUAL MARKET TYPES ------- */
 
 export interface PerpetualMarketCreateObject {
-  id: string;
-  clobPairId: string;
-  ticker: string;
-  marketId: number;
-  status: PerpetualMarketStatus;
-  priceChange24H: string;
-  volume24H: string;
-  trades24H: number;
-  nextFundingRate: string;
-  openInterest: string;
-  quantumConversionExponent: number;
-  atomicResolution: number;
-  subticksPerTick: number;
-  stepBaseQuantums: number;
-  liquidityTierId: number;
-  marketType: PerpetualMarketType;
-  baseOpenInterest: string;
+  id: string,
+  clobPairId: string,
+  ticker: string,
+  marketId: number,
+  status: PerpetualMarketStatus,
+  priceChange24H: string,
+  volume24H: string,
+  trades24H: number,
+  nextFundingRate: string,
+  openInterest: string,
+  quantumConversionExponent: number,
+  atomicResolution: number,
+  subticksPerTick: number,
+  stepBaseQuantums: number,
+  liquidityTierId: number,
+  marketType: PerpetualMarketType,
+  baseOpenInterest: string,
 }
 
 export interface PerpetualMarketUpdateObject {
-  id?: string;
-  clobPairId?: string;
-  ticker?: string;
-  marketId?: number;
-  status?: PerpetualMarketStatus;
-  priceChange24H?: string;
-  volume24H?: string;
-  trades24H?: number;
-  nextFundingRate?: string;
-  openInterest?: string;
-  quantumConversionExponent?: number;
-  atomicResolution?: number;
-  subticksPerTick?: number;
-  stepBaseQuantums?: number;
-  liquidityTierId?: number;
+  id?: string,
+  clobPairId?: string,
+  ticker?: string,
+  marketId?: number,
+  status?: PerpetualMarketStatus,
+  priceChange24H?: string,
+  volume24H?: string,
+  trades24H?: number,
+  nextFundingRate?: string,
+  openInterest?: string,
+  quantumConversionExponent?: number,
+  atomicResolution?: number,
+  subticksPerTick?: number,
+  stepBaseQuantums?: number,
+  liquidityTierId?: number,
 }
 
 export enum PerpetualMarketColumns {

--- a/indexer/packages/postgres/src/types/perpetual-position-types.ts
+++ b/indexer/packages/postgres/src/types/perpetual-position-types.ts
@@ -16,43 +16,43 @@ export enum PerpetualPositionStatus {
 }
 
 export interface PerpetualPositionCreateObject {
-  subaccountId: string;
-  perpetualId: string;
-  side: PositionSide;
-  status: PerpetualPositionStatus;
-  size: string;
-  maxSize: string;
-  sumOpen?: string;
-  sumClose?: string;
-  entryPrice?: string;
-  createdAt: IsoString;
-  createdAtHeight: string;
-  openEventId: Buffer;
-  lastEventId: Buffer;
-  settledFunding: string;
-  closedAt?: IsoString;
-  closedAtHeight?: string;
-  closeEventId?: Buffer;
-  exitPrice?: string;
+  subaccountId: string,
+  perpetualId: string,
+  side: PositionSide,
+  status: PerpetualPositionStatus,
+  size: string,
+  maxSize: string,
+  sumOpen?: string,
+  sumClose?: string,
+  entryPrice?: string,
+  createdAt: IsoString,
+  createdAtHeight: string,
+  openEventId: Buffer,
+  lastEventId: Buffer,
+  settledFunding: string,
+  closedAt?: IsoString,
+  closedAtHeight?: string,
+  closeEventId?: Buffer,
+  exitPrice?: string,
 }
 
 export interface PerpetualPositionUpdateObject {
-  id: string;
-  side?: PositionSide;
-  status?: PerpetualPositionStatus;
-  size?: string;
-  maxSize?: string;
-  entryPrice?: string;
-  exitPrice?: string | null;
-  sumOpen?: string;
-  sumClose?: string;
-  createdAt?: IsoString;
-  closedAt?: IsoString | null;
-  createdAtHeight?: string;
-  closedAtHeight?: string | null;
-  closeEventId?: Buffer | null;
-  lastEventId?: Buffer;
-  settledFunding?: string;
+  id: string,
+  side?: PositionSide,
+  status?: PerpetualPositionStatus,
+  size?: string,
+  maxSize?: string,
+  entryPrice?: string,
+  exitPrice?: string | null,
+  sumOpen?: string,
+  sumClose?: string,
+  createdAt?: IsoString,
+  closedAt?: IsoString | null,
+  createdAtHeight?: string,
+  closedAtHeight?: string | null,
+  closeEventId?: Buffer | null,
+  lastEventId?: Buffer,
+  settledFunding?: string,
 }
 
 // Object used to update a subaccount's perpetual position in the SubaccountUpdateHandler
@@ -60,9 +60,9 @@ export interface PerpetualPositionSubaccountUpdateObject {
   id: string,
   closedAt?: IsoString | null,
   closedAtHeight?: string | null,
-  closeEventId?: Buffer | null;
-  lastEventId: Buffer;
-  settledFunding: string;
+  closeEventId?: Buffer | null,
+  lastEventId: Buffer,
+  settledFunding: string,
   status: PerpetualPositionStatus,
   size: string,
 }
@@ -76,21 +76,21 @@ This is all of the fields in PerpetualPositionFromDatabase with the exception of
 closedAt, closedAtHeight, and closeEventId are nullable.
 */
 export interface UpdatedPerpetualPositionSubaccountKafkaObject {
-  id: string;
-  perpetualId: string;
-  side: PositionSide;
-  status: PerpetualPositionStatus;
-  size: string;
-  maxSize: string;
-  entryPrice: string;
-  exitPrice?: string;
-  sumOpen: string;
-  sumClose: string;
-  closedAt?: IsoString | null;
-  closedAtHeight?: string | null;
-  lastEventId: Buffer;
-  closeEventId?: Buffer | null;
-  settledFunding: string;
+  id: string,
+  perpetualId: string,
+  side: PositionSide,
+  status: PerpetualPositionStatus,
+  size: string,
+  maxSize: string,
+  entryPrice: string,
+  exitPrice?: string,
+  sumOpen: string,
+  sumClose: string,
+  closedAt?: IsoString | null,
+  closedAtHeight?: string | null,
+  lastEventId: Buffer,
+  closeEventId?: Buffer | null,
+  settledFunding: string,
   realizedPnl?: string,
   unrealizedPnl?: string,
 }

--- a/indexer/packages/postgres/src/types/pnl-ticks-types.ts
+++ b/indexer/packages/postgres/src/types/pnl-ticks-types.ts
@@ -9,7 +9,7 @@ export interface PnlTicksCreateObject {
   netTransfers: string,
   createdAt: string,
   blockHeight: string,
-  blockTime: IsoString;
+  blockTime: IsoString,
 }
 
 export enum PnlTicksColumns {

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -91,233 +91,233 @@ export enum QueryableField {
 }
 
 export interface QueryConfig {
-  [QueryableField.LIMIT]?: number;
-  [QueryableField.PAGE]?: number;
+  [QueryableField.LIMIT]?: number,
+  [QueryableField.PAGE]?: number,
 }
 
 export interface SubaccountQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.ADDRESS]?: string;
-  [QueryableField.SUBACCOUNT_NUMBER]?: number;
-  [QueryableField.UPDATED_BEFORE_OR_AT]?: string;
-  [QueryableField.UPDATED_ON_OR_AFTER]?: string;
+  [QueryableField.ID]?: string[],
+  [QueryableField.ADDRESS]?: string,
+  [QueryableField.SUBACCOUNT_NUMBER]?: number,
+  [QueryableField.UPDATED_BEFORE_OR_AT]?: string,
+  [QueryableField.UPDATED_ON_OR_AFTER]?: string,
 }
 
 export interface SubaccountUsernamesQueryConfig extends QueryConfig {
-  [QueryableField.USERNAME]?: string[];
-  [QueryableField.SUBACCOUNT_ID]?: string[];
+  [QueryableField.USERNAME]?: string[],
+  [QueryableField.SUBACCOUNT_ID]?: string[],
 }
 
 export interface WalletQueryConfig extends QueryConfig {
-  [QueryableField.ADDRESS]?: string;
+  [QueryableField.ADDRESS]?: string,
 }
 
 export interface PerpetualPositionQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.SUBACCOUNT_ID]?: string[];
-  [QueryableField.PERPETUAL_ID]?: string[];
-  [QueryableField.SIDE]?: PositionSide;
-  [QueryableField.STATUS]?: PerpetualPositionStatus[];
-  [QueryableField.CREATED_BEFORE_OR_AT_HEIGHT]?: string;
-  [QueryableField.CREATED_BEFORE_OR_AT]?: string;
+  [QueryableField.ID]?: string[],
+  [QueryableField.SUBACCOUNT_ID]?: string[],
+  [QueryableField.PERPETUAL_ID]?: string[],
+  [QueryableField.SIDE]?: PositionSide,
+  [QueryableField.STATUS]?: PerpetualPositionStatus[],
+  [QueryableField.CREATED_BEFORE_OR_AT_HEIGHT]?: string,
+  [QueryableField.CREATED_BEFORE_OR_AT]?: string,
 }
 
 export interface OrderQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.SUBACCOUNT_ID]?: string[];
-  [QueryableField.CLIENT_ID]?: string;
-  [QueryableField.CLOB_PAIR_ID]?: string;
-  [QueryableField.SIDE]?: OrderSide;
-  [QueryableField.SIZE]?: string;
-  [QueryableField.TOTAL_FILLED]?: string;
-  [QueryableField.PRICE]?: string;
-  [QueryableField.TYPE]?: OrderType;
-  [QueryableField.STATUSES]?: OrderStatus[];
-  [QueryableField.POST_ONLY]?: boolean;
-  [QueryableField.REDUCE_ONLY]?: boolean;
-  [QueryableField.GOOD_TIL_BLOCK_BEFORE_OR_AT]?: string;
-  [QueryableField.GOOD_TIL_BLOCK_TIME_BEFORE_OR_AT]?: string;
-  [QueryableField.ORDER_FLAGS]?: string;
-  [QueryableField.CLIENT_METADATA]?: string;
-  [QueryableField.TRIGGER_PRICE]?: string;
+  [QueryableField.ID]?: string[],
+  [QueryableField.SUBACCOUNT_ID]?: string[],
+  [QueryableField.CLIENT_ID]?: string,
+  [QueryableField.CLOB_PAIR_ID]?: string,
+  [QueryableField.SIDE]?: OrderSide,
+  [QueryableField.SIZE]?: string,
+  [QueryableField.TOTAL_FILLED]?: string,
+  [QueryableField.PRICE]?: string,
+  [QueryableField.TYPE]?: OrderType,
+  [QueryableField.STATUSES]?: OrderStatus[],
+  [QueryableField.POST_ONLY]?: boolean,
+  [QueryableField.REDUCE_ONLY]?: boolean,
+  [QueryableField.GOOD_TIL_BLOCK_BEFORE_OR_AT]?: string,
+  [QueryableField.GOOD_TIL_BLOCK_TIME_BEFORE_OR_AT]?: string,
+  [QueryableField.ORDER_FLAGS]?: string,
+  [QueryableField.CLIENT_METADATA]?: string,
+  [QueryableField.TRIGGER_PRICE]?: string,
 }
 
 export interface PerpetualMarketQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.MARKET_ID]?: number[];
-  [QueryableField.LIQUIDITY_TIER_ID]?: number[];
+  [QueryableField.ID]?: string[],
+  [QueryableField.MARKET_ID]?: number[],
+  [QueryableField.LIQUIDITY_TIER_ID]?: number[],
 }
 
 export interface FillQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.SUBACCOUNT_ID]?: string[];
-  [QueryableField.SIDE]?: OrderSide;
-  [QueryableField.LIQUIDITY]?: Liquidity;
-  [QueryableField.TYPE]?: OrderType;
-  [QueryableField.CLOB_PAIR_ID]?: string;
-  [QueryableField.EVENT_ID]?: Buffer;
-  [QueryableField.TRANSACTION_HASH]?: string;
-  [QueryableField.CREATED_BEFORE_OR_AT_HEIGHT]?: string;
-  [QueryableField.CREATED_BEFORE_OR_AT]?: string;
-  [QueryableField.CREATED_ON_OR_AFTER_HEIGHT]?: string;
-  [QueryableField.CREATED_ON_OR_AFTER]?: string;
-  [QueryableField.CLIENT_METADATA]?: string;
-  [QueryableField.FEE]?: string;
+  [QueryableField.ID]?: string[],
+  [QueryableField.SUBACCOUNT_ID]?: string[],
+  [QueryableField.SIDE]?: OrderSide,
+  [QueryableField.LIQUIDITY]?: Liquidity,
+  [QueryableField.TYPE]?: OrderType,
+  [QueryableField.CLOB_PAIR_ID]?: string,
+  [QueryableField.EVENT_ID]?: Buffer,
+  [QueryableField.TRANSACTION_HASH]?: string,
+  [QueryableField.CREATED_BEFORE_OR_AT_HEIGHT]?: string,
+  [QueryableField.CREATED_BEFORE_OR_AT]?: string,
+  [QueryableField.CREATED_ON_OR_AFTER_HEIGHT]?: string,
+  [QueryableField.CREATED_ON_OR_AFTER]?: string,
+  [QueryableField.CLIENT_METADATA]?: string,
+  [QueryableField.FEE]?: string,
 }
 
 export interface BlockQueryConfig extends QueryConfig {
-  [QueryableField.BLOCK_HEIGHT]?: string[];
-  [QueryableField.CREATED_ON_OR_AFTER]?: string;
+  [QueryableField.BLOCK_HEIGHT]?: string[],
+  [QueryableField.CREATED_ON_OR_AFTER]?: string,
 }
 
 export interface TendermintEventQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: Buffer[];
-  [QueryableField.BLOCK_HEIGHT]?: string[];
-  [QueryableField.TRANSACTION_INDEX]?: number[];
-  [QueryableField.EVENT_INDEX]?: number[];
+  [QueryableField.ID]?: Buffer[],
+  [QueryableField.BLOCK_HEIGHT]?: string[],
+  [QueryableField.TRANSACTION_INDEX]?: number[],
+  [QueryableField.EVENT_INDEX]?: number[],
 }
 
 export interface TransactionQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.BLOCK_HEIGHT]?: string[];
-  [QueryableField.TRANSACTION_INDEX]?: number[];
-  [QueryableField.TRANSACTION_HASH]?: string[];
+  [QueryableField.ID]?: string[],
+  [QueryableField.BLOCK_HEIGHT]?: string[],
+  [QueryableField.TRANSACTION_INDEX]?: number[],
+  [QueryableField.TRANSACTION_HASH]?: string[],
 }
 
 export interface AssetQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.SYMBOL]?: string;
-  [QueryableField.ATOMIC_RESOLUTION]?: number;
-  [QueryableField.HAS_MARKET]?: boolean;
-  [QueryableField.MARKET_ID]?: number;
+  [QueryableField.ID]?: string[],
+  [QueryableField.SYMBOL]?: string,
+  [QueryableField.ATOMIC_RESOLUTION]?: number,
+  [QueryableField.HAS_MARKET]?: boolean,
+  [QueryableField.MARKET_ID]?: number,
 }
 
 export interface AssetPositionQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.ASSET_ID]?: string[];
-  [QueryableField.SUBACCOUNT_ID]?: string[];
-  [QueryableField.SIZE]?: string;
-  [QueryableField.IS_LONG]?: boolean;
+  [QueryableField.ID]?: string[],
+  [QueryableField.ASSET_ID]?: string[],
+  [QueryableField.SUBACCOUNT_ID]?: string[],
+  [QueryableField.SIZE]?: string,
+  [QueryableField.IS_LONG]?: boolean,
 }
 
 export interface TransferQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.SENDER_SUBACCOUNT_ID]?: string[];
-  [QueryableField.RECIPIENT_SUBACCOUNT_ID]?: string[];
-  [QueryableField.SENDER_WALLET_ADDRESS]?: string[];
-  [QueryableField.RECIPIENT_WALLET_ADDRESS]?: string[];
-  [QueryableField.ASSET_ID]?: string[];
-  [QueryableField.SIZE]?: string;
-  [QueryableField.EVENT_ID]?: Buffer[];
-  [QueryableField.TRANSACTION_HASH]?: string[];
-  [QueryableField.CREATED_AT]?: string;
-  [QueryableField.CREATED_AT_HEIGHT]?: string[];
-  [QueryableField.CREATED_BEFORE_OR_AT_HEIGHT]?: string;
-  [QueryableField.CREATED_BEFORE_OR_AT]?: string;
-  [QueryableField.CREATED_AFTER]?: string;
-  [QueryableField.CREATED_AFTER_HEIGHT]?: string;
+  [QueryableField.ID]?: string[],
+  [QueryableField.SENDER_SUBACCOUNT_ID]?: string[],
+  [QueryableField.RECIPIENT_SUBACCOUNT_ID]?: string[],
+  [QueryableField.SENDER_WALLET_ADDRESS]?: string[],
+  [QueryableField.RECIPIENT_WALLET_ADDRESS]?: string[],
+  [QueryableField.ASSET_ID]?: string[],
+  [QueryableField.SIZE]?: string,
+  [QueryableField.EVENT_ID]?: Buffer[],
+  [QueryableField.TRANSACTION_HASH]?: string[],
+  [QueryableField.CREATED_AT]?: string,
+  [QueryableField.CREATED_AT_HEIGHT]?: string[],
+  [QueryableField.CREATED_BEFORE_OR_AT_HEIGHT]?: string,
+  [QueryableField.CREATED_BEFORE_OR_AT]?: string,
+  [QueryableField.CREATED_AFTER]?: string,
+  [QueryableField.CREATED_AFTER_HEIGHT]?: string,
 }
 
 export interface ToAndFromSubaccountTransferQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.SUBACCOUNT_ID]?: string[];
-  [QueryableField.ASSET_ID]?: string[];
-  [QueryableField.SIZE]?: string;
-  [QueryableField.EVENT_ID]?: Buffer[];
-  [QueryableField.TRANSACTION_HASH]?: string[];
-  [QueryableField.CREATED_AT]?: string;
-  [QueryableField.CREATED_AT_HEIGHT]?: string[];
-  [QueryableField.CREATED_BEFORE_OR_AT_HEIGHT]?: string | undefined;
-  [QueryableField.CREATED_BEFORE_OR_AT]?: string | undefined;
-  [QueryableField.CREATED_AFTER_HEIGHT]?: string | undefined;
-  [QueryableField.CREATED_AFTER]?: string | undefined;
+  [QueryableField.ID]?: string[],
+  [QueryableField.SUBACCOUNT_ID]?: string[],
+  [QueryableField.ASSET_ID]?: string[],
+  [QueryableField.SIZE]?: string,
+  [QueryableField.EVENT_ID]?: Buffer[],
+  [QueryableField.TRANSACTION_HASH]?: string[],
+  [QueryableField.CREATED_AT]?: string,
+  [QueryableField.CREATED_AT_HEIGHT]?: string[],
+  [QueryableField.CREATED_BEFORE_OR_AT_HEIGHT]?: string | undefined,
+  [QueryableField.CREATED_BEFORE_OR_AT]?: string | undefined,
+  [QueryableField.CREATED_AFTER_HEIGHT]?: string | undefined,
+  [QueryableField.CREATED_AFTER]?: string | undefined,
 }
 
 export interface OraclePriceQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.MARKET_ID]?: number[];
-  [QueryableField.PRICE]?: string[];
-  [QueryableField.EFFECTIVE_AT]?: string;
-  [QueryableField.EFFECTIVE_AT_HEIGHT]?: string;
-  [QueryableField.EFFECTIVE_BEFORE_OR_AT]?: string;
-  [QueryableField.EFFECTIVE_BEFORE_OR_AT_HEIGHT]?: string;
+  [QueryableField.ID]?: string[],
+  [QueryableField.MARKET_ID]?: number[],
+  [QueryableField.PRICE]?: string[],
+  [QueryableField.EFFECTIVE_AT]?: string,
+  [QueryableField.EFFECTIVE_AT_HEIGHT]?: string,
+  [QueryableField.EFFECTIVE_BEFORE_OR_AT]?: string,
+  [QueryableField.EFFECTIVE_BEFORE_OR_AT_HEIGHT]?: string,
 }
 
 export interface MarketQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: number[];
-  [QueryableField.PAIR]?: string[];
+  [QueryableField.ID]?: number[],
+  [QueryableField.PAIR]?: string[],
 }
 
 export interface CandleQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: number[];
-  [QueryableField.TICKER]?: string[];
-  [QueryableField.RESOLUTION]?: CandleResolution;
-  [QueryableField.FROM_ISO]?: IsoString;
-  [QueryableField.TO_ISO]?: IsoString;
+  [QueryableField.ID]?: number[],
+  [QueryableField.TICKER]?: string[],
+  [QueryableField.RESOLUTION]?: CandleResolution,
+  [QueryableField.FROM_ISO]?: IsoString,
+  [QueryableField.TO_ISO]?: IsoString,
 }
 
 export interface PnlTicksQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.SUBACCOUNT_ID]?: string[];
-  [QueryableField.CREATED_AT]?: string;
-  [QueryableField.BLOCK_HEIGHT]?: string;
-  [QueryableField.BLOCK_TIME]?: string;
-  [QueryableField.CREATED_BEFORE_OR_AT]?: string;
-  [QueryableField.CREATED_BEFORE_OR_AT_BLOCK_HEIGHT]?: string;
-  [QueryableField.CREATED_ON_OR_AFTER]?: string;
-  [QueryableField.CREATED_ON_OR_AFTER_BLOCK_HEIGHT]?: string;
+  [QueryableField.ID]?: string[],
+  [QueryableField.SUBACCOUNT_ID]?: string[],
+  [QueryableField.CREATED_AT]?: string,
+  [QueryableField.BLOCK_HEIGHT]?: string,
+  [QueryableField.BLOCK_TIME]?: string,
+  [QueryableField.CREATED_BEFORE_OR_AT]?: string,
+  [QueryableField.CREATED_BEFORE_OR_AT_BLOCK_HEIGHT]?: string,
+  [QueryableField.CREATED_ON_OR_AFTER]?: string,
+  [QueryableField.CREATED_ON_OR_AFTER_BLOCK_HEIGHT]?: string,
 }
 
 export interface FundingIndexUpdatesQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
-  [QueryableField.PERPETUAL_ID]?: string[];
-  [QueryableField.EVENT_ID]?: Buffer;
-  [QueryableField.EFFECTIVE_AT]?: string;
-  [QueryableField.EFFECTIVE_AT_HEIGHT]?: string;
-  [QueryableField.EFFECTIVE_BEFORE_OR_AT]?: string;
-  [QueryableField.EFFECTIVE_BEFORE_OR_AT_HEIGHT]?: string;
+  [QueryableField.ID]?: string[],
+  [QueryableField.PERPETUAL_ID]?: string[],
+  [QueryableField.EVENT_ID]?: Buffer,
+  [QueryableField.EFFECTIVE_AT]?: string,
+  [QueryableField.EFFECTIVE_AT_HEIGHT]?: string,
+  [QueryableField.EFFECTIVE_BEFORE_OR_AT]?: string,
+  [QueryableField.EFFECTIVE_BEFORE_OR_AT_HEIGHT]?: string,
 }
 
 export interface LiquidityTiersQueryConfig extends QueryConfig {
-  [QueryableField.ID]?: string[];
+  [QueryableField.ID]?: string[],
 }
 
 export interface ComplianceDataQueryConfig extends QueryConfig {
-  [QueryableField.ADDRESS]?: string[];
-  [QueryableField.UPDATED_BEFORE_OR_AT]?: string;
-  [QueryableField.PROVIDER]?: string;
-  [QueryableField.BLOCKED]?: boolean;
+  [QueryableField.ADDRESS]?: string[],
+  [QueryableField.UPDATED_BEFORE_OR_AT]?: string,
+  [QueryableField.PROVIDER]?: string,
+  [QueryableField.BLOCKED]?: boolean,
 }
 
 export interface ComplianceStatusQueryConfig extends QueryConfig {
-  [QueryableField.ADDRESS]?: string[];
-  [QueryableField.STATUS]?: string[];
-  [QueryableField.CREATED_BEFORE_OR_AT]?: string;
-  [QueryableField.UPDATED_BEFORE_OR_AT]?: string;
-  [QueryableField.REASON]?: string;
+  [QueryableField.ADDRESS]?: string[],
+  [QueryableField.STATUS]?: string[],
+  [QueryableField.CREATED_BEFORE_OR_AT]?: string,
+  [QueryableField.UPDATED_BEFORE_OR_AT]?: string,
+  [QueryableField.REASON]?: string,
 }
 
 export interface TradingRewardQueryConfig extends QueryConfig {
-  [QueryableField.ADDRESS]?: string;
-  [QueryableField.BLOCK_HEIGHT]?: string;
-  [QueryableField.BLOCK_TIME_BEFORE_OR_AT]?: IsoString;
-  [QueryableField.BLOCK_TIME_AFTER_OR_AT]?: IsoString;
-  [QueryableField.BLOCK_TIME_BEFORE]?: IsoString;
-  [QueryableField.BLOCK_HEIGHT_BEFORE_OR_AT]?: IsoString;
+  [QueryableField.ADDRESS]?: string,
+  [QueryableField.BLOCK_HEIGHT]?: string,
+  [QueryableField.BLOCK_TIME_BEFORE_OR_AT]?: IsoString,
+  [QueryableField.BLOCK_TIME_AFTER_OR_AT]?: IsoString,
+  [QueryableField.BLOCK_TIME_BEFORE]?: IsoString,
+  [QueryableField.BLOCK_HEIGHT_BEFORE_OR_AT]?: IsoString,
 }
 
 export interface TradingRewardAggregationQueryConfig extends QueryConfig {
-  [QueryableField.ADDRESS]?: string;
-  [QueryableField.ADDRESSES]?: string[];
-  [QueryableField.STARTED_AT_HEIGHT]?: string;
-  [QueryableField.STARTED_AT_HEIGHT_OR_AFTER]?: string;
-  [QueryableField.PERIOD]?: TradingRewardAggregationPeriod;
-  [QueryableField.STARTED_AT_BEFORE_OR_AT]?: IsoString;
-  [QueryableField.STARTED_AT_HEIGHT_BEFORE_OR_AT]?: string;
+  [QueryableField.ADDRESS]?: string,
+  [QueryableField.ADDRESSES]?: string[],
+  [QueryableField.STARTED_AT_HEIGHT]?: string,
+  [QueryableField.STARTED_AT_HEIGHT_OR_AFTER]?: string,
+  [QueryableField.PERIOD]?: TradingRewardAggregationPeriod,
+  [QueryableField.STARTED_AT_BEFORE_OR_AT]?: IsoString,
+  [QueryableField.STARTED_AT_HEIGHT_BEFORE_OR_AT]?: string,
 }
 
 export interface LeaderboardPnlQueryConfig extends QueryConfig {
-  [QueryableField.ADDRESS]?: string[];
-  [QueryableField.TIMESPAN]?: string[];
-  [QueryableField.RANK]?: number[];
+  [QueryableField.ADDRESS]?: string[],
+  [QueryableField.TIMESPAN]?: string[],
+  [QueryableField.RANK]?: number[],
 }

--- a/indexer/packages/postgres/src/types/subaccount-usernames-types.ts
+++ b/indexer/packages/postgres/src/types/subaccount-usernames-types.ts
@@ -11,5 +11,5 @@ export enum SubaccountUsernamesColumns {
 }
 
 export interface SubaccountsWithoutUsernamesResult {
-  subaccountId: string
+  subaccountId: string,
 }

--- a/indexer/packages/postgres/src/types/tendermint-event-types.ts
+++ b/indexer/packages/postgres/src/types/tendermint-event-types.ts
@@ -1,9 +1,9 @@
 /* ------- TENDERMINT EVENT TYPES ------- */
 
 export interface TendermintEventCreateObject {
-  blockHeight: string;
-  transactionIndex: number;
-  eventIndex: number;
+  blockHeight: string,
+  transactionIndex: number,
+  eventIndex: number,
 }
 
 export enum TendermintEventColumns {

--- a/indexer/packages/postgres/src/types/trading-reward-aggregation-types.ts
+++ b/indexer/packages/postgres/src/types/trading-reward-aggregation-types.ts
@@ -7,20 +7,20 @@ export enum TradingRewardAggregationPeriod {
 }
 
 export interface TradingRewardAggregationCreateObject {
-  address: string;
-  startedAt: IsoString;
-  startedAtHeight: string;
-  endedAt?: IsoString;
-  endedAtHeight?: string;
-  period: TradingRewardAggregationPeriod;
-  amount: string;
+  address: string,
+  startedAt: IsoString,
+  startedAtHeight: string,
+  endedAt?: IsoString,
+  endedAtHeight?: string,
+  period: TradingRewardAggregationPeriod,
+  amount: string,
 }
 
 export interface TradingRewardAggregationUpdateObject {
-  id: string;
-  endedAt?: IsoString;
-  endedAtHeight?: string;
-  amount?: string;
+  id: string,
+  endedAt?: IsoString,
+  endedAtHeight?: string,
+  amount?: string,
 }
 
 export enum TradingRewardAggregationColumns {

--- a/indexer/packages/postgres/src/types/trading-reward-types.ts
+++ b/indexer/packages/postgres/src/types/trading-reward-types.ts
@@ -1,10 +1,10 @@
 import { IsoString } from './utility-types';
 
 export interface TradingRewardCreateObject {
-  address: string;
-  blockTime: IsoString;
-  blockHeight: string;
-  amount: string;
+  address: string,
+  blockTime: IsoString,
+  blockHeight: string,
+  amount: string,
 }
 
 export enum TradingRewardColumns {

--- a/indexer/packages/postgres/src/types/utility-types.ts
+++ b/indexer/packages/postgres/src/types/utility-types.ts
@@ -13,15 +13,15 @@ export enum IsolationLevel {
 }
 
 export interface Options {
-  txId?: number;
-  forUpdate?: boolean;
-  noWait?: boolean;
-  orderBy?: [string, Ordering][];
+  txId?: number,
+  forUpdate?: boolean,
+  noWait?: boolean,
+  orderBy?: [string, Ordering][],
   readReplica?: boolean,
-  random?: boolean;
-  bindings?: readonly RawBinding[];
+  random?: boolean,
+  bindings?: readonly RawBinding[],
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sqlOptions?: Readonly<{ [key: string]: any }>;
+  sqlOptions?: Readonly<{ [key: string]: any }>,
 }
 
 export enum Ordering {

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -99,53 +99,53 @@ export const APIOrderStatusEnum = {
 };
 
 export interface OrderSubaccountMessageContents {
-  id: string;
-  subaccountId: string;
-  clientId: string;
-  clobPairId?: string;
-  side?: OrderSide;
-  size?: string;
+  id: string,
+  subaccountId: string,
+  clientId: string,
+  clobPairId?: string,
+  side?: OrderSide,
+  size?: string,
   ticker?: string,
-  price?: string;
-  type?: OrderType;
-  timeInForce?: APITimeInForce;
-  postOnly?: boolean;
-  reduceOnly?: boolean;
-  status: APIOrderStatus;
-  orderFlags: string;
+  price?: string,
+  type?: OrderType,
+  timeInForce?: APITimeInForce,
+  postOnly?: boolean,
+  reduceOnly?: boolean,
+  status: APIOrderStatus,
+  orderFlags: string,
 
-  totalFilled?: string;
-  totalOptimisticFilled?: string;
-  goodTilBlock?: string;
-  goodTilBlockTime?: string;
-  triggerPrice?: string;
-  updatedAt?: IsoString;
-  updatedAtHeight?: string;
+  totalFilled?: string,
+  totalOptimisticFilled?: string,
+  goodTilBlock?: string,
+  goodTilBlockTime?: string,
+  triggerPrice?: string,
+  updatedAt?: IsoString,
+  updatedAtHeight?: string,
 
   // This will only be filled if the order was removed
-  removalReason?: string;
+  removalReason?: string,
   // This will only be set for stateful orders
-  createdAtHeight?: string;
-  clientMetadata?: string;
+  createdAtHeight?: string,
+  clientMetadata?: string,
 }
 
 export interface FillSubaccountMessageContents {
-  id: string;
-  subaccountId: string;
-  side: OrderSide;
-  liquidity: Liquidity;
-  type: FillType;
-  clobPairId: string;
-  size: string;
-  price: string;
-  quoteAmount: string;
+  id: string,
+  subaccountId: string,
+  side: OrderSide,
+  liquidity: Liquidity,
+  type: FillType,
+  clobPairId: string,
+  size: string,
+  price: string,
+  quoteAmount: string,
   eventId: string,
-  transactionHash: string;
-  createdAt: IsoString;
-  createdAtHeight: string;
-  orderId?: string;
-  ticker: string;
-  clientMetadata?: string;
+  transactionHash: string,
+  createdAt: IsoString,
+  createdAtHeight: string,
+  orderId?: string,
+  ticker: string,
+  clientMetadata?: string,
 }
 
 export interface TransferSubaccountMessageContents {
@@ -161,14 +161,14 @@ export interface TransferSubaccountMessageContents {
   size: string,
   type: TransferType,
   transactionHash: string,
-  createdAt: IsoString;
-  createdAtHeight: string;
+  createdAt: IsoString,
+  createdAtHeight: string,
 }
 
 export interface TradingRewardSubaccountMessageContents {
-  tradingReward: string;
-  createdAtHeight: string;
-  createdAt: string;
+  tradingReward: string,
+  createdAtHeight: string,
+  createdAt: string,
 }
 
 /* ------- TradeMessageContents ------- */
@@ -195,34 +195,34 @@ export interface MarketMessageContents {
 }
 
 export type TradingMarketMessageContents = {
-  [ticker: string]: TradingPerpetualMarketMessage
+  [ticker: string]: TradingPerpetualMarketMessage,
 };
 
 // All the fields in PerpetualMarketFromDatabase, but optional
 export interface TradingPerpetualMarketMessage {
   // These fields are very unlikely to change
-  id?: string;
-  clobPairId?: string;
-  ticker?: string;
-  marketId?: number;
-  status?: PerpetualMarketStatus;
-  initialMarginFraction?: string;
-  maintenanceMarginFraction?: string;
-  openInterest?: string;
-  quantumConversionExponent?: number;
-  atomicResolution?: number;
-  subticksPerTick?: number;
-  stepBaseQuantums?: number;
-  marketType?: PerpetualMarketType;
-  openInterestLowerCap?: string;
-  openInterestUpperCap?: string;
-  baseOpenInterest?: string;
+  id?: string,
+  clobPairId?: string,
+  ticker?: string,
+  marketId?: number,
+  status?: PerpetualMarketStatus,
+  initialMarginFraction?: string,
+  maintenanceMarginFraction?: string,
+  openInterest?: string,
+  quantumConversionExponent?: number,
+  atomicResolution?: number,
+  subticksPerTick?: number,
+  stepBaseQuantums?: number,
+  marketType?: PerpetualMarketType,
+  openInterestLowerCap?: string,
+  openInterestUpperCap?: string,
+  baseOpenInterest?: string,
 
   // Fields that are likely to change
-  priceChange24H?: string;
-  volume24H?: string;
-  trades24H?: number;
-  nextFundingRate?: string;
+  priceChange24H?: string,
+  volume24H?: string,
+  trades24H?: number,
+  nextFundingRate?: string,
 }
 
 export type OraclePriceMarketMessageContentsMapping = {
@@ -248,6 +248,6 @@ export interface CandleMessageContents {
   close: string,
   baseTokenVolume: string,
   trades: number,
-  usdVolume: string
+  usdVolume: string,
   startingOpenInterest: string,
 }

--- a/indexer/packages/redis/src/helpers/redis.ts
+++ b/indexer/packages/redis/src/helpers/redis.ts
@@ -378,7 +378,7 @@ export async function hSetnxAsync(
   }: {
     hash: string,
     key: string,
-    value: string
+    value: string,
   },
   client: RedisClient,
 ): Promise<number> {

--- a/indexer/packages/redis/src/types.ts
+++ b/indexer/packages/redis/src/types.ts
@@ -6,7 +6,7 @@ export interface PlaceOrderResult {
   // true if an order was placed
   placed: boolean,
   // true if an order was replaced
-  replaced: boolean
+  replaced: boolean,
   // total filled of the old order in quantums, undefined if an order was not replaced
   oldTotalFilledQuantums?: number,
   // whether the old order was resting on the book, undefined if an order was not replaced
@@ -60,11 +60,11 @@ export interface OrderData {
 
 export type LuaScript = {
   // The name of the script
-  readonly name: string;
+  readonly name: string,
   // The contents of the script
-  readonly script: string;
+  readonly script: string,
   // The SHA1 hash of the contents of the script
-  readonly hash: string;
+  readonly hash: string,
 };
 
 export enum CanceledOrderStatus {
@@ -78,7 +78,7 @@ export type PnlTickForSubaccounts = {
   // Stores a PnlTicksCreateObject for the most recent pnl tick for each subaccount.
   // Opted for PnlTicksCreateObject instead ofPnlTicksFromDatabase as we don't need to store
   // the uuid.
-  [subaccountId: string]: PnlTicksCreateObject
+  [subaccountId: string]: PnlTicksCreateObject,
 };
 
 /* -------- Stateful order update cache types -------- */

--- a/indexer/services/auxo/src/types.ts
+++ b/indexer/services/auxo/src/types.ts
@@ -8,13 +8,13 @@
 }
  */
 export interface AuxoEventJson {
-  upgrade_tag: string;
-  prefix: string;
-  region: string;
+  upgrade_tag: string,
+  prefix: string,
+  region: string,
   // In our naming we often times use the appreviated region name
-  regionAbbrev: string;
-  addNewKafkaTopics: boolean;
-  onlyRunDbMigrationAndCreateKafkaTopics: boolean;
+  regionAbbrev: string,
+  addNewKafkaTopics: boolean,
+  onlyRunDbMigrationAndCreateKafkaTopics: boolean,
 }
 
 // EcsServiceName to task definition arn mapping

--- a/indexer/services/bazooka/src/index.ts
+++ b/indexer/services/bazooka/src/index.ts
@@ -36,30 +36,30 @@ const KAFKA_TOPICS_TO_PARTITIONS: { [key in KafkaTopics]: number } = {
 
 export interface BazookaEventJson {
   // Run knex migrations
-  migrate: boolean;
+  migrate: boolean,
 
   // Clearing data inside the database, but not deleting the tables and schemas
-  clear_db: boolean;
+  clear_db: boolean,
 
   // Reset the database and all migrations
-  reset_db: boolean;
+  reset_db: boolean,
 
   // Create all kafka topics with replication and parition counts
-  create_kafka_topics: boolean;
+  create_kafka_topics: boolean,
 
   // Clearing data inside all topics, not removing the Kafka Topics
-  clear_kafka_topics: boolean;
+  clear_kafka_topics: boolean,
 
   // Clearing all data in redis
-  clear_redis: boolean;
+  clear_redis: boolean,
 
   // Force flag that is required to perform any breaking actions in testnet/mainnet
   // A breaking action is any action in bazooka other that db migration
-  force: boolean;
+  force: boolean,
 
   // Send stateful orders to Vulcan. This is done during Indexer fast sync to
   // uncross the orderbook.
-  send_stateful_orders_to_vulcan: boolean;
+  send_stateful_orders_to_vulcan: boolean,
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/indexer/services/comlink/__tests__/lib/helpers.test.ts
+++ b/indexer/services/comlink/__tests__/lib/helpers.test.ts
@@ -406,7 +406,7 @@ describe('helpers', () => {
         adjustedUSDCAssetPositionSize,
       }: {
         assetPositionsMap: AssetPositionsMap,
-        adjustedUSDCAssetPositionSize: string
+        adjustedUSDCAssetPositionSize: string,
       } = adjustUSDCAssetPosition(assetPositions, unsettledFunding);
 
       // Original asset positions object should be unchanged
@@ -474,7 +474,7 @@ describe('helpers', () => {
         adjustedUSDCAssetPositionSize,
       }: {
         assetPositionsMap: AssetPositionsMap,
-        adjustedUSDCAssetPositionSize: string
+        adjustedUSDCAssetPositionSize: string,
       } = adjustUSDCAssetPosition(assetPositions, Big(unsettledFunding));
 
       // Original asset positions object should be unchanged
@@ -532,7 +532,7 @@ describe('helpers', () => {
         adjustedUSDCAssetPositionSize,
       }: {
         assetPositionsMap: AssetPositionsMap,
-        adjustedUSDCAssetPositionSize: string
+        adjustedUSDCAssetPositionSize: string,
       } = adjustUSDCAssetPosition(assetPositions, Big(funding));
 
       // Original asset positions object should be unchanged
@@ -591,7 +591,7 @@ describe('helpers', () => {
         adjustedUSDCAssetPositionSize,
       }: {
         assetPositionsMap: AssetPositionsMap,
-        adjustedUSDCAssetPositionSize: string
+        adjustedUSDCAssetPositionSize: string,
       } = adjustUSDCAssetPosition(assetPositions, Big(unsettledFunding));
 
       // Original asset positions object should be unchanged

--- a/indexer/services/comlink/src/caches/rate-limiters.ts
+++ b/indexer/services/comlink/src/caches/rate-limiters.ts
@@ -6,7 +6,7 @@ import config from '../config';
 
 export const ratelimitRedis: {
   client: RedisClient,
-  connect: () => Promise<void>
+  connect: () => Promise<void>,
 } = redisLib.createRedisClient(
   config.RATE_LIMIT_REDIS_URL, config.REDIS_RECONNECT_TIMEOUT_MS,
 );

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -28,7 +28,7 @@ const controllerName: string = 'vault-controller';
 // TODO(TRA-570): Placeholder interface for mapping of vault subaccounts to tickers until vaults
 // table is added.
 interface VaultMapping {
-  [subaccountId: string]: string;
+  [subaccountId: string]: string,
 }
 
 @Route('vault/v1')

--- a/indexer/services/comlink/src/helpers/compliance/compliance-clients.ts
+++ b/indexer/services/comlink/src/helpers/compliance/compliance-clients.ts
@@ -5,8 +5,8 @@ import {
 import { ComplianceProvider } from '@dydxprotocol-indexer/postgres';
 
 export interface ClientAndProvider {
-  client: ComplianceClient;
-  provider: ComplianceProvider;
+  client: ComplianceClient,
+  provider: ComplianceProvider,
 }
 
 export const complianceProvider: ClientAndProvider = {

--- a/indexer/services/comlink/src/lib/helpers.ts
+++ b/indexer/services/comlink/src/lib/helpers.ts
@@ -182,7 +182,7 @@ export function calculateEquityAndFreeCollateral(
     totalPositionRisk,
   }: {
     signedPositionNotional: Big,
-    totalPositionRisk: Big
+    totalPositionRisk: Big,
   } = perpetualPositions.reduce((acc, position) => {
     // get the positionNotional for each position and the individualRisk of the position
     const {
@@ -420,7 +420,7 @@ export function adjustUSDCAssetPosition(
   unsettledFunding: Big,
 ): {
   assetPositionsMap: AssetPositionsMap,
-  adjustedUSDCAssetPositionSize: string
+  adjustedUSDCAssetPositionSize: string,
 } {
   let adjustedAssetPositionsMap: AssetPositionsMap = _.cloneDeep(assetPositionsMap);
   const usdcPosition: AssetPositionResponseObject = _.get(assetPositionsMap, USDC_SYMBOL);

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -31,7 +31,7 @@ import express from 'express';
 /* ------- GENERAL/UNCATEGORIZED TYPES ------- */
 
 export interface ResponseWithBody extends express.Response {
-  body: unknown
+  body: unknown,
 }
 
 export enum RequestMethod {
@@ -80,14 +80,14 @@ export interface SubaccountResponseObject {
 }
 
 export interface ParentSubaccountResponse {
-  address: string;
+  address: string,
   /**
    * @isInt
    */
-  parentSubaccountNumber: number;
-  equity: string; // aggregated over all child subaccounts
-  freeCollateral: string; // aggregated over all child subaccounts
-  childSubaccounts: SubaccountResponseObject[];
+  parentSubaccountNumber: number,
+  equity: string, // aggregated over all child subaccounts
+  freeCollateral: string, // aggregated over all child subaccounts
+  childSubaccounts: SubaccountResponseObject[],
 }
 
 export type SubaccountById = {[id: string]: SubaccountFromDatabase};
@@ -102,50 +102,50 @@ export interface TimeResponse {
 /* ------- POSITION TYPES ------- */
 
 export interface PerpetualPositionResponse {
-  positions: PerpetualPositionResponseObject[];
+  positions: PerpetualPositionResponseObject[],
 }
 
 export interface PerpetualPositionWithFunding extends PerpetualPositionFromDatabase {
-  unsettledFunding: string;
+  unsettledFunding: string,
 }
 
 export interface PerpetualPositionResponseObject {
-  market: string;
-  status: PerpetualPositionStatus;
-  side: PositionSide;
-  size: string;
-  maxSize: string;
-  entryPrice: string;
-  realizedPnl: string;
-  createdAt: IsoString;
-  createdAtHeight: string;
-  sumOpen: string;
-  sumClose: string;
-  netFunding: string;
-  unrealizedPnl: string;
-  closedAt?: IsoString | null;
-  exitPrice?: string | null;
+  market: string,
+  status: PerpetualPositionStatus,
+  side: PositionSide,
+  size: string,
+  maxSize: string,
+  entryPrice: string,
+  realizedPnl: string,
+  createdAt: IsoString,
+  createdAtHeight: string,
+  sumOpen: string,
+  sumClose: string,
+  netFunding: string,
+  unrealizedPnl: string,
+  closedAt?: IsoString | null,
+  exitPrice?: string | null,
   /**
    * @isInt
    */
-  subaccountNumber: number;
+  subaccountNumber: number,
 }
 
 export type PerpetualPositionsMap = { [market: string]: PerpetualPositionResponseObject };
 
 export interface AssetPositionResponse {
-  positions: AssetPositionResponseObject[];
+  positions: AssetPositionResponseObject[],
 }
 
 export interface AssetPositionResponseObject {
-  symbol: string;
-  side: PositionSide;
-  size: string;
-  assetId: string;
+  symbol: string,
+  side: PositionSide,
+  size: string,
+  assetId: string,
   /**
    * @isInt
    */
-  subaccountNumber: number;
+  subaccountNumber: number,
 }
 
 export type AssetPositionsMap = { [symbol: string]: AssetPositionResponseObject };
@@ -304,46 +304,46 @@ export enum MarketType {
 export interface PerpetualMarketResponse {
   markets: {
     [ticker: string]: PerpetualMarketResponseObject,
-  }
+  },
 }
 
 export interface PerpetualMarketResponseObject {
-  clobPairId: string;
-  ticker: string;
-  status: PerpetualMarketStatus;
-  oraclePrice: string;
-  priceChange24H: string;
-  volume24H: string;
+  clobPairId: string,
+  ticker: string,
+  status: PerpetualMarketStatus,
+  oraclePrice: string,
+  priceChange24H: string,
+  volume24H: string,
   /**
    * @isInt
    */
-  trades24H: number;
-  nextFundingRate: string;
-  initialMarginFraction: string;
-  maintenanceMarginFraction: string;
-  openInterest: string;
+  trades24H: number,
+  nextFundingRate: string,
+  initialMarginFraction: string,
+  maintenanceMarginFraction: string,
+  openInterest: string,
   /**
    * @isInt
    */
-  atomicResolution: number;
+  atomicResolution: number,
   /**
    * @isInt
    */
-  quantumConversionExponent: number;
-  tickSize: string;
-  stepSize: string;
+  quantumConversionExponent: number,
+  tickSize: string,
+  stepSize: string,
   /**
    * @isInt
    */
-  stepBaseQuantums: number;
+  stepBaseQuantums: number,
   /**
    * @isInt
    */
-  subticksPerTick: number;
-  marketType: PerpetualMarketType;
-  openInterestLowerCap?: string;
-  openInterestUpperCap?: string;
-  baseOpenInterest: string;
+  subticksPerTick: number,
+  marketType: PerpetualMarketType,
+  openInterestLowerCap?: string,
+  openInterestUpperCap?: string,
+  baseOpenInterest: string,
 }
 
 /* ------- ORDERBOOK TYPES ------- */
@@ -365,13 +365,13 @@ export interface OrderResponseObject extends Omit<OrderFromDatabase, 'timeInForc
   timeInForce: APITimeInForce,
   status: APIOrderStatus,
   postOnly: boolean,
-  ticker: string;
-  updatedAt?: IsoString;
-  updatedAtHeight?: string
+  ticker: string,
+  updatedAt?: IsoString,
+  updatedAtHeight?: string,
   /**
    * @isInt
    */
-  subaccountNumber: number;
+  subaccountNumber: number,
 }
 
 export type RedisOrderMap = { [orderId: string]: RedisOrder };
@@ -426,7 +426,7 @@ export interface ParentSubaccountRequest extends AddressRequest {
 }
 
 export interface PaginationRequest {
-  page?: number;
+  page?: number,
 }
 
 export interface LimitRequest {
@@ -552,22 +552,22 @@ export interface HistoricalFundingRequest extends LimitAndEffectiveBeforeRequest
 /* ------- COLLATERALIZATION TYPES ------- */
 
 export interface Risk {
-  initial: Big;
-  maintenance: Big;
+  initial: Big,
+  maintenance: Big,
 }
 
 /* ------- COMPLIANCE TYPES ------- */
 
 export interface ComplianceResponse {
-  restricted: boolean;
-  reason?: string;
+  restricted: boolean,
+  reason?: string,
 }
 
 export interface ComplianceRequest extends AddressRequest {}
 
 export interface SetComplianceStatusRequest extends AddressRequest {
-  status: ComplianceStatus;
-  reason?: ComplianceReason;
+  status: ComplianceStatus,
+  reason?: ComplianceReason,
 }
 
 export enum BlockedCode {
@@ -576,9 +576,9 @@ export enum BlockedCode {
 }
 
 export interface ComplianceV2Response {
-  status: ComplianceStatus;
-  reason?: ComplianceReason;
-  updatedAt?: string;
+  status: ComplianceStatus,
+  reason?: ComplianceReason,
+  updatedAt?: string,
 }
 
 /* ------- HISTORICAL TRADING REWARD TYPES ------- */
@@ -627,7 +627,7 @@ export interface HistoricalBlockTradingReward {
 /* ------- Social Trading Types ------- */
 
 export interface TraderSearchResponse {
-  result?: TraderSearchResponseObject
+  result?: TraderSearchResponseObject,
 }
 
 export interface TraderSearchRequest {
@@ -644,27 +644,27 @@ export interface TraderSearchResponseObject {
 /* ------- Vault Types ------- */
 
 export interface VaultHistoricalPnl {
-  ticker: string;
-  historicalPnl: PnlTicksResponseObject[];
+  ticker: string,
+  historicalPnl: PnlTicksResponseObject[],
 }
 
 export interface MegavaultHistoricalPnlResponse {
-  megavaultPnl: PnlTicksResponseObject[];
+  megavaultPnl: PnlTicksResponseObject[],
 }
 
 export interface VaultsHistoricalPnlResponse {
-  vaultsPnl: VaultHistoricalPnl[];
+  vaultsPnl: VaultHistoricalPnl[],
 }
 
 export interface VaultPosition {
-  ticker: string;
-  assetPosition: AssetPositionResponseObject;
-  perpetualPosition?: PerpetualPositionResponseObject;
-  equity: string;
+  ticker: string,
+  assetPosition: AssetPositionResponseObject,
+  perpetualPosition?: PerpetualPositionResponseObject,
+  equity: string,
 }
 
 export interface MegavaultPositionResponse {
-  positions: VaultPosition[];
+  positions: VaultPosition[],
 }
 
 /* ------- Affiliates Types ------- */

--- a/indexer/services/ender/__tests__/handlers/liquidity-tier-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/liquidity-tier-handler.test.ts
@@ -319,7 +319,7 @@ function createKafkaMessageFromLiquidityTiersEvent({
   height: number,
   time: Timestamp,
   txHash: string,
-  version: number
+  version: number,
 }) {
   const events: IndexerTendermintEvent[] = [];
   events.push(

--- a/indexer/services/ender/__tests__/helpers/kafka-helper.test.ts
+++ b/indexer/services/ender/__tests__/helpers/kafka-helper.test.ts
@@ -536,8 +536,8 @@ describe('kafka-helper', () => {
         realizedPnl,
         unrealizedPnl,
       }: {
-        realizedPnl: string | undefined;
-        unrealizedPnl: string | undefined;
+        realizedPnl: string | undefined,
+        unrealizedPnl: string | undefined,
       } = getPnl(
         updatedObject,
         perpetualMarketRefresher.getPerpetualMarketsMap()[updatedObject.perpetualId],
@@ -557,8 +557,8 @@ describe('kafka-helper', () => {
         realizedPnl,
         unrealizedPnl,
       }: {
-        realizedPnl: string | undefined;
-        unrealizedPnl: string | undefined;
+        realizedPnl: string | undefined,
+        unrealizedPnl: string | undefined,
       } = getPnl(
         updatedObject2,
         perpetualMarketRefresher.getPerpetualMarketsMap()[updatedObject2.perpetualId],

--- a/indexer/services/ender/src/handlers/order-fills/abstract-order-fill-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/abstract-order-fill-handler.ts
@@ -32,16 +32,16 @@ import {
 import { Handler } from '../handler';
 
 export type OrderFillEventBase = {
-  subaccountId: string;
-  orderId: string | undefined;
-  fillType: FillType;
-  clobPairId: string;
-  side: OrderSide;
+  subaccountId: string,
+  orderId: string | undefined,
+  fillType: FillType,
+  clobPairId: string,
+  side: OrderSide,
   makerOrder: IndexerOrder,
-  fillAmount: Long;
-  liquidity: Liquidity;
-  clientMetadata?: string;
-  fee: Long;
+  fillAmount: Long,
+  liquidity: Liquidity,
+  clientMetadata?: string,
+  fee: Long,
 };
 
 export abstract class AbstractOrderFillHandler<T> extends Handler<T> {

--- a/indexer/services/ender/src/helpers/postgres/postgres-functions.ts
+++ b/indexer/services/ender/src/helpers/postgres/postgres-functions.ts
@@ -6,9 +6,9 @@ import { dbHelpers, storeHelpers } from '@dydxprotocol-indexer/postgres';
 
 export type PostgresFunction = {
   // The name of the script
-  readonly name: string;
+  readonly name: string,
   // The contents of the script
-  readonly script: string;
+  readonly script: string,
 };
 
 /**

--- a/indexer/services/ender/src/lib/block-processor.ts
+++ b/indexer/services/ender/src/lib/block-processor.ts
@@ -70,12 +70,12 @@ function serializeSubtypeAndVersion(
 }
 
 type DecodedIndexerTendermintBlock = Omit<IndexerTendermintBlock, 'events'> & {
-  events: DecodedIndexerTendermintEvent[];
+  events: DecodedIndexerTendermintEvent[],
 };
 
 type DecodedIndexerTendermintEvent = Omit<IndexerTendermintEvent, 'dataBytes'> & {
   /** Decoded tendermint event. */
-  dataBytes: object;
+  dataBytes: object,
 };
 
 export class BlockProcessor {

--- a/indexer/services/ender/src/lib/candles-generator.ts
+++ b/indexer/services/ender/src/lib/candles-generator.ts
@@ -34,13 +34,13 @@ import { ConsolidatedKafkaEvent, SingleTradeMessage } from './types';
 
 type BlockCandleUpdatesMap = { [ticker: string]: BlockCandleUpdate};
 type BlockCandleUpdate = {
-  low: string;
-  high: string;
-  open: string;
-  close: string;
-  baseTokenVolume: string;
-  usdVolume: string;
-  trades: number;
+  low: string,
+  high: string,
+  open: string,
+  close: string,
+  baseTokenVolume: string,
+  usdVolume: string,
+  trades: number,
 };
 
 type OrderbookMidPrice = string | undefined;
@@ -533,7 +533,7 @@ export class CandlesGenerator {
 /**
    * Get the cached orderbook mid price for a given ticker
 */
-export async function getOrderbookMidPriceMap(): Promise<{ [ticker: string]: OrderbookMidPrice; }> {
+export async function getOrderbookMidPriceMap(): Promise<{ [ticker: string]: OrderbookMidPrice }> {
   const start: number = Date.now();
   const perpetualMarkets = Object.values(perpetualMarketRefresher.getPerpetualMarketsMap());
 
@@ -546,7 +546,7 @@ export async function getOrderbookMidPriceMap(): Promise<{ [ticker: string]: Ord
   });
 
   const pricesArray = await Promise.all(promises);
-  const priceMap: { [ticker: string]: OrderbookMidPrice; } = {};
+  const priceMap: { [ticker: string]: OrderbookMidPrice } = {};
   pricesArray.forEach((price) => {
     Object.assign(priceMap, price);
   });

--- a/indexer/services/ender/src/lib/kafka-publisher.ts
+++ b/indexer/services/ender/src/lib/kafka-publisher.ts
@@ -28,8 +28,8 @@ import {
 } from './types';
 
 type TopicKafkaMessages = {
-  topic: KafkaTopics;
-  messages: ProducerMessage[];
+  topic: KafkaTopics,
+  messages: ProducerMessage[],
 };
 
 type OrderedMessage = AnnotatedSubaccountMessage | SingleTradeMessage;

--- a/indexer/services/ender/src/lib/translated-types.ts
+++ b/indexer/services/ender/src/lib/translated-types.ts
@@ -10,30 +10,30 @@ import { Long } from '@dydxprotocol-indexer/v4-protos/build/codegen/helpers';
 /* Canonical object types for handling onchain messages from the protocol. */
 
 export interface SubaccountUpdate {
-  subaccountId?: IndexerSubaccountId;
-  updatedPerpetualPositions: IndexerPerpetualPosition[];
-  updatedAssetPositions: IndexerAssetPosition[];
+  subaccountId?: IndexerSubaccountId,
+  updatedPerpetualPositions: IndexerPerpetualPosition[],
+  updatedAssetPositions: IndexerAssetPosition[],
 }
 
 export interface OrderFillWithLiquidity {
-  makerOrder?: IndexerOrder;
-  order?: IndexerOrder;
-  liquidationOrder?: LiquidationOrderV1;
+  makerOrder?: IndexerOrder,
+  order?: IndexerOrder,
+  liquidationOrder?: LiquidationOrderV1,
   /** Fill amount in base quantums. */
-  fillAmount: Long;
+  fillAmount: Long,
   /** Maker fee in USDC quantums. */
-  makerFee: Long;
+  makerFee: Long,
   /**
    * Taker fee in USDC quantums. If the taker order is a liquidation, then this
    * represents the special liquidation fee, not the standard taker fee.
    */
-  takerFee: Long;
+  takerFee: Long,
   /** Total filled of the maker order in base quantums. */
-  totalFilledMaker: Long;
+  totalFilledMaker: Long,
   /** Total filled of the taker order in base quantums. */
-  totalFilledTaker: Long;
+  totalFilledTaker: Long,
   /** Liquidity of the order in the match to process in the handler. */
-  liquidity: Liquidity;
+  liquidity: Liquidity,
   /** Affiliate rev share in USDC quantums. */
-  affiliateRevShare: Long;
+  affiliateRevShare: Long,
 }

--- a/indexer/services/ender/src/lib/types.ts
+++ b/indexer/services/ender/src/lib/types.ts
@@ -263,7 +263,7 @@ export type ConsolidatedKafkaEvent = {
   message: VulcanMessage,
 } | {
   topic: KafkaTopics.TO_WEBSOCKETS_BLOCK_HEIGHT,
-  message: BlockHeightMessage
+  message: BlockHeightMessage,
 };
 
 export enum TransferEventType {

--- a/indexer/services/roundtable/__tests__/tasks/update-compliance-data.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/update-compliance-data.test.ts
@@ -24,7 +24,7 @@ import { ComplianceClientResponse } from '@dydxprotocol-indexer/compliance';
 import { DateTime } from 'luxon';
 
 interface ComplianceClientResponseWithNull extends Omit<ComplianceClientResponse, 'riskScore'> {
-  riskScore: string | undefined | null;
+  riskScore: string | undefined | null,
 }
 
 describe('update-compliance-data', () => {

--- a/indexer/services/roundtable/src/helpers/compliance-clients.ts
+++ b/indexer/services/roundtable/src/helpers/compliance-clients.ts
@@ -5,8 +5,8 @@ import {
 import { ComplianceProvider } from '@dydxprotocol-indexer/postgres';
 
 export interface ClientAndProvider {
-  client: ComplianceClient;
-  provider: ComplianceProvider;
+  client: ComplianceClient,
+  provider: ComplianceProvider,
 }
 
 export const complianceProvider: ClientAndProvider = {

--- a/indexer/services/roundtable/src/helpers/loops-helper.ts
+++ b/indexer/services/roundtable/src/helpers/loops-helper.ts
@@ -44,7 +44,7 @@ export function loopMetricNames(taskName: string): {
   exceededMaxConcurrentTasksStat: string,
   couldNotAcquireExtendedLockStat: string,
   redisKey: string,
-  extendedLockKey: string
+  extendedLockKey: string,
 } {
   return {
     startedStat: `${config.SERVICE_NAME}.loops.${taskName}.started`,

--- a/indexer/services/roundtable/src/helpers/types.ts
+++ b/indexer/services/roundtable/src/helpers/types.ts
@@ -1,9 +1,9 @@
 import Big from 'big.js';
 
 export interface SubaccountUsdcTransferMap {
-  [subaccountId: string]: Big;
+  [subaccountId: string]: Big,
 }
 export interface AthenaTableDDLQueries {
-  generateRawTable: (tablePrefix: string, rdsExportIdentifier: string) => string;
-  generateTable: (tablePrefix: string, add?: string) => string;
+  generateRawTable: (tablePrefix: string, rdsExportIdentifier: string) => string,
+  generateTable: (tablePrefix: string, add?: string) => string,
 }

--- a/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
+++ b/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
@@ -39,8 +39,8 @@ import { UTC_OPTIONS } from '../lib/constants';
  */
 type IntervalTradingRewardsByAddress = _.Dictionary<string>;
 interface AggregationUpdateAndCreateObjects {
-  updateObjects: TradingRewardAggregationUpdateObject[];
-  createObjects: TradingRewardAggregationCreateObject[];
+  updateObjects: TradingRewardAggregationUpdateObject[],
+  createObjects: TradingRewardAggregationCreateObject[],
 }
 
 enum DateTimeUnit {

--- a/indexer/services/roundtable/src/tasks/pnl-instrumentation.ts
+++ b/indexer/services/roundtable/src/tasks/pnl-instrumentation.ts
@@ -40,7 +40,7 @@ export default async function runTask(): Promise<void> {
   const mostRecentPnlTicks: PnlTickForSubaccounts = await getMostRecentPnlTicksForEachAccount();
   const mostRecentPnlTickTimes:
   {
-    [subaccountId: string]: string
+    [subaccountId: string]: string,
   } = _.mapValues(
     mostRecentPnlTicks,
     (pnlTick: PnlTicksCreateObject) => pnlTick.blockTime,

--- a/indexer/services/roundtable/src/tasks/track-lag.ts
+++ b/indexer/services/roundtable/src/tasks/track-lag.ts
@@ -8,13 +8,13 @@ import config from '../config';
 const VALIDATOR_BLOCK_HEIGHT_URL_SUFFIX = '/block';
 
 type BlockData = {
-  block: string;
-  timestamp: IsoString;
+  block: string,
+  timestamp: IsoString,
 };
 
 type ValidatorHeader = {
-  height: string;
-  time: IsoString;
+  height: string,
+  time: IsoString,
 };
 
 export default async function runTask(): Promise<void> {

--- a/indexer/services/scripts/src/helpers/pnl-validation-helpers.ts
+++ b/indexer/services/scripts/src/helpers/pnl-validation-helpers.ts
@@ -55,7 +55,7 @@ export async function getUnsettledFunding(
       }: {
         clobPairId: string,
         openSize: string,
-        fundingIndex: string
+        fundingIndex: string,
       } = item;
       const fundingIndexDiff: Big = Big(mappedLastFundingIndexMap[clobPairId]).minus(fundingIndex);
       const unsettledFunding: Big = Big(openSize).mul(fundingIndexDiff);

--- a/indexer/services/scripts/src/helpers/types.ts
+++ b/indexer/services/scripts/src/helpers/types.ts
@@ -1,11 +1,11 @@
 import { IndexerTendermintBlock, IndexerTendermintEvent } from '@dydxprotocol-indexer/v4-protos';
 
 export interface AnnotatedIndexerTendermintEvent extends IndexerTendermintEvent {
-  data: string;
+  data: string,
 }
 
 export interface AnnotatedIndexerTendermintBlock extends IndexerTendermintBlock {
-  annotatedEvents: AnnotatedIndexerTendermintEvent[];
+  annotatedEvents: AnnotatedIndexerTendermintEvent[],
 }
 
 export enum DydxIndexerSubtypes {

--- a/indexer/services/socks/src/lib/message-forwarder.ts
+++ b/indexer/services/socks/src/lib/message-forwarder.ts
@@ -36,9 +36,9 @@ const BATCH_SEND_INTERVAL_MS: number = config.BATCH_SEND_INTERVAL_MS;
 const BUFFER_KEY_SEPARATOR: string = ':';
 
 type VersionedContents = {
-  contents: string;
-  version: string;
-  subaccountNumber?: number;
+  contents: string,
+  version: string,
+  subaccountNumber?: number,
 };
 
 export class MessageForwarder {
@@ -485,7 +485,7 @@ export class MessageForwarder {
   ): {
       channel: Channel,
       channelString: string,
-      id: string
+      id: string,
     } {
     const [channelString, id]: string[] = bufferKey.split(BUFFER_KEY_SEPARATOR);
     const channel: Channel = channelString as Channel;

--- a/indexer/services/socks/src/lib/rate-limit.ts
+++ b/indexer/services/socks/src/lib/rate-limit.ts
@@ -5,8 +5,8 @@ export class RateLimiter {
   private messageInfo: {
     [connectionId: string]: {
       [key: string]: {
-        points: number;
-        startMs: number | null;
+        points: number,
+        startMs: number | null,
       },
     },
   };

--- a/indexer/services/socks/src/types.ts
+++ b/indexer/services/socks/src/types.ts
@@ -28,25 +28,25 @@ export enum Channel {
 export const ALL_CHANNELS = Object.values(Channel);
 
 export interface IncomingMessage extends IncomingMessageHttp {
-  type: IncomingMessageType;
+  type: IncomingMessageType,
 }
 
 export interface SubscribeMessage extends IncomingMessage {
-  channel: Channel;
-  id?: string;
-  batched?: boolean;
-  timestamp?: string;
-  includeOffsets?: boolean;
+  channel: Channel,
+  id?: string,
+  batched?: boolean,
+  timestamp?: string,
+  includeOffsets?: boolean,
 }
 
 export interface UnsubscribeMessage extends IncomingMessage {
-  channel: Channel;
-  id?: string;
-  timestamp?: string;
+  channel: Channel,
+  id?: string,
+  timestamp?: string,
 }
 
 export interface PingMessage extends IncomingMessage {
-  id?: number;
+  id?: number,
 }
 
 export enum OutgoingMessageType {
@@ -60,83 +60,83 @@ export enum OutgoingMessageType {
 }
 
 export interface OutgoingMessage {
-  type: OutgoingMessageType;
-  connection_id: string;
-  message_id: number;
+  type: OutgoingMessageType,
+  connection_id: string,
+  message_id: number,
 }
 
 export interface ErrorMessage extends OutgoingMessage {
-  message: string;
+  message: string,
 }
 
 export interface SubscribedMessage extends OutgoingMessage {
-  channel: Channel;
-  id?: string;
+  channel: Channel,
+  id?: string,
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  contents: any;
+  contents: any,
 }
 
 export interface UnsubscribedMessage extends OutgoingMessage {
-  channel: Channel;
-  id?: string;
+  channel: Channel,
+  id?: string,
 }
 
 export interface ChannelDataMessage extends OutgoingMessage {
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  contents: any;
-  channel: Channel;
-  id?: string;
-  version: string;
-  subaccountNumber?: number;
+  contents: any,
+  channel: Channel,
+  id?: string,
+  version: string,
+  subaccountNumber?: number,
 }
 
 export interface ChannelBatchDataMessage extends OutgoingMessage {
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  contents: any[];
-  channel: Channel;
-  id?: string;
-  version: string;
-  subaccountNumber?: number;
+  contents: any[],
+  channel: Channel,
+  id?: string,
+  version: string,
+  subaccountNumber?: number,
 }
 
 export interface ConnectedMessage extends OutgoingMessage {}
 
 export interface PongMessage extends OutgoingMessage {
-  id?: number;
+  id?: number,
 }
 
 export interface Subscription {
-  channel: Channel;
-  id: string;
-  batched?: boolean;
+  channel: Channel,
+  id: string,
+  batched?: boolean,
 }
 
 export interface SubscriptionInfo {
-  connectionId: string;
-  pending: boolean;
-  pendingMessages: MessageToForward[];
-  batched?: boolean;
+  connectionId: string,
+  pending: boolean,
+  pendingMessages: MessageToForward[],
+  batched?: boolean,
 }
 
 export interface Connection {
-  ws: WebSocket;
-  messageId: number;
-  heartbeat?: NodeJS.Timeout;
-  disconnect?: NodeJS.Timeout;
-  countryCode?: string;
+  ws: WebSocket,
+  messageId: number,
+  heartbeat?: NodeJS.Timeout,
+  disconnect?: NodeJS.Timeout,
+  countryCode?: string,
 }
 
 export interface MessageToForward {
-  channel: Channel;
-  id: string;
+  channel: Channel,
+  id: string,
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  contents: any;
-  version: string;
-  subaccountNumber?: number;
+  contents: any,
+  version: string,
+  subaccountNumber?: number,
 }
 
 export interface ResponseWithBody extends express.Response {
-  body: unknown
+  body: unknown,
 }
 
 export enum WebsocketTopics {

--- a/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
@@ -70,7 +70,7 @@ jest.mock('@dydxprotocol-indexer/base', () => ({
 
 interface OffchainUpdateRecord {
   key: Buffer,
-  offchainUpdate: OffChainUpdateV1
+  offchainUpdate: OffChainUpdateV1,
 }
 
 describe('order-place-handler', () => {


### PR DESCRIPTION
### Changelist
changed indexer/packages/dev/.eslintrc.js 

comma is the more prevalent than semi, so the eslint config was changed to use comma

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated property declarations in various TypeScript interfaces across multiple files to use commas instead of semicolons for improved consistency and readability.
	- Added trailing commas in function parameters and type definitions to facilitate future modifications and maintain uniformity.
- **Chores**
	- Enhanced ESLint configuration to enforce consistent formatting rules for TypeScript code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->