### PR TITLE
[OTE-694]implement queries for affiliates

### DIFF
--- a/protocol/x/affiliates/keeper/grpc_query.go
+++ b/protocol/x/affiliates/keeper/grpc_query.go
@@ -3,6 +3,10 @@ package keeper
 import (
 	"context"
 
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	"github.com/dydxprotocol/v4-chain/protocol/x/affiliates/types"
 )
 
@@ -10,15 +14,62 @@ var _ types.QueryServer = Keeper{}
 
 func (k Keeper) AffiliateInfo(c context.Context,
 	req *types.AffiliateInfoRequest) (*types.AffiliateInfoResponse, error) {
-	return nil, nil
+	ctx := sdk.UnwrapSDKContext(c)
+
+	addr, err := sdk.AccAddressFromBech32(req.GetAddress())
+	if err != nil {
+		return nil, errorsmod.Wrapf(types.ErrInvalidAddress, "address: %s, error: %s",
+			req.GetAddress(), err.Error())
+	}
+
+	tierLevel, feeSharePpm, err := k.GetTierForAffiliate(ctx, addr.String())
+	if err != nil {
+		return nil, err
+	}
+
+	referredVolume, err := k.GetReferredVolume(ctx, req.GetAddress())
+	if err != nil {
+		return nil, err
+	}
+
+	stakedAmount := k.statsKeeper.GetStakedAmount(ctx, req.GetAddress())
+
+	return &types.AffiliateInfoResponse{
+		Tier:           tierLevel,
+		FeeSharePpm:    feeSharePpm,
+		ReferredVolume: dtypes.NewIntFromBigInt(referredVolume),
+		StakedAmount:   dtypes.NewIntFromBigInt(stakedAmount),
+	}, nil
 }
 
 func (k Keeper) ReferredBy(ctx context.Context,
 	req *types.ReferredByRequest) (*types.ReferredByResponse, error) {
-	return nil, nil
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	affiliateAddr, exists := k.GetReferredBy(sdkCtx, req.GetAddress())
+	if !exists {
+		return &types.ReferredByResponse{}, errorsmod.Wrapf(
+			types.ErrAffiliateNotFound,
+			"affiliate not found for address: %s",
+			req.GetAddress(),
+		)
+	}
+
+	return &types.ReferredByResponse{
+		AffiliateAddress: affiliateAddr,
+	}, nil
 }
 
 func (k Keeper) AllAffiliateTiers(c context.Context,
 	req *types.AllAffiliateTiersRequest) (*types.AllAffiliateTiersResponse, error) {
-	return nil, nil
+	ctx := sdk.UnwrapSDKContext(c)
+
+	affiliateTiers, err := k.GetAllAffiliateTiers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.AllAffiliateTiersResponse{
+		Tiers: affiliateTiers,
+	}, nil
 }

--- a/protocol/x/affiliates/keeper/grpc_query_test.go
+++ b/protocol/x/affiliates/keeper/grpc_query_test.go
@@ -1,0 +1,184 @@
+package keeper_test
+
+import (
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	"github.com/dydxprotocol/v4-chain/protocol/x/affiliates/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/affiliates/types"
+	"github.com/stretchr/testify/require"
+
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	constants "github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+)
+
+func TestAffiliateInfo(t *testing.T) {
+	testCases := map[string]struct {
+		req         *types.AffiliateInfoRequest
+		res         *types.AffiliateInfoResponse
+		setup       func(ctx sdk.Context, k keeper.Keeper, tApp *testapp.TestApp)
+		expectError error
+	}{
+
+		"Success": {
+			req: &types.AffiliateInfoRequest{
+				Address: constants.AliceAccAddress.String(),
+			},
+			res: &types.AffiliateInfoResponse{
+				Tier:           0,
+				FeeSharePpm:    types.DefaultAffiliateTiers.Tiers[0].TakerFeeSharePpm,
+				ReferredVolume: dtypes.NewIntFromUint64(types.DefaultAffiliateTiers.Tiers[0].ReqReferredVolumeQuoteQuantums),
+				StakedAmount:   dtypes.NewIntFromUint64(uint64(types.DefaultAffiliateTiers.Tiers[0].ReqStakedWholeCoins) * 1e18),
+			},
+			setup: func(ctx sdk.Context, k keeper.Keeper, tApp *testapp.TestApp) {
+				err := k.RegisterAffiliate(ctx, constants.BobAccAddress.String(), constants.AliceAccAddress.String())
+				require.NoError(t, err)
+
+				stakingKeeper := tApp.App.StakingKeeper
+
+				err = stakingKeeper.SetDelegation(ctx,
+					stakingtypes.NewDelegation(constants.AliceAccAddress.String(),
+						constants.AliceValAddress.String(), math.LegacyNewDecFromBigInt(
+							new(big.Int).Mul(
+								big.NewInt(int64(types.DefaultAffiliateTiers.Tiers[0].ReqStakedWholeCoins)),
+								big.NewInt(1e18),
+							),
+						),
+					),
+				)
+				require.NoError(t, err)
+			},
+		},
+		"NonExistentAddress": {
+			req: &types.AffiliateInfoRequest{
+				Address: constants.AliceAccAddress.String(),
+			},
+			res: &types.AffiliateInfoResponse{
+				Tier:           0,
+				FeeSharePpm:    types.DefaultAffiliateTiers.Tiers[0].TakerFeeSharePpm,
+				ReferredVolume: dtypes.NewIntFromUint64(types.DefaultAffiliateTiers.Tiers[0].ReqReferredVolumeQuoteQuantums),
+				StakedAmount:   dtypes.NewIntFromUint64(uint64(types.DefaultAffiliateTiers.Tiers[0].ReqStakedWholeCoins) * 1e18),
+			},
+			setup: func(ctx sdk.Context, k keeper.Keeper, tApp *testapp.TestApp) {
+				stakingKeeper := tApp.App.StakingKeeper
+				err := stakingKeeper.SetDelegation(ctx,
+					stakingtypes.NewDelegation(constants.AliceAccAddress.String(),
+						constants.AliceValAddress.String(), math.LegacyNewDecFromBigInt(
+							big.NewInt(int64(types.DefaultAffiliateTiers.Tiers[0].ReqStakedWholeCoins)),
+						),
+					),
+				)
+				require.NoError(t, err)
+			},
+		},
+		"InvalidAddress": {
+			req: &types.AffiliateInfoRequest{
+				Address: "invalid_address",
+			},
+			res:         nil,
+			setup:       func(ctx sdk.Context, k keeper.Keeper, tApp *testapp.TestApp) {},
+			expectError: types.ErrInvalidAddress,
+		},
+		"EmptyRequest": {
+			req:         &types.AffiliateInfoRequest{},
+			res:         nil,
+			setup:       func(ctx sdk.Context, k keeper.Keeper, tApp *testapp.TestApp) {},
+			expectError: types.ErrInvalidAddress,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).Build()
+			ctx := tApp.InitChain()
+			k := tApp.App.AffiliatesKeeper
+
+			// Set up affiliate tiers
+			tiers := types.DefaultAffiliateTiers
+			k.UpdateAffiliateTiers(ctx, tiers)
+
+			// Run the setup function
+			tc.setup(ctx, k, tApp)
+
+			// Call the AffiliateInfo method
+			res, err := k.AffiliateInfo(ctx, tc.req)
+
+			// Check the result
+			if tc.res == nil {
+				require.ErrorIs(t, err, tc.expectError)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				require.Equal(t, tc.res, res)
+			}
+		})
+	}
+}
+
+func TestReferredBy(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+	k := tApp.App.AffiliatesKeeper
+	testCases := map[string]struct {
+		req         *types.ReferredByRequest
+		setup       func(ctx sdk.Context, k keeper.Keeper)
+		expected    *types.ReferredByResponse
+		expectError error
+	}{
+		"Success": {
+			req: &types.ReferredByRequest{
+				Address: constants.AliceAccAddress.String(),
+			},
+			setup: func(ctx sdk.Context, k keeper.Keeper) {
+				err := k.RegisterAffiliate(ctx, constants.AliceAccAddress.String(), constants.BobAccAddress.String())
+				require.NoError(t, err)
+			},
+			expected: &types.ReferredByResponse{
+				AffiliateAddress: constants.BobAccAddress.String(),
+			},
+		},
+		"Affiliate not found": {
+			req: &types.ReferredByRequest{
+				Address: constants.DaveAccAddress.String(),
+			},
+			setup:       func(ctx sdk.Context, k keeper.Keeper) {},
+			expected:    nil,
+			expectError: types.ErrAffiliateNotFound,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.setup(ctx, k)
+			res, err := k.ReferredBy(ctx, tc.req)
+
+			if tc.expected == nil {
+				require.ErrorIs(t, err, tc.expectError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, res)
+			}
+		})
+	}
+}
+
+func TestAllAffiliateTiers(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+	k := tApp.App.AffiliatesKeeper
+
+	req := &types.AllAffiliateTiersRequest{}
+
+	tiers := types.DefaultAffiliateTiers
+	k.UpdateAffiliateTiers(ctx, tiers)
+
+	res, err := k.AllAffiliateTiers(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, &types.AllAffiliateTiersResponse{Tiers: tiers}, res)
+}

--- a/protocol/x/affiliates/types/errors.go
+++ b/protocol/x/affiliates/types/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrInvalidAffiliateTiers            = errorsmod.Register(ModuleName, 3, "Invalid affiliate tier data")
 	ErrUpdatingAffiliateReferredVolume  = errorsmod.Register(ModuleName, 4, "Error updating affiliate referred volume")
 	ErrInvalidAddress                   = errorsmod.Register(ModuleName, 5, "Invalid address")
+	ErrAffiliateNotFound                = errorsmod.Register(ModuleName, 6, "Affiliate not found")
 )


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new message definition for managing a list of referees associated with affiliates.
	- Implemented methods for retrieving affiliate information, associated referees, and all affiliate tiers.

- **Bug Fixes**
	- Enhanced error handling with a new specific error for when an affiliate is not found.

- **Tests**
	- Added comprehensive unit tests for the new affiliate features, ensuring robust functionality and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->