### PR TITLE
[OTE-755] Add update wallet total volume roundtable task

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240906134410_add_fills_created_at_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240906134410_add_fills_created_at_index.ts
@@ -1,0 +1,17 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "fills_createdat_index" ON "fills" ("createdAt");
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "fills_createdat_index";
+    `);
+}
+
+export const config = {
+  transaction: false,
+};

--- a/indexer/services/roundtable/__tests__/tasks/update-wallet-total-volume.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/update-wallet-total-volume.test.ts
@@ -32,54 +32,18 @@ describe('update-wallet-total-volume', () => {
     await dbHelpers.clearData();
   });
 
-  it('Succeeds in populating historical totalVolume on first run', async () => {
-    const referenceDt: DateTime = DateTime.fromISO('2020-01-01T00:00:00Z');
+  it('Successfully updates totalVolume multiple times', async () => {
     const defaultSubaccountId = await SubaccountTable.findAll(
       { subaccountNumber: testConstants.defaultSubaccount.subaccountNumber },
       [],
       {},
     );
-
-    await FillTable.create({
-      ...testConstants.defaultFill,
-      subaccountId: defaultSubaccountId[0].id,
-      createdAt: referenceDt.toISO(),
-      eventId: testConstants.defaultTendermintEventId,
-      price: '1',
-      size: '1',
+    // Set persistent cache totalVolumeUpdateTime so walletTotalVolumeUpdateTask() does not attempt
+    // to backfill
+    await PersistentCacheTable.create({
+      key: 'totalVolumeUpdateTime',
+      value: DateTime.utc().toISO(),
     });
-    await FillTable.create({
-      ...testConstants.defaultFill,
-      subaccountId: defaultSubaccountId[0].id,
-      createdAt: referenceDt.plus({ years: 1 }).toISO(),
-      eventId: testConstants.defaultTendermintEventId2,
-      price: '2',
-      size: '2',
-    });
-    await FillTable.create({
-      ...testConstants.defaultFill,
-      subaccountId: defaultSubaccountId[0].id,
-      createdAt: referenceDt.plus({ years: 2 }).toISO(),
-      eventId: testConstants.defaultTendermintEventId3,
-      price: '3',
-      size: '3',
-    });
-
-    await walletTotalVolumeUpdateTask();
-
-    const wallet = await WalletTable.findById(testConstants.defaultWallet.address);
-    expect(wallet).toEqual(expect.objectContaining({
-      ...testConstants.defaultWallet,
-      totalVolume: '14', // 1 + 4 + 9
-    }));
-  });
-
-  it('Succeeds in incremental totalVolume updates', async () => {
-    const defaultSubaccountId = await SubaccountTable.findAll(
-      { subaccountNumber: testConstants.defaultSubaccount.subaccountNumber },
-      [],
-      {},
-    );
 
     // First task run: one new fill
     await FillTable.create({
@@ -123,11 +87,15 @@ describe('update-wallet-total-volume', () => {
   });
 
   it('Successfully updates totalVolumeUpdateTime in persistent cache table', async () => {
+    // Set persistent cache totalVolumeUpdateTime so walletTotalVolumeUpdateTask() does not attempt
+    // to backfill
+    await PersistentCacheTable.create({
+      key: 'totalVolumeUpdateTime',
+      value: DateTime.utc().toISO(),
+    });
+
     await walletTotalVolumeUpdateTask();
     const lastUpdateTime1 = await getTotalVolumeUpdateTime();
-
-    // Sleep for 1s
-    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     await walletTotalVolumeUpdateTask();
     const lastUpdateTime2 = await getTotalVolumeUpdateTime();
@@ -136,8 +104,111 @@ describe('update-wallet-total-volume', () => {
     expect(lastUpdateTime2).not.toBeUndefined();
     if (lastUpdateTime1?.toMillis() !== undefined && lastUpdateTime2?.toMillis() !== undefined) {
       expect(lastUpdateTime2.toMillis())
-        .toBeGreaterThan(lastUpdateTime1.plus({ seconds: 1 }).toMillis());
+        .toBeGreaterThan(lastUpdateTime1.toMillis());
     }
+  });
+
+  it('Successfully backfills from past date', async () => {
+    const currentDt: DateTime = DateTime.utc();
+    const defaultSubaccountId = await SubaccountTable.findAll(
+      { subaccountNumber: testConstants.defaultSubaccount.subaccountNumber },
+      [],
+      {},
+    );
+
+    // Create 3 fills spanning 2 weeks in the past
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: currentDt.toISO(),
+      eventId: testConstants.defaultTendermintEventId,
+      price: '1',
+      size: '1',
+    });
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: currentDt.minus({ weeks: 1 }).toISO(),
+      eventId: testConstants.defaultTendermintEventId2,
+      price: '2',
+      size: '2',
+    });
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: currentDt.minus({ weeks: 2 }).toISO(),
+      eventId: testConstants.defaultTendermintEventId3,
+      price: '3',
+      size: '3',
+    });
+
+    // Set persistent cache totalVolumeUpdateTime to 3 weeks ago to emulate backfill from 3 weeks.
+    await PersistentCacheTable.create({
+      key: 'totalVolumeUpdateTime',
+      value: currentDt.minus({ weeks: 3 }).toISO(),
+    });
+
+    let backfillTime = await getTotalVolumeUpdateTime();
+    while (backfillTime !== undefined && DateTime.fromISO(backfillTime.toISO()) < currentDt) {
+      await walletTotalVolumeUpdateTask();
+      backfillTime = await getTotalVolumeUpdateTime();
+    }
+
+    const wallet = await WalletTable.findById(testConstants.defaultWallet.address);
+    expect(wallet).toEqual(expect.objectContaining({
+      ...testConstants.defaultWallet,
+      totalVolume: '14', // 1 + 4 + 9
+    }));
+  });
+
+  it('Successfully backfills on first run', async () => {
+    const defaultSubaccountId = await SubaccountTable.findAll(
+      { subaccountNumber: testConstants.defaultSubaccount.subaccountNumber },
+      [],
+      {},
+    );
+
+    // Leave persistent cache totalVolumeUpdateTime empty and create fills around
+    // `defaultLastUpdateTime` value to emulate backfilling from very beginning
+    expect(await getTotalVolumeUpdateTime()).toBeUndefined();
+
+    const referenceDt = DateTime.fromISO('2020-01-01T00:00:00Z');
+
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: referenceDt.plus({ days: 1 }).toISO(),
+      eventId: testConstants.defaultTendermintEventId,
+      price: '1',
+      size: '1',
+    });
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: referenceDt.plus({ days: 2 }).toISO(),
+      eventId: testConstants.defaultTendermintEventId2,
+      price: '2',
+      size: '2',
+    });
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: referenceDt.plus({ days: 3 }).toISO(),
+      eventId: testConstants.defaultTendermintEventId3,
+      price: '3',
+      size: '3',
+    });
+
+    // Emulate 10 roundtable runs (this should backfill all the fills)
+    for (let i = 0; i < 10; i++) {
+      await walletTotalVolumeUpdateTask();
+    }
+
+    const wallet = await WalletTable.findById(testConstants.defaultWallet.address);
+    expect(wallet).toEqual(expect.objectContaining({
+      ...testConstants.defaultWallet,
+      totalVolume: '14', // 1 + 4 + 9
+    }));
   });
 });
 

--- a/indexer/services/roundtable/__tests__/tasks/update-wallet-total-volume.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/update-wallet-total-volume.test.ts
@@ -1,0 +1,150 @@
+import {
+  dbHelpers,
+  testConstants,
+  testMocks,
+  WalletTable,
+  SubaccountTable,
+  PersistentCacheTable,
+  FillTable,
+  OrderTable,
+} from '@dydxprotocol-indexer/postgres';
+import walletTotalVolumeUpdateTask from '../../src/tasks/update-wallet-total-volume';
+import { DateTime } from 'luxon';
+
+describe('update-wallet-total-volume', () => {
+  beforeAll(async () => {
+    await dbHelpers.migrate();
+    await dbHelpers.clearData();
+  });
+
+  beforeEach(async () => {
+    await testMocks.seedData();
+    await OrderTable.create(testConstants.defaultOrder);
+    await OrderTable.create(testConstants.isolatedMarketOrder);
+  });
+
+  afterAll(async () => {
+    await dbHelpers.teardown();
+    jest.resetAllMocks();
+  });
+
+  afterEach(async () => {
+    await dbHelpers.clearData();
+  });
+
+  it('Succeeds in populating historical totalVolume on first run', async () => {
+    const referenceDt: DateTime = DateTime.fromISO('2020-01-01T00:00:00Z');
+    const defaultSubaccountId = await SubaccountTable.findAll(
+      { subaccountNumber: testConstants.defaultSubaccount.subaccountNumber },
+      [],
+      {},
+    );
+
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: referenceDt.toISO(),
+      eventId: testConstants.defaultTendermintEventId,
+      price: '1',
+      size: '1',
+    });
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: referenceDt.plus({ years: 1 }).toISO(),
+      eventId: testConstants.defaultTendermintEventId2,
+      price: '2',
+      size: '2',
+    });
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: referenceDt.plus({ years: 2 }).toISO(),
+      eventId: testConstants.defaultTendermintEventId3,
+      price: '3',
+      size: '3',
+    });
+
+    await walletTotalVolumeUpdateTask();
+
+    const wallet = await WalletTable.findById(testConstants.defaultWallet.address);
+    expect(wallet).toEqual(expect.objectContaining({
+      ...testConstants.defaultWallet,
+      totalVolume: '14', // 1 + 4 + 9
+    }));
+  });
+
+  it('Succeeds in incremental totalVolume updates', async () => {
+    const defaultSubaccountId = await SubaccountTable.findAll(
+      { subaccountNumber: testConstants.defaultSubaccount.subaccountNumber },
+      [],
+      {},
+    );
+
+    // First task run: one new fill
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: DateTime.utc().toISO(),
+      eventId: testConstants.defaultTendermintEventId,
+      price: '1',
+      size: '1',
+    });
+    await walletTotalVolumeUpdateTask();
+    let wallet = await WalletTable.findById(testConstants.defaultWallet.address);
+    expect(wallet).toEqual(expect.objectContaining({
+      ...testConstants.defaultWallet,
+      totalVolume: '1',
+    }));
+
+    // Second task run: no new fills
+    await walletTotalVolumeUpdateTask();
+    wallet = await WalletTable.findById(testConstants.defaultWallet.address);
+    expect(wallet).toEqual(expect.objectContaining({
+      ...testConstants.defaultWallet,
+      totalVolume: '1',
+    }));
+
+    // Third task run: one new fill
+    await FillTable.create({
+      ...testConstants.defaultFill,
+      subaccountId: defaultSubaccountId[0].id,
+      createdAt: DateTime.utc().toISO(),
+      eventId: testConstants.defaultTendermintEventId2,
+      price: '1',
+      size: '1',
+    });
+    await walletTotalVolumeUpdateTask();
+    wallet = await WalletTable.findById(testConstants.defaultWallet.address);
+    expect(wallet).toEqual(expect.objectContaining({
+      ...testConstants.defaultWallet,
+      totalVolume: '2',
+    }));
+  });
+
+  it('Successfully updates totalVolumeUpdateTime in persistent cache table', async () => {
+    await walletTotalVolumeUpdateTask();
+    const lastUpdateTime1 = await getTotalVolumeUpdateTime();
+
+    // Sleep for 1s
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    await walletTotalVolumeUpdateTask();
+    const lastUpdateTime2 = await getTotalVolumeUpdateTime();
+
+    expect(lastUpdateTime1).not.toBeUndefined();
+    expect(lastUpdateTime2).not.toBeUndefined();
+    if (lastUpdateTime1?.toMillis() !== undefined && lastUpdateTime2?.toMillis() !== undefined) {
+      expect(lastUpdateTime2.toMillis())
+        .toBeGreaterThan(lastUpdateTime1.plus({ seconds: 1 }).toMillis());
+    }
+  });
+});
+
+async function getTotalVolumeUpdateTime(): Promise<DateTime | undefined> {
+  const persistentCache = await PersistentCacheTable.findById('totalVolumeUpdateTime');
+  const lastUpdateTime1 = persistentCache?.value
+    ? DateTime.fromISO(persistentCache.value)
+    : undefined;
+  return lastUpdateTime1;
+}

--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -57,6 +57,7 @@ export const configSchema = {
   LOOPS_ENABLED_LEADERBOARD_PNL_WEEKLY: parseBoolean({ default: false }),
   LOOPS_ENABLED_LEADERBOARD_PNL_MONTHLY: parseBoolean({ default: false }),
   LOOPS_ENABLED_LEADERBOARD_PNL_YEARLY: parseBoolean({ default: false }),
+  LOOPS_ENABLED_UPDATE_WALLET_TOTAL_VOLUME: parseBoolean({ default: true }),
 
   // Loop Timing
   LOOPS_INTERVAL_MS_MARKET_UPDATER: parseInteger({
@@ -124,6 +125,9 @@ export const configSchema = {
   }),
   LOOPS_INTERVAL_MS_LEADERBOARD_PNL_YEARLY: parseInteger({
     default: THIRTY_SECONDS_IN_MILLISECONDS,
+  }),
+  LOOPS_INTERVAL_MS_UPDATE_WALLET_TOTAL_VOLUME: parseInteger({
+    default: FIVE_MINUTES_IN_MILLISECONDS,
   }),
 
   // Start delay

--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -127,7 +127,7 @@ export const configSchema = {
     default: THIRTY_SECONDS_IN_MILLISECONDS,
   }),
   LOOPS_INTERVAL_MS_UPDATE_WALLET_TOTAL_VOLUME: parseInteger({
-    default: FIVE_MINUTES_IN_MILLISECONDS,
+    default: THIRTY_SECONDS_IN_MILLISECONDS,
   }),
 
   // Start delay

--- a/indexer/services/roundtable/src/index.ts
+++ b/indexer/services/roundtable/src/index.ts
@@ -27,6 +27,7 @@ import trackLag from './tasks/track-lag';
 import uncrossOrderbookTask from './tasks/uncross-orderbook';
 import updateComplianceDataTask from './tasks/update-compliance-data';
 import updateResearchEnvironmentTask from './tasks/update-research-environment';
+import updateWalletTotalVolumeTask from './tasks/update-wallet-total-volume';
 
 process.on('SIGTERM', () => {
   logger.info({
@@ -245,6 +246,13 @@ async function start(): Promise<void> {
       yearlyLeaderboardTask,
       'create_leaderboard_pnl_yearly',
       config.LOOPS_INTERVAL_MS_LEADERBOARD_PNL_YEARLY,
+    );
+  }
+  if (config.LOOPS_ENABLED_UPDATE_WALLET_TOTAL_VOLUME) {
+    startLoop(
+      updateWalletTotalVolumeTask,
+      'update_wallet_total_volume',
+      config.LOOPS_INTERVAL_MS_UPDATE_WALLET_TOTAL_VOLUME,
     );
   }
 

--- a/indexer/services/roundtable/src/tasks/update-wallet-total-volume.ts
+++ b/indexer/services/roundtable/src/tasks/update-wallet-total-volume.ts
@@ -1,0 +1,54 @@
+import { logger, stats } from '@dydxprotocol-indexer/base';
+import {
+  PersistentCacheTable,
+  WalletTable,
+} from '@dydxprotocol-indexer/postgres';
+import config from '../config';
+
+const defaultLastUpdateTime: string = '2000-01-01T00:00:00Z';
+const persistentCacheKey: string = 'totalVolumeUpdateTime';
+
+/**
+ * Update the total volume for each address in the wallet table.
+ */
+export default async function runTask(): Promise<void> {
+  try {
+    const start = Date.now();
+    const persistentCacheEntry = await PersistentCacheTable.findById(persistentCacheKey);
+
+    if (!persistentCacheEntry) {
+      logger.info({
+        at: 'update-address-total-volume#runTask',
+        message: `No previous totalVolumeUpdateTime found in persistent cache table. Will use default value: ${defaultLastUpdateTime}`,
+      });
+    }
+
+    const lastUpdateTime = persistentCacheEntry 
+      ? persistentCacheEntry.value 
+      : defaultLastUpdateTime;
+    const currentTime = new Date().toISOString();
+
+    // On the first run of this roundtable, we need to calculate the total volume for all historical
+    // fills. This is a much more demanding task than regular roundtable runs.
+    // At time of commit, the total number of rows in 'fills' table in imperator mainnet is ~250M.
+    // This can be processed in ~1min with the introduction of 'createdAt' index in 'fills' table.
+    // This is relatively short and significanlty shorter than roundtable task cadence. Hence, 
+    // special handling for the first run is not required.
+    await WalletTable.updateTotalVolume(lastUpdateTime, currentTime);
+    await PersistentCacheTable.upsert({
+      key: persistentCacheKey,
+      value: currentTime,
+    });
+
+    stats.timing(
+      `${config.SERVICE_NAME}.update_wallet_total_volume_timing`,
+      Date.now() - start,
+    );
+  } catch (error) {
+    logger.error({
+      at: 'update-address-total-volume#runTask',
+      message: 'Error when updating totalVolume in wallets table',
+      error,
+    });
+  }
+}


### PR DESCRIPTION
### Changelist
Add new index on createdAt for fills table
Add new roundtable task to update wallet total volume

### Test Plan
local unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced functionality to dynamically update wallet total volume based on transaction data over specified time windows.
	- Added configuration options to control wallet total volume update intervals.

- **Bug Fixes**
	- Enhanced test coverage for wallet volume calculations, ensuring robust functionality under various scenarios.

- **Documentation**
	- Improved clarity and structure of test cases related to wallet total volume updates.

- **Chores**
	- Implemented a migration script to optimize database performance for volume calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->