### PR TITLE
[CT-1194] add more relevant authenticators

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1945,6 +1945,11 @@ func (app *App) SimulationManager() *module.SimulationManager {
 	return nil
 }
 
+// GetKVStoreKey gets KV Store keys.
+func (app *App) GetKVStoreKey() map[string]*storetypes.KVStoreKey {
+	return app.keys
+}
+
 // buildAnteHandler builds an AnteHandler object configured for the app.
 func (app *App) buildAnteHandler(txConfig client.TxConfig) sdk.AnteHandler {
 	anteHandler, err := NewAnteHandler(

--- a/protocol/x/accountplus/authenticator/all_of.go
+++ b/protocol/x/accountplus/authenticator/all_of.go
@@ -1,0 +1,154 @@
+package authenticator
+
+import (
+	"encoding/json"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+type AllOf struct {
+	SubAuthenticators   []Authenticator
+	am                  *AuthenticatorManager
+	signatureAssignment SignatureAssignment
+}
+
+var _ Authenticator = &AllOf{}
+
+func NewAllOf(am *AuthenticatorManager) AllOf {
+	return AllOf{
+		am:                  am,
+		SubAuthenticators:   []Authenticator{},
+		signatureAssignment: Single,
+	}
+}
+
+func NewPartitionedAllOf(am *AuthenticatorManager) AllOf {
+	return AllOf{
+		am:                  am,
+		SubAuthenticators:   []Authenticator{},
+		signatureAssignment: Partitioned,
+	}
+}
+
+func (aoa AllOf) Type() string {
+	if aoa.signatureAssignment == Single {
+		return "AllOf"
+	}
+	return "PartitionedAllOf"
+}
+
+func (aoa AllOf) StaticGas() uint64 {
+	var totalGas uint64
+	for _, auth := range aoa.SubAuthenticators {
+		totalGas += auth.StaticGas()
+	}
+	return totalGas
+}
+
+func (aoa AllOf) Initialize(config []byte) (Authenticator, error) {
+	var initDatas []SubAuthenticatorInitData
+	if err := json.Unmarshal(config, &initDatas); err != nil {
+		return nil, errorsmod.Wrap(err, "failed to parse sub-authenticators initialization data")
+	}
+
+	if len(initDatas) <= 1 {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "allOf must have at least 2 sub-authenticators")
+	}
+
+	for _, initData := range initDatas {
+		authenticatorCode := aoa.am.GetAuthenticatorByType(initData.Type)
+		instance, err := authenticatorCode.Initialize(initData.Config)
+		if err != nil {
+			return nil, errorsmod.Wrapf(err, "failed to initialize sub-authenticator (type = %s)", initData.Type)
+		}
+		aoa.SubAuthenticators = append(aoa.SubAuthenticators, instance)
+	}
+
+	// If not all sub-authenticators are registered, return an error
+	if len(aoa.SubAuthenticators) != len(initDatas) {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "failed to initialize all sub-authenticators")
+	}
+
+	return aoa, nil
+}
+
+func (aoa AllOf) Authenticate(ctx sdk.Context, request AuthenticationRequest) error {
+	if len(aoa.SubAuthenticators) == 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "no sub-authenticators provided")
+	}
+
+	var signatures [][]byte
+	var err error
+	if aoa.signatureAssignment == Partitioned {
+		// Partitioned signatures are decoded and passed one by one as the signature of the sub-authenticator
+		signatures, err = splitSignatures(request.Signature, len(aoa.SubAuthenticators))
+		if err != nil {
+			return err
+		}
+	}
+
+	baseId := request.AuthenticatorId
+	for i, auth := range aoa.SubAuthenticators {
+		// update the authenticator id to include the sub-authenticator id
+		request.AuthenticatorId = compositeId(baseId, i)
+		// update the request to include the sub-authenticator signature
+		if aoa.signatureAssignment == Partitioned {
+			request.Signature = signatures[i]
+		}
+		if err := auth.Authenticate(ctx, request); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (aoa AllOf) Track(ctx sdk.Context, request AuthenticationRequest) error {
+	return subTrack(ctx, request, aoa.SubAuthenticators)
+}
+
+func (aoa AllOf) ConfirmExecution(ctx sdk.Context, request AuthenticationRequest) error {
+	var signatures [][]byte
+	var err error
+	if aoa.signatureAssignment == Partitioned {
+		// Partitioned signatures are decoded and passed one by one as the signature of the sub-authenticator
+		signatures, err = splitSignatures(request.Signature, len(aoa.SubAuthenticators))
+		if err != nil {
+			return err
+		}
+	}
+
+	baseId := request.AuthenticatorId
+	for i, auth := range aoa.SubAuthenticators {
+		// update the authenticator id to include the sub-authenticator id
+		request.AuthenticatorId = compositeId(baseId, i)
+		// update the request to include the sub-authenticator signature
+		if aoa.signatureAssignment == Partitioned {
+			request.Signature = signatures[i]
+		}
+
+		if err := auth.ConfirmExecution(ctx, request); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (aoa AllOf) OnAuthenticatorAdded(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return onSubAuthenticatorsAdded(ctx, account, config, authenticatorId, aoa.am)
+}
+
+func (aoa AllOf) OnAuthenticatorRemoved(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return onSubAuthenticatorsRemoved(ctx, account, config, authenticatorId, aoa.am)
+}

--- a/protocol/x/accountplus/authenticator/any_of.go
+++ b/protocol/x/accountplus/authenticator/any_of.go
@@ -1,0 +1,207 @@
+package authenticator
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	errorsmod "cosmossdk.io/errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+type SignatureAssignment string
+
+const (
+	Single      SignatureAssignment = "single"
+	Partitioned SignatureAssignment = "partitioned"
+)
+
+type AnyOf struct {
+	SubAuthenticators   []Authenticator
+	am                  *AuthenticatorManager
+	signatureAssignment SignatureAssignment
+}
+
+var _ Authenticator = &AnyOf{}
+
+func NewAnyOf(am *AuthenticatorManager) AnyOf {
+	return AnyOf{
+		am:                  am,
+		SubAuthenticators:   []Authenticator{},
+		signatureAssignment: Single,
+	}
+}
+
+func NewPartitionedAnyOf(am *AuthenticatorManager) AnyOf {
+	return AnyOf{
+		am:                  am,
+		SubAuthenticators:   []Authenticator{},
+		signatureAssignment: Partitioned,
+	}
+}
+
+func (aoa AnyOf) Type() string {
+	if aoa.signatureAssignment == Single {
+		return "AnyOf"
+	}
+	return "PartitionedAnyOf"
+}
+
+func (aoa AnyOf) StaticGas() uint64 {
+	var totalGas uint64
+	for _, auth := range aoa.SubAuthenticators {
+		totalGas += auth.StaticGas()
+	}
+	return totalGas
+}
+
+func (aoa AnyOf) Initialize(config []byte) (Authenticator, error) {
+	// Decode the initialization data for each sub-authenticator
+	var initDatas []SubAuthenticatorInitData
+	if err := json.Unmarshal(config, &initDatas); err != nil {
+		return nil, errorsmod.Wrap(err, "failed to parse sub-authenticators initialization data")
+	}
+
+	if len(initDatas) <= 1 {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "anyOf must have at least 2 sub-authenticators")
+	}
+
+	// Call Initialize on each sub-authenticator with its appropriate data using AuthenticatorManager
+	for _, initData := range initDatas {
+		authenticatorCode := aoa.am.GetAuthenticatorByType(initData.Type)
+		instance, err := authenticatorCode.Initialize(initData.Config)
+		if err != nil {
+			return nil, errorsmod.Wrapf(err, "failed to initialize sub-authenticator (type = %s)", initData.Type)
+		}
+		aoa.SubAuthenticators = append(aoa.SubAuthenticators, instance)
+	}
+
+	// If not all sub-authenticators are registered, return an error
+	if len(aoa.SubAuthenticators) != len(initDatas) {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "failed to initialize all sub-authenticators")
+	}
+
+	return aoa, nil
+}
+
+func (aoa AnyOf) Authenticate(ctx sdk.Context, request AuthenticationRequest) error {
+	if len(aoa.SubAuthenticators) == 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "no sub-authenticators provided")
+	}
+
+	var subAuthErrors []string
+	var err error
+
+	// If the signature assignment is partitioned, we need to split the signatures and pass them to the sub-authenticators
+	var signatures [][]byte
+	if aoa.signatureAssignment == Partitioned {
+		// Partitioned signatures are decoded and passed one by one as the signature of the sub-authenticator
+		signatures, err = splitSignatures(request.Signature, len(aoa.SubAuthenticators))
+		if err != nil {
+			return err
+		}
+	}
+
+	baseId := request.AuthenticatorId
+	for i, auth := range aoa.SubAuthenticators {
+		// update the authenticator id to include the sub-authenticator id
+		request.AuthenticatorId = compositeId(baseId, i)
+		// update the request to include the sub-authenticator signature
+		if aoa.signatureAssignment == Partitioned {
+			request.Signature = signatures[i]
+		}
+		err = auth.Authenticate(ctx, request)
+		if err == nil { // Success!
+			return nil
+		}
+
+		// If the sub-authenticator fails, we want to continue to the next one.
+		// We accumulate any errors so that they can all be surfaced to the user
+		subAuthErrors = append(subAuthErrors, fmt.Sprintf("[%s (id = %s)] %s; ", auth.Type(), request.AuthenticatorId, err))
+	}
+
+	if err != nil {
+		// return all errors
+		return errorsmod.Wrapf(
+			sdkerrors.ErrUnauthorized,
+			"all sub-authenticators failed to authenticate: %s",
+			strings.Join(subAuthErrors, "; "),
+		)
+	}
+
+	return nil
+}
+
+func (aoa AnyOf) Track(ctx sdk.Context, request AuthenticationRequest) error {
+	return subTrack(ctx, request, aoa.SubAuthenticators)
+}
+
+// ConfirmExecution is called on all sub-authenticators, but only the changes
+// made by the authenticator that succeeds are written.
+func (aoa AnyOf) ConfirmExecution(ctx sdk.Context, request AuthenticationRequest) error {
+	var signatures [][]byte
+	var err error
+
+	// If the signature assignment is partitioned, we need to split the signatures and pass them to the sub-authenticators
+	if aoa.signatureAssignment == Partitioned {
+		// Partitioned signatures are decoded and passed one by one as the signature of the sub-authenticator
+		signatures, err = splitSignatures(request.Signature, len(aoa.SubAuthenticators))
+		if err != nil {
+			return err
+		}
+	}
+	var subAuthErrors []string
+
+	baseId := request.AuthenticatorId
+	for i, auth := range aoa.SubAuthenticators {
+		// update the request to include the sub-authenticator id
+		request.AuthenticatorId = compositeId(baseId, i)
+		if aoa.signatureAssignment == Partitioned {
+			// update the request to include the sub-authenticator signature
+			request.Signature = signatures[i]
+		}
+		// We only want to write changes made by the authenticator that succeeds.
+		// If the authenticator fails,its changes are discarded, and we want to continue to the next one.
+		cacheCtx, write := ctx.CacheContext()
+		err = auth.ConfirmExecution(cacheCtx, request)
+		if err == nil {
+			write()
+			return nil
+		}
+		subAuthErrors = append(
+			subAuthErrors,
+			fmt.Sprintf(
+				"[%s (id = %s)] %s; ",
+				auth.Type(),
+				request.AuthenticatorId,
+				err,
+			),
+		)
+	}
+
+	return errorsmod.Wrapf(
+		sdkerrors.ErrUnauthorized,
+		"all sub-authenticators failed to confirm execution: %s",
+		strings.Join(subAuthErrors, "; "),
+	)
+}
+
+func (aoa AnyOf) OnAuthenticatorAdded(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return onSubAuthenticatorsAdded(ctx, account, config, authenticatorId, aoa.am)
+}
+
+func (aoa AnyOf) OnAuthenticatorRemoved(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return onSubAuthenticatorsRemoved(ctx, account, config, authenticatorId, aoa.am)
+}

--- a/protocol/x/accountplus/authenticator/composite.go
+++ b/protocol/x/accountplus/authenticator/composite.go
@@ -1,0 +1,124 @@
+package authenticator
+
+import (
+	"encoding/json"
+	"strconv"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+type SubAuthenticatorInitData struct {
+	Type   string `json:"type"`
+	Config []byte `json:"config"`
+}
+
+func subTrack(
+	ctx sdk.Context,
+	request AuthenticationRequest,
+	subAuthenticators []Authenticator,
+) error {
+	baseId := request.AuthenticatorId
+	for id, auth := range subAuthenticators {
+		request.AuthenticatorId = compositeId(baseId, id)
+		err := auth.Track(ctx, request)
+		if err != nil {
+			return errorsmod.Wrapf(err, "sub-authenticator track failed (sub-authenticator id = %s)", request.AuthenticatorId)
+		}
+	}
+	return nil
+}
+
+func splitSignatures(signature []byte, total int) ([][]byte, error) {
+	var signatures [][]byte
+	err := json.Unmarshal(signature, &signatures)
+	if err != nil {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "failed to parse signatures")
+	}
+	if len(signatures) != total {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "invalid number of signatures")
+	}
+	return signatures, nil
+}
+
+func onSubAuthenticatorsAdded(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	data []byte,
+	authenticatorId string,
+	am *AuthenticatorManager,
+) error {
+	var initDatas []SubAuthenticatorInitData
+	if err := json.Unmarshal(data, &initDatas); err != nil {
+		return errorsmod.Wrapf(err, "failed to unmarshal sub-authenticator init data")
+	}
+
+	if len(initDatas) <= 1 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "no sub-authenticators provided")
+	}
+
+	baseId := authenticatorId
+	subAuthenticatorCount := 0
+	for id, initData := range initDatas {
+		authenticatorCode := am.GetAuthenticatorByType(initData.Type)
+		if authenticatorCode == nil {
+			return errorsmod.Wrapf(
+				sdkerrors.ErrInvalidRequest,
+				"sub-authenticator failed to be added in function `OnAuthenticatorAdded` as type is not registered in manager",
+			)
+		}
+		subId := compositeId(baseId, id)
+		err := authenticatorCode.OnAuthenticatorAdded(ctx, account, initData.Config, subId)
+		if err != nil {
+			return errorsmod.Wrapf(
+				err,
+				"sub-authenticator `OnAuthenticatorAdded` failed (sub-authenticator id = %s)",
+				subId,
+			)
+		}
+
+		subAuthenticatorCount++
+	}
+
+	// If not all sub-authenticators are registered, return an error
+	if subAuthenticatorCount != len(initDatas) {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "failed to initialize all sub-authenticators")
+	}
+
+	return nil
+}
+
+func onSubAuthenticatorsRemoved(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	data []byte,
+	authenticatorId string,
+	am *AuthenticatorManager,
+) error {
+	var initDatas []SubAuthenticatorInitData
+	if err := json.Unmarshal(data, &initDatas); err != nil {
+		return err
+	}
+
+	baseId := authenticatorId
+	for id, initData := range initDatas {
+		authenticatorCode := am.GetAuthenticatorByType(initData.Type)
+		if authenticatorCode == nil {
+			return errorsmod.Wrapf(
+				sdkerrors.ErrInvalidRequest,
+				"sub-authenticator failed to be removed in function `OnAuthenticatorRemoved` as type is not registered in manager",
+			)
+		}
+		subId := compositeId(baseId, id)
+		err := authenticatorCode.OnAuthenticatorRemoved(ctx, account, initData.Config, subId)
+		if err != nil {
+			return errorsmod.Wrapf(err, "sub-authenticator `OnAuthenticatorRemoved` failed (sub-authenticator id = %s)", subId)
+		}
+	}
+	return nil
+}
+
+func compositeId(baseId string, subId int) string {
+	return baseId + "." + strconv.Itoa(subId)
+}

--- a/protocol/x/accountplus/authenticator/composition_test.go
+++ b/protocol/x/accountplus/authenticator/composition_test.go
@@ -1,0 +1,898 @@
+package authenticator_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/authenticator"
+	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/testutils"
+	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
+)
+
+type AggregatedAuthenticatorsTest struct {
+	BaseAuthenticatorSuite
+
+	AnyOfAuth        authenticator.AnyOf
+	AllOfAuth        authenticator.AllOf
+	alwaysApprove    testutils.TestingAuthenticator
+	neverApprove     testutils.TestingAuthenticator
+	approveAndBlock  testutils.TestingAuthenticator
+	rejectAndConfirm testutils.TestingAuthenticator
+	spyAuth          testutils.SpyAuthenticator
+}
+
+func TestAggregatedAuthenticatorsTest(t *testing.T) {
+	suite.Run(t, new(AggregatedAuthenticatorsTest))
+}
+
+func (s *AggregatedAuthenticatorsTest) SetupTest() {
+	s.SetupKeys()
+	am := authenticator.NewAuthenticatorManager()
+
+	// Define authenticators
+	s.AnyOfAuth = authenticator.NewAnyOf(am)
+	s.AllOfAuth = authenticator.NewAllOf(am)
+	s.alwaysApprove = testutils.TestingAuthenticator{
+		Approve:        testutils.Always,
+		GasConsumption: 10,
+		Confirm:        testutils.Always,
+	}
+	s.neverApprove = testutils.TestingAuthenticator{
+		Approve:        testutils.Never,
+		GasConsumption: 10,
+		Confirm:        testutils.Never,
+	}
+	s.approveAndBlock = testutils.TestingAuthenticator{
+		Approve:        testutils.Always,
+		GasConsumption: 10,
+		Confirm:        testutils.Never,
+	}
+	s.rejectAndConfirm = testutils.TestingAuthenticator{
+		Approve:        testutils.Never,
+		GasConsumption: 10,
+		Confirm:        testutils.Always,
+	}
+	s.spyAuth = testutils.NewSpyAuthenticator(
+		s.tApp.App.GetKVStoreKey()[types.StoreKey],
+	)
+
+	am.RegisterAuthenticator(s.AnyOfAuth)
+	am.RegisterAuthenticator(s.AllOfAuth)
+	am.RegisterAuthenticator(s.alwaysApprove)
+	am.RegisterAuthenticator(s.neverApprove)
+	am.RegisterAuthenticator(s.approveAndBlock)
+	am.RegisterAuthenticator(s.rejectAndConfirm)
+	am.RegisterAuthenticator(s.spyAuth)
+}
+
+func (s *AggregatedAuthenticatorsTest) TearDownTest() {
+	os.RemoveAll(s.HomeDir)
+}
+
+func (s *AggregatedAuthenticatorsTest) TestAnyOf() {
+	// Define data
+	testData := []byte{}
+
+	// Define test cases
+	type testCase struct {
+		name             string
+		authenticators   []authenticator.Authenticator
+		expectInit       bool
+		expectSuccessful bool
+		expectConfirm    bool
+	}
+
+	testCases := []testCase{
+		{
+			name:             "alwaysApprove + neverApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.neverApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "neverApprove + neverApprove",
+			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "alwaysApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "neverApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.neverApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "alwaysApprove + alwaysApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "alwaysApprove + alwaysApprove + neverApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "alwaysApprove + neverApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "neverApprove + neverApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "neverApprove + neverApprove + neverApprove",
+			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove, s.neverApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "approveAndBlock",
+			authenticators:   []authenticator.Authenticator{s.approveAndBlock},
+			expectInit:       false,
+			expectSuccessful: true,
+			expectConfirm:    false,
+		},
+		{
+			name:             "rejectAndConfirm",
+			authenticators:   []authenticator.Authenticator{s.rejectAndConfirm},
+			expectInit:       false,
+			expectSuccessful: false,
+			expectConfirm:    true,
+		},
+		{
+			name:             "approveAndBlock + rejectAndConfirm",
+			authenticators:   []authenticator.Authenticator{s.approveAndBlock, s.rejectAndConfirm},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+	}
+
+	// Simulating a transaction
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			// Convert the authenticators to InitializationData
+			initData := []authenticator.SubAuthenticatorInitData{}
+			for _, auth := range tc.authenticators {
+				initData = append(initData, authenticator.SubAuthenticatorInitData{
+					Type:   auth.Type(),
+					Config: testData,
+				})
+			}
+
+			data, _ := json.Marshal(initData)
+			initializedAuth, err := s.AnyOfAuth.Initialize(data)
+			if !tc.expectInit {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+
+				// Generate authentication request
+				ak := s.tApp.App.AccountKeeper
+				sigModeHandler := s.EncodingConfig.TxConfig.SignModeHandler()
+				// sample msg
+				msg := &bank.MsgSend{
+					FromAddress: s.TestAccAddress[0].String(),
+					ToAddress:   "to",
+					Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
+				}
+				// sample tx
+				tx, err := s.GenSimpleTx([]sdk.Msg{msg}, []cryptotypes.PrivKey{s.TestPrivKeys[0]})
+				s.Require().NoError(err)
+				request, err := authenticator.GenerateAuthenticationRequest(
+					s.Ctx,
+					s.tApp.App.AppCodec(),
+					ak,
+					sigModeHandler,
+					s.TestAccAddress[0],
+					s.TestAccAddress[0],
+					nil,
+					sdk.NewCoins(),
+					msg,
+					tx,
+					0,
+					false,
+				)
+				s.Require().NoError(err)
+
+				// Attempt to authenticate using initialized authenticator
+				err = initializedAuth.Authenticate(s.Ctx, request)
+				s.Require().Equal(tc.expectSuccessful, err == nil)
+
+				err = initializedAuth.ConfirmExecution(s.Ctx, request)
+				s.Require().Equal(tc.expectConfirm, err == nil)
+			}
+		})
+	}
+}
+
+func (s *AggregatedAuthenticatorsTest) TestAllOf() {
+	// Define data
+	testData := []byte{}
+
+	// Define test cases
+	type testCase struct {
+		name             string
+		authenticators   []authenticator.Authenticator
+		expectInit       bool
+		expectSuccessful bool
+		expectConfirm    bool
+	}
+
+	testCases := []testCase{
+		{
+			name:             "alwaysApprove + neverApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.neverApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "neverApprove + neverApprove",
+			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "alwaysApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "neverApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.neverApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "alwaysApprove + alwaysApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: true,
+			expectConfirm:    true,
+		},
+		{
+			name:             "alwaysApprove + alwaysApprove + neverApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.alwaysApprove, s.neverApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "alwaysApprove + neverApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.alwaysApprove, s.neverApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "neverApprove + neverApprove + alwaysApprove",
+			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove, s.alwaysApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "neverApprove + neverApprove + neverApprove",
+			authenticators:   []authenticator.Authenticator{s.neverApprove, s.neverApprove, s.neverApprove},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+		{
+			name:             "approveAndBlock",
+			authenticators:   []authenticator.Authenticator{s.approveAndBlock},
+			expectInit:       false,
+			expectSuccessful: true,
+			expectConfirm:    false,
+		},
+		{
+			name:             "rejectAndConfirm",
+			authenticators:   []authenticator.Authenticator{s.rejectAndConfirm},
+			expectInit:       false,
+			expectSuccessful: false,
+			expectConfirm:    true,
+		},
+		{
+			name:             "approveAndBlock + rejectAndConfirm",
+			authenticators:   []authenticator.Authenticator{s.approveAndBlock, s.rejectAndConfirm},
+			expectInit:       true,
+			expectSuccessful: false,
+			expectConfirm:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			// Convert the authenticators to InitializationData
+			initData := []authenticator.SubAuthenticatorInitData{}
+			for _, auth := range tc.authenticators {
+				initData = append(initData, authenticator.SubAuthenticatorInitData{
+					Type:   auth.Type(),
+					Config: testData,
+				})
+			}
+
+			data, _ := json.Marshal(initData)
+			initializedAuth, err := s.AllOfAuth.Initialize(data)
+			if !tc.expectInit {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+
+				// Generate authentication request
+				ak := s.tApp.App.AccountKeeper
+				sigModeHandler := s.EncodingConfig.TxConfig.SignModeHandler()
+
+				// sample msg
+				msg := &bank.MsgSend{
+					FromAddress: s.TestAccAddress[0].String(),
+					ToAddress:   "to",
+					Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
+				}
+				// sample tx
+				tx, err := s.GenSimpleTx([]sdk.Msg{msg}, []cryptotypes.PrivKey{s.TestPrivKeys[0]})
+				s.Require().NoError(err)
+				cdc := s.tApp.App.AppCodec()
+				request, err := authenticator.GenerateAuthenticationRequest(
+					s.Ctx,
+					cdc,
+					ak,
+					sigModeHandler,
+					s.TestAccAddress[0],
+					s.TestAccAddress[0],
+					nil,
+					sdk.NewCoins(),
+					msg,
+					tx,
+					0,
+					false,
+				)
+				s.Require().NoError(err)
+
+				// Attempt to authenticate using initialized authenticator
+				err = initializedAuth.Authenticate(s.Ctx, request)
+				s.Require().Equal(tc.expectSuccessful, err == nil)
+
+				err = initializedAuth.ConfirmExecution(s.Ctx, request)
+				s.Require().Equal(tc.expectConfirm, err == nil)
+			}
+		})
+	}
+}
+
+type testAuth struct {
+	name          string
+	authenticator authenticator.Authenticator
+	subAuths      []testAuth
+}
+
+func (s *AggregatedAuthenticatorsTest) TestComposedAuthenticator() {
+	testData := []byte{}
+
+	// Helper function to create a name and a list of testAuths.
+	createAuth := func(prefix string, sub ...testAuth) testAuth {
+		var names []string
+		for _, s := range sub {
+			names = append(names, s.name)
+		}
+		name := prefix + "(" + strings.Join(names, ", ") + ")"
+		var auth authenticator.Authenticator
+		if prefix == "AnyOf" {
+			auth = s.AnyOfAuth
+		} else {
+			auth = s.AllOfAuth
+		}
+		return testAuth{name: name, authenticator: auth, subAuths: sub}
+	}
+
+	// Shorthand functions using the helper.
+	AnyOf := func(sub ...testAuth) testAuth {
+		return createAuth("AnyOf", sub...)
+	}
+
+	AllOf := func(sub ...testAuth) testAuth {
+		return createAuth("AllOf", sub...)
+	}
+
+	always := testAuth{name: "always", authenticator: s.alwaysApprove}
+	never := testAuth{name: "never", authenticator: s.neverApprove}
+
+	type testCase struct {
+		auth    testAuth
+		success bool
+	}
+
+	testCases := []testCase{
+		{
+			auth:    AnyOf(AllOf(always, always), AnyOf(always, never)),
+			success: true,
+		},
+		{
+			auth:    AllOf(AnyOf(always, never), AnyOf(never, always)),
+			success: true,
+		},
+		{
+			auth:    AllOf(AnyOf(never, never, never), AnyOf(never, always, never)),
+			success: false,
+		},
+		{
+			auth:    AnyOf(AnyOf(never, never, never), AnyOf(never, never, never)),
+			success: false,
+		},
+		{
+			auth:    AnyOf(AnyOf(never, never, never), AnyOf(never, never, never), AllOf(always, always)),
+			success: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.auth.name, func(t *testing.T) {
+			data, err := marshalAuth(tc.auth, testData)
+			s.Require().NoError(err)
+
+			initializedTop, err := tc.auth.authenticator.Initialize(data)
+			s.Require().NoError(err)
+
+			// Generate authentication request
+			ak := s.tApp.App.AccountKeeper
+			sigModeHandler := s.EncodingConfig.TxConfig.SignModeHandler()
+			// sample msg
+			msg := &bank.MsgSend{
+				FromAddress: s.TestAccAddress[0].String(),
+				ToAddress:   "to",
+				Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
+			}
+			// sample tx
+			tx, err := s.GenSimpleTx([]sdk.Msg{msg}, []cryptotypes.PrivKey{s.TestPrivKeys[0]})
+			s.Require().NoError(err)
+			request, err := authenticator.GenerateAuthenticationRequest(
+				s.Ctx,
+				s.tApp.App.AppCodec(),
+				ak,
+				sigModeHandler,
+				s.TestAccAddress[0],
+				s.TestAccAddress[0],
+				nil,
+				sdk.NewCoins(),
+				msg,
+				tx,
+				0,
+				false,
+			)
+			s.Require().NoError(err)
+
+			err = initializedTop.Authenticate(s.Ctx, request)
+			s.Require().Equal(tc.success, err == nil)
+		})
+	}
+}
+
+type CompositeSpyAuth struct {
+	anyOf []*CompositeSpyAuth
+	allOf []*CompositeSpyAuth
+
+	name        string
+	failureFlag testutils.FailureFlag
+}
+
+func allOf(sub ...*CompositeSpyAuth) *CompositeSpyAuth {
+	return &CompositeSpyAuth{allOf: sub}
+}
+
+func anyOf(sub ...*CompositeSpyAuth) *CompositeSpyAuth {
+	return &CompositeSpyAuth{anyOf: sub}
+}
+
+func spy(name string) *CompositeSpyAuth {
+	return &CompositeSpyAuth{name: name, failureFlag: 0}
+}
+
+func spyWithFailure(name string, failureFlag testutils.FailureFlag) *CompositeSpyAuth {
+	return &CompositeSpyAuth{name: name, failureFlag: failureFlag}
+}
+
+func (csa *CompositeSpyAuth) Type() string {
+	am := authenticator.NewAuthenticatorManager()
+
+	if len(csa.name) > 0 {
+		return testutils.SpyAuthenticator{}.Type()
+	} else if len(csa.anyOf) > 0 {
+		return authenticator.NewAnyOf(am).Type()
+	} else if len(csa.allOf) > 0 {
+		return authenticator.NewAllOf(am).Type()
+	}
+
+	panic("unreachable")
+}
+
+func (csa *CompositeSpyAuth) isAnyOf() bool {
+	return len(csa.anyOf) > 0
+}
+
+func (csa *CompositeSpyAuth) isAllOf() bool {
+	return len(csa.allOf) > 0
+}
+
+func (csa *CompositeSpyAuth) buildInitData() ([]byte, error) {
+	// root
+	if len(csa.name) > 0 {
+		spyData := testutils.SpyAuthenticatorData{
+			Name:    csa.name,
+			Failure: csa.failureFlag,
+		}
+		return json.Marshal(spyData)
+	} else if len(csa.anyOf) > 0 {
+		var initData []authenticator.SubAuthenticatorInitData
+		for _, subAuth := range csa.anyOf {
+			data, err := subAuth.buildInitData()
+			if err != nil {
+				return nil, err
+			}
+
+			initData = append(initData, authenticator.SubAuthenticatorInitData{
+				Type:   subAuth.Type(),
+				Config: data,
+			})
+		}
+
+		return json.Marshal(initData)
+	} else if len(csa.allOf) > 0 {
+		var initData []authenticator.SubAuthenticatorInitData
+		for _, subAuth := range csa.allOf {
+			data, err := subAuth.buildInitData()
+			if err != nil {
+				return nil, err
+			}
+
+			initData = append(initData, authenticator.SubAuthenticatorInitData{
+				Type:   subAuth.Type(),
+				Config: data,
+			})
+		}
+
+		return json.Marshal(initData)
+	}
+
+	return nil, fmt.Errorf("unreachable")
+}
+
+func (s *AggregatedAuthenticatorsTest) TestNestedAuthenticatorCalls() {
+	// Define test cases
+	type testCase struct {
+		name          string
+		compositeAuth CompositeSpyAuth
+		names         []string
+		id            string
+		expectedIds   []string
+	}
+
+	testCases := []testCase{
+		{
+			name:          "AllOf(a, b)",
+			compositeAuth: *allOf(spy("a"), spy("b")),
+			id:            "2",
+			names:         []string{"a", "b"},
+			expectedIds:   []string{"2.0", "2.1"},
+		},
+		{
+			name:          "AllOf(AnyOf(a, b), c)",
+			compositeAuth: *allOf(anyOf(spy("a"), spy("b")), spy("c")),
+			id:            "3",
+			names:         []string{"a", "c"}, // b is not called because anyOf is short-circuited
+			expectedIds:   []string{"3.0.0", "3.1"},
+		},
+		{
+			name:          "AnyOf(AllOf(a, b), c)",
+			compositeAuth: *anyOf(allOf(spy("a"), spy("b")), spy("c")),
+			id:            "4",
+			names:         []string{"a", "b"}, // c is not called because allOf is short-circuited
+			expectedIds:   []string{"4.0.0", "4.0.1"},
+		},
+		{
+			name:          "AnyOf(c, AllOf(a, b))",
+			compositeAuth: *anyOf(spy("c"), allOf(spy("a"), spy("b"))),
+			id:            "5",
+			names:         []string{"c"}, // a and b are not called because allOf is short-circuited
+			expectedIds:   []string{"5.0"},
+		},
+		{
+			name:          "AnyOf(AllOf(AnyOf(a, b), c), AnyOf(d, e))",
+			compositeAuth: *anyOf(allOf(anyOf(spy("a"), spy("b")), spy("c")), anyOf(spy("d"), spy("e"))),
+			id:            "6",
+			names:         []string{"a"}, // b,c,d and e are not called because allOf is short-circuited
+			expectedIds:   []string{"6.0.0.0"},
+		},
+	}
+
+	for _, tc := range testCases {
+		originalCtx := s.Ctx
+		s.Ctx, _ = s.Ctx.WithGasMeter(storetypes.NewGasMeter(2_000_000)).CacheContext()
+		data, err := tc.compositeAuth.buildInitData()
+		s.Require().NoError(err)
+
+		var auth authenticator.Authenticator
+		if tc.compositeAuth.isAllOf() {
+			auth, err = s.AllOfAuth.Initialize(data)
+			s.Require().NoError(err)
+		} else if tc.compositeAuth.isAnyOf() {
+			auth, err = s.AnyOfAuth.Initialize(data)
+			s.Require().NoError(err)
+		} else {
+			panic("top lv must be allOf or anyOf")
+		}
+
+		msg := &bank.MsgSend{
+			FromAddress: s.TestAccAddress[0].String(),
+			ToAddress:   "to",
+			Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
+		}
+
+		encodedMsg, err := codectypes.NewAnyWithValue(msg)
+		s.Require().NoError(err, "Should encode Any value successfully")
+
+		// mock the authentication request
+		authReq := authenticator.AuthenticationRequest{
+			AuthenticatorId: tc.id,
+			Account:         s.TestAccAddress[0],
+			FeePayer:        s.TestAccAddress[0],
+			FeeGranter:      nil,
+			Fee:             sdk.NewCoins(),
+			Msg:             authenticator.LocalAny{TypeURL: encodedMsg.TypeUrl, Value: encodedMsg.Value},
+			MsgIndex:        0,
+			Signature:       []byte{1, 1, 1, 1, 1},
+			SignModeTxData:  authenticator.SignModeData{Direct: []byte{1, 1, 1, 1, 1}},
+			SignatureData: authenticator.SimplifiedSignatureData{
+				Signers:    []sdk.AccAddress{s.TestAccAddress[0]},
+				Signatures: [][]byte{{1, 1, 1, 1, 1}},
+			},
+			Simulate:            false,
+			AuthenticatorParams: []byte{1, 1, 1, 1, 1},
+		}
+
+		// make calls
+		s.Require().NoError(auth.OnAuthenticatorAdded(s.Ctx, authReq.Account, data, authReq.AuthenticatorId))
+		s.Require().NoError(auth.Authenticate(s.Ctx, authReq))
+		s.Require().NoError(auth.Track(s.Ctx, authReq))
+		s.Require().NoError(auth.ConfirmExecution(s.Ctx, authReq))
+		s.Require().NoError(auth.OnAuthenticatorRemoved(s.Ctx, authReq.Account, data, authReq.AuthenticatorId))
+
+		// Check that the spy authenticator was called with the expected data
+		for i, name := range tc.names {
+			expectedAuthReq := authReq
+			expectedAuthReq.AuthenticatorId = tc.expectedIds[i]
+
+			spy := testutils.SpyAuthenticator{KvStoreKey: s.spyAuth.KvStoreKey, Name: name}
+			latestCalls := spy.GetLatestCalls(s.Ctx)
+
+			spyData, err := json.Marshal(testutils.SpyAuthenticatorData{Name: name})
+			s.Require().NoError(err, "Should marshal spy data successfully")
+
+			s.Require().Equal(
+				testutils.SpyAddRequest{
+					Account:         expectedAuthReq.Account,
+					Data:            spyData,
+					AuthenticatorId: expectedAuthReq.AuthenticatorId,
+				},
+				latestCalls.OnAuthenticatorAdded,
+			)
+			s.Require().Equal(expectedAuthReq, latestCalls.Authenticate)
+			s.Require().Equal(
+				testutils.SpyTrackRequest{
+					AuthenticatorId: expectedAuthReq.AuthenticatorId,
+					Account:         expectedAuthReq.Account,
+					Msg:             expectedAuthReq.Msg,
+					MsgIndex:        expectedAuthReq.MsgIndex,
+				},
+				latestCalls.Track,
+			)
+			s.Require().Equal(expectedAuthReq, latestCalls.ConfirmExecution)
+			s.Require().Equal(
+				testutils.SpyRemoveRequest{
+					Account:         expectedAuthReq.Account,
+					Data:            spyData,
+					AuthenticatorId: expectedAuthReq.AuthenticatorId,
+				},
+				latestCalls.OnAuthenticatorRemoved,
+			)
+		}
+
+		s.Ctx = originalCtx
+	}
+}
+
+// any_of can have failed sub-authenticators's confirm_execution but not failing the whole transaction
+// that means that the failed sub-authenticators could write to the store if not handled properly
+// which we don't want to happen since it breaks the semantics of not committing failed tx state
+func (s *AggregatedAuthenticatorsTest) TestAnyOfNotWritingFailedSubAuthState() {
+	// Define test cases
+	type testCase struct {
+		name            string
+		compositeAuth   CompositeSpyAuth
+		names           []string
+		isStateReverted []bool
+	}
+
+	testCases := []testCase{
+		{
+			name:            "AnyOf(fail, pass)",
+			compositeAuth:   *anyOf(spyWithFailure("fail", testutils.CONFIRM_EXECUTION_FAIL), spy("pass")),
+			names:           []string{"fail", "pass"},
+			isStateReverted: []bool{true, false},
+		},
+		{
+			name: "AnyOf(fail_1, fail_2, pass)",
+			compositeAuth: *anyOf(
+				spyWithFailure("fail_1", testutils.CONFIRM_EXECUTION_FAIL),
+				spyWithFailure("fail_2", testutils.CONFIRM_EXECUTION_FAIL),
+				spy("pass"),
+			),
+			names:           []string{"fail_1", "fail_2", "pass"},
+			isStateReverted: []bool{true, true, false},
+		},
+		{
+			name: "AnyOf(fail, AllOf(fail_2, pass_1), pass_2)",
+			compositeAuth: *anyOf(
+				spyWithFailure("fail_1", testutils.CONFIRM_EXECUTION_FAIL),
+				allOf(
+					spyWithFailure("fail_2", testutils.CONFIRM_EXECUTION_FAIL),
+					spy("pass_1"),
+				),
+				spy("pass_2"),
+			),
+			names: []string{"fail_1", "fail_2", "pass_1", "pass_2"},
+			// pass_1 reverted since it's inside all of with failed auth
+			isStateReverted: []bool{true, true, true, false},
+		},
+		{
+			name: "AllOf(pass_1, AnyOf(fail_1, pass_2)",
+			compositeAuth: *allOf(
+				spy("pass_1"),
+				anyOf(
+					spyWithFailure("fail_1", testutils.CONFIRM_EXECUTION_FAIL),
+					spy("pass_2"),
+				),
+			),
+			names:           []string{"pass_1", "fail_1", "pass_2"},
+			isStateReverted: []bool{false, true, false},
+		},
+		{
+			name: "AnyOf(AnyOf(AllOf(pass_1, fail_1), pass_2), pass_3)",
+			compositeAuth: *anyOf(
+				anyOf(
+					allOf(
+						spy("pass_1"),
+						spyWithFailure("fail_1", testutils.CONFIRM_EXECUTION_FAIL),
+					),
+					spy("pass_2"),
+				),
+				spy("pass_3"),
+			),
+			// pass_3 is short circuited, so ignored here
+			names:           []string{"pass_1", "fail_1", "pass_2"},
+			isStateReverted: []bool{true, true, false},
+		},
+	}
+
+	for _, tc := range testCases {
+		originalCtx := s.Ctx
+		s.Ctx, _ = s.Ctx.WithGasMeter(storetypes.NewGasMeter(2_000_000)).CacheContext()
+		data, err := tc.compositeAuth.buildInitData()
+		s.Require().NoError(err)
+
+		var auth authenticator.Authenticator
+		if tc.compositeAuth.isAllOf() {
+			auth, err = s.AllOfAuth.Initialize(data)
+			s.Require().NoError(err)
+		} else if tc.compositeAuth.isAnyOf() {
+			auth, err = s.AnyOfAuth.Initialize(data)
+			s.Require().NoError(err)
+		} else {
+			panic("top lv must be  anyOf")
+		}
+
+		msg := &bank.MsgSend{
+			FromAddress: s.TestAccAddress[0].String(),
+			ToAddress:   "to",
+			Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
+		}
+
+		encodedMsg, err := codectypes.NewAnyWithValue(msg)
+		s.Require().NoError(err, "Should encode Any value successfully")
+
+		// mock the authentication request
+		authReq := authenticator.AuthenticationRequest{
+			AuthenticatorId: "1",
+			Account:         s.TestAccAddress[0],
+			FeePayer:        s.TestAccAddress[0],
+			Msg:             authenticator.LocalAny{TypeURL: encodedMsg.TypeUrl, Value: encodedMsg.Value},
+			MsgIndex:        0,
+			Signature:       []byte{1, 1, 1, 1, 1},
+			SignModeTxData:  authenticator.SignModeData{Direct: []byte{1, 1, 1, 1, 1}},
+			SignatureData: authenticator.SimplifiedSignatureData{
+				Signers:    []sdk.AccAddress{s.TestAccAddress[0]},
+				Signatures: [][]byte{{1, 1, 1, 1, 1}},
+			},
+			Simulate:            false,
+			AuthenticatorParams: []byte{1, 1, 1, 1, 1},
+		}
+
+		// make calls
+		s.Require().NoError(auth.ConfirmExecution(s.Ctx, authReq))
+
+		for i, name := range tc.names {
+			spy := testutils.SpyAuthenticator{KvStoreKey: s.spyAuth.KvStoreKey, Name: name}
+			latestCalls := spy.GetLatestCalls(s.Ctx)
+			latestConfirmExecuion := latestCalls.ConfirmExecution
+
+			// NOTE: This assertion relying on the fact that latestCalls are stored in kv store
+			// so if state is reverted, latest call will be empty.
+			// This is not ideal since it could be interpreted as not being called at all
+			// but it's good enough for now.
+			//
+			// Maybe using in mem naked Map to track calls instead and having kvstore
+			// for actual state tracking would be better
+			if tc.isStateReverted[i] {
+				s.Require().Empty(latestConfirmExecuion)
+			} else {
+				s.Require().NotEmpty(latestConfirmExecuion)
+			}
+		}
+
+		s.Ctx = originalCtx
+	}
+}
+
+func marshalAuth(ta testAuth, testData []byte) ([]byte, error) {
+	initData := []authenticator.SubAuthenticatorInitData{}
+
+	for _, sub := range ta.subAuths {
+		subData, err := marshalAuth(sub, testData)
+		if err != nil {
+			return nil, err
+		}
+		initData = append(initData, authenticator.SubAuthenticatorInitData{
+			Type:   sub.authenticator.Type(),
+			Config: subData,
+		})
+	}
+
+	return json.Marshal(initData)
+}

--- a/protocol/x/accountplus/authenticator/message_filter.go
+++ b/protocol/x/accountplus/authenticator/message_filter.go
@@ -1,0 +1,82 @@
+package authenticator
+
+import (
+	errorsmod "cosmossdk.io/errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+var _ Authenticator = &MessageFilter{}
+
+// MessageFilter filters incoming messages based on a predefined JSON pattern.
+// It allows for complex pattern matching to support advanced authentication flows.
+type MessageFilter struct {
+	msgType string
+}
+
+// NewMessageFilter creates a new MessageFilter with the provided EncodingConfig.
+func NewMessageFilter() MessageFilter {
+	return MessageFilter{}
+}
+
+// Type returns the type of the authenticator.
+func (m MessageFilter) Type() string {
+	return "MessageFilter"
+}
+
+// StaticGas returns the static gas amount for the authenticator. Currently, it's set to zero.
+func (m MessageFilter) StaticGas() uint64 {
+	return 0
+}
+
+// Initialize sets up the authenticator with the given data, which should be a valid JSON pattern for message filtering.
+func (m MessageFilter) Initialize(config []byte) (Authenticator, error) {
+	m.msgType = string(config)
+	return m, nil
+}
+
+// Track is a no-op in this implementation but can be used to track message handling.
+func (m MessageFilter) Track(ctx sdk.Context, request AuthenticationRequest) error {
+	return nil
+}
+
+// Authenticate checks if the provided message conforms to the set JSON pattern.
+// It returns an AuthenticationResult based on the evaluation.
+func (m MessageFilter) Authenticate(ctx sdk.Context, request AuthenticationRequest) error {
+	if request.Msg.TypeURL != m.msgType {
+		return errorsmod.Wrapf(
+			sdkerrors.ErrUnauthorized,
+			"message types do not match. Got %s, Expected %s",
+			request.Msg.TypeURL,
+			m.msgType,
+		)
+	}
+	return nil
+}
+
+// ConfirmExecution confirms the execution of a message. Currently, it always confirms.
+func (m MessageFilter) ConfirmExecution(ctx sdk.Context, request AuthenticationRequest) error {
+	return nil
+}
+
+// OnAuthenticatorAdded performs additional checks when an authenticator is added.
+// Specifically, it ensures numbers in JSON are encoded as strings.
+func (m MessageFilter) OnAuthenticatorAdded(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return nil
+}
+
+// OnAuthenticatorRemoved is a no-op in this implementation but can be used when an authenticator is removed.
+func (m MessageFilter) OnAuthenticatorRemoved(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return nil
+}

--- a/protocol/x/accountplus/authenticator/message_filter_test.go
+++ b/protocol/x/accountplus/authenticator/message_filter_test.go
@@ -1,0 +1,105 @@
+package authenticator_test
+
+import (
+	"os"
+	"testing"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/authenticator"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type MessageFilterTest struct {
+	BaseAuthenticatorSuite
+
+	MessageFilter authenticator.MessageFilter
+}
+
+func TestMessageFilterTest(t *testing.T) {
+	suite.Run(t, new(MessageFilterTest))
+}
+
+func (s *MessageFilterTest) SetupTest() {
+	s.SetupKeys()
+	s.MessageFilter = authenticator.NewMessageFilter()
+}
+
+func (s *MessageFilterTest) TearDownTest() {
+	os.RemoveAll(s.HomeDir)
+}
+
+// TestBankSend tests the MessageFilter with multiple bank send messages
+func (s *MessageFilterTest) TestBankSend() {
+	tests := map[string]struct {
+		msgType string
+		msg     sdk.Msg
+
+		match bool
+	}{
+		"bank send": {
+			msgType: "/cosmos.bank.v1beta1.MsgSend",
+			msg: &bank.MsgSend{
+				FromAddress: s.TestAccAddress[0].String(),
+				ToAddress:   "to",
+				Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 100)),
+			},
+			match: true,
+		},
+		"bank send. fail on different message type": {
+			msgType: "/cosmos.bank.v1beta1.MsgSend",
+			msg: &clobtypes.MsgPlaceOrder{
+				Order: clobtypes.Order{
+					OrderId: clobtypes.OrderId{
+						SubaccountId: satypes.SubaccountId{
+							Owner: s.TestAccAddress[0].String(),
+						},
+					},
+				},
+			},
+			match: false,
+		},
+	}
+
+	for name, tt := range tests {
+		s.Run(name, func() {
+			err := s.MessageFilter.OnAuthenticatorAdded(s.Ctx, sdk.AccAddress{}, []byte(tt.msgType), "1")
+			s.Require().NoError(err)
+			filter, err := s.MessageFilter.Initialize([]byte(tt.msgType))
+			s.Require().NoError(err)
+
+			ak := s.tApp.App.AccountKeeper
+			sigModeHandler := s.EncodingConfig.TxConfig.SignModeHandler()
+			tx, err := s.GenSimpleTx([]sdk.Msg{tt.msg}, []cryptotypes.PrivKey{s.TestPrivKeys[0]})
+			s.Require().NoError(err)
+			request, err := authenticator.GenerateAuthenticationRequest(
+				s.Ctx,
+				s.tApp.App.AppCodec(),
+				ak,
+				sigModeHandler,
+				s.TestAccAddress[0],
+				s.TestAccAddress[0],
+				nil,
+				sdk.NewCoins(),
+				tt.msg,
+				tx,
+				0,
+				false,
+			)
+			s.Require().NoError(err)
+
+			err = filter.Authenticate(s.Ctx, request)
+			if tt.match {
+				s.Require().NoError(err)
+			} else {
+				s.Require().ErrorIs(err, sdkerrors.ErrUnauthorized)
+			}
+		})
+	}
+}

--- a/protocol/x/accountplus/authenticator/message_filter_test.go
+++ b/protocol/x/accountplus/authenticator/message_filter_test.go
@@ -52,8 +52,30 @@ func (s *MessageFilterTest) TestBankSend() {
 			},
 			match: true,
 		},
+		"bank send - multiple types": {
+			msgType: "/cosmos.bank.v1beta1.MsgMultiSend,/cosmos.bank.v1beta1.MsgSend",
+			msg: &bank.MsgSend{
+				FromAddress: s.TestAccAddress[0].String(),
+				ToAddress:   "to",
+				Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 100)),
+			},
+			match: true,
+		},
 		"bank send. fail on different message type": {
 			msgType: "/cosmos.bank.v1beta1.MsgSend",
+			msg: &clobtypes.MsgPlaceOrder{
+				Order: clobtypes.Order{
+					OrderId: clobtypes.OrderId{
+						SubaccountId: satypes.SubaccountId{
+							Owner: s.TestAccAddress[0].String(),
+						},
+					},
+				},
+			},
+			match: false,
+		},
+		"bank send - multiple types. fail on different message type": {
+			msgType: "/cosmos.bank.v1beta1.MsgMultiSend,/cosmos.bank.v1beta1.MsgSend",
 			msg: &clobtypes.MsgPlaceOrder{
 				Order: clobtypes.Order{
 					OrderId: clobtypes.OrderId{

--- a/protocol/x/accountplus/testutils/generic_authenticator.go
+++ b/protocol/x/accountplus/testutils/generic_authenticator.go
@@ -1,0 +1,108 @@
+package testutils
+
+import (
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/authenticator"
+)
+
+var (
+	_ authenticator.Authenticator = &TestingAuthenticator{}
+)
+
+type ApproveOn int
+
+const (
+	Always ApproveOn = iota
+	Never
+)
+
+type (
+	TestingAuthenticatorData struct{}
+	TestingAuthenticator     struct {
+		Approve        ApproveOn
+		GasConsumption int
+		BlockAddition  bool
+		BlockRemoval   bool
+		Confirm        ApproveOn
+	}
+)
+
+func (t TestingAuthenticator) Type() string {
+	var when string
+	if t.Approve == Always {
+		when = "Always"
+	} else {
+		when = "Never"
+	}
+
+	var confirm string
+	if t.Confirm == Always {
+		confirm = "Confirm"
+	} else {
+		confirm = "Block"
+	}
+
+	return "TestingAuthenticator" +
+		when +
+		confirm +
+		fmt.Sprintf("GasConsumption%d", t.GasConsumption) +
+		fmt.Sprintf("BlockAddition%t", t.BlockAddition) +
+		fmt.Sprintf("BlockRemoval%t", t.BlockRemoval)
+}
+
+func (t TestingAuthenticator) StaticGas() uint64 {
+	return uint64(t.GasConsumption)
+}
+
+func (t TestingAuthenticator) Initialize(config []byte) (authenticator.Authenticator, error) {
+	return t, nil
+}
+
+func (t TestingAuthenticator) Authenticate(ctx sdk.Context, request authenticator.AuthenticationRequest) error {
+	if t.Approve == Always {
+		return nil
+	} else {
+		return errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "TestingAuthenticator authentication error")
+	}
+}
+
+func (t TestingAuthenticator) Track(ctx sdk.Context, request authenticator.AuthenticationRequest) error {
+	return nil
+}
+
+func (t TestingAuthenticator) ConfirmExecution(ctx sdk.Context, request authenticator.AuthenticationRequest) error {
+	if t.Confirm == Always {
+		return nil
+	} else {
+		return errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "TestingAuthenticator block")
+	}
+}
+
+func (t TestingAuthenticator) OnAuthenticatorAdded(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	if t.BlockAddition {
+		return fmt.Errorf("authenticator could not be added")
+	}
+	return nil
+}
+
+func (t TestingAuthenticator) OnAuthenticatorRemoved(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	if t.BlockRemoval {
+		return fmt.Errorf("authenticator could not be removed")
+	}
+	return nil
+}

--- a/protocol/x/accountplus/testutils/spy_authenticator.go
+++ b/protocol/x/accountplus/testutils/spy_authenticator.go
@@ -1,0 +1,219 @@
+package testutils
+
+import (
+	"encoding/json"
+
+	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/store/prefix"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/authenticator"
+)
+
+var _ authenticator.Authenticator = &SpyAuthenticator{}
+
+type SpyTrackRequest struct {
+	AuthenticatorId string                 `json:"authenticator_id"`
+	Account         sdk.AccAddress         `json:"account"`
+	Msg             authenticator.LocalAny `json:"msg"`
+	MsgIndex        uint64                 `json:"msg_index"`
+}
+
+type SpyAddRequest struct {
+	Account         sdk.AccAddress `json:"account"`
+	Data            []byte         `json:"data"`
+	AuthenticatorId string         `json:"authenticator_id"`
+}
+
+type SpyRemoveRequest struct {
+	Account         sdk.AccAddress `json:"account"`
+	Data            []byte         `json:"data"`
+	AuthenticatorId string         `json:"authenticator_id"`
+}
+
+type LatestCalls struct {
+	Authenticate           authenticator.AuthenticationRequest
+	Track                  SpyTrackRequest
+	ConfirmExecution       authenticator.AuthenticationRequest
+	OnAuthenticatorAdded   SpyAddRequest
+	OnAuthenticatorRemoved SpyRemoveRequest
+}
+
+type FailureFlag = uint8
+
+const (
+	AUTHENTICATE_FAIL FailureFlag = 1 << iota
+	CONFIRM_EXECUTION_FAIL
+)
+
+func Has(fixed, toCheck FailureFlag) bool {
+	return fixed&toCheck != 0
+}
+
+type SpyAuthenticatorData struct {
+	Name    string      `json:"name"`
+	Failure FailureFlag `json:"failure"` // bit flag representing authenticator failure
+}
+
+// SpyAuthenticator tracks latest call and can be used to test the authenticator
+type SpyAuthenticator struct {
+	KvStoreKey storetypes.StoreKey
+	Name       string
+	Failure    FailureFlag
+}
+
+func NewSpyAuthenticator(kvStoreKey storetypes.StoreKey) SpyAuthenticator {
+	return SpyAuthenticator{KvStoreKey: kvStoreKey}
+}
+
+func (s SpyAuthenticator) Type() string {
+	return "Spy"
+}
+
+func (s SpyAuthenticator) StaticGas() uint64 {
+	return 1000
+}
+
+func (s SpyAuthenticator) Initialize(config []byte) (authenticator.Authenticator, error) {
+	var spyData SpyAuthenticatorData
+	err := json.Unmarshal(config, &spyData)
+	if err != nil {
+		return nil, err
+	}
+	s.Name = spyData.Name
+	s.Failure = spyData.Failure
+	return s, nil
+}
+
+func (s SpyAuthenticator) Authenticate(ctx sdk.Context, request authenticator.AuthenticationRequest) error {
+	s.UpdateLatestCalls(ctx, func(calls LatestCalls) LatestCalls {
+		calls.Authenticate = request
+		return calls
+	})
+
+	if Has(s.Failure, AUTHENTICATE_FAIL) {
+		return errorsmod.Wrap(sdkerrors.ErrUnauthorized, "not authenticated")
+	}
+	return nil
+}
+
+func (s SpyAuthenticator) Track(ctx sdk.Context, request authenticator.AuthenticationRequest) error {
+	s.UpdateLatestCalls(ctx, func(calls LatestCalls) LatestCalls {
+		calls.Track = SpyTrackRequest{
+			AuthenticatorId: request.AuthenticatorId,
+			Account:         request.Account,
+			Msg:             request.Msg,
+			MsgIndex:        request.MsgIndex,
+		}
+		return calls
+	})
+	return nil
+}
+
+func (s SpyAuthenticator) ConfirmExecution(ctx sdk.Context, request authenticator.AuthenticationRequest) error {
+	// intentionlly call update before check to test state revert
+	s.UpdateLatestCalls(ctx, func(calls LatestCalls) LatestCalls {
+		calls.ConfirmExecution = request
+		return calls
+	})
+
+	if Has(s.Failure, CONFIRM_EXECUTION_FAIL) {
+		return errorsmod.Wrap(sdkerrors.ErrUnauthorized, "not authenticated")
+	}
+	return nil
+}
+
+func (s SpyAuthenticator) OnAuthenticatorAdded(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	spy, err := s.Initialize(config)
+	if err != nil {
+		return err
+	}
+	spyAuth, ok := spy.(SpyAuthenticator)
+	if !ok {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "failed to cast authenticator to SpyAuthenticator")
+	}
+
+	spyAuth.UpdateLatestCalls(ctx, func(calls LatestCalls) LatestCalls {
+		calls.OnAuthenticatorAdded = SpyAddRequest{
+			Account:         account,
+			Data:            config,
+			AuthenticatorId: authenticatorId,
+		}
+		return calls
+	})
+	return nil
+}
+
+func (s SpyAuthenticator) OnAuthenticatorRemoved(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	spy, err := s.Initialize(config)
+	if err != nil {
+		return err
+	}
+	spyAuth, ok := spy.(SpyAuthenticator)
+	if !ok {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "failed to cast authenticator to SpyAuthenticator")
+	}
+
+	spyAuth.UpdateLatestCalls(ctx, func(calls LatestCalls) LatestCalls {
+		calls.OnAuthenticatorRemoved = SpyRemoveRequest{
+			Account:         account,
+			Data:            config,
+			AuthenticatorId: authenticatorId,
+		}
+		return calls
+	})
+	return nil
+}
+
+func (s SpyAuthenticator) GetLatestCalls(ctx sdk.Context) LatestCalls {
+	if s.Name == "" {
+		panic("SpyAuthenticator is not initialized")
+	}
+	kvStore := s.storeByName(ctx)
+	bz := kvStore.Get([]byte("calls"))
+	var calls LatestCalls
+	_ = json.Unmarshal(bz, &calls)
+	return calls
+}
+
+func (s SpyAuthenticator) UpdateLatestCalls(ctx sdk.Context, f func(calls LatestCalls) LatestCalls) LatestCalls {
+	if s.Name == "" {
+		panic("SpyAuthenticator is not initialized")
+	}
+
+	kvStore := s.storeByName(ctx)
+	bz := kvStore.Get([]byte("calls"))
+	var calls LatestCalls
+
+	_ = json.Unmarshal(bz, &calls)
+
+	calls = f(calls)
+	newBz, _ := json.Marshal(calls)
+	kvStore.Set([]byte("calls"), newBz)
+
+	return calls
+}
+
+func (s SpyAuthenticator) ResetLatestCalls(ctx sdk.Context) {
+	s.store(ctx).Delete([]byte("calls"))
+}
+
+func (s SpyAuthenticator) store(ctx sdk.Context) storetypes.KVStore {
+	return prefix.NewStore(ctx.KVStore(s.KvStoreKey), []byte(s.Type()))
+}
+
+func (s SpyAuthenticator) storeByName(ctx sdk.Context) storetypes.KVStore {
+	return prefix.NewStore(ctx.KVStore(s.KvStoreKey), []byte(s.Name))
+}


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new authenticators (`AllOf` and `AnyOf`) for flexible authentication strategies.
	- Added a `MessageFilter` to enhance message authentication based on JSON patterns.
	- Implemented a method to retrieve KV Store keys from the `App` struct.

- **Bug Fixes**
	- Improved error handling and tracking for sub-authenticators.

- **Tests**
	- Added comprehensive test suites for the new authenticators and message filtering logic to ensure robust functionality.
	- Included tests for the `MessageFilter` to validate its authentication capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->