### PR TITLE
add quoting logic of deactivated, stand-by, close-only modes of vaults

### DIFF
--- a/protocol/x/vault/keeper/orders.go
+++ b/protocol/x/vault/keeper/orders.go
@@ -34,11 +34,10 @@ func (k Keeper) RefreshAllVaultOrders(ctx sdk.Context) {
 		var vaultParams types.VaultParams
 		k.cdc.MustUnmarshal(vaultParamsIterator.Value(), &vaultParams)
 
-		if vaultParams.Status != types.VaultStatus_VAULT_STATUS_QUOTING {
-			// TODO (TRA-546): cancel any existing orders and don't place new orders.
+		if vaultParams.Status != types.VaultStatus_VAULT_STATUS_QUOTING &&
+			vaultParams.Status != types.VaultStatus_VAULT_STATUS_CLOSE_ONLY {
 			continue
 		}
-		// TODO (TRA-547): implement close-only mode.
 
 		// Skip if vault has no perpetual positions and strictly less than `activation_threshold_quote_quantums` USDC.
 		if vaultParams.QuotingParams == nil {
@@ -108,7 +107,8 @@ func (k Keeper) RefreshVaultClobOrders(ctx sdk.Context, vaultId types.VaultId) (
 				orderToPlace.OrderId.ClientId = oldClientId ^ 1
 				err = k.PlaceVaultClobOrder(ctx, vaultId, orderToPlace)
 			} else if oldOrderPlacement.Order.Quantums != orderToPlace.Quantums ||
-				oldOrderPlacement.Order.Subticks != orderToPlace.Subticks {
+				oldOrderPlacement.Order.Subticks != orderToPlace.Subticks ||
+				oldOrderPlacement.Order.Side != orderToPlace.Side {
 				// Replace old order with new order.
 				// Flip last bit of old client ID to get new client ID to make sure they are different
 				// as order placement fails if the same order ID is already marked for cancellation.
@@ -126,6 +126,22 @@ func (k Keeper) RefreshVaultClobOrders(ctx sdk.Context, vaultId types.VaultId) (
 		clientIds[i] = orderToPlace.OrderId.ClientId
 	}
 	k.SetMostRecentClientIds(ctx, vaultId, clientIds)
+
+	// Cancel any orders that are no longer needed.
+	_, quotingParams, exists := k.GetVaultAndQuotingParams(ctx, vaultId)
+	if !exists {
+		return types.ErrVaultParamsNotFound
+	}
+	for i := len(ordersToPlace); i < len(mostRecentClientIds); i++ {
+		orderId := vaultId.GetClobOrderId(mostRecentClientIds[i])
+		_, exists := k.clobKeeper.GetLongTermOrderPlacement(ctx, *orderId)
+		if exists {
+			err := k.CancelVaultClobOrder(ctx, vaultId, orderId, quotingParams.OrderExpirationSeconds)
+			if err != nil {
+				log.ErrorLogWithError(ctx, "Failed to cancel vault clob order", err, "vaultId", vaultId)
+			}
+		}
+	}
 
 	return nil
 }
@@ -179,12 +195,19 @@ func (k Keeper) GetVaultClobOrders(
 	leveragePpm = lib.BigDivCeil(leveragePpm, leverage.Denom())
 
 	// Get vault parameters.
-	quotingParams, exists := k.GetVaultQuotingParams(ctx, vaultId)
+	vaultParams, quotingParams, exists := k.GetVaultAndQuotingParams(ctx, vaultId)
 	if !exists {
 		return orders, errorsmod.Wrap(
 			types.ErrVaultParamsNotFound,
 			fmt.Sprintf("VaultId: %v", vaultId),
 		)
+	}
+
+	// No orders if vault is deactivated, stand-by, or close-only with zero leverage.
+	if vaultParams.Status == types.VaultStatus_VAULT_STATUS_DEACTIVATED ||
+		vaultParams.Status == types.VaultStatus_VAULT_STATUS_STAND_BY ||
+		vaultParams.Status == types.VaultStatus_VAULT_STATUS_CLOSE_ONLY && leverage.Sign() == 0 {
+		return []*clobtypes.Order{}, nil
 	}
 
 	// Calculate order size (in base quantums).
@@ -344,6 +367,26 @@ func (k Keeper) GetVaultClobOrders(
 		orders[2*i+1] = constructOrder(clobtypes.Order_SIDE_BUY, i, orderIds[2*i+1])
 	}
 
+	if vaultParams.Status == types.VaultStatus_VAULT_STATUS_CLOSE_ONLY {
+		// In close-only mode with non-zero leverage.
+		reduceOnlyOrders := make([]*clobtypes.Order, quotingParams.Layers)
+		reduceOnlyMaxOrderSize := k.GetVaultInventoryInPerpetual(ctx, vaultId, perpetual.Params.Id)
+		stepSize := lib.BigU(clobPair.StepBaseQuantums)
+		reduceOnlyMaxOrderSize.Quo(reduceOnlyMaxOrderSize, stepSize)
+		reduceOnlyMaxOrderSize.Mul(reduceOnlyMaxOrderSize, stepSize)
+		// If vault is long, only need sell orders (even indices).
+		i := 0
+		if leverage.Sign() < 0 {
+			// If vault is short, only need buy orders (odd indices).
+			i = 1
+		}
+		for ; i < len(orders); i += 2 {
+			reduceOnlyOrders[i/2] = orders[i]
+			reduceOnlyOrders[i/2].Quantums = lib.Min(reduceOnlyOrders[i/2].Quantums, reduceOnlyMaxOrderSize.Uint64())
+		}
+		return reduceOnlyOrders, nil
+	}
+
 	return orders, nil
 }
 
@@ -368,7 +411,7 @@ func (k Keeper) GetVaultClobOrderIds(
 		}
 	}
 
-	quotingParams, exists := k.GetVaultQuotingParams(ctx, vaultId)
+	_, quotingParams, exists := k.GetVaultAndQuotingParams(ctx, vaultId)
 	if !exists {
 		return []*clobtypes.OrderId{}
 	}
@@ -403,6 +446,27 @@ func (k Keeper) PlaceVaultClobOrder(
 	return err
 }
 
+// CancelVaultClobOrder cancels a vault CLOB order.
+func (k Keeper) CancelVaultClobOrder(
+	ctx sdk.Context,
+	vaultId types.VaultId,
+	orderId *clobtypes.OrderId,
+	orderExpirationSeconds uint32,
+) error {
+	err := k.clobKeeper.HandleMsgCancelOrder(ctx, clobtypes.NewMsgCancelOrderStateful(
+		*orderId,
+		uint32(ctx.BlockTime().Unix())+orderExpirationSeconds,
+	))
+	if err != nil {
+		log.ErrorLogWithError(ctx, "Failed to cancel order", err, "orderId", orderId, "vaultId", vaultId)
+	}
+	vaultId.IncrCounterWithLabels(
+		metrics.VaultCancelOrder,
+		metrics.GetLabelForBoolValue(metrics.Success, err == nil),
+	)
+	return err
+}
+
 // ReplaceVaultClobOrder replaces a vault CLOB order internal to the protocol and
 // emits order replacement indexer event.
 func (k Keeper) ReplaceVaultClobOrder(
@@ -411,7 +475,7 @@ func (k Keeper) ReplaceVaultClobOrder(
 	oldOrderId *clobtypes.OrderId,
 	newOrder *clobtypes.Order,
 ) error {
-	quotingParams, exists := k.GetVaultQuotingParams(ctx, vaultId)
+	_, quotingParams, exists := k.GetVaultAndQuotingParams(ctx, vaultId)
 	if !exists {
 		return errorsmod.Wrap(
 			types.ErrVaultParamsNotFound,
@@ -419,16 +483,8 @@ func (k Keeper) ReplaceVaultClobOrder(
 		)
 	}
 	// Cancel old order.
-	err := k.clobKeeper.HandleMsgCancelOrder(ctx, clobtypes.NewMsgCancelOrderStateful(
-		*oldOrderId,
-		uint32(ctx.BlockTime().Unix())+quotingParams.OrderExpirationSeconds,
-	))
-	vaultId.IncrCounterWithLabels(
-		metrics.VaultCancelOrder,
-		metrics.GetLabelForBoolValue(metrics.Success, err == nil),
-	)
+	err := k.CancelVaultClobOrder(ctx, vaultId, oldOrderId, quotingParams.OrderExpirationSeconds)
 	if err != nil {
-		log.ErrorLogWithError(ctx, "Failed to cancel order", err, "orderId", oldOrderId, "vaultId", vaultId)
 		return err
 	}
 

--- a/protocol/x/vault/keeper/params.go
+++ b/protocol/x/vault/keeper/params.go
@@ -94,25 +94,27 @@ func (k Keeper) getVaultParamsIterator(ctx sdk.Context) storetypes.Iterator {
 	return storetypes.KVStorePrefixIterator(store, []byte{})
 }
 
-// GetVaultQuotingParams returns quoting parameters for a given vault, which is
+// GetVaultAndQuotingParams returns vault params and quoting parameters for a given vault.
+// Quoting parameters is
 // - `VaultParams.QuotingParams` if set
 // - `DefaultQuotingParams` otherwise
 // `exists` is false if `VaultParams` does not exist for the given vault.
-func (k Keeper) GetVaultQuotingParams(
+func (k Keeper) GetVaultAndQuotingParams(
 	ctx sdk.Context,
 	vaultId types.VaultId,
 ) (
-	params types.QuotingParams,
+	vaultParams types.VaultParams,
+	quotingParams types.QuotingParams,
 	exists bool,
 ) {
-	vaultParams, exists := k.GetVaultParams(ctx, vaultId)
+	vaultParams, exists = k.GetVaultParams(ctx, vaultId)
 	if !exists {
-		return params, false
+		return vaultParams, quotingParams, false
 	}
 	if vaultParams.QuotingParams == nil {
-		return k.GetDefaultQuotingParams(ctx), true
+		return vaultParams, k.GetDefaultQuotingParams(ctx), true
 	} else {
-		return *vaultParams.QuotingParams, true
+		return vaultParams, *vaultParams.QuotingParams, true
 	}
 }
 

--- a/protocol/x/vault/keeper/params_test.go
+++ b/protocol/x/vault/keeper/params_test.go
@@ -146,7 +146,7 @@ func TestGetSetVaultParams(t *testing.T) {
 	}
 }
 
-func TestGetVaultQuotingParams(t *testing.T) {
+func TestGetVaultAndQuotingParams(t *testing.T) {
 	tests := map[string]struct {
 		/* Setup */
 		// Vault id.
@@ -184,15 +184,16 @@ func TestGetVaultQuotingParams(t *testing.T) {
 			if tc.vaultParams != nil {
 				err := k.SetVaultParams(ctx, tc.vaultId, *tc.vaultParams)
 				require.NoError(t, err)
-				p, exists := k.GetVaultQuotingParams(ctx, tc.vaultId)
+				v, q, exists := k.GetVaultAndQuotingParams(ctx, tc.vaultId)
 				require.True(t, exists)
+				require.Equal(t, *tc.vaultParams, v)
 				if tc.shouldBeDefault {
-					require.Equal(t, types.DefaultQuotingParams(), p)
+					require.Equal(t, types.DefaultQuotingParams(), q)
 				} else {
-					require.Equal(t, *tc.vaultParams.QuotingParams, p)
+					require.Equal(t, *tc.vaultParams.QuotingParams, q)
 				}
 			} else {
-				_, exists := k.GetVaultQuotingParams(ctx, tc.vaultId)
+				_, _, exists := k.GetVaultAndQuotingParams(ctx, tc.vaultId)
 				require.False(t, exists)
 			}
 		})

--- a/protocol/x/vault/keeper/withdraw.go
+++ b/protocol/x/vault/keeper/withdraw.go
@@ -55,7 +55,7 @@ func (k Keeper) GetVaultWithdrawalSlippage(
 		)
 	}
 
-	quotingParams, exists := k.GetVaultQuotingParams(ctx, vaultId)
+	_, quotingParams, exists := k.GetVaultAndQuotingParams(ctx, vaultId)
 	if !exists {
 		return nil, types.ErrVaultParamsNotFound
 	}


### PR DESCRIPTION
### Changelist
in deactivated and stand-by mode, don't quote
in close-only mode: quote only if short or long

in another PR, i'm thinking:
1. when setting a vault to deactivated or stand-by, cancel its existing orders, if any

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced vault order management with improved status checks and order placement logic.
	- Introduced a new cancellation function for vault orders to streamline operations.
	- Updated function to retrieve both vault and quoting parameters for better clarity.

- **Bug Fixes**
	- Refined logic to prevent unnecessary order processing in inactive vault states.

- **Documentation**
	- Updated function names and return values for clarity regarding vault and quoting parameters.

- **Tests**
	- Expanded and restructured test cases to validate new functionalities and edge cases for vault orders and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->