### PR TITLE
Set to-vulcan topic to 150 partitions

### DIFF
--- a/indexer/services/bazooka/src/index.ts
+++ b/indexer/services/bazooka/src/index.ts
@@ -25,7 +25,7 @@ const DEFAULT_NUM_REPLICAS: number = 3;
 
 const KAFKA_TOPICS_TO_PARTITIONS: { [key in KafkaTopics]: number } = {
   [KafkaTopics.TO_ENDER]: 1,
-  [KafkaTopics.TO_VULCAN]: 60,
+  [KafkaTopics.TO_VULCAN]: 150,
   [KafkaTopics.TO_WEBSOCKETS_ORDERBOOKS]: 1,
   [KafkaTopics.TO_WEBSOCKETS_SUBACCOUNTS]: 3,
   [KafkaTopics.TO_WEBSOCKETS_TRADES]: 1,


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the number of partitions for the Kafka topic `TO_VULCAN` from 60 to 150, enhancing message throughput and scalability.
  
- **Performance Improvements**
	- Adjustments made to optimize data handling and distribution for the `TO_VULCAN` topic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->