### PR TITLE
bug: Fix market update antehandler

### DIFF
--- a/protocol/app/ante/market_update_test.go
+++ b/protocol/app/ante/market_update_test.go
@@ -1,6 +1,7 @@
 package ante_test
 
 import (
+	storetypes "cosmossdk.io/store/types"
 	"math/rand"
 	"testing"
 
@@ -820,12 +821,19 @@ func TestValidateMarketUpdateDecorator_AnteHandle(t *testing.T) {
 			)
 			require.NoError(t, err)
 
+			ctx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
 			_, err = anteHandler(ctx, tx, tt.args.simulate)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
+			gasConsumed := ctx.GasMeter().GasConsumed()
+			// Execute twice to ensure deterministic gas usage
+			ctx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+			_, err = anteHandler(ctx, tx, tt.args.simulate)
+			require.NoError(t, err)
+			require.Equal(t, gasConsumed, ctx.GasMeter().GasConsumed())
 		})
 	}
 }


### PR DESCRIPTION
### Changelist
Remove the cross-invocation cache from the market update antehandler.

### Test Plan
Added unit tests to ensure determinism of gas usage across multiple invocations.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [X] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of market updates by streamlining the validation process, enhancing efficiency and reducing complexity.
  
- **Bug Fixes**
	- Enhanced test reliability for market update validation by ensuring consistent gas consumption measurements.

- **Refactor**
	- Removed cache-based mapping in favor of a direct mapping strategy, simplifying the control flow in market update validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->