### PR TITLE
add check for invalid skew factor

### DIFF
--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -121,4 +121,9 @@ var (
 		23,
 		"Locked shares exceeds owner shares",
 	)
+	ErrInvalidSkewFactor = errorsmod.Register(
+		ModuleName,
+		24,
+		"Skew factor times order_size_pct must be less than 2 to avoid skewing over the spread",
+	)
 )

--- a/protocol/x/vault/types/params.go
+++ b/protocol/x/vault/types/params.go
@@ -41,6 +41,10 @@ func (p QuotingParams) Validate() error {
 	if p.ActivationThresholdQuoteQuantums.Sign() < 0 {
 		return ErrInvalidActivationThresholdQuoteQuantums
 	}
+	// Skew factor times order_size_pct must be less than 2 to avoid skewing over the spread
+	if uint64(p.SkewFactorPpm)*uint64(p.OrderSizePctPpm) >= 2_000_000*1_000_000 {
+		return ErrInvalidSkewFactor
+	}
 
 	return nil
 }

--- a/protocol/x/vault/types/params_test.go
+++ b/protocol/x/vault/types/params_test.go
@@ -80,6 +80,30 @@ func TestValidateQuotingParams(t *testing.T) {
 			},
 			expectedErr: types.ErrInvalidActivationThresholdQuoteQuantums,
 		},
+		"Failure - SkewFactorPpm is high. Product of SkewFactorPpm and OrderSizePctPpm is above threshold.": {
+			params: types.QuotingParams{
+				Layers:                           2,
+				SpreadMinPpm:                     3_000,
+				SpreadBufferPpm:                  1_500,
+				SkewFactorPpm:                    20_000_000,
+				OrderSizePctPpm:                  100_000,
+				OrderExpirationSeconds:           5,
+				ActivationThresholdQuoteQuantums: dtypes.NewInt(1),
+			},
+			expectedErr: types.ErrInvalidSkewFactor,
+		},
+		"Failure - OrderSizePctPpm is high. Product of SkewFactorPpm and OrderSizePctPpm is above threshold.": {
+			params: types.QuotingParams{
+				Layers:                           2,
+				SpreadMinPpm:                     3_000,
+				SpreadBufferPpm:                  1_500,
+				SkewFactorPpm:                    2_000_000,
+				OrderSizePctPpm:                  1_000_000,
+				OrderExpirationSeconds:           5,
+				ActivationThresholdQuoteQuantums: dtypes.NewInt(1),
+			},
+			expectedErr: types.ErrInvalidSkewFactor,
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
### Changelist
What is the change:
- Ensure that the product of the skew factor and half spread parameters is less than 2

Reason for change:
- It is dangerous for the skew to offset the vault's distance from oracle after a single fill, since one could take advantage of the vault AMM buy buying then selling for an immediate profit
- Assuming the general form of skewing is `skew ~ skew_factor*leverage*halfspread`, Then ensure  `skew_factor*leverage*halfspread < vault spread `
- Assume the leverage = order_size_pct after a single fill: `skew_factor*order_size_pct*halfspread <  2*halfspread`
- Therefore, `skew_factor*order_size_pct < 2`


### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
