### PR TITLE
disable deactivating vaults with positive equity

### DIFF
--- a/protocol/x/vault/keeper/msg_server_withdraw_from_megavault_test.go
+++ b/protocol/x/vault/keeper/msg_server_withdraw_from_megavault_test.go
@@ -160,7 +160,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 				{
 					id: constants.Vault_Clob0,
 					params: vaulttypes.VaultParams{
-						Status: vaulttypes.VaultStatus_VAULT_STATUS_DEACTIVATED,
+						Status: vaulttypes.VaultStatus_VAULT_STATUS_STAND_BY,
 					},
 					assetQuoteQuantums:   big.NewInt(400),
 					positionBaseQuantums: big.NewInt(0),

--- a/protocol/x/vault/keeper/orders_test.go
+++ b/protocol/x/vault/keeper/orders_test.go
@@ -66,7 +66,7 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 			},
 			activationThresholdQuoteQuantums: big.NewInt(1_000_000_000),
 		},
-		"Two Vaults, One Stand-By, One Deactivated, Both Above Activation Threshold": {
+		"Two Vaults, One Stand-By, One Deactivated, One Above Activation Threshold": {
 			vaultIds: []vaulttypes.VaultId{
 				constants.Vault_Clob0,
 				constants.Vault_Clob1,
@@ -77,7 +77,7 @@ func TestRefreshAllVaultOrders(t *testing.T) {
 			},
 			assetQuantums: []*big.Int{
 				big.NewInt(1_000_000_000), // 1,000 USDC
-				big.NewInt(1_000_000_001),
+				big.NewInt(0),
 			},
 			activationThresholdQuoteQuantums: big.NewInt(1_000_000_000),
 		},

--- a/protocol/x/vault/keeper/params.go
+++ b/protocol/x/vault/keeper/params.go
@@ -68,6 +68,13 @@ func (k Keeper) SetVaultParams(
 		return err
 	}
 
+	if vaultParams.Status == types.VaultStatus_VAULT_STATUS_DEACTIVATED {
+		vault := k.subaccountsKeeper.GetSubaccount(ctx, *vaultId.ToSubaccountId())
+		if vault.GetUsdcPosition().Sign() != 0 {
+			return types.ErrVaultDeactivation
+		}
+	}
+
 	b := k.cdc.MustMarshal(&vaultParams)
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.VaultParamsKeyPrefix))
 	store.Set(vaultId.ToStateKey(), b)

--- a/protocol/x/vault/keeper/params.go
+++ b/protocol/x/vault/keeper/params.go
@@ -69,9 +69,12 @@ func (k Keeper) SetVaultParams(
 	}
 
 	if vaultParams.Status == types.VaultStatus_VAULT_STATUS_DEACTIVATED {
-		vault := k.subaccountsKeeper.GetSubaccount(ctx, *vaultId.ToSubaccountId())
-		if vault.GetUsdcPosition().Sign() != 0 {
-			return types.ErrVaultDeactivation
+		vaultEquity, err := k.GetVaultEquity(ctx, vaultId)
+		if err != nil {
+			return err
+		}
+		if vaultEquity.Sign() > 0 {
+			return types.ErrDeactivatePositiveEquityVault
 		}
 	}
 

--- a/protocol/x/vault/keeper/vault_test.go
+++ b/protocol/x/vault/keeper/vault_test.go
@@ -37,7 +37,7 @@ func TestDecommissionNonPositiveEquityVaults(t *testing.T) {
 			},
 			statuses: []vaulttypes.VaultStatus{
 				vaulttypes.VaultStatus_VAULT_STATUS_QUOTING,
-				vaulttypes.VaultStatus_VAULT_STATUS_DEACTIVATED,
+				vaulttypes.VaultStatus_VAULT_STATUS_STAND_BY,
 			},
 			equities: []*big.Int{
 				big.NewInt(1),
@@ -464,7 +464,7 @@ func TestGetMegavaultEquity(t *testing.T) {
 			},
 			expectedMegavaultEquity: big.NewInt(1_345),
 		},
-		"Megavault subaccount with 1000 equity, One quoting vault with 345 equity, One deactivated vault with 5 equity,": {
+		"Megavault subaccount with 1000 equity, One quoting vault with 345 equity, One deactivated vault with -5 equity,": {
 			megavaultSaEquity: big.NewInt(1_000),
 			vaults: []vaulttypes.Vault{
 				{
@@ -482,9 +482,9 @@ func TestGetMegavaultEquity(t *testing.T) {
 			},
 			vaultEquities: []*big.Int{
 				big.NewInt(345),
-				big.NewInt(5),
+				big.NewInt(-5),
 			},
-			expectedMegavaultEquity: big.NewInt(1_350),
+			expectedMegavaultEquity: big.NewInt(1_345),
 		},
 	}
 	for name, tc := range tests {

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -145,9 +145,9 @@ var (
 		28,
 		"Insufficient redeemed quote quantums",
 	)
-	ErrVaultDeactivation = errorsmod.Register(
+	ErrDeactivatePositiveEquityVault = errorsmod.Register(
 		ModuleName,
 		29,
-		"Can only deactivate vaults with zero usdc",
+		"Cannot deactivate vaults with positive equity",
 	)
 )

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -145,4 +145,9 @@ var (
 		28,
 		"Insufficient redeemed quote quantums",
 	)
+	ErrVaultDeactivation = errorsmod.Register(
+		ModuleName,
+		29,
+		"Can only deactivate vaults with zero usdc",
+	)
 )


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a validation check to prevent deactivation of vaults with positive equity.
	- Added specific error messages for failed vault deactivation attempts.

- **Bug Fixes**
	- Enhanced error handling related to vault management, ensuring stricter compliance with deactivation rules.

- **Tests**
	- Expanded test cases to cover new scenarios around vault deactivation and equity conditions.
	- Updated test structure for clarity and alignment with new naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->