### PR TITLE
[TRA-599] Set market pair for telemetry in Slinky Daemon

### DIFF
--- a/protocol/daemons/slinky/client/market_pair_fetcher.go
+++ b/protocol/daemons/slinky/client/market_pair_fetcher.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	appflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	pricefeedmetrics "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
 	daemonlib "github.com/dydxprotocol/v4-chain/protocol/daemons/shared"
 	daemontypes "github.com/dydxprotocol/v4-chain/protocol/daemons/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
@@ -101,6 +102,7 @@ func (m *MarketPairFetcherImpl) FetchIdMappings(ctx context.Context) error {
 		}
 		m.Logger.Debug("Mapped market to pair", "market id", mp.Id, "currency pair", cp.String())
 		compatMappings[cp] = mp.Id
+		pricefeedmetrics.SetMarketPairForTelemetry(mp.Id, mp.Pair)
 	}
 	m.compatMu.Lock()
 	defer m.compatMu.Unlock()

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"math/big"
 	"sort"
 	"time"
@@ -73,11 +74,21 @@ func (k Keeper) UpdateMarketPrices(
 		} else {
 			result, _ = new(big.Rat).SetInt(updatePrice.Mul(updatePrice, p10)).Float32()
 		}
+
+		// Get the market pair name for telemetry label
+		marketsParams, exists := k.GetMarketParam(ctx, marketPrice.Id)
+		var marketPair string
+		if exists {
+			marketPair = marketsParams.Pair
+		} else {
+			marketPair = fmt.Sprintf("invalid_id:%v", marketPrice.Id)
+		}
+
 		telemetry.SetGaugeWithLabels(
 			[]string{types.ModuleName, metrics.CurrentMarketPrices},
 			result,
 			[]gometrics.Label{ // To track per market, include the id as a label.
-				pricefeedmetrics.GetLabelForMarketId(marketPrice.Id),
+				metrics.GetLabelForStringValue(metrics.MarketId, marketPair),
 			},
 		)
 	}

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	"math/big"
 	"sort"
 	"time"
@@ -74,21 +73,11 @@ func (k Keeper) UpdateMarketPrices(
 		} else {
 			result, _ = new(big.Rat).SetInt(updatePrice.Mul(updatePrice, p10)).Float32()
 		}
-
-		// Get the market pair name for telemetry label
-		marketsParams, exists := k.GetMarketParam(ctx, marketPrice.Id)
-		var marketPair string
-		if exists {
-			marketPair = marketsParams.Pair
-		} else {
-			marketPair = fmt.Sprintf("invalid_id:%v", marketPrice.Id)
-		}
-
 		telemetry.SetGaugeWithLabels(
 			[]string{types.ModuleName, metrics.CurrentMarketPrices},
 			result,
 			[]gometrics.Label{ // To track per market, include the id as a label.
-				metrics.GetLabelForStringValue(metrics.MarketId, marketPair),
+				pricefeedmetrics.GetLabelForMarketId(marketPrice.Id),
 			},
 		)
 	}


### PR DESCRIPTION
### Changelist
This used to be set in the pricing daemon, which is usually not run anymore. Set this in Slinky Daemon as well.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced market price updating functionality with improved telemetry capabilities for better monitoring.
	- Introduced clearer telemetry data representation by using market pair names instead of market price IDs.
	- Added telemetry support for market pair mappings, improving tracking of market data.

- **Bug Fixes**
	- Improved error handling for invalid market price IDs, providing clearer feedback in telemetry metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->