### PR TITLE
Fix vulcan post processing metrics not emitted for short term orders

### DIFF
--- a/indexer/services/vulcan/src/lib/on-message.ts
+++ b/indexer/services/vulcan/src/lib/on-message.ts
@@ -122,10 +122,10 @@ export async function onMessage(message: KafkaMessage): Promise<void> {
     await handler.handleUpdate(update, headers);
 
     const postProcessingTime: number = Date.now();
-    if (originalMessageTimestamp !== undefined) {
+    if (headers.message_received_timestamp !== undefined) {
       stats.timing(
         `${config.SERVICE_NAME}.message_time_since_received_post_processing`,
-        postProcessingTime - Number(originalMessageTimestamp),
+        postProcessingTime - Number(headers.message_received_timestamp),
         STATS_NO_SAMPLING,
         {
           topic: KafkaTopics.TO_VULCAN,


### PR DESCRIPTION
### Changelist
Stale variable was used causing these metrics not to appear.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy of message processing timing by updating the timestamp check to utilize a more reliable header.
  
- **Chores**
	- Refined internal logging mechanisms for better performance metrics tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->