### PR TITLE
Add repartitioning step to bazooka

### DIFF
--- a/indexer/services/bazooka/src/index.ts
+++ b/indexer/services/bazooka/src/index.ts
@@ -27,7 +27,7 @@ const KAFKA_TOPICS_TO_PARTITIONS: { [key in KafkaTopics]: number } = {
   [KafkaTopics.TO_ENDER]: 1,
   [KafkaTopics.TO_VULCAN]: 60,
   [KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS]: 1,
-  [KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS]: 1,
+  [KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS]: 30,
   [KafkaTopics.TO_WEBSOCKETS_TRADES]: 1,
   [KafkaTopics.TO_WEBSOCKETS_MARKETS]: 1,
   [KafkaTopics.TO_WEBSOCKETS_CANDLES]: 1,
@@ -182,6 +182,7 @@ async function maybeClearAndCreateKafkaTopics(
 
   if (event.create_kafka_topics) {
     await createKafkaTopics(existingKafkaTopics);
+    await partitionKafkaTopics();
   }
 
   if (event.clear_kafka_topics) {
@@ -231,6 +232,29 @@ async function createKafkaTopics(
     at: 'index#createKafkaTopics',
     message: 'Successfully created kafka topics',
   });
+}
+
+async function partitionKafkaTopics(): Promise<void> {
+  for (const kafkaTopic of KAFKA_TOPICS) {
+    const topicMetadata: { topics: Array<ITopicMetadata> } = await admin.fetchTopicMetadata({
+      topics: [kafkaTopic],
+    });
+    if (topicMetadata.topics.length === 1) {
+      if (topicMetadata.topics[0].partitions.length !== KAFKA_TOPICS_TO_PARTITIONS[kafkaTopic]) {
+        await admin.createPartitions({
+          validateOnly: false,
+          topicPartitions: [{
+            topic: kafkaTopic,
+            count: KAFKA_TOPICS_TO_PARTITIONS[kafkaTopic],
+          }],
+        });
+        logger.info({
+          at: 'index#createKafka  Topics',
+          message: `Successfully set topic ${kafkaTopic} to ${KAFKA_TOPICS_TO_PARTITIONS[kafkaTopic]} partitions`,
+        });
+      }
+    }
+  }
 }
 
 async function clearKafkaTopics(


### PR DESCRIPTION
### Changelist
Also, change TO_WEBSOCKETS_SUBACCOUNTS to have 30 partitions.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced Kafka topic management with increased partition count for improved scalability and performance.
	- Introduced a new asynchronous function to ensure Kafka topics are correctly partitioned based on updated configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->