### PR TITLE
[OTE-793] modify affiliate api stubs

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/affiliates-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/affiliates-controller.test.ts
@@ -3,17 +3,19 @@ import request from 'supertest';
 import { sendRequest } from '../../../helpers/helpers';
 
 describe('affiliates-controller#V4', () => {
-  describe('GET /referral_code', () => {
+  describe('GET /metadata', () => {
     it('should return referral code for a valid address string', async () => {
       const address = 'some_address';
       const response: request.Response = await sendRequest({
         type: RequestMethod.GET,
-        path: `/v4/affiliates/referral_code?address=${address}`,
+        path: `/v4/affiliates/metadata?address=${address}`,
       });
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         referralCode: 'TempCode123',
+        isVolumeEligible: true,
+        isAffiliate: false,
       });
     });
   });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -368,9 +368,9 @@ fetch(`${baseURL}/addresses/{address}/parentSubaccountNumber/{parentSubaccountNu
 This operation does not require authentication
 </aside>
 
-## GetReferralCode
+## GetMetadata
 
-<a id="opIdGetReferralCode"></a>
+<a id="opIdGetMetadata"></a>
 
 > Code samples
 
@@ -384,7 +384,7 @@ headers = {
 # baseURL = 'https://indexer.dydx.trade/v4'
 baseURL = 'https://dydx-testnet.imperator.co/v4'
 
-r = requests.get(f'{baseURL}/affiliates/referral_code', params={
+r = requests.get(f'{baseURL}/affiliates/metadata', params={
   'address': 'string'
 }, headers = headers)
 
@@ -402,7 +402,7 @@ const headers = {
 // const baseURL = 'https://indexer.dydx.trade/v4';
 const baseURL = 'https://dydx-testnet.imperator.co/v4';
 
-fetch(`${baseURL}/affiliates/referral_code?address=string`,
+fetch(`${baseURL}/affiliates/metadata?address=string`,
 {
   method: 'GET',
 
@@ -416,7 +416,7 @@ fetch(`${baseURL}/affiliates/referral_code?address=string`,
 
 ```
 
-`GET /affiliates/referral_code`
+`GET /affiliates/metadata`
 
 ### Parameters
 
@@ -430,7 +430,9 @@ fetch(`${baseURL}/affiliates/referral_code?address=string`,
 
 ```json
 {
-  "referralCode": "string"
+  "referralCode": "string",
+  "isVolumeEligible": true,
+  "isAffiliate": true
 }
 ```
 
@@ -438,7 +440,7 @@ fetch(`${baseURL}/affiliates/referral_code?address=string`,
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Ok|[AffiliateReferralCodeResponse](#schemaaffiliatereferralcoderesponse)|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Ok|[AffiliateMetadataResponse](#schemaaffiliatemetadataresponse)|
 
 <aside class="success">
 This operation does not require authentication
@@ -509,12 +511,13 @@ fetch(`${baseURL}/affiliates/snapshot`,
   "affiliateList": [
     {
       "affiliateAddress": "string",
-      "affiliateEarnings": 0.1,
       "affiliateReferralCode": "string",
+      "affiliateEarnings": 0.1,
       "affiliateReferredTrades": 0.1,
       "affiliateTotalReferredFees": 0.1,
       "affiliateReferredUsers": 0.1,
-      "affiliateReferredNetProtocolEarnings": 0.1
+      "affiliateReferredNetProtocolEarnings": 0.1,
+      "affiliateReferredTotalVolume": 0.1
     }
   ],
   "total": 0.1,
@@ -4019,16 +4022,18 @@ This operation does not require authentication
 |freeCollateral|string|true|none|none|
 |childSubaccounts|[[SubaccountResponseObject](#schemasubaccountresponseobject)]|true|none|none|
 
-## AffiliateReferralCodeResponse
+## AffiliateMetadataResponse
 
-<a id="schemaaffiliatereferralcoderesponse"></a>
-<a id="schema_AffiliateReferralCodeResponse"></a>
-<a id="tocSaffiliatereferralcoderesponse"></a>
-<a id="tocsaffiliatereferralcoderesponse"></a>
+<a id="schemaaffiliatemetadataresponse"></a>
+<a id="schema_AffiliateMetadataResponse"></a>
+<a id="tocSaffiliatemetadataresponse"></a>
+<a id="tocsaffiliatemetadataresponse"></a>
 
 ```json
 {
-  "referralCode": "string"
+  "referralCode": "string",
+  "isVolumeEligible": true,
+  "isAffiliate": true
 }
 
 ```
@@ -4037,7 +4042,9 @@ This operation does not require authentication
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|referralCode|string¦null|true|none|none|
+|referralCode|string|true|none|none|
+|isVolumeEligible|boolean|true|none|none|
+|isAffiliate|boolean|true|none|none|
 
 ## AffiliateAddressResponse
 
@@ -4057,7 +4064,7 @@ This operation does not require authentication
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|address|string¦null|true|none|none|
+|address|string|true|none|none|
 
 ## AffiliateSnapshotResponseObject
 
@@ -4069,12 +4076,13 @@ This operation does not require authentication
 ```json
 {
   "affiliateAddress": "string",
-  "affiliateEarnings": 0.1,
   "affiliateReferralCode": "string",
+  "affiliateEarnings": 0.1,
   "affiliateReferredTrades": 0.1,
   "affiliateTotalReferredFees": 0.1,
   "affiliateReferredUsers": 0.1,
-  "affiliateReferredNetProtocolEarnings": 0.1
+  "affiliateReferredNetProtocolEarnings": 0.1,
+  "affiliateReferredTotalVolume": 0.1
 }
 
 ```
@@ -4084,12 +4092,13 @@ This operation does not require authentication
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |affiliateAddress|string|true|none|none|
-|affiliateEarnings|number(double)|true|none|none|
 |affiliateReferralCode|string|true|none|none|
+|affiliateEarnings|number(double)|true|none|none|
 |affiliateReferredTrades|number(double)|true|none|none|
 |affiliateTotalReferredFees|number(double)|true|none|none|
 |affiliateReferredUsers|number(double)|true|none|none|
 |affiliateReferredNetProtocolEarnings|number(double)|true|none|none|
+|affiliateReferredTotalVolume|number(double)|true|none|none|
 
 ## AffiliateSnapshotResponse
 
@@ -4103,12 +4112,13 @@ This operation does not require authentication
   "affiliateList": [
     {
       "affiliateAddress": "string",
-      "affiliateEarnings": 0.1,
       "affiliateReferralCode": "string",
+      "affiliateEarnings": 0.1,
       "affiliateReferredTrades": 0.1,
       "affiliateTotalReferredFees": 0.1,
       "affiliateReferredUsers": 0.1,
-      "affiliateReferredNetProtocolEarnings": 0.1
+      "affiliateReferredNetProtocolEarnings": 0.1,
+      "affiliateReferredTotalVolume": 0.1
     }
   ],
   "total": 0.1,

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -240,15 +240,22 @@
         "type": "object",
         "additionalProperties": false
       },
-      "AffiliateReferralCodeResponse": {
+      "AffiliateMetadataResponse": {
         "properties": {
           "referralCode": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
+          },
+          "isVolumeEligible": {
+            "type": "boolean"
+          },
+          "isAffiliate": {
+            "type": "boolean"
           }
         },
         "required": [
-          "referralCode"
+          "referralCode",
+          "isVolumeEligible",
+          "isAffiliate"
         ],
         "type": "object",
         "additionalProperties": false
@@ -256,8 +263,7 @@
       "AffiliateAddressResponse": {
         "properties": {
           "address": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           }
         },
         "required": [
@@ -271,12 +277,12 @@
           "affiliateAddress": {
             "type": "string"
           },
+          "affiliateReferralCode": {
+            "type": "string"
+          },
           "affiliateEarnings": {
             "type": "number",
             "format": "double"
-          },
-          "affiliateReferralCode": {
-            "type": "string"
           },
           "affiliateReferredTrades": {
             "type": "number",
@@ -293,16 +299,21 @@
           "affiliateReferredNetProtocolEarnings": {
             "type": "number",
             "format": "double"
+          },
+          "affiliateReferredTotalVolume": {
+            "type": "number",
+            "format": "double"
           }
         },
         "required": [
           "affiliateAddress",
-          "affiliateEarnings",
           "affiliateReferralCode",
+          "affiliateEarnings",
           "affiliateReferredTrades",
           "affiliateTotalReferredFees",
           "affiliateReferredUsers",
-          "affiliateReferredNetProtocolEarnings"
+          "affiliateReferredNetProtocolEarnings",
+          "affiliateReferredTotalVolume"
         ],
         "type": "object",
         "additionalProperties": false
@@ -1668,16 +1679,16 @@
         ]
       }
     },
-    "/affiliates/referral_code": {
+    "/affiliates/metadata": {
       "get": {
-        "operationId": "GetReferralCode",
+        "operationId": "GetMetadata",
         "responses": {
           "200": {
             "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AffiliateReferralCodeResponse"
+                  "$ref": "#/components/schemas/AffiliateMetadataResponse"
                 }
               }
             }

--- a/indexer/services/comlink/src/controllers/api/v4/affiliates-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/affiliates-controller.ts
@@ -13,8 +13,8 @@ import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import {
   AffiliateAddressRequest,
-  AffiliateReferralCodeRequest,
-  AffiliateReferralCodeResponse,
+  AffiliateMetadataRequest,
+  AffiliateMetadataResponse,
   AffiliateAddressResponse,
   AffiliateSnapshotResponse,
   AffiliateSnapshotResponseObject,
@@ -29,14 +29,16 @@ const controllerName: string = 'affiliates-controller';
 // TODO(OTE-731): replace api stubs with real logic
 @Route('affiliates')
 class AffiliatesController extends Controller {
-  @Get('/referral_code')
-  async getReferralCode(
+  @Get('/metadata')
+  async getMetadata(
     @Query() address: string, // eslint-disable-line @typescript-eslint/no-unused-vars
-  ): Promise<AffiliateReferralCodeResponse> {
+  ): Promise<AffiliateMetadataResponse> {
     // simulate a delay
     await new Promise((resolve) => setTimeout(resolve, 100));
     return {
       referralCode: 'TempCode123',
+      isVolumeEligible: true,
+      isAffiliate: false,
     };
   }
 
@@ -67,12 +69,13 @@ class AffiliatesController extends Controller {
 
     const snapshot: AffiliateSnapshotResponseObject = {
       affiliateAddress: 'some_address',
-      affiliateEarnings: 100,
       affiliateReferralCode: 'TempCode123',
+      affiliateEarnings: 100,
       affiliateReferredTrades: 1000,
       affiliateTotalReferredFees: 100,
       affiliateReferredUsers: 10,
       affiliateReferredNetProtocolEarnings: 1000,
+      affiliateReferredTotalVolume: 1000000,
     };
 
     const affiliateSnapshots: AffiliateSnapshotResponseObject[] = [];
@@ -102,7 +105,7 @@ class AffiliatesController extends Controller {
 }
 
 router.get(
-  '/referral_code',
+  '/metadata',
   rateLimiterMiddleware(getReqRateLimiter),
   ...checkSchema({
     address: {
@@ -117,15 +120,15 @@ router.get(
     const start: number = Date.now();
     const {
       address,
-    }: AffiliateReferralCodeRequest = matchedData(req) as AffiliateReferralCodeRequest;
+    }: AffiliateMetadataRequest = matchedData(req) as AffiliateMetadataRequest;
 
     try {
       const controller: AffiliatesController = new AffiliatesController();
-      const response: AffiliateReferralCodeResponse = await controller.getReferralCode(address);
+      const response: AffiliateMetadataResponse = await controller.getMetadata(address);
       return res.send(response);
     } catch (error) {
       return handleControllerError(
-        'AffiliatesController GET /referral_code',
+        'AffiliatesController GET /metadata',
         'Affiliates referral code error',
         error,
         req,
@@ -133,7 +136,7 @@ router.get(
       );
     } finally {
       stats.timing(
-        `${config.SERVICE_NAME}.${controllerName}.get_referral_code.timing`,
+        `${config.SERVICE_NAME}.${controllerName}.get_metadata.timing`,
         Date.now() - start,
       );
     }

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -669,7 +669,7 @@ export interface MegavaultPositionResponse {
 }
 
 /* ------- Affiliates Types ------- */
-export interface AffiliateReferralCodeRequest{
+export interface AffiliateMetadataRequest{
   address: string,
 }
 
@@ -687,12 +687,14 @@ export interface AffiliateTotalVolumeRequest{
   address: string,
 }
 
-export interface AffiliateReferralCodeResponse {
-  referralCode: string | null,
+export interface AffiliateMetadataResponse {
+  referralCode: string,
+  isVolumeEligible: boolean,
+  isAffiliate: boolean,
 }
 
 export interface AffiliateAddressResponse {
-  address: string | null,
+  address: string,
 }
 
 export interface AffiliateSnapshotResponse {
@@ -703,12 +705,13 @@ export interface AffiliateSnapshotResponse {
 
 export interface AffiliateSnapshotResponseObject {
   affiliateAddress: string,
-  affiliateEarnings: number,
   affiliateReferralCode: string,
+  affiliateEarnings: number,
   affiliateReferredTrades: number,
   affiliateTotalReferredFees: number,
   affiliateReferredUsers: number,
   affiliateReferredNetProtocolEarnings: number,
+  affiliateReferredTotalVolume: number,
 }
 
 export interface AffiliateTotalVolumeResponse {


### PR DESCRIPTION
### Changelist
Changed api stubs according to modified design doc:
https://www.notion.so/dydx/Affiliates-Indexer-spec-78b1383d1e9a40178f021c3df006a06d#7f1568bef1834413a199588b84b1ea63

stubs enable testing for FE team

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated API endpoint from `/affiliates/referral_code` to `/affiliates/metadata`, enhancing the functionality to retrieve metadata.
	- Introduced new properties, `isVolumeEligible` and `isAffiliate`, in the API response for more comprehensive affiliate metrics.
  
- **Documentation**
	- Renamed API documentation section from `GetReferralCode` to `GetMetadata` to reflect the updated functionality.
	- Updated API documentation to include the new fields and revised endpoint details.

- **Bug Fixes**
	- Corrected test cases to align with the new `/metadata` endpoint, ensuring accurate validation of API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->