### PR TITLE
[TRA-571] Add query to get intervaled PnL ticks.

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
@@ -458,7 +458,7 @@ describe('PnlTicks store', () => {
     const createdTicks: PnlTicksFromDatabase[] = await setupIntervalPnlTicks();
     const pnlTicks: PnlTicksFromDatabase[] = await PnlTicksTable.getPnlTicksAtIntervals(
       interval,
-      604800,
+      7 * 24 * 60 * 60, // 1 week
       [defaultSubaccountId, defaultSubaccountIdWithAlternateAddress],
     );
     // See setup function for created ticks.

--- a/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
@@ -2,8 +2,10 @@ import {
   IsoString,
   LeaderboardPnlCreateObject,
   Ordering,
+  PnlTickInterval,
   PnlTicksColumns,
   PnlTicksCreateObject,
+  PnlTicksFromDatabase,
 } from '../../src/types';
 import * as PnlTicksTable from '../../src/stores/pnl-ticks-table';
 import * as BlockTable from '../../src/stores/block-table';
@@ -439,6 +441,51 @@ describe('PnlTicks store', () => {
     expect(leaderboardRankedData.length).toEqual(2);
   });
 
+  it.each([
+    {
+      description: 'Get hourly pnl ticks',
+      interval: PnlTickInterval.hour,
+    },
+    {
+      description: 'Get daily pnl ticks',
+      interval: PnlTickInterval.day,
+    },
+  ])('$description', async ({
+    interval,
+  }: {
+    interval: PnlTickInterval,
+  }) => {
+    const createdTicks: PnlTicksFromDatabase[] = await setupIntervalPnlTicks();
+    const pnlTicks: PnlTicksFromDatabase[] = await PnlTicksTable.getPnlTicksAtIntervals(
+      interval,
+      604800,
+      [defaultSubaccountId, defaultSubaccountIdWithAlternateAddress],
+    );
+    // See setup function for created ticks.
+    // Should exclude tick that is within the same hour except the first.
+    const expectedHourlyTicks: PnlTicksFromDatabase[] = [
+      createdTicks[8],
+      createdTicks[7],
+      createdTicks[5],
+      createdTicks[3],
+      createdTicks[2],
+      createdTicks[0],
+    ];
+    // Should exclude ticks that is within the same day except for the first.
+    const expectedDailyTicks: PnlTicksFromDatabase[] = [
+      createdTicks[8],
+      createdTicks[7],
+      createdTicks[3],
+      createdTicks[2],
+    ];
+
+    if (interval === PnlTickInterval.day) {
+      expect(pnlTicks).toEqual(expectedDailyTicks);
+    } else if (interval === PnlTickInterval.hour) {
+      expect(pnlTicks).toEqual(expectedHourlyTicks);
+    }
+  });
+
 });
 
 async function setupRankedPnlTicksData() {
@@ -543,4 +590,119 @@ async function setupRankedPnlTicksData() {
       blockTime: defaultBlock.time,
     },
   ]);
+}
+
+async function setupIntervalPnlTicks(): Promise<PnlTicksFromDatabase[]> {
+  const currentTime: DateTime = DateTime.utc().startOf('day');
+  const tenMinAgo: string = currentTime.minus({ minute: 10 }).toISO();
+  const almostTenMinAgo: string = currentTime.minus({ second: 603 }).toISO();
+  const twoHoursAgo: string = currentTime.minus({ hour: 2 }).toISO();
+  const twoDaysAgo: string = currentTime.minus({ day: 2 }).toISO();
+  const monthAgo: string = currentTime.minus({ day: 30 }).toISO();
+  await Promise.all([
+    BlockTable.create({
+      blockHeight: '3',
+      time: monthAgo,
+    }),
+    BlockTable.create({
+      blockHeight: '4',
+      time: twoDaysAgo,
+    }),
+    BlockTable.create({
+      blockHeight: '6',
+      time: twoHoursAgo,
+    }),
+    BlockTable.create({
+      blockHeight: '8',
+      time: almostTenMinAgo,
+    }),
+    BlockTable.create({
+      blockHeight: '10',
+      time: tenMinAgo,
+    }),
+  ]);
+  const createdTicks: PnlTicksFromDatabase[] = await PnlTicksTable.createMany([
+    {
+      subaccountId: defaultSubaccountId,
+      equity: '1100',
+      createdAt: almostTenMinAgo,
+      totalPnl: '1200',
+      netTransfers: '50',
+      blockHeight: '10',
+      blockTime: almostTenMinAgo,
+    },
+    {
+      subaccountId: defaultSubaccountId,
+      equity: '1090',
+      createdAt: tenMinAgo,
+      totalPnl: '1190',
+      netTransfers: '50',
+      blockHeight: '8',
+      blockTime: tenMinAgo,
+    },
+    {
+      subaccountId: defaultSubaccountId,
+      equity: '1080',
+      createdAt: twoHoursAgo,
+      totalPnl: '1180',
+      netTransfers: '50',
+      blockHeight: '6',
+      blockTime: twoHoursAgo,
+    },
+    {
+      subaccountId: defaultSubaccountId,
+      equity: '1070',
+      createdAt: twoDaysAgo,
+      totalPnl: '1170',
+      netTransfers: '50',
+      blockHeight: '4',
+      blockTime: twoDaysAgo,
+    },
+    {
+      subaccountId: defaultSubaccountId,
+      equity: '1200',
+      createdAt: monthAgo,
+      totalPnl: '1170',
+      netTransfers: '50',
+      blockHeight: '3',
+      blockTime: monthAgo,
+    },
+    {
+      subaccountId: defaultSubaccountIdWithAlternateAddress,
+      equity: '200',
+      createdAt: almostTenMinAgo,
+      totalPnl: '300',
+      netTransfers: '50',
+      blockHeight: '10',
+      blockTime: almostTenMinAgo,
+    },
+    {
+      subaccountId: defaultSubaccountIdWithAlternateAddress,
+      equity: '210',
+      createdAt: tenMinAgo,
+      totalPnl: '310',
+      netTransfers: '50',
+      blockHeight: '8',
+      blockTime: tenMinAgo,
+    },
+    {
+      subaccountId: defaultSubaccountIdWithAlternateAddress,
+      equity: '220',
+      createdAt: twoHoursAgo,
+      totalPnl: '320',
+      netTransfers: '50',
+      blockHeight: '6',
+      blockTime: twoHoursAgo,
+    },
+    {
+      subaccountId: defaultSubaccountIdWithAlternateAddress,
+      equity: '230',
+      createdAt: twoDaysAgo,
+      totalPnl: '330',
+      netTransfers: '50',
+      blockHeight: '4',
+      blockTime: twoDaysAgo,
+    },
+  ]);
+  return createdTicks;
 }

--- a/indexer/packages/postgres/src/types/pnl-ticks-types.ts
+++ b/indexer/packages/postgres/src/types/pnl-ticks-types.ts
@@ -22,3 +22,8 @@ export enum PnlTicksColumns {
   blockHeight = 'blockHeight',
   blockTime = 'blockTime',
 }
+
+export enum PnlTickInterval {
+  hour = 'hour',
+  day = 'day',
+}


### PR DESCRIPTION
### Changelist
Add new query function to pnl ticks table to get pnl ticks with specific interval / timeframe to support vault pnl queries (need coarser interval than hourly).

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to retrieve Profit and Loss (PnL) ticks at specified intervals (hourly and daily).
	- Added a new enumeration for time intervals to enhance data retrieval capabilities.

- **Bug Fixes**
	- Implemented new test cases to validate the accuracy of PnL tick retrieval at different intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->