### PR TITLE
Fix bug in clearing topics

### DIFF
--- a/indexer/services/bazooka/src/index.ts
+++ b/indexer/services/bazooka/src/index.ts
@@ -241,6 +241,10 @@ async function partitionKafkaTopics(): Promise<void> {
     });
     if (topicMetadata.topics.length === 1) {
       if (topicMetadata.topics[0].partitions.length !== KAFKA_TOPICS_TO_PARTITIONS[kafkaTopic]) {
+        logger.info({
+          at: 'index#partitionKafkaTopics',
+          message: `Setting topic ${kafkaTopic} to ${KAFKA_TOPICS_TO_PARTITIONS[kafkaTopic]} partitions`,
+        });
         await admin.createPartitions({
           validateOnly: false,
           topicPartitions: [{
@@ -249,7 +253,7 @@ async function partitionKafkaTopics(): Promise<void> {
           }],
         });
         logger.info({
-          at: 'index#createKafka  Topics',
+          at: 'index#partitionKafkaTopics',
           message: `Successfully set topic ${kafkaTopic} to ${KAFKA_TOPICS_TO_PARTITIONS[kafkaTopic]} partitions`,
         });
       }
@@ -261,7 +265,7 @@ async function clearKafkaTopics(
   existingKafkaTopics: string[],
 ): Promise<void> {
   await Promise.all(
-    _.map(KAFKA_TOPICS_TO_PARTITIONS,
+    _.map(KAFKA_TOPICS,
       clearKafkaTopic.bind(null,
         1,
         config.CLEAR_KAFKA_TOPIC_RETRY_MS,


### PR DESCRIPTION
### Changelist
Calling clearKafkaTopic with wrong arguments.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Expanded the GitHub Actions workflow to trigger on additional branch patterns, enhancing build and deployment capabilities.

- **Bug Fixes**
	- Improved logging and clarity in the handling of Kafka topics, enhancing traceability and application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->