### PR TITLE
Delete topics based on existing partitions

### DIFF
--- a/indexer/services/bazooka/__tests__/index.test.ts
+++ b/indexer/services/bazooka/__tests__/index.test.ts
@@ -21,12 +21,23 @@ describe('index', () => {
       adminDeleteSpy
         .mockRejectedValueOnce(new Error('test'))
         .mockResolvedValueOnce(Promise<void>);
+      fetchTopicMetadataSpy
+        .mockResolvedValue({
+          topics: [
+            {
+              topic: KafkaTopics.TO_ENDER,
+              partitions: [
+                {},
+                {},
+              ],
+            },
+          ],
+        });
 
       await clearKafkaTopic(1,
         5,
         3,
         [KafkaTopics.TO_ENDER],
-        2,
         KafkaTopics.TO_ENDER);
       expect(adminDeleteSpy).toHaveBeenCalledTimes(2);
     });
@@ -37,13 +48,24 @@ describe('index', () => {
         .mockRejectedValueOnce(new Error('test'))
         .mockRejectedValueOnce(new Error('test'))
         .mockRejectedValueOnce(new Error('test'));
+      fetchTopicMetadataSpy
+        .mockResolvedValue({
+          topics: [
+            {
+              topic: KafkaTopics.TO_ENDER,
+              partitions: [
+                {},
+                {},
+              ],
+            },
+          ],
+        });
 
       await expect(async () => {
         await clearKafkaTopic(1,
           5,
           3,
           [KafkaTopics.TO_ENDER],
-          2,
           KafkaTopics.TO_ENDER);
       }).rejects.toThrowError('test');
       expect(adminDeleteSpy).toHaveBeenCalledTimes(3);

--- a/indexer/services/bazooka/src/index.ts
+++ b/indexer/services/bazooka/src/index.ts
@@ -299,7 +299,7 @@ export async function clearKafkaTopic(
     return;
   }
 
-  let numPartitions = topicMetadata.topics[0].partitions.length;
+  const numPartitions = topicMetadata.topics[0].partitions.length;
 
   logger.info({
     at: 'index#clearKafkaTopics',
@@ -318,10 +318,6 @@ export async function clearKafkaTopic(
       ),
     });
   } catch (error) {
-    const topicMetadata: { topics: Array<ITopicMetadata> } = await admin.fetchTopicMetadata({
-      topics: [kafkaTopic],
-    });
-
     logger.error({
       at: 'index#clearKafkaTopics',
       message: 'Failed to delete topic records',


### PR DESCRIPTION
### Changelist
As opposed to used the hard-coded partitions.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the `clearKafkaTopic` function to automatically determine the number of partitions by fetching metadata from Kafka, improving usability and reliability.

- **Bug Fixes**
	- Added validation to ensure the Kafka topic exists before proceeding, preventing potential errors during execution.

- **Tests**
	- Improved test coverage for the `clearKafkaTopic` function by simulating both successful and error conditions, ensuring robustness in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->