### PR TITLE
test

### DIFF
--- a/protocol/mempool/noop.go
+++ b/protocol/mempool/noop.go
@@ -11,6 +11,7 @@ import (
 // sign
 // another sign
 // think it should work now
+// okay should really work now
 // TODO(DEC-1194): this is copied from SDK. Remove this forked impl in favor of SDK's NoOpMempool.
 var _ mempool.Mempool = (*noOpMempool)(nil)
 

--- a/protocol/mempool/noop.go
+++ b/protocol/mempool/noop.go
@@ -12,6 +12,7 @@ import (
 // another sign
 // think it should work now
 // okay should really work now
+// okay updated key
 // TODO(DEC-1194): this is copied from SDK. Remove this forked impl in favor of SDK's NoOpMempool.
 var _ mempool.Mempool = (*noOpMempool)(nil)
 

--- a/protocol/mempool/noop.go
+++ b/protocol/mempool/noop.go
@@ -9,6 +9,7 @@ import (
 
 // testing
 // sign
+// another sign
 // TODO(DEC-1194): this is copied from SDK. Remove this forked impl in favor of SDK's NoOpMempool.
 var _ mempool.Mempool = (*noOpMempool)(nil)
 

--- a/protocol/mempool/noop.go
+++ b/protocol/mempool/noop.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/mempool"
 )
 
+// testing
 // TODO(DEC-1194): this is copied from SDK. Remove this forked impl in favor of SDK's NoOpMempool.
 var _ mempool.Mempool = (*noOpMempool)(nil)
 

--- a/protocol/mempool/noop.go
+++ b/protocol/mempool/noop.go
@@ -10,6 +10,7 @@ import (
 // testing
 // sign
 // another sign
+// think it should work now
 // TODO(DEC-1194): this is copied from SDK. Remove this forked impl in favor of SDK's NoOpMempool.
 var _ mempool.Mempool = (*noOpMempool)(nil)
 

--- a/protocol/mempool/noop.go
+++ b/protocol/mempool/noop.go
@@ -8,6 +8,7 @@ import (
 )
 
 // testing
+// sign
 // TODO(DEC-1194): this is copied from SDK. Remove this forked impl in favor of SDK's NoOpMempool.
 var _ mempool.Mempool = (*noOpMempool)(nil)
 


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added comments clarifying the purpose of the `NoOpMempool` code for testing.
	- Included a note regarding a future task to transition to the original SDK's implementation.

- **Chores**
	- Minor updates made for future planning without affecting existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->