### PR TITLE
Add tests for when market pair name changes

### DIFF
--- a/protocol/testing/e2e/gov/prices_test.go
+++ b/protocol/testing/e2e/gov/prices_test.go
@@ -67,6 +67,20 @@ func TestUpdateMarketParam(t *testing.T) {
 			},
 			expectedProposalStatus: govtypesv1.ProposalStatus_PROPOSAL_STATUS_FAILED,
 		},
+		"Failure: new pair name does not exist in marketmap": {
+			msg: &pricestypes.MsgUpdateMarketParam{
+				Authority: lib.GovModuleAddress.String(),
+				MarketParam: pricestypes.MarketParam{
+					Id:                 MODIFIED_MARKET_PARAM.Id,
+					Pair:               "nonexistent-pair",
+					Exponent:           MODIFIED_MARKET_PARAM.Exponent,
+					MinExchanges:       MODIFIED_MARKET_PARAM.MinExchanges,
+					MinPriceChangePpm:  MODIFIED_MARKET_PARAM.MinPriceChangePpm,
+					ExchangeConfigJson: MODIFIED_MARKET_PARAM.ExchangeConfigJson,
+				},
+			},
+			expectedProposalStatus: govtypesv1.ProposalStatus_PROPOSAL_STATUS_FAILED,
+		},
 		"Failure: exponent is updated": {
 			msg: &pricestypes.MsgUpdateMarketParam{
 				Authority: lib.GovModuleAddress.String(),

--- a/protocol/x/prices/keeper/msg_server_update_market_param_test.go
+++ b/protocol/x/prices/keeper/msg_server_update_market_param_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
@@ -206,7 +205,6 @@ func TestUpdateMarketParam(t *testing.T) {
 
 				// If pair name changed, verify that old pair is disabled in the marketmap and new pair is enabled
 				if initialMarketParam.Pair != updatedMarketParam.Pair {
-					fmt.Println("Inside test")
 					oldCp, err := slinky.MarketPairToCurrencyPair(initialMarketParam.Pair)
 					require.NoError(t, err)
 					oldMarket, err := marketMapKeeper.GetMarket(ctx, oldCp.String())

--- a/protocol/x/prices/keeper/msg_server_update_market_param_test.go
+++ b/protocol/x/prices/keeper/msg_server_update_market_param_test.go
@@ -10,7 +10,6 @@ import (
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/keeper"
-	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	"github.com/stretchr/testify/require"
 )
@@ -185,7 +184,7 @@ func TestUpdateMarketParam(t *testing.T) {
 					t,
 					ctx,
 					marketMapKeeper,
-					[]types.MarketParam{tc.msg.MarketParam},
+					[]pricestypes.MarketParam{tc.msg.MarketParam},
 				)
 			}
 


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced test coverage for market parameter updates, including scenarios for both successful updates and failure cases.

- **Bug Fixes**
	- Improved handling of invalid market pair names during updates, ensuring appropriate error messages are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->