### PR TITLE
[OTE-696] Emit register affiliate event on successful registration

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -941,6 +941,7 @@ func New(
 			lib.GovModuleAddress.String(),
 		},
 		app.StatsKeeper,
+		app.IndexerEventManager,
 	)
 	affiliatesModule := affiliatesmodule.NewAppModule(appCodec, app.AffiliatesKeeper)
 

--- a/protocol/indexer/events/affiliates.go
+++ b/protocol/indexer/events/affiliates.go
@@ -1,0 +1,13 @@
+package events
+
+// NewRegisterAffiliateEventV1 creates a RegisterAffiliateEventV1 representing
+// a referee being registered with an affiliate.
+func NewRegisterAffiliateEventV1(
+	referee string,
+	affiliate string,
+) *RegisterAffiliateEventV1 {
+	return &RegisterAffiliateEventV1{
+		Referee:   referee,
+		Affiliate: affiliate,
+	}
+}

--- a/protocol/indexer/events/affiliates_test.go
+++ b/protocol/indexer/events/affiliates_test.go
@@ -1,0 +1,19 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegisterAffiliateEventV1_Success(t *testing.T) {
+	registerAffiliateEvent := NewRegisterAffiliateEventV1(
+		"referee",
+		"affiliate",
+	)
+	expectedRegisterAffiliateEventProto := &RegisterAffiliateEventV1{
+		Referee:   "referee",
+		Affiliate: "affiliate",
+	}
+	require.Equal(t, expectedRegisterAffiliateEventProto, registerAffiliateEvent)
+}

--- a/protocol/indexer/events/constants.go
+++ b/protocol/indexer/events/constants.go
@@ -24,20 +24,21 @@ const (
 
 const (
 	// Indexer event versions.
-	OrderFillEventVersion        uint32 = 1
-	SubaccountUpdateEventVersion uint32 = 1
-	TransferEventVersion         uint32 = 1
-	MarketEventVersion           uint32 = 1
-	FundingValuesEventVersion    uint32 = 1
-	StatefulOrderEventVersion    uint32 = 1
-	AssetEventVersion            uint32 = 1
-	PerpetualMarketEventVersion  uint32 = 2
-	LiquidityTierEventVersion    uint32 = 2
-	UpdatePerpetualEventVersion  uint32 = 1
-	UpdateClobPairEventVersion   uint32 = 1
-	DeleveragingEventVersion     uint32 = 1
-	TradingRewardVersion         uint32 = 1
-	OpenInterestUpdateVersion    uint32 = 1
+	OrderFillEventVersion         uint32 = 1
+	SubaccountUpdateEventVersion  uint32 = 1
+	TransferEventVersion          uint32 = 1
+	MarketEventVersion            uint32 = 1
+	FundingValuesEventVersion     uint32 = 1
+	StatefulOrderEventVersion     uint32 = 1
+	AssetEventVersion             uint32 = 1
+	PerpetualMarketEventVersion   uint32 = 2
+	LiquidityTierEventVersion     uint32 = 2
+	UpdatePerpetualEventVersion   uint32 = 1
+	UpdateClobPairEventVersion    uint32 = 1
+	DeleveragingEventVersion      uint32 = 1
+	TradingRewardVersion          uint32 = 1
+	OpenInterestUpdateVersion     uint32 = 1
+	RegisterAffiliateEventVersion uint32 = 1
 )
 
 var OnChainEventSubtypes = []string{
@@ -54,4 +55,5 @@ var OnChainEventSubtypes = []string{
 	SubtypeUpdateClobPair,
 	SubtypeDeleveraging,
 	SubtypeTradingReward,
+	SubtypeRegisterAffiliate,
 }

--- a/protocol/testutil/keeper/affiliates.go
+++ b/protocol/testutil/keeper/affiliates.go
@@ -1,28 +1,80 @@
 package keeper
 
 import (
+	"testing"
+
 	storetypes "cosmossdk.io/store/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
+	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	affiliateskeeper "github.com/dydxprotocol/v4-chain/protocol/x/affiliates/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/affiliates/types"
 	statskeeper "github.com/dydxprotocol/v4-chain/protocol/x/stats/keeper"
 )
+
+func AffiliatesKeepers(t testing.TB, msgSenderEnabled bool) (
+	ctx sdk.Context,
+	keeper *affiliateskeeper.Keeper,
+	statsKeeper *statskeeper.Keeper,
+	storeKey storetypes.StoreKey,
+) {
+	ctx = initKeepers(t, func(
+		db *dbm.MemDB,
+		registry codectypes.InterfaceRegistry,
+		cdc *codec.ProtoCodec,
+		stateStore storetypes.CommitMultiStore,
+		transientStoreKey storetypes.StoreKey,
+	) []GenesisInitializer {
+		// Define necessary keepers here for unit tests
+		epochsKeeper, _ := createEpochsKeeper(stateStore, db, cdc)
+
+		accountKeeper, _ := createAccountKeeper(stateStore, db, cdc, registry)
+		bankKeeper, _ := createBankKeeper(stateStore, db, cdc, accountKeeper)
+		stakingKeeper, _ := createStakingKeeper(stateStore, db, cdc, accountKeeper, bankKeeper)
+		statsKeeper, _ := createStatsKeeper(stateStore, epochsKeeper, db, cdc, stakingKeeper)
+
+		keeper, storeKey = createAffiliatesKeeper(
+			stateStore,
+			db,
+			cdc,
+			statsKeeper,
+			transientStoreKey,
+			msgSenderEnabled,
+		)
+
+		return []GenesisInitializer{statsKeeper, keeper}
+	})
+
+	return ctx,
+		keeper,
+		statsKeeper,
+		storeKey
+}
 
 func createAffiliatesKeeper(
 	stateStore storetypes.CommitMultiStore,
 	db *dbm.MemDB,
 	cdc *codec.ProtoCodec,
 	statsKeeper *statskeeper.Keeper,
+	transientStoreKey storetypes.StoreKey,
+	msgSenderEnabled bool,
 ) (*affiliateskeeper.Keeper, storetypes.StoreKey) {
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
 	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+
+	mockMsgSender := &mocks.IndexerMessageSender{}
+	mockMsgSender.On("Enabled").Return(msgSenderEnabled)
+	mockIndexerEventsManager := indexer_manager.NewIndexerEventManager(mockMsgSender, transientStoreKey, true)
 
 	k := affiliateskeeper.NewKeeper(
 		cdc,
 		storeKey,
 		[]string{},
 		statsKeeper,
+		mockIndexerEventsManager,
 	)
 	return k, storeKey
 }

--- a/protocol/testutil/keeper/assets.go
+++ b/protocol/testutil/keeper/assets.go
@@ -79,7 +79,7 @@ func AssetsKeepers(
 			cdc,
 			stakingKeeper,
 		)
-		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper)
+		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper, transientStoreKey, msgSenderEnabled)
 		revShareKeeper, _, _ := createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 		marketMapKeeper, _ := createMarketMapKeeper(stateStore, db, cdc)
 		pricesKeeper, _, _, mockTimeProvider = createPricesKeeper(

--- a/protocol/testutil/keeper/clob.go
+++ b/protocol/testutil/keeper/clob.go
@@ -105,7 +105,8 @@ func NewClobKeepersTestContextWithUninitializedMemStore(
 			cdc,
 			stakingKeeper,
 		)
-		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, ks.StatsKeeper)
+		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, ks.StatsKeeper,
+			indexerEventsTransientStoreKey, true)
 		revShareKeeper, _, _ := createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 		ks.MarketMapKeeper, _ = createMarketMapKeeper(stateStore, db, cdc)
 		ks.PricesKeeper, _, _, mockTimeProvider = createPricesKeeper(

--- a/protocol/testutil/keeper/listing.go
+++ b/protocol/testutil/keeper/listing.go
@@ -70,7 +70,7 @@ func ListingKeepers(
 				cdc,
 				stakingKeeper,
 			)
-			affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper)
+			affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper, transientStoreKey, true)
 			revShareKeeper, _, _ := createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 			marketMapKeeper, _ = createMarketMapKeeper(stateStore, db, cdc)
 			pricesKeeper, _, _, mockTimeProvider = createPricesKeeper(

--- a/protocol/testutil/keeper/perpetuals.go
+++ b/protocol/testutil/keeper/perpetuals.go
@@ -88,7 +88,7 @@ func PerpetualsKeepersWithClobHelpers(
 				cdc,
 				stakingKeeper,
 			)
-			affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper)
+			affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper, transientStoreKey, true)
 			revShareKeeper, _, _ := createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 			pc.MarketMapKeeper, _ = createMarketMapKeeper(stateStore, db, cdc)
 			pc.PricesKeeper, _, pc.IndexPriceCache, pc.MockTimeProvider = createPricesKeeper(

--- a/protocol/testutil/keeper/prices.go
+++ b/protocol/testutil/keeper/prices.go
@@ -69,7 +69,7 @@ func PricesKeepers(t testing.TB) (
 			cdc,
 			stakingKeeper,
 		)
-		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper)
+		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper, transientStoreKey, true)
 		revShareKeeper, _, _ = createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 		marketMapKeeper, _ = createMarketMapKeeper(stateStore, db, cdc)
 		// Define necessary keepers here for unit tests

--- a/protocol/testutil/keeper/revshare.go
+++ b/protocol/testutil/keeper/revshare.go
@@ -53,7 +53,7 @@ func RevShareKeepers(t testing.TB) (
 				cdc,
 				stakingKeeper,
 			)
-			affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper)
+			affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper, transientStoreKey, true)
 			keeper, storeKey, mockTimeProvider =
 				createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 

--- a/protocol/testutil/keeper/rewards.go
+++ b/protocol/testutil/keeper/rewards.go
@@ -65,7 +65,7 @@ func RewardsKeepers(
 			cdc,
 			stakingKeeper,
 		)
-		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper)
+		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper, transientStoreKey, true)
 		revShareKeeper, _, _ := createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 		marketMapKeeper, _ := createMarketMapKeeper(stateStore, db, cdc)
 		pricesKeeper, _, _, _ = createPricesKeeper(stateStore, db, cdc, transientStoreKey, revShareKeeper, marketMapKeeper)

--- a/protocol/testutil/keeper/sending.go
+++ b/protocol/testutil/keeper/sending.go
@@ -77,7 +77,7 @@ func SendingKeepersWithSubaccountsKeeper(t testing.TB, saKeeper types.Subaccount
 			cdc,
 			stakingKeeper,
 		)
-		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper)
+		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper, transientStoreKey, true)
 		revShareKeeper, _, _ := createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 		marketMapKeeper, _ := createMarketMapKeeper(stateStore, db, cdc)
 		ks.PricesKeeper, _, _, mockTimeProvider = createPricesKeeper(

--- a/protocol/testutil/keeper/subaccounts.go
+++ b/protocol/testutil/keeper/subaccounts.go
@@ -74,7 +74,7 @@ func SubaccountsKeepers(t testing.TB, msgSenderEnabled bool) (
 			cdc,
 			stakingKeeper,
 		)
-		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper)
+		affiliatesKeeper, _ := createAffiliatesKeeper(stateStore, db, cdc, statsKeeper, transientStoreKey, true)
 		revShareKeeper, _, _ = createRevShareKeeper(stateStore, db, cdc, affiliatesKeeper)
 		marketMapKeeper, _ := createMarketMapKeeper(stateStore, db, cdc)
 		pricesKeeper, _, _, mockTimeProvider = createPricesKeeper(


### PR DESCRIPTION
### Changelist
Emits affiliate event

### Test Plan
Adds unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new event management capability for affiliate registrations.
	- Added a structured way to create and manage `RegisterAffiliateEventV1` events.
	- Enhanced the `Keeper` functionality to directly manage indexer events.

- **Bug Fixes**
	- Improved event handling logic to ensure accurate affiliate registration processing.

- **Tests**
	- Added unit tests for the new affiliate registration event functionality, ensuring reliability and correctness.

- **Chores**
	- Updated constants and structures to accommodate new event types and improve event tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->