### PR TITLE
[TRA-571] Add vault table and vault event version/subtype.

### DIFF
--- a/indexer/packages/postgres/__tests__/db/migrations.test.ts
+++ b/indexer/packages/postgres/__tests__/db/migrations.test.ts
@@ -12,7 +12,7 @@ import { seedData } from '../helpers/mock-generators';
 
 // NOTE: If a model is modified for a migration then these
 // tests must be skipped until the following migration
-describe.skip('Test new migration', () => {
+describe('Test new migration', () => {
   beforeEach(async () => {
     await migrate();
   });

--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -60,6 +60,8 @@ import {
   TransferCreateObject,
   WalletCreateObject,
   PersistentCacheCreateObject,
+  VaultCreateObject,
+  VaultStatus,
 } from '../../src/types';
 import { denomToHumanReadableConversion } from './conversion-helpers';
 
@@ -989,5 +991,17 @@ export const defaultFirebaseNotificationToken = {
   token: 'DEFAULT_TOKEN',
   address: defaultAddress,
   language: 'en',
+  updatedAt: createdDateTime.toISO(),
+};
+
+// ==============  Vaults  =============
+
+export const defaultVaultAddress: string = 'dydx1pzaql7h3tkt9uet8yht80me5td6gh0aprf58yk';
+
+export const defaultVault: VaultCreateObject = {
+  address: defaultVaultAddress,
+  clobPairId: '0',
+  status: VaultStatus.QUOTING,
+  createdAt: createdDateTime.toISO(),
   updatedAt: createdDateTime.toISO(),
 };

--- a/indexer/packages/postgres/__tests__/stores/vault-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/vault-table.test.ts
@@ -1,0 +1,81 @@
+import * as VaultTable from '../../src/stores/vault-table';
+import {
+  clearData,
+  migrate,
+  teardown,
+} from '../../src/helpers/db-helpers';
+import { defaultVault, defaultAddress } from '../helpers/constants';
+import { VaultFromDatabase, VaultStatus } from '../../src/types';
+
+describe('Vault store', () => {
+  beforeAll(async () => {
+    await migrate();
+  });
+
+  afterEach(async () => {
+    await clearData();
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  it('Successfully creates a vault', async () => {
+    await VaultTable.create(defaultVault);
+  });
+
+  it('Successfully finds all vaults', async () => {
+    await Promise.all([
+      VaultTable.create(defaultVault),
+      VaultTable.create({
+        ...defaultVault,
+        address: defaultAddress,
+        clobPairId: '1',
+      }),
+    ]);
+
+    const vaults: VaultFromDatabase[] = await VaultTable.findAll(
+      {},
+      [],
+      { readReplica: true },
+    );
+
+    expect(vaults.length).toEqual(2);
+    expect(vaults[0]).toEqual(expect.objectContaining(defaultVault));
+    expect(vaults[1]).toEqual(expect.objectContaining({
+      ...defaultVault,
+      address: defaultAddress,
+      clobPairId: '1',
+    }));
+  });
+
+  it('Succesfully upserts a vault', async () => {
+    await VaultTable.create(defaultVault);
+
+    let vaults: VaultFromDatabase[] = await VaultTable.findAll(
+      {},
+      [],
+      { readReplica: true },
+    );
+
+    expect(vaults.length).toEqual(1);
+    expect(vaults[0]).toEqual(expect.objectContaining(defaultVault));
+
+    await VaultTable.upsert({
+      ...defaultVault,
+      status: VaultStatus.CLOSE_ONLY,
+    });
+
+    vaults = await VaultTable.findAll(
+      {},
+      [],
+      { readReplica: true },
+    );
+
+    expect(vaults.length).toEqual(1);
+    expect(vaults[0]).toEqual(expect.objectContaining({
+      ...defaultVault,
+      status: VaultStatus.CLOSE_ONLY,
+    }));
+  });
+});

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240912180829_create_vaults_table.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240912180829_create_vaults_table.ts
@@ -1,0 +1,20 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.createTable('vaults', (table) => {
+    table.string('address').primary().notNullable(); // address of vault
+    table.bigInteger('clobPairId').notNullable(); // clob pair id for vault
+    table.enum('status', [
+      'DEACTIVATED',
+      'STANDBY',
+      'QUOTING',
+      'CLOSE_ONLY',
+    ]).notNullable(); // quoting status of vault
+    table.timestamp('createdAt').notNullable();
+    table.timestamp('updatedAt').notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable('vaults');
+}

--- a/indexer/packages/postgres/src/helpers/db-helpers.ts
+++ b/indexer/packages/postgres/src/helpers/db-helpers.ts
@@ -31,6 +31,7 @@ const layer1Tables = [
   'affiliate_referred_users',
   'persistent_cache',
   'affiliate_info',
+  'vaults',
 ];
 
 /**

--- a/indexer/packages/postgres/src/models/vault-model.ts
+++ b/indexer/packages/postgres/src/models/vault-model.ts
@@ -1,0 +1,44 @@
+import { IntegerPattern } from '../lib/validators';
+import { IsoString, VaultStatus } from '../types';
+import BaseModel from './base-model';
+
+export default class VaultModel extends BaseModel {
+
+  static get tableName() {
+    return 'vaults';
+  }
+
+  static get idColumn() {
+    return ['address'];
+  }
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: [
+        'address',
+        'clobPairId',
+        'status',
+        'createdAt',
+        'updatedAt',
+      ],
+      properties: {
+        address: { type: 'string' },
+        clobPairId: { type: 'string', pattern: IntegerPattern },
+        status: { type: 'string' },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' },
+      },
+    };
+  }
+
+  address!: string;
+
+  clobPairId!: string;
+
+  status!: VaultStatus;
+
+  createdAt!: IsoString;
+
+  updatedAt!: IsoString;
+}

--- a/indexer/packages/postgres/src/stores/vault-table.ts
+++ b/indexer/packages/postgres/src/stores/vault-table.ts
@@ -1,0 +1,100 @@
+import { QueryBuilder } from 'objection';
+
+import { DEFAULT_POSTGRES_OPTIONS } from '../constants';
+import {
+  verifyAllRequiredFields,
+  setupBaseQuery,
+} from '../helpers/stores-helpers';
+import Transaction from '../helpers/transaction';
+import VaultModel from '../models/vault-model';
+import {
+  QueryConfig,
+  VaultQueryConfig,
+  VaultColumns,
+  Options,
+  Ordering,
+  QueryableField,
+  VaultFromDatabase,
+  VaultCreateObject,
+} from '../types';
+
+export async function findAll(
+  {
+    address,
+    clobPairId,
+    status,
+    limit,
+  }: VaultQueryConfig,
+  requiredFields: QueryableField[],
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
+): Promise<VaultFromDatabase[]> {
+  verifyAllRequiredFields(
+    {
+      address,
+      clobPairId,
+      status,
+      limit,
+    } as QueryConfig,
+    requiredFields,
+  );
+
+  let baseQuery: QueryBuilder<VaultModel> = setupBaseQuery<VaultModel>(
+    VaultModel,
+    options,
+  );
+
+  if (address) {
+    baseQuery = baseQuery.whereIn(VaultColumns.address, address);
+  }
+
+  if (clobPairId) {
+    baseQuery = baseQuery.whereIn(VaultColumns.clobPairId, clobPairId);
+  }
+
+  if (status) {
+    baseQuery = baseQuery.whereIn(VaultColumns.status, status);
+  }
+
+  if (options.orderBy !== undefined) {
+    for (const [column, order] of options.orderBy) {
+      baseQuery = baseQuery.orderBy(
+        column,
+        order,
+      );
+    }
+  } else {
+    baseQuery = baseQuery.orderBy(
+      VaultColumns.clobPairId,
+      Ordering.ASC,
+    );
+  }
+
+  if (limit) {
+    baseQuery = baseQuery.limit(limit);
+  }
+
+  return baseQuery.returning('*');
+}
+
+export async function create(
+  vaultToCreate: VaultCreateObject,
+  options: Options = { txId: undefined },
+): Promise<VaultFromDatabase> {
+  return VaultModel.query(
+    Transaction.get(options.txId),
+  ).insert({
+    ...vaultToCreate,
+  });
+}
+
+export async function upsert(
+  vaultToUpsert: VaultCreateObject,
+  options: Options = { txId: undefined },
+): Promise<VaultFromDatabase> {
+  const vaults: VaultModel[] = await VaultModel.query(
+    Transaction.get(options.txId),
+  ).upsert({
+    ...vaultToUpsert,
+  }).returning('*');
+  return vaults[0];
+}

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -11,6 +11,7 @@ import { PerpetualMarketStatus, PerpetualMarketType } from './perpetual-market-t
 import { PerpetualPositionStatus } from './perpetual-position-types';
 import { PositionSide } from './position-types';
 import { TradingRewardAggregationPeriod } from './trading-reward-aggregation-types';
+import { VaultStatus } from './vault-types';
 
 type IsoString = string;
 
@@ -299,6 +300,14 @@ export interface FirebaseNotificationTokenFromDatabase {
   token: string,
   updatedAt: IsoString,
   language: string,
+}
+
+export interface VaultFromDatabase {
+  address: string,
+  clobPairId: string,
+  status: VaultStatus,
+  createdAt: IsoString,
+  updatedAt: IsoString,
 }
 
 export type SubaccountAssetNetTransferMap = { [subaccountId: string]:

--- a/indexer/packages/postgres/src/types/index.ts
+++ b/indexer/packages/postgres/src/types/index.ts
@@ -32,4 +32,5 @@ export * from './affiliate-referred-users-types';
 export * from './persistent-cache-types';
 export * from './affiliate-info-types';
 export * from './firebase-notification-token-types';
+export * from './vault-types';
 export { PositionSide } from './position-types';

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -344,3 +344,9 @@ export interface FirebaseNotificationTokenQueryConfig extends QueryConfig {
   [QueryableField.TOKEN]?: string,
   [QueryableField.UPDATED_BEFORE_OR_AT]?: IsoString,
 }
+
+export interface VaultQueryConfig extends QueryConfig {
+  [QueryableField.ADDRESS]?: string[],
+  [QueryableField.CLOB_PAIR_ID]?: string[],
+  [QueryableField.STATUS]?: string[],
+}

--- a/indexer/packages/postgres/src/types/vault-types.ts
+++ b/indexer/packages/postgres/src/types/vault-types.ts
@@ -1,0 +1,24 @@
+import { IsoString } from './utility-types';
+
+export interface VaultCreateObject {
+  address: string,
+  clobPairId: string,
+  status: VaultStatus,
+  createdAt: IsoString,
+  updatedAt: IsoString,
+}
+
+export enum VaultStatus {
+  DEACTIVATED = 'DEACTIVATED',
+  STAND_BY = 'STAND_BY',
+  QUOTING = 'QUOTING',
+  CLOSE_ONLY = 'CLOSE_ONLY',
+}
+
+export enum VaultColumns {
+  address = 'address',
+  clobPairId = 'clobPairId',
+  status = 'status',
+  createdAt = 'createdAt',
+  updatedAt = 'updatedAt',
+}

--- a/protocol/indexer/events/constants.go
+++ b/protocol/indexer/events/constants.go
@@ -20,6 +20,7 @@ const (
 	SubtypeTradingReward      = "trading_reward"
 	SubtypeOpenInterestUpdate = "open_interest_update"
 	SubtypeRegisterAffiliate  = "register_affiliate"
+	SubtypeUpsertVault        = "upsert_vault"
 )
 
 const (
@@ -39,6 +40,7 @@ const (
 	TradingRewardVersion          uint32 = 1
 	OpenInterestUpdateVersion     uint32 = 1
 	RegisterAffiliateEventVersion uint32 = 1
+	UpsertVaultEventVersion       uint32 = 1
 )
 
 var OnChainEventSubtypes = []string{
@@ -56,4 +58,5 @@ var OnChainEventSubtypes = []string{
 	SubtypeDeleveraging,
 	SubtypeTradingReward,
 	SubtypeRegisterAffiliate,
+	SubtypeUpsertVault,
 }


### PR DESCRIPTION
### Changelist
Add subtype for vault event + vault table in Indexer.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a vault management system with default configurations and CRUD operations.
	- Added support for upsert events related to vaults, enhancing event handling capabilities.

- **Bug Fixes**
	- Improved vault retrieval and upsert functionalities, ensuring data integrity.

- **Documentation**
	- Expanded type definitions and interfaces for vaults, enhancing clarity and type safety.

- **Tests**
	- Added comprehensive unit tests for vault management functionalities, ensuring robust performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->