### PR TITLE
[TRA-572] Send upsert vault event when setting parameters of vault.

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1184,6 +1184,7 @@ func New(
 		app.PricesKeeper,
 		app.SendingKeeper,
 		app.SubaccountsKeeper,
+		app.IndexerEventManager,
 		[]string{
 			lib.GovModuleAddress.String(),
 			delaymsgmoduletypes.ModuleAddress.String(),

--- a/protocol/indexer/events/upsert_vault.go
+++ b/protocol/indexer/events/upsert_vault.go
@@ -2,7 +2,6 @@ package events
 
 import (
 	v1 "github.com/dydxprotocol/v4-chain/protocol/indexer/protocol/v1"
-	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
@@ -10,12 +9,12 @@ import (
 // representing an create / update of a vault.
 func NewUpsertVaultEvent(
 	vaultAddress string,
-	clobPairId clobtypes.ClobPairId,
+	clobPairId uint32,
 	status types.VaultStatus,
 ) *UpsertVaultEventV1 {
 	return &UpsertVaultEventV1{
 		Address:    vaultAddress,
-		ClobPairId: uint32(clobPairId),
+		ClobPairId: clobPairId,
 		Status:     v1.VaultStatusToIndexerVaultStatus(status),
 	}
 }

--- a/protocol/testutil/keeper/vault.go
+++ b/protocol/testutil/keeper/vault.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	delaymsgtypes "github.com/dydxprotocol/v4-chain/protocol/x/delaymsg/types"
+	"github.com/stretchr/testify/mock"
 
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -50,6 +52,13 @@ func createVaultKeeper(
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
 	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
 
+	mockMsgSender := &mocks.IndexerMessageSender{}
+	mockMsgSender.On("Enabled").Return(true)
+	mockMsgSender.On("SendOnchainData", mock.Anything).Return()
+	mockMsgSender.On("SendOffchainData", mock.Anything).Return()
+
+	mockIndexerEventsManager := indexer_manager.NewIndexerEventManager(mockMsgSender, transientStoreKey, true)
+
 	k := keeper.NewKeeper(
 		cdc,
 		storeKey,
@@ -59,6 +68,7 @@ func createVaultKeeper(
 		&mocks.PricesKeeper{},
 		&mocks.SendingKeeper{},
 		&mocks.SubaccountsKeeper{},
+		mockIndexerEventsManager,
 		[]string{
 			lib.GovModuleAddress.String(),
 			delaymsgtypes.ModuleAddress.String(),

--- a/protocol/x/vault/keeper/keeper.go
+++ b/protocol/x/vault/keeper/keeper.go
@@ -7,21 +7,23 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
 type (
 	Keeper struct {
-		cdc               codec.BinaryCodec
-		storeKey          storetypes.StoreKey
-		clobKeeper        types.ClobKeeper
-		delayMsgKeeper    types.DelayMsgKeeper
-		perpetualsKeeper  types.PerpetualsKeeper
-		pricesKeeper      types.PricesKeeper
-		sendingKeeper     types.SendingKeeper
-		subaccountsKeeper types.SubaccountsKeeper
-		authorities       map[string]struct{}
+		cdc                 codec.BinaryCodec
+		storeKey            storetypes.StoreKey
+		clobKeeper          types.ClobKeeper
+		delayMsgKeeper      types.DelayMsgKeeper
+		perpetualsKeeper    types.PerpetualsKeeper
+		pricesKeeper        types.PricesKeeper
+		sendingKeeper       types.SendingKeeper
+		subaccountsKeeper   types.SubaccountsKeeper
+		indexerEventManager indexer_manager.IndexerEventManager
+		authorities         map[string]struct{}
 	}
 )
 
@@ -34,18 +36,20 @@ func NewKeeper(
 	pricesKeeper types.PricesKeeper,
 	sendingKeeper types.SendingKeeper,
 	subaccountsKeeper types.SubaccountsKeeper,
+	indexerEventManager indexer_manager.IndexerEventManager,
 	authorities []string,
 ) *Keeper {
 	return &Keeper{
-		cdc:               cdc,
-		storeKey:          storeKey,
-		clobKeeper:        clobKeeper,
-		delayMsgKeeper:    delayMsgKeeper,
-		perpetualsKeeper:  perpetualsKeeper,
-		pricesKeeper:      pricesKeeper,
-		sendingKeeper:     sendingKeeper,
-		subaccountsKeeper: subaccountsKeeper,
-		authorities:       lib.UniqueSliceToSet(authorities),
+		cdc:                 cdc,
+		storeKey:            storeKey,
+		clobKeeper:          clobKeeper,
+		delayMsgKeeper:      delayMsgKeeper,
+		perpetualsKeeper:    perpetualsKeeper,
+		pricesKeeper:        pricesKeeper,
+		sendingKeeper:       sendingKeeper,
+		subaccountsKeeper:   subaccountsKeeper,
+		indexerEventManager: indexerEventManager,
+		authorities:         lib.UniqueSliceToSet(authorities),
 	}
 }
 
@@ -56,6 +60,10 @@ func (k Keeper) HasAuthority(authority string) bool {
 
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With(log.ModuleKey, fmt.Sprintf("x/%s", types.ModuleName))
+}
+
+func (k Keeper) GetIndexerEventManager() indexer_manager.IndexerEventManager {
+	return k.indexerEventManager
 }
 
 func (k Keeper) InitializeForGenesis(ctx sdk.Context) {}

--- a/protocol/x/vault/keeper/orders_test.go
+++ b/protocol/x/vault/keeper/orders_test.go
@@ -168,6 +168,8 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 				)
 				require.NoError(t, err)
 			}
+			// Clear events from setting vault params
+			tApp.App.IndexerEventManager.ClearEvents(ctx)
 
 			// Check that there's no stateful orders yet.
 			allStatefulOrders := tApp.App.ClobKeeper.GetAllStatefulOrders(ctx)

--- a/protocol/x/vault/keeper/params.go
+++ b/protocol/x/vault/keeper/params.go
@@ -4,6 +4,8 @@ import (
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
@@ -69,6 +71,19 @@ func (k Keeper) SetVaultParams(
 	b := k.cdc.MustMarshal(&vaultParams)
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.VaultParamsKeyPrefix))
 	store.Set(vaultId.ToStateKey(), b)
+
+	k.GetIndexerEventManager().AddTxnEvent(
+		ctx,
+		indexerevents.SubtypeUpsertVault,
+		indexerevents.UpsertVaultEventVersion,
+		indexer_manager.GetBytes(
+			indexerevents.NewUpsertVaultEvent(
+				vaultId.ToModuleAccountAddress(),
+				vaultId.Number,
+				vaultParams.Status,
+			),
+		),
+	)
 
 	return nil
 }


### PR DESCRIPTION
### Changelist
When a vault is updated / initially created the vault params are set. Send the upsert vault event to the Indexer at this time.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced event management capabilities through the addition of the `IndexerEventManager`.
	- Introduced event logging for vault parameter changes, improving monitoring and auditing.

- **Bug Fixes**
	- Simplified the handling of the `clobPairId` parameter in vault events, improving code efficiency.

- **Tests**
	- Improved test coverage for vault parameters by validating emitted indexer events during parameter settings.
	- Enhanced test reliability by clearing previous events before running tests on vault orders.
	- Introduced a mock implementation of the `IndexerMessageSender` for controlled testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->