### PR TITLE
Remove unnecessary workflow token

### DIFF
--- a/protocol/.github/workflows/release-sims.yml
+++ b/protocol/.github/workflows/release-sims.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-          token: ${{ secrets.GH_REPO_READ_TOKEN }}
       - run: |
           make build
 


### PR DESCRIPTION
Token is not needed since the repo is public