### PR TITLE
[CT-1190] Emit `FinalizeBlock` updates in single batch. 

### DIFF
--- a/protocol/streaming/full_node_streaming_manager.go
+++ b/protocol/streaming/full_node_streaming_manager.go
@@ -840,7 +840,12 @@ func (sm *FullNodeStreamingManagerImpl) GetSubaccountSnapshotsForInitStreams(
 	return ret
 }
 
-func (sm *FullNodeStreamingManagerImpl) addBatchUpdatesToCache(
+// addBatchUpdatesToCacheWithLock adds batched updates to the cache.
+// Used by `StreamBatchUpdatesAfterFinalizeBlock` to batch orderbook, fill
+// and subaccount updates in a single stream.
+// Note this method requires the lock and assumes that the lock has already been
+// acquired by the caller.
+func (sm *FullNodeStreamingManagerImpl) addBatchUpdatesToCacheWithLock(
 	orderbookStreamUpdates []clobtypes.StreamUpdate,
 	orderbookClobPairIds []uint32,
 	fillStreamUpdates []clobtypes.StreamUpdate,
@@ -911,7 +916,7 @@ func (sm *FullNodeStreamingManagerImpl) StreamBatchUpdatesAfterFinalizeBlock(
 	// Flush all pending updates, since we want the onchain updates to arrive in a batch.
 	sm.FlushStreamUpdatesWithLock()
 
-	sm.addBatchUpdatesToCache(
+	sm.addBatchUpdatesToCacheWithLock(
 		orderbookStreamUpdates,
 		orderbookClobPairIds,
 		fillStreamUpdates,


### PR DESCRIPTION
### Changelist
Stream FinalizeBlock updates in a batch. Add to cache and flush before and after. 

### Test Plan
TODO: test in validation mode

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced `StagedFinalizeBlockEvent` for managing events during block finalization.
	- Added methods for staging and streaming updates related to order fills and subaccount updates.
	- Implemented a new constant for tracking streaming updates after block finalization.

- **Bug Fixes**
	- Streamlined handling of order book fills by directly staging updates.

- **Refactor**
	- Restructured the `dydxprotocol` namespace for improved clarity and maintainability.
	- Enhanced the `FullNodeStreamingManager` to better manage event staging and streaming.

- **Documentation**
	- Updated comments and structure for clarity on new functionalities and methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->