### PR TITLE
[OTE-776] Implement GetAllRevshares

### DIFF
--- a/protocol/x/clob/types/types.go
+++ b/protocol/x/clob/types/types.go
@@ -1,1 +1,63 @@
 package types
+
+import "math/big"
+
+type FillForProcess interface {
+	TakerAddr() string
+	TakerFeeQuoteQuantums() *big.Int
+	MakerAddr() string
+	MakerFeeQuoteQuantums() *big.Int
+	FillQuoteQuantums() *big.Int
+	PerpetualId() uint32
+}
+
+type PerpetualFillForProcess struct {
+	takerAddr             string
+	takerFeeQuoteQuantums *big.Int
+	makerAddr             string
+	makerFeeQuoteQuantums *big.Int
+	fillQuoteQuantums     *big.Int
+	perpetualId           uint32
+}
+
+func (perpetualFillForProcess PerpetualFillForProcess) TakerAddr() string {
+	return perpetualFillForProcess.takerAddr
+}
+
+func (perpetualFillForProcess PerpetualFillForProcess) TakerFeeQuoteQuantums() *big.Int {
+	return perpetualFillForProcess.takerFeeQuoteQuantums
+}
+
+func (perpetualFillForProcess PerpetualFillForProcess) MakerAddr() string {
+	return perpetualFillForProcess.makerAddr
+}
+
+func (perpetualFillForProcess PerpetualFillForProcess) MakerFeeQuoteQuantums() *big.Int {
+	return perpetualFillForProcess.makerFeeQuoteQuantums
+}
+
+func (perpetualFillForProcess PerpetualFillForProcess) FillQuoteQuantums() *big.Int {
+	return perpetualFillForProcess.fillQuoteQuantums
+}
+
+func (perpetualFillForProcess PerpetualFillForProcess) PerpetualId() uint32 {
+	return perpetualFillForProcess.perpetualId
+}
+
+func CreatePerpetualFillForProcess(
+	takerAddr string,
+	takerFeeQuoteQuantums *big.Int,
+	makerAddr string,
+	makerFeeQuoteQuantums *big.Int,
+	fillQuoteQuantums *big.Int,
+	perpetualId uint32,
+) PerpetualFillForProcess {
+	return PerpetualFillForProcess{
+		takerAddr:             takerAddr,
+		takerFeeQuoteQuantums: takerFeeQuoteQuantums,
+		makerAddr:             makerAddr,
+		makerFeeQuoteQuantums: makerFeeQuoteQuantums,
+		fillQuoteQuantums:     fillQuoteQuantums,
+		perpetualId:           perpetualId,
+	}
+}

--- a/protocol/x/clob/types/types.go
+++ b/protocol/x/clob/types/types.go
@@ -9,6 +9,12 @@ type FillForProcess interface {
 	MakerFeeQuoteQuantums() *big.Int
 	FillQuoteQuantums() *big.Int
 	ProductId() uint32
+	// MonthlyRollingTakerVolumeQuantums is the total taker volume for
+	// the given taker address in the last 30 days. This rolling volume
+	// does not include stats of the current block being processed.
+	// If there are multiple fills for the taker address in the
+	// same block, this volume will not be included in the function
+	// below
 	MonthlyRollingTakerVolumeQuantums() uint64
 }
 

--- a/protocol/x/clob/types/types.go
+++ b/protocol/x/clob/types/types.go
@@ -8,7 +8,7 @@ type FillForProcess interface {
 	MakerAddr() string
 	MakerFeeQuoteQuantums() *big.Int
 	FillQuoteQuantums() *big.Int
-	FillSourceId() uint32
+	ProductId() uint32
 	MonthlyRollingTakerVolumeQuantums() uint64
 }
 
@@ -42,7 +42,7 @@ func (perpetualFillForProcess PerpetualFillForProcess) FillQuoteQuantums() *big.
 	return perpetualFillForProcess.fillQuoteQuantums
 }
 
-func (perpetualFillForProcess PerpetualFillForProcess) FillSourceId() uint32 {
+func (perpetualFillForProcess PerpetualFillForProcess) ProductId() uint32 {
 	return perpetualFillForProcess.perpetualId
 }
 

--- a/protocol/x/clob/types/types.go
+++ b/protocol/x/clob/types/types.go
@@ -8,16 +8,18 @@ type FillForProcess interface {
 	MakerAddr() string
 	MakerFeeQuoteQuantums() *big.Int
 	FillQuoteQuantums() *big.Int
-	PerpetualId() uint32
+	FillSourceId() uint32
+	MonthlyRollingTakerVolumeQuantums() uint64
 }
 
 type PerpetualFillForProcess struct {
-	takerAddr             string
-	takerFeeQuoteQuantums *big.Int
-	makerAddr             string
-	makerFeeQuoteQuantums *big.Int
-	fillQuoteQuantums     *big.Int
-	perpetualId           uint32
+	takerAddr                         string
+	takerFeeQuoteQuantums             *big.Int
+	makerAddr                         string
+	makerFeeQuoteQuantums             *big.Int
+	fillQuoteQuantums                 *big.Int
+	perpetualId                       uint32
+	monthlyRollingTakerVolumeQuantums uint64
 }
 
 func (perpetualFillForProcess PerpetualFillForProcess) TakerAddr() string {
@@ -40,8 +42,12 @@ func (perpetualFillForProcess PerpetualFillForProcess) FillQuoteQuantums() *big.
 	return perpetualFillForProcess.fillQuoteQuantums
 }
 
-func (perpetualFillForProcess PerpetualFillForProcess) PerpetualId() uint32 {
+func (perpetualFillForProcess PerpetualFillForProcess) FillSourceId() uint32 {
 	return perpetualFillForProcess.perpetualId
+}
+
+func (perpetualFillForProcess PerpetualFillForProcess) MonthlyRollingTakerVolumeQuantums() uint64 {
+	return perpetualFillForProcess.monthlyRollingTakerVolumeQuantums
 }
 
 func CreatePerpetualFillForProcess(
@@ -51,13 +57,15 @@ func CreatePerpetualFillForProcess(
 	makerFeeQuoteQuantums *big.Int,
 	fillQuoteQuantums *big.Int,
 	perpetualId uint32,
+	monthlyRollingTakerVolumeQuantums uint64,
 ) PerpetualFillForProcess {
 	return PerpetualFillForProcess{
-		takerAddr:             takerAddr,
-		takerFeeQuoteQuantums: takerFeeQuoteQuantums,
-		makerAddr:             makerAddr,
-		makerFeeQuoteQuantums: makerFeeQuoteQuantums,
-		fillQuoteQuantums:     fillQuoteQuantums,
-		perpetualId:           perpetualId,
+		takerAddr:                         takerAddr,
+		takerFeeQuoteQuantums:             takerFeeQuoteQuantums,
+		makerAddr:                         makerAddr,
+		makerFeeQuoteQuantums:             makerFeeQuoteQuantums,
+		fillQuoteQuantums:                 fillQuoteQuantums,
+		perpetualId:                       perpetualId,
+		monthlyRollingTakerVolumeQuantums: monthlyRollingTakerVolumeQuantums,
 	}
 }

--- a/protocol/x/clob/types/types.go
+++ b/protocol/x/clob/types/types.go
@@ -2,76 +2,18 @@ package types
 
 import "math/big"
 
-type FillForProcess interface {
-	TakerAddr() string
-	TakerFeeQuoteQuantums() *big.Int
-	MakerAddr() string
-	MakerFeeQuoteQuantums() *big.Int
-	FillQuoteQuantums() *big.Int
-	ProductId() uint32
+type FillForProcess struct {
+	TakerAddr             string
+	TakerFeeQuoteQuantums *big.Int
+	MakerAddr             string
+	MakerFeeQuoteQuantums *big.Int
+	FillQuoteQuantums     *big.Int
+	ProductId             uint32
 	// MonthlyRollingTakerVolumeQuantums is the total taker volume for
 	// the given taker address in the last 30 days. This rolling volume
 	// does not include stats of the current block being processed.
 	// If there are multiple fills for the taker address in the
 	// same block, this volume will not be included in the function
 	// below
-	MonthlyRollingTakerVolumeQuantums() uint64
-}
-
-type PerpetualFillForProcess struct {
-	takerAddr                         string
-	takerFeeQuoteQuantums             *big.Int
-	makerAddr                         string
-	makerFeeQuoteQuantums             *big.Int
-	fillQuoteQuantums                 *big.Int
-	perpetualId                       uint32
-	monthlyRollingTakerVolumeQuantums uint64
-}
-
-func (perpetualFillForProcess PerpetualFillForProcess) TakerAddr() string {
-	return perpetualFillForProcess.takerAddr
-}
-
-func (perpetualFillForProcess PerpetualFillForProcess) TakerFeeQuoteQuantums() *big.Int {
-	return perpetualFillForProcess.takerFeeQuoteQuantums
-}
-
-func (perpetualFillForProcess PerpetualFillForProcess) MakerAddr() string {
-	return perpetualFillForProcess.makerAddr
-}
-
-func (perpetualFillForProcess PerpetualFillForProcess) MakerFeeQuoteQuantums() *big.Int {
-	return perpetualFillForProcess.makerFeeQuoteQuantums
-}
-
-func (perpetualFillForProcess PerpetualFillForProcess) FillQuoteQuantums() *big.Int {
-	return perpetualFillForProcess.fillQuoteQuantums
-}
-
-func (perpetualFillForProcess PerpetualFillForProcess) ProductId() uint32 {
-	return perpetualFillForProcess.perpetualId
-}
-
-func (perpetualFillForProcess PerpetualFillForProcess) MonthlyRollingTakerVolumeQuantums() uint64 {
-	return perpetualFillForProcess.monthlyRollingTakerVolumeQuantums
-}
-
-func CreatePerpetualFillForProcess(
-	takerAddr string,
-	takerFeeQuoteQuantums *big.Int,
-	makerAddr string,
-	makerFeeQuoteQuantums *big.Int,
-	fillQuoteQuantums *big.Int,
-	perpetualId uint32,
-	monthlyRollingTakerVolumeQuantums uint64,
-) PerpetualFillForProcess {
-	return PerpetualFillForProcess{
-		takerAddr:                         takerAddr,
-		takerFeeQuoteQuantums:             takerFeeQuoteQuantums,
-		makerAddr:                         makerAddr,
-		makerFeeQuoteQuantums:             makerFeeQuoteQuantums,
-		fillQuoteQuantums:                 fillQuoteQuantums,
-		perpetualId:                       perpetualId,
-		monthlyRollingTakerVolumeQuantums: monthlyRollingTakerVolumeQuantums,
-	}
+	MonthlyRollingTakerVolumeQuantums uint64
 }

--- a/protocol/x/revshare/keeper/revshare.go
+++ b/protocol/x/revshare/keeper/revshare.go
@@ -153,8 +153,8 @@ func (k Keeper) GetAllRevShares(
 ) ([]types.RevShare, error) {
 	revShares := []types.RevShare{}
 	totalFeesShared := big.NewInt(0)
-	takerFees := fill.TakerFeeQuoteQuantums()
-	makerFees := fill.MakerFeeQuoteQuantums()
+	takerFees := fill.TakerFeeQuoteQuantums
+	makerFees := fill.MakerFeeQuoteQuantums
 	netFees := big.NewInt(0).Add(takerFees, makerFees)
 
 	affiliateRevShares, err := k.getAffiliateRevShares(ctx, fill)
@@ -167,7 +167,7 @@ func (k Keeper) GetAllRevShares(
 		return nil, err
 	}
 
-	marketMapperRevShares, err := k.getMarketMapperRevShare(ctx, fill.ProductId(), netFees)
+	marketMapperRevShares, err := k.getMarketMapperRevShare(ctx, fill.ProductId, netFees)
 	if err != nil {
 		return nil, err
 	}
@@ -191,9 +191,9 @@ func (k Keeper) getAffiliateRevShares(
 	ctx sdk.Context,
 	fill clobtypes.FillForProcess,
 ) ([]types.RevShare, error) {
-	takerAddr := fill.TakerAddr()
-	takerFee := fill.TakerFeeQuoteQuantums()
-	if fill.MonthlyRollingTakerVolumeQuantums() >= types.Max30dRefereeVolumeQuantums {
+	takerAddr := fill.TakerAddr
+	takerFee := fill.TakerFeeQuoteQuantums
+	if fill.MonthlyRollingTakerVolumeQuantums >= types.Max30dRefereeVolumeQuantums {
 		return nil, nil
 	}
 

--- a/protocol/x/revshare/keeper/revshare.go
+++ b/protocol/x/revshare/keeper/revshare.go
@@ -194,7 +194,6 @@ func (k Keeper) getAffiliateRevShares(
 ) ([]types.RevShare, *big.Int, error) {
 	takerAddr := fill.TakerAddr()
 	takerFee := fill.TakerFeeQuoteQuantums()
-	feesShared := big.NewInt(0)
 	if fill.MonthlyRollingTakerVolumeQuantums() >= types.Max30dRefereeVolumeQuantums {
 		return nil, big.NewInt(0), nil
 	}
@@ -206,7 +205,7 @@ func (k Keeper) getAffiliateRevShares(
 	if !exists {
 		return nil, big.NewInt(0), nil
 	}
-	feesShared = lib.BigMulPpm(takerFee, lib.BigU(feeSharePpm), false)
+	feesShared := lib.BigMulPpm(takerFee, lib.BigU(feeSharePpm), false)
 	return []types.RevShare{
 		{
 			Recipient:         takerAffiliateAddr,

--- a/protocol/x/revshare/keeper/revshare_test.go
+++ b/protocol/x/revshare/keeper/revshare_test.go
@@ -268,15 +268,6 @@ func TestValidateRevShareSafety(t *testing.T) {
 }
 
 func TestKeeper_GetAllRevShares_Valid(t *testing.T) {
-	marketId := uint32(1)
-	fill := clobtypes.CreatePerpetualFillForProcess(
-		constants.AliceAccAddress.String(),
-		big.NewInt(10_000_000),
-		constants.BobAccAddress.String(),
-		big.NewInt(2_000_000),
-		big.NewInt(100000),
-		marketId,
-	)
 	tests := []struct {
 		name                              string
 		revenueSharePpmNetFees            uint32
@@ -411,6 +402,17 @@ func TestKeeper_GetAllRevShares_Valid(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
+			marketId := uint32(1)
+			fill := clobtypes.CreatePerpetualFillForProcess(
+				constants.AliceAccAddress.String(),
+				big.NewInt(10_000_000),
+				constants.BobAccAddress.String(),
+				big.NewInt(2_000_000),
+				big.NewInt(100000),
+				marketId,
+				tc.monthlyRollingTakerVolumeQuantums,
+			)
+
 			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			keeper := tApp.App.RevShareKeeper
@@ -421,7 +423,7 @@ func TestKeeper_GetAllRevShares_Valid(t *testing.T) {
 
 			keeper.CreateNewMarketRevShare(ctx, marketId)
 
-			revShares, err := keeper.GetAllRevShares(ctx, fill, tc.monthlyRollingTakerVolumeQuantums)
+			revShares, err := keeper.GetAllRevShares(ctx, fill)
 
 			require.NoError(t, err)
 			require.Len(t, revShares, tc.expectedRevShares)
@@ -445,15 +447,6 @@ func TestKeeper_GetAllRevShares_Valid(t *testing.T) {
 
 func TestKeeper_GetAllRevShares_Invalid(t *testing.T) {
 	marketId := uint32(1)
-
-	fill := clobtypes.CreatePerpetualFillForProcess(
-		constants.AliceAccAddress.String(),
-		big.NewInt(10_000_000),
-		constants.BobAccAddress.String(),
-		big.NewInt(2_000_000),
-		big.NewInt(100000),
-		marketId,
-	)
 	tests := []struct {
 		name                              string
 		revenueSharePpmNetFees            uint32
@@ -565,6 +558,15 @@ func TestKeeper_GetAllRevShares_Invalid(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
+			fill := clobtypes.CreatePerpetualFillForProcess(
+				constants.AliceAccAddress.String(),
+				big.NewInt(10_000_000),
+				constants.BobAccAddress.String(),
+				big.NewInt(2_000_000),
+				big.NewInt(100000),
+				uint32(1),
+				tc.monthlyRollingTakerVolumeQuantums,
+			)
 			tApp := testapp.NewTestAppBuilder(t).Build()
 			ctx := tApp.InitChain()
 			keeper := tApp.App.RevShareKeeper
@@ -575,7 +577,7 @@ func TestKeeper_GetAllRevShares_Invalid(t *testing.T) {
 
 			keeper.CreateNewMarketRevShare(ctx, marketId)
 
-			_, err := keeper.GetAllRevShares(ctx, fill, tc.monthlyRollingTakerVolumeQuantums)
+			_, err := keeper.GetAllRevShares(ctx, fill)
 
 			require.ErrorIs(t, err, tc.expectedError)
 		})

--- a/protocol/x/revshare/types/constants.go
+++ b/protocol/x/revshare/types/constants.go
@@ -1,0 +1,6 @@
+package types
+
+const (
+	// 25 million USDC
+	Max30dRefereeVolumeQuantums = uint64(25_000_000_000_000)
+)

--- a/protocol/x/revshare/types/errors.go
+++ b/protocol/x/revshare/types/errors.go
@@ -31,4 +31,9 @@ var (
 		5,
 		"rev shares greater than or equal to 100%",
 	)
+	ErrTotalFeesSharedExceedsNetFees = errorsmod.Register(
+		ModuleName,
+		6,
+		"total fees shared exceeds net fees",
+	)
 )

--- a/protocol/x/revshare/types/types.go
+++ b/protocol/x/revshare/types/types.go
@@ -1,6 +1,10 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 type RevShareKeeper interface {
 	// MarketMapperRevenueShareParams
@@ -24,3 +28,27 @@ type RevShareKeeper interface {
 	) (params MarketMapperRevShareDetails, err error)
 	CreateNewMarketRevShare(ctx sdk.Context, marketId uint32)
 }
+
+type RevShare struct {
+	Recipient         string
+	RevShareFeeSource RevShareFeeSource
+	RevShareType      RevShareType
+	QuoteQuantums     *big.Int
+}
+
+type RevShareFeeSource int
+
+const (
+	REV_SHARE_FEE_SOURCE_UNSPECIFIED RevShareFeeSource = iota
+	REV_SHARE_FEE_SOURCE_NET_FEE
+	REV_SHARE_FEE_SOURCE_TAKER_FEE
+)
+
+type RevShareType int
+
+const (
+	REV_SHARE_TYPE_UNSPECIFIED RevShareType = iota
+	REV_SHARE_TYPE_MARKET_MAPPER
+	REV_SHARE_TYPE_UNCONDITIONAL
+	REV_SHARE_TYPE_AFFILIATE
+)


### PR DESCRIPTION
### Changelist
Implement functions to get all revshares for all market types

### Test Plan
Adds unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new interface and struct for processing perpetual fills, improving data organization and encapsulation.
	- Enhanced revenue share calculations with new methods for retrieving and aggregating shares from various sources.
	- Added a constant for maximum referee transaction volume over 30 days to ensure consistency in financial metrics.
	- Implemented new error handling for scenarios where total fees shared exceed net fees.

- **Bug Fixes**
	- Improved error handling in revenue share calculations to manage potential issues effectively.

- **Tests**
	- Added tests to validate revenue share retrieval under both valid and invalid scenarios, enhancing the reliability of the revenue sharing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->