### PR TITLE
Fix broken vulcan tests

### DIFF
--- a/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-place-handler.test.ts
@@ -1092,15 +1092,16 @@ function expectStats(orderWasReplaced: boolean = false): void {
   expect(stats.timing).toHaveBeenCalledWith(
     `vulcan.${STATS_FUNCTION_NAME}.timing`,
     expect.any(Number),
-    { className: 'OrderPlaceHandler', fnName: 'place_order_cache_update' },
+    { className: 'OrderPlaceHandler', fnName: 'place_order_cache_update', instance: '' },
   );
 
   if (orderWasReplaced) {
-    expect(stats.increment).toHaveBeenCalledWith('vulcan.place_order_handler.replaced_order', 1);
+    expect(stats.increment).toHaveBeenCalledWith('vulcan.place_order_handler.replaced_order', 1, { instance: '' });
   } else {
     expect(stats.increment).not.toHaveBeenCalledWith(
       'vulcan.place_order_handler.replaced_order',
       expect.any(Number),
+      { instance: '' },
     );
   }
 }

--- a/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-remove-handler.test.ts
@@ -1974,7 +1974,7 @@ describe('OrderRemoveHandler', () => {
         );
 
         expect(producerSendSpy).not.toHaveBeenCalled();
-        expect(stats.increment).toHaveBeenCalledWith('vulcan.indexer_expired_order_not_found', 1);
+        expect(stats.increment).toHaveBeenCalledWith('vulcan.indexer_expired_order_not_found', 1, { instance: '' });
 
         await Promise.all([
           expectOrderStatus(expectedOrderUuid, OrderStatus.OPEN),
@@ -2117,7 +2117,7 @@ describe('OrderRemoveHandler', () => {
       expect(producerSendSpy).not.toHaveBeenCalled();
       expect(
         stats.increment,
-      ).toHaveBeenCalledWith('vulcan.indexer_expired_order_is_not_expired', 1);
+      ).toHaveBeenCalledWith('vulcan.indexer_expired_order_is_not_expired', 1, { instance: '' });
 
       await Promise.all([
         expectOrderStatus(expectedOrderUuid, OrderStatus.OPEN),
@@ -2282,6 +2282,6 @@ function expectTimingStat(fnName: string) {
   expect(stats.timing).toHaveBeenCalledWith(
     `vulcan.${STATS_FUNCTION_NAME}.timing`,
     expect.any(Number),
-    { className: 'OrderRemoveHandler', fnName },
+    { className: 'OrderRemoveHandler', fnName, instance: '' },
   );
 }

--- a/indexer/services/vulcan/__tests__/handlers/order-update-handler.test.ts
+++ b/indexer/services/vulcan/__tests__/handlers/order-update-handler.test.ts
@@ -343,6 +343,7 @@ describe('OrderUpdateHandler', () => {
         expect(stats.increment).toHaveBeenCalledWith(
           'vulcan.order_update_total_filled_exceeds_size',
           1,
+          { instance: '' },
         );
         expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({
           at: 'OrderUpdateHandler#getCappedNewTotalFilledQuantums',
@@ -413,6 +414,7 @@ describe('OrderUpdateHandler', () => {
         expect(stats.increment).toHaveBeenCalledWith(
           'vulcan.order_update_old_total_filled_exceeds_size',
           1,
+          { instance: '' },
         );
         expectTimingStats();
       },
@@ -535,6 +537,7 @@ describe('OrderUpdateHandler', () => {
         1,
         {
           orderFlags: String(redisTestConstants.orderUpdate.orderUpdate.orderId!.orderFlags),
+          instance: '',
         },
       );
     });
@@ -571,6 +574,7 @@ describe('OrderUpdateHandler', () => {
         1,
         {
           orderFlags: String(statefulOrderUpdate.orderUpdate.orderId!.orderFlags),
+          instance: '',
         },
       );
     });
@@ -600,7 +604,7 @@ function expectTimingStat(fnName: string) {
   expect(stats.timing).toHaveBeenCalledWith(
     `vulcan.${STATS_FUNCTION_NAME}.timing`,
     expect.any(Number),
-    { className: 'OrderUpdateHandler', fnName },
+    { className: 'OrderUpdateHandler', fnName, instance: '' },
   );
 }
 

--- a/indexer/services/vulcan/__tests__/lib/on-message.test.ts
+++ b/indexer/services/vulcan/__tests__/lib/on-message.test.ts
@@ -67,13 +67,14 @@ describe('onMessage', () => {
     expect(handleUpdateMock).toHaveBeenCalledWith(update, message.headers ?? {});
     expect(handleUpdateMock).toHaveBeenCalledTimes(1);
 
-    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1);
+    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1, { instance: '' });
     expect(stats.timing).toHaveBeenCalledWith(
       'vulcan.message_time_in_queue',
       expect.any(Number),
       1,
       {
         topic: KafkaTopics.TO_VULCAN,
+        instance: '',
       },
     );
     expect(stats.timing).toHaveBeenCalledWith(
@@ -83,6 +84,7 @@ describe('onMessage', () => {
       {
         success: 'true',
         messageType,
+        instance: '',
       },
     );
 
@@ -104,13 +106,14 @@ describe('onMessage', () => {
       expect(mockHandler).not.toHaveBeenCalled();
     });
 
-    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1);
+    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1, { instance: '' });
     expect(stats.timing).toHaveBeenCalledWith(
       'vulcan.message_time_in_queue',
       expect.any(Number),
       1,
       {
         topic: KafkaTopics.TO_VULCAN,
+        instance: '',
       },
     );
     expect(logger.crit).toHaveBeenCalledWith(
@@ -131,13 +134,14 @@ describe('onMessage', () => {
       expect(mockHandler).not.toHaveBeenCalled();
     });
 
-    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1);
+    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1, { instance: '' });
     expect(stats.timing).toHaveBeenCalledWith(
       'vulcan.message_time_in_queue',
       expect.any(Number),
       1,
       {
         topic: KafkaTopics.TO_VULCAN,
+        instance: '',
       },
     );
     expect(stats.timing).toHaveBeenCalledWith(
@@ -147,6 +151,7 @@ describe('onMessage', () => {
       {
         success: 'false',
         messageType: 'unknown',
+        instance: '',
       },
     );
     expect(logger.crit).toHaveBeenCalledWith(
@@ -164,13 +169,14 @@ describe('onMessage', () => {
     );
 
     await expect(onMessage(message)).rejects.toEqual(unexpectedError);
-    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1);
+    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1, { instance: '' });
     expect(stats.timing).toHaveBeenCalledWith(
       'vulcan.message_time_in_queue',
       expect.any(Number),
       1,
       {
         topic: KafkaTopics.TO_VULCAN,
+        instance: '',
       },
     );
     expect(stats.timing).toHaveBeenCalledWith(
@@ -180,6 +186,7 @@ describe('onMessage', () => {
       {
         success: 'false',
         messageType: 'orderPlace',
+        instance: '',
       },
     );
     expect(logger.error).toHaveBeenCalledWith(
@@ -192,8 +199,8 @@ describe('onMessage', () => {
   it('logs error and does not process message if message is empty', async () => {
     await onMessage(undefined as any as KafkaMessage);
 
-    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1);
-    expect(stats.increment).toHaveBeenCalledWith('vulcan.empty_kafka_message', 1);
+    expect(stats.increment).toHaveBeenCalledWith('vulcan.received_kafka_message', 1, { instance: '' });
+    expect(stats.increment).toHaveBeenCalledWith('vulcan.empty_kafka_message', 1, { instance: '' });
     expect(logger.error).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Empty message',

--- a/indexer/services/vulcan/__tests__/lib/send-message-helper.test.ts
+++ b/indexer/services/vulcan/__tests__/lib/send-message-helper.test.ts
@@ -228,6 +228,7 @@ function expectStats(
   const tags: {[name: string]: string} = {
     topic,
     success: success.toString(),
+    instance: '',
   };
   expect(timingSpy).toHaveBeenCalledWith(timingStat, expect.any(Number), STATS_NO_SAMPLING, tags);
   expect(histogramSpy).toHaveBeenCalledWith(sizeStat, size, STATS_NO_SAMPLING, tags);

--- a/indexer/services/vulcan/src/handlers/handler.ts
+++ b/indexer/services/vulcan/src/handlers/handler.ts
@@ -1,4 +1,4 @@
-import { logger, ParseMessageError } from '@dydxprotocol-indexer/base';
+import { getInstanceId, logger, ParseMessageError } from '@dydxprotocol-indexer/base';
 import {
   ORDERBOOKS_WEBSOCKET_MESSAGE_VERSION,
 } from '@dydxprotocol-indexer/kafka';
@@ -65,6 +65,7 @@ export abstract class Handler {
     return {
       className: this.constructor.name,
       fnName,
+      instance: getInstanceId(),
     };
   }
 }


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced test assertions for `OrderPlaceHandler`, `OrderRemoveHandler`, `OrderUpdateHandler`, and `onMessage` functions to allow for more flexible parameter matching, improving test robustness.

- **Tests**
	- Updated assertions to include empty strings as valid parameters, accommodating varying instances and enhancing the reliability of test outcomes.

- **New Features**
	- Added an instance identifier to the metadata returned by the `getMetadata` method, providing additional context for logging and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->