### PR TITLE
[OTE-815] Update GetTierForAffiliates and MsgRegisterAffiliates to handle empty tiers

### DIFF
--- a/protocol/x/affiliates/keeper/grpc_query_test.go
+++ b/protocol/x/affiliates/keeper/grpc_query_test.go
@@ -194,6 +194,8 @@ func TestReferredBy(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			err := k.UpdateAffiliateTiers(ctx, types.DefaultAffiliateTiers)
+			require.NoError(t, err)
 			tc.setup(ctx, k)
 			res, err := k.ReferredBy(ctx, tc.req)
 

--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -71,6 +71,14 @@ func (k Keeper) RegisterAffiliate(
 		return errorsmod.Wrapf(types.ErrAffiliateAlreadyExistsForReferee, "referee: %s, affiliate: %s",
 			referee, affiliateAddr)
 	}
+	affiliateTiers, err := k.GetAllAffiliateTiers(ctx)
+	if err != nil {
+		return err
+	}
+	// Return error if no tiers are set.
+	if len(affiliateTiers.GetTiers()) == 0 {
+		return errorsmod.Wrapf(types.ErrAffiliateTiersNotSet, "affiliate tiers are not set")
+	}
 	prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.ReferredByKeyPrefix)).Set([]byte(referee), []byte(affiliateAddr))
 	k.GetIndexerEventManager().AddTxnEvent(
 		ctx,
@@ -204,6 +212,10 @@ func (k Keeper) GetTierForAffiliate(
 		return 0, 0, err
 	}
 	tiers := affiliateTiers.GetTiers()
+	// Return 0 tier if no tiers are set.
+	if len(tiers) == 0 {
+		return 0, 0, errorsmod.Wrapf(types.ErrAffiliateTiersNotSet, "affiliate tiers are not set")
+	}
 	numTiers := uint32(len(tiers))
 	maxTierLevel := numTiers - 1
 	currentTier := uint32(0)

--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -214,7 +214,7 @@ func (k Keeper) GetTierForAffiliate(
 	tiers := affiliateTiers.GetTiers()
 	// Return 0 tier if no tiers are set.
 	if len(tiers) == 0 {
-		return 0, 0, errorsmod.Wrapf(types.ErrAffiliateTiersNotSet, "affiliate tiers are not set")
+		return 0, 0, nil
 	}
 	numTiers := uint32(len(tiers))
 	maxTierLevel := numTiers - 1

--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -77,7 +77,7 @@ func (k Keeper) RegisterAffiliate(
 	}
 	// Return error if no tiers are set.
 	if len(affiliateTiers.GetTiers()) == 0 {
-		return errorsmod.Wrapf(types.ErrAffiliateTiersNotSet, "affiliate tiers are not set")
+		return types.ErrAffiliateTiersNotSet
 	}
 	prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.ReferredByKeyPrefix)).Set([]byte(referee), []byte(affiliateAddr))
 	k.GetIndexerEventManager().AddTxnEvent(

--- a/protocol/x/affiliates/keeper/keeper_test.go
+++ b/protocol/x/affiliates/keeper/keeper_test.go
@@ -405,8 +405,10 @@ func TestRegisterAffiliateEmitEvent(t *testing.T) {
 
 	affiliate := constants.AliceAccAddress.String()
 	referee := constants.BobAccAddress.String()
+	err := k.UpdateAffiliateTiers(ctx, types.DefaultAffiliateTiers)
+	require.NoError(t, err)
 
-	err := k.RegisterAffiliate(ctx, referee, affiliate)
+	err = k.RegisterAffiliate(ctx, referee, affiliate)
 	require.NoError(t, err)
 	expectedEvent := &indexerevents.RegisterAffiliateEventV1{
 		Referee:   referee,
@@ -758,9 +760,12 @@ func TestAggregateAffiliateReferredVolumeForFills(t *testing.T) {
 			k := tApp.App.AffiliatesKeeper
 			statsKeeper := tApp.App.StatsKeeper
 
+			err := k.UpdateAffiliateTiers(ctx, types.DefaultAffiliateTiers)
+			require.NoError(t, err)
+
 			tc.setup(t, ctx, &k, &statsKeeper)
 
-			err := k.AggregateAffiliateReferredVolumeForFills(ctx)
+			err = k.AggregateAffiliateReferredVolumeForFills(ctx)
 			require.NoError(t, err)
 
 			referredVolume, err := k.GetReferredVolume(ctx, affiliate)

--- a/protocol/x/affiliates/keeper/msg_server_test.go
+++ b/protocol/x/affiliates/keeper/msg_server_test.go
@@ -77,10 +77,12 @@ func TestMsgServer_RegisterAffiliate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			k, ms, ctx := setupMsgServer(t)
 			sdkCtx := sdk.UnwrapSDKContext(ctx)
+			err := k.UpdateAffiliateTiers(sdkCtx, types.DefaultAffiliateTiers)
+			require.NoError(t, err)
 			if tc.setup != nil {
 				tc.setup(sdkCtx, k)
 			}
-			_, err := ms.RegisterAffiliate(ctx, tc.msg)
+			_, err = ms.RegisterAffiliate(ctx, tc.msg)
 			if tc.expectErr != nil {
 				require.ErrorIs(t, err, tc.expectErr)
 			} else {

--- a/protocol/x/affiliates/types/errors.go
+++ b/protocol/x/affiliates/types/errors.go
@@ -14,5 +14,5 @@ var (
 		ModuleName, 7, "Rev share safety violation")
 	ErrDuplicateAffiliateAddressForWhitelist = errorsmod.Register(
 		ModuleName, 8, "Duplicate affiliate address for whitelist")
-	ErrAffiliateTiersNotSet = errorsmod.Register(ModuleName, 9, "Affiliate tiers not set")
+	ErrAffiliateTiersNotSet = errorsmod.Register(ModuleName, 9, "Affiliate tiers not set (affiliate program is not active)")
 )

--- a/protocol/x/affiliates/types/errors.go
+++ b/protocol/x/affiliates/types/errors.go
@@ -14,5 +14,6 @@ var (
 		ModuleName, 7, "Rev share safety violation")
 	ErrDuplicateAffiliateAddressForWhitelist = errorsmod.Register(
 		ModuleName, 8, "Duplicate affiliate address for whitelist")
-	ErrAffiliateTiersNotSet = errorsmod.Register(ModuleName, 9, "Affiliate tiers not set (affiliate program is not active)")
+	ErrAffiliateTiersNotSet = errorsmod.Register(ModuleName, 9,
+		"Affiliate tiers not set (affiliate program is not active)")
 )

--- a/protocol/x/affiliates/types/errors.go
+++ b/protocol/x/affiliates/types/errors.go
@@ -14,4 +14,5 @@ var (
 		ModuleName, 7, "Rev share safety violation")
 	ErrDuplicateAffiliateAddressForWhitelist = errorsmod.Register(
 		ModuleName, 8, "Duplicate affiliate address for whitelist")
+	ErrAffiliateTiersNotSet = errorsmod.Register(ModuleName, 9, "Affiliate tiers not set")
 )

--- a/protocol/x/feetiers/keeper/keeper_test.go
+++ b/protocol/x/feetiers/keeper/keeper_test.go
@@ -7,6 +7,7 @@ import (
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	affiliateskeeper "github.com/dydxprotocol/v4-chain/protocol/x/affiliates/keeper"
+	affiliatetypes "github.com/dydxprotocol/v4-chain/protocol/x/affiliates/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
 	statskeeper "github.com/dydxprotocol/v4-chain/protocol/x/stats/keeper"
 	stattypes "github.com/dydxprotocol/v4-chain/protocol/x/stats/types"
@@ -247,6 +248,11 @@ func TestGetPerpetualFeePpm_Referral(t *testing.T) {
 
 			statsKeeper := tApp.App.StatsKeeper
 			affiliatesKeeper := tApp.App.AffiliatesKeeper
+
+			// common setup
+			err = affiliatesKeeper.UpdateAffiliateTiers(ctx, affiliatetypes.DefaultAffiliateTiers)
+			require.NoError(t, err)
+
 			if tc.setup != nil {
 				tc.setup(ctx, &affiliatesKeeper, &statsKeeper)
 			}

--- a/protocol/x/subaccounts/keeper/transfer_test.go
+++ b/protocol/x/subaccounts/keeper/transfer_test.go
@@ -1625,6 +1625,8 @@ func TestDistributeFees(t *testing.T) {
 					},
 				)
 			}
+			err = affiliatesKeeper.UpdateAffiliateTiers(ctx, affiliatetypes.DefaultAffiliateTiers)
+			require.NoError(t, err)
 			if tc.affiliateRevShareAcctAddr != "" {
 				err := affiliatesKeeper.RegisterAffiliate(ctx, refereeAccAddr, tc.affiliateRevShareAcctAddr)
 				require.NoError(t, err)


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced affiliate registration process to ensure predefined tiers are set before registration.
	- Introduced a specific error message for cases where affiliate tiers are not configured.

- **Bug Fixes**
	- Improved error handling for retrieving tier information when no tiers are available.

- **Tests**
	- Added new tests to validate behavior when no affiliate tiers are set, ensuring robust error handling and expected defaults.
	- Updated test setups to ensure affiliate tiers are initialized before executing tests, enhancing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->