### PR TITLE
[OTE-779] Check affiliate tiers are strictly increasing before updating tiers

### DIFF
--- a/protocol/x/affiliates/keeper/grpc_query_test.go
+++ b/protocol/x/affiliates/keeper/grpc_query_test.go
@@ -99,7 +99,8 @@ func TestAffiliateInfo(t *testing.T) {
 
 			// Set up affiliate tiers
 			tiers := types.DefaultAffiliateTiers
-			k.UpdateAffiliateTiers(ctx, tiers)
+			err := k.UpdateAffiliateTiers(ctx, tiers)
+			require.NoError(t, err)
 
 			// Run the setup function
 			tc.setup(ctx, k, tApp)
@@ -174,7 +175,8 @@ func TestAllAffiliateTiers(t *testing.T) {
 	req := &types.AllAffiliateTiersRequest{}
 
 	tiers := types.DefaultAffiliateTiers
-	k.UpdateAffiliateTiers(ctx, tiers)
+	err := k.UpdateAffiliateTiers(ctx, tiers)
+	require.NoError(t, err)
 
 	res, err := k.AllAffiliateTiers(ctx, req)
 

--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -222,11 +222,7 @@ func (k Keeper) GetTierForAffiliate(
 // Used primarily through governance.
 func (k Keeper) UpdateAffiliateTiers(ctx sdk.Context, affiliateTiers types.AffiliateTiers) error {
 	store := ctx.KVStore(k.storeKey)
-	affiliateTiersBytes, err := k.cdc.Marshal(&affiliateTiers)
-	if err != nil {
-		return errorsmod.Wrapf(types.ErrInvalidAffiliateTiers,
-			"error marshalling affiliate tiers: %s", err)
-	}
+	affiliateTiersBytes := k.cdc.MustMarshal(&affiliateTiers)
 	tiers := affiliateTiers.GetTiers()
 	// start at 1, since 0 is the default tier.
 	for i := 1; i < len(tiers); i++ {

--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -220,11 +220,24 @@ func (k Keeper) GetTierForAffiliate(
 
 // UpdateAffiliateTiers updates the affiliate tiers.
 // Used primarily through governance.
-func (k Keeper) UpdateAffiliateTiers(ctx sdk.Context, affiliateTiers types.AffiliateTiers) {
+func (k Keeper) UpdateAffiliateTiers(ctx sdk.Context, affiliateTiers types.AffiliateTiers) error {
 	store := ctx.KVStore(k.storeKey)
-	// TODO(OTE-779): Check strictly increasing volume and
-	// staking requirements hold in UpdateAffiliateTiers
-	store.Set([]byte(types.AffiliateTiersKey), k.cdc.MustMarshal(&affiliateTiers))
+	affiliateTiersBytes, err := k.cdc.Marshal(&affiliateTiers)
+	if err != nil {
+		return errorsmod.Wrapf(types.ErrInvalidAffiliateTiers,
+			"error marshalling affiliate tiers: %s", err)
+	}
+	tiers := affiliateTiers.GetTiers()
+	// start at 1, since 0 is the default tier.
+	for i := 1; i < len(tiers); i++ {
+		if tiers[i].ReqReferredVolumeQuoteQuantums <= tiers[i-1].ReqReferredVolumeQuoteQuantums ||
+			tiers[i].ReqStakedWholeCoins <= tiers[i-1].ReqStakedWholeCoins {
+			return errorsmod.Wrapf(types.ErrInvalidAffiliateTiers,
+				"tiers values must be strictly increasing")
+		}
+	}
+	store.Set([]byte(types.AffiliateTiersKey), affiliateTiersBytes)
+	return nil
 }
 
 func (k *Keeper) SetRevShareKeeper(revShareKeeper types.RevShareKeeper) {

--- a/protocol/x/affiliates/keeper/msg_server.go
+++ b/protocol/x/affiliates/keeper/msg_server.go
@@ -51,7 +51,10 @@ func (k msgServer) UpdateAffiliateTiers(ctx context.Context,
 		)
 	}
 
-	k.Keeper.UpdateAffiliateTiers(sdkCtx, msg.Tiers)
+	err = k.Keeper.UpdateAffiliateTiers(sdkCtx, msg.Tiers)
+	if err != nil {
+		return nil, err
+	}
 
 	return &types.MsgUpdateAffiliateTiersResponse{}, nil
 }


### PR DESCRIPTION
### Changelist
Checks volume and staking requirements are strictly increasing in affiliate tiers

### Test Plan
Added unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and validation for updating affiliate tiers.
	- Introduced checks to ensure affiliate tiers are strictly increasing based on defined criteria.

- **Bug Fixes**
	- Improved test coverage for the `UpdateAffiliateTiers` method to capture and assert errors during tier updates.

- **Tests**
	- Restructured test cases to validate both valid and invalid configurations of affiliate tiers, ensuring adherence to business rules.
	- Enhanced error handling in test functions to ensure proper reporting of issues during tier updates. 
	- Improved error management in the messaging server for tier updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->