### PR TITLE
Backwards compatible patch for bug with market map antehandler gas usage.

### DIFF
--- a/protocol/app/ante/market_update.go
+++ b/protocol/app/ante/market_update.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	storetypes "cosmossdk.io/store/types"
+
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -85,6 +87,12 @@ func (d ValidateMarketUpdateDecorator) AnteHandle(
 	default:
 		return ctx, fmt.Errorf("unrecognized message type: %T", msg)
 	}
+
+	// FOR BACKWARDS COMPATABILITY
+	// For the bug found in https://github.com/dydxprotocol/v4-chain/pull/2176, this is a
+	// backwards compatible bug-fix, which lets a node sync past blocks that were committed
+	// by nodes running with the bug.
+	_ = d.doMarketsContainCrossMarket(ctx.WithGasMeter(storetypes.NewInfiniteGasMeter()), markets)
 
 	if contains := d.doMarketsContainCrossMarket(ctx, markets); contains {
 		return ctx, ErrNoCrossMarketUpdates


### PR DESCRIPTION
### Changelist
The market map antehandler has a bug where an in-memory cache will affect the gas used when executing upsert/update transactions on the market map module. This breaks nodes that are sync-ing and don't populate the cache from a `CheckTx` call on the transaction as the gas used when executing the transaction will be different from a node that had a populated cache.

This patch ensures that the gas used when executing the antehandler is always the same as the gas used with a fully populated cache, which matches the gas used for a node that had ran the ante handler during `CheckTx` for the upsert/update transaction by running the logic to populate the cache twice and discounting the gas usage from the first run.

See https://github.com/dydxprotocol/v4-chain/pull/2176 for the permanent fix that will go into the official release, this bug fix is intended only for the test-net.

### Test Plan
Tested sync-ing using this patch on the test-net with a block that could not be successfully sync'd w/ the bugged version of the application.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
