### PR TITLE
Short-circuit `RegisterAffiliate` state read when address is invalid

### DIFF
--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -55,15 +55,15 @@ func (k Keeper) RegisterAffiliate(
 	referee string,
 	affiliateAddr string,
 ) error {
-	if _, found := k.GetReferredBy(ctx, referee); found {
-		return errorsmod.Wrapf(types.ErrAffiliateAlreadyExistsForReferee, "referee: %s, affiliate: %s",
-			referee, affiliateAddr)
-	}
 	if _, err := sdk.AccAddressFromBech32(referee); err != nil {
 		return errorsmod.Wrapf(types.ErrInvalidAddress, "referee: %s", referee)
 	}
 	if _, err := sdk.AccAddressFromBech32(affiliateAddr); err != nil {
 		return errorsmod.Wrapf(types.ErrInvalidAddress, "affiliate: %s", affiliateAddr)
+	}
+	if _, found := k.GetReferredBy(ctx, referee); found {
+		return errorsmod.Wrapf(types.ErrAffiliateAlreadyExistsForReferee, "referee: %s, affiliate: %s",
+			referee, affiliateAddr)
 	}
 	prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.ReferredByKeyPrefix)).Set([]byte(referee), []byte(affiliateAddr))
 	// TODO(OTE-696): Emit indexer event.


### PR DESCRIPTION
### Changelist
Minor fix (re-ordering)

### Test Plan
Existing unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the affiliate registration process by adjusting the order of checks, allowing for better validation of referee and affiliate addresses before verifying existing affiliations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->