### PR TITLE
[TRA-531] When market pair changes, disable old market and enable new market

### DIFF
--- a/protocol/x/prices/types/errors.go
+++ b/protocol/x/prices/types/errors.go
@@ -31,6 +31,8 @@ var (
 		"Market pair conversion to currency pair failed",
 	)
 	ErrTickerNotFoundInMarketMap = errorsmod.Register(ModuleName, 207, "Ticker not found in market map")
+	ErrMarketCouldNotBeDisabled  = errorsmod.Register(ModuleName, 208, "Market could not be disabled")
+	ErrMarketCouldNotBeEnabled   = errorsmod.Register(ModuleName, 209, "Market could not be enabled")
 
 	// 300 - 399: Price related errors.
 	ErrIndexPriceNotAvailable = errorsmod.Register(ModuleName, 300, "Index price is not available")

--- a/protocol/x/prices/types/expected_keepers.go
+++ b/protocol/x/prices/types/expected_keepers.go
@@ -35,4 +35,5 @@ type MarketMapKeeper interface {
 	GetAllMarkets(ctx sdk.Context) (map[string]marketmaptypes.Market, error)
 	GetMarket(ctx sdk.Context, tickerStr string) (marketmaptypes.Market, error)
 	EnableMarket(ctx sdk.Context, tickerStr string) error
+	DisableMarket(ctx sdk.Context, tickerStr string) error
 }


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of market parameters for better management of currency pairs.
	- Introduced a method to disable markets, providing users with more control over market states.
  
- **Bug Fixes**
	- Improved error handling for enabling and disabling markets with specific error messages.

- **Tests**
	- Added a new test to validate market parameter modifications and their impact on market states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->