### PR TITLE
[CT-1196] move replay protectin out of sigverify

### DIFF
--- a/protocol/app/ante/replay_protection.go
+++ b/protocol/app/ante/replay_protection.go
@@ -1,0 +1,120 @@
+package ante
+
+import (
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
+	accountpluskeeper "github.com/dydxprotocol/v4-chain/protocol/x/accountplus/keeper"
+	gometrics "github.com/hashicorp/go-metrics"
+)
+
+type ReplayProtectionDecorator struct {
+	ak  sdkante.AccountKeeper
+	akp accountpluskeeper.Keeper
+}
+
+func NewReplayProtectionDecorator(
+	ak sdkante.AccountKeeper,
+	akp accountpluskeeper.Keeper,
+) ReplayProtectionDecorator {
+	return ReplayProtectionDecorator{
+		ak:  ak,
+		akp: akp,
+	}
+}
+
+func (rpd ReplayProtectionDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (newCtx sdk.Context, err error) {
+	sigTx, ok := tx.(authsigning.Tx)
+	if !ok {
+		return ctx, errorsmod.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+	}
+
+	// stdSigs contains the sequence number, account number, and signatures.
+	// When simulating, this would just be a 0-length slice.
+	sigs, err := sigTx.GetSignaturesV2()
+	if err != nil {
+		return ctx, err
+	}
+
+	signers, err := sigTx.GetSigners()
+	if err != nil {
+		return ctx, err
+	}
+
+	// Check that signer length and signature length are the same.
+	// The ordering of the sigs and signers have matching ordering (sigs[i] belongs to signers[i]).
+	if len(sigs) != len(signers) {
+		err := errorsmod.Wrapf(
+			sdkerrors.ErrUnauthorized,
+			"invalid number of signer;  expected: %d, got %d",
+			len(signers),
+			len(sigs),
+		)
+		return ctx, err
+	}
+
+	// Sequence number validation can be skipped if the given transaction consists of
+	// only messages that use `GoodTilBlock` for replay protection.
+	skipSequenceValidation := ShouldSkipSequenceValidation(tx.GetMsgs())
+
+	if !skipSequenceValidation {
+		// Iterate on sig and signer pairs.
+		for i, sig := range sigs {
+			acc, err := sdkante.GetSignerAcc(ctx, rpd.ak, signers[i])
+			if err != nil {
+				return ctx, err
+			}
+
+			// Check account sequence number.
+			// Skip individual sequence number validation since this transaction use
+			// `GoodTilBlock` for replay protection.
+			if accountpluskeeper.IsTimestampNonce(sig.Sequence) {
+				if err := rpd.akp.ProcessTimestampNonce(ctx, acc, sig.Sequence); err != nil {
+					telemetry.IncrCounterWithLabels(
+						[]string{metrics.TimestampNonce, metrics.Invalid, metrics.Count},
+						1,
+						[]gometrics.Label{metrics.GetLabelForIntValue(metrics.ExecMode, int(ctx.ExecMode()))},
+					)
+					return ctx, errorsmod.Wrapf(sdkerrors.ErrWrongSequence, err.Error())
+				}
+				telemetry.IncrCounterWithLabels(
+					[]string{metrics.TimestampNonce, metrics.Valid, metrics.Count},
+					1,
+					[]gometrics.Label{metrics.GetLabelForIntValue(metrics.ExecMode, int(ctx.ExecMode()))},
+				)
+			} else {
+				if sig.Sequence != acc.GetSequence() {
+					labels := make([]gometrics.Label, 0)
+					if len(tx.GetMsgs()) > 0 {
+						labels = append(
+							labels,
+							metrics.GetLabelForStringValue(metrics.MessageType, fmt.Sprintf("%T", tx.GetMsgs()[0])),
+						)
+					}
+					telemetry.IncrCounterWithLabels(
+						[]string{metrics.SequenceNumber, metrics.Invalid, metrics.Count},
+						1,
+						labels,
+					)
+					return ctx, errorsmod.Wrapf(
+						sdkerrors.ErrWrongSequence,
+						"account sequence mismatch, expected %d, got %d", acc.GetSequence(), sig.Sequence,
+					)
+				}
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/protocol/app/ante/sigverify_test.go
+++ b/protocol/app/ante/sigverify_test.go
@@ -104,12 +104,15 @@ func TestSigVerification(t *testing.T) {
 		txConfigOpts,
 	)
 	require.NoError(t, err)
-	svd := customante.NewSigVerificationDecorator(
+	rpd := customante.NewReplayProtectionDecorator(
 		suite.AccountKeeper,
 		suite.AccountplusKeeper,
+	)
+	svd := customante.NewSigVerificationDecorator(
+		suite.AccountKeeper,
 		anteTxConfig.SignModeHandler(),
 	)
-	antehandler := sdk.ChainAnteDecorators(spkd, svd)
+	antehandler := sdk.ChainAnteDecorators(spkd, rpd, svd)
 	defaultSignMode, err := authsign.APISignModeToInternal(anteTxConfig.SignModeHandler().DefaultMode())
 	require.NoError(t, err)
 
@@ -468,12 +471,15 @@ func runSigDecorators(t *testing.T, params types.Params, _ bool, privs ...crypto
 
 	spkd := sdkante.NewSetPubKeyDecorator(suite.AccountKeeper)
 	svgc := sdkante.NewSigGasConsumeDecorator(suite.AccountKeeper, sdkante.DefaultSigVerificationGasConsumer)
-	svd := customante.NewSigVerificationDecorator(
+	rpd := customante.NewReplayProtectionDecorator(
 		suite.AccountKeeper,
 		suite.AccountplusKeeper,
+	)
+	svd := customante.NewSigVerificationDecorator(
+		suite.AccountKeeper,
 		suite.ClientCtx.TxConfig.SignModeHandler(),
 	)
-	antehandler := sdk.ChainAnteDecorators(spkd, svgc, svd)
+	antehandler := sdk.ChainAnteDecorators(spkd, svgc, rpd, svd)
 
 	txBytes, err := suite.ClientCtx.TxConfig.TxEncoder()(tx)
 	require.NoError(t, err)


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `ReplayProtectionDecorator` to enhance transaction security by preventing replay attacks.
	- Adjusted the order of decorators in transaction processing to prioritize replay protection before signature verification.

- **Bug Fixes**
	- Streamlined the `SigVerificationDecorator` by removing unnecessary checks related to sequence number validation.

- **Tests**
	- Updated tests to incorporate the new replay protection layer, ensuring it is applied before signature verification during transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->