### PR TITLE
Expose maxWaitTimeInMs and set subaccounts partitions to 3

### DIFF
--- a/indexer/packages/kafka/src/config.ts
+++ b/indexer/packages/kafka/src/config.ts
@@ -36,6 +36,7 @@ export const kafkaConfigSchema = {
   KAFKA_MAX_BATCH_WEBSOCKET_MESSAGE_SIZE_BYTES: parseInteger({
     default: 900000, // ~900 kB, 100 kB smaller than the 1 MB default max size of messages in Kafka
   }),
+  KAFKA_WAIT_MAX_TIME_MS: parseInteger({ default: 5_000 }),
 };
 
 export default parseSchema(kafkaConfigSchema);

--- a/indexer/packages/kafka/src/consumer.ts
+++ b/indexer/packages/kafka/src/consumer.ts
@@ -18,6 +18,7 @@ export const consumer: Consumer = kafka.consumer({
   sessionTimeout: config.KAFKA_SESSION_TIMEOUT_MS,
   rebalanceTimeout: config.KAFKA_REBALANCE_TIMEOUT_MS,
   heartbeatInterval: config.KAFKA_HEARTBEAT_INTERVAL_MS,
+  maxWaitTimeInMs: config.KAFKA_WAIT_MAX_TIME_MS,
   readUncommitted: false,
   maxBytes: 4194304, // 4MB
 });

--- a/indexer/services/bazooka/src/index.ts
+++ b/indexer/services/bazooka/src/index.ts
@@ -27,7 +27,7 @@ const KAFKA_TOPICS_TO_PARTITIONS: { [key in KafkaTopics]: number } = {
   [KafkaTopics.TO_ENDER]: 1,
   [KafkaTopics.TO_VULCAN]: 60,
   [KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS]: 1,
-  [KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS]: 30,
+  [KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS]: 3,
   [KafkaTopics.TO_WEBSOCKETS_TRADES]: 1,
   [KafkaTopics.TO_WEBSOCKETS_MARKETS]: 1,
   [KafkaTopics.TO_WEBSOCKETS_CANDLES]: 1,


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter to set the maximum wait time for Kafka message processing, enhancing control over message retrieval.
	- Reduced the partition count for the `TO_WEBSOCKETS_SUBACCOUNTS` topic, optimizing message processing distribution.

- **Bug Fixes**
	- Adjusted Kafka topic configurations to improve throughput and scalability for specific message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->