### PR TITLE
emit transfer event on vault allocation, retrieval, and withdrawal

### DIFF
--- a/protocol/x/vault/keeper/deposit.go
+++ b/protocol/x/vault/keeper/deposit.go
@@ -65,7 +65,7 @@ func (k Keeper) MintShares(
 ) (mintedShares *big.Int, err error) {
 	// Quantums to deposit should be positive.
 	if quantumsToDeposit.Sign() <= 0 {
-		return nil, types.ErrInvalidDepositAmount
+		return nil, types.ErrInvalidQuoteQuantums
 	}
 	// Get existing TotalShares of the vault.
 	existingTotalShares := k.GetTotalShares(ctx).NumShares.BigInt()

--- a/protocol/x/vault/keeper/deposit_test.go
+++ b/protocol/x/vault/keeper/deposit_test.go
@@ -123,14 +123,14 @@ func TestMintShares(t *testing.T) {
 			totalShares:       big.NewInt(1),
 			owner:             constants.AliceAccAddress.String(),
 			quantumsToDeposit: big.NewInt(0),
-			expectedErr:       vaulttypes.ErrInvalidDepositAmount,
+			expectedErr:       vaulttypes.ErrInvalidQuoteQuantums,
 		},
 		"Equity 0, TotalShares 0, Deposit -1": {
 			equity:            big.NewInt(0),
 			totalShares:       big.NewInt(0),
 			owner:             constants.AliceAccAddress.String(),
 			quantumsToDeposit: big.NewInt(-1),
-			expectedErr:       vaulttypes.ErrInvalidDepositAmount,
+			expectedErr:       vaulttypes.ErrInvalidQuoteQuantums,
 		},
 		"Equity 1000, TotalShares 1, Deposit 100": {
 			equity:            big.NewInt(1_000),

--- a/protocol/x/vault/keeper/msg_server_allocate_to_vault.go
+++ b/protocol/x/vault/keeper/msg_server_allocate_to_vault.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	assetstypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
@@ -53,12 +54,14 @@ func (k msgServer) AllocateToVault(
 	}
 
 	// Transfer from main vault to the specified vault.
-	if err := k.Keeper.subaccountsKeeper.TransferFundsFromSubaccountToSubaccount(
+	if err := k.Keeper.sendingKeeper.ProcessTransfer(
 		ctx,
-		types.MegavaultMainSubaccount,
-		*msg.VaultId.ToSubaccountId(),
-		assetstypes.AssetUsdc.Id,
-		msg.QuoteQuantums.BigInt(),
+		&sendingtypes.Transfer{
+			Sender:    types.MegavaultMainSubaccount,
+			Recipient: *msg.VaultId.ToSubaccountId(),
+			AssetId:   assetstypes.AssetUsdc.Id,
+			Amount:    msg.QuoteQuantums.BigInt().Uint64(), // validated to be positive above.
+		},
 	); err != nil {
 		return nil, err
 	}

--- a/protocol/x/vault/keeper/msg_server_deposit_to_megavault_test.go
+++ b/protocol/x/vault/keeper/msg_server_deposit_to_megavault_test.go
@@ -211,7 +211,7 @@ func TestMsgDepositToMegavault(t *testing.T) {
 					depositAmount:           big.NewInt(0),
 					msgSigner:               constants.Alice_Num0.Owner,
 					checkTxFails:            true,
-					checkTxResponseContains: "Deposit amount is invalid",
+					checkTxResponseContains: vaulttypes.ErrInvalidQuoteQuantums.Error(),
 					expectedOwnerShares:     nil,
 				},
 				{
@@ -219,7 +219,7 @@ func TestMsgDepositToMegavault(t *testing.T) {
 					depositAmount:           big.NewInt(-1),
 					msgSigner:               constants.Bob_Num0.Owner,
 					checkTxFails:            true,
-					checkTxResponseContains: "Deposit amount is invalid",
+					checkTxResponseContains: vaulttypes.ErrInvalidQuoteQuantums.Error(),
 					expectedOwnerShares:     nil,
 				},
 				{
@@ -230,7 +230,7 @@ func TestMsgDepositToMegavault(t *testing.T) {
 					),
 					msgSigner:               constants.Bob_Num0.Owner,
 					checkTxFails:            true,
-					checkTxResponseContains: "Deposit amount is invalid",
+					checkTxResponseContains: vaulttypes.ErrInvalidQuoteQuantums.Error(),
 					expectedOwnerShares:     nil,
 				},
 			},

--- a/protocol/x/vault/keeper/msg_server_retrieve_from_vault.go
+++ b/protocol/x/vault/keeper/msg_server_retrieve_from_vault.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	assetstypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
 
@@ -33,12 +34,14 @@ func (k msgServer) RetrieveFromVault(
 	}
 
 	// Transfer from specified vault to main vault.
-	if err := k.Keeper.subaccountsKeeper.TransferFundsFromSubaccountToSubaccount(
+	if err := k.Keeper.sendingKeeper.ProcessTransfer(
 		ctx,
-		*msg.VaultId.ToSubaccountId(),
-		types.MegavaultMainSubaccount,
-		assetstypes.AssetUsdc.Id,
-		msg.QuoteQuantums.BigInt(),
+		&sendingtypes.Transfer{
+			Sender:    *msg.VaultId.ToSubaccountId(),
+			Recipient: types.MegavaultMainSubaccount,
+			AssetId:   assetstypes.AssetUsdc.Id,
+			Amount:    msg.QuoteQuantums.BigInt().Uint64(), // validated to be positive above.
+		},
 	); err != nil {
 		return nil, err
 	}

--- a/protocol/x/vault/keeper/msg_server_withdraw_from_megavault_test.go
+++ b/protocol/x/vault/keeper/msg_server_withdraw_from_megavault_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 	tests := map[string]struct {
 		/* --- Setup --- */
 		// Quote quantums that main vault has.
-		mainVaultBalance uint64
+		mainVaultBalance *big.Int
 		// Total shares before withdrawal.
 		totalShares uint64
 		// Owner address.
@@ -53,6 +54,10 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 		minQuoteQuantums int64
 
 		/* --- Expectations --- */
+		// A string that CheckTx response contains, if any.
+		checkTxResponseContains string
+		// Whether CheckTx should fail.
+		checkTxFails bool
 		// Whether DeliverTx should fail.
 		deliverTxFails bool
 		// Quote quantums that should be redeemed.
@@ -63,7 +68,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 		expectedOwnerShares uint64
 	}{
 		"Success: Withdraw some unlocked shares (5% of total), No sub-vaults, Redeemed quantums = Min quantums": {
-			mainVaultBalance:      100,
+			mainVaultBalance:      big.NewInt(100),
 			totalShares:           200,
 			owner:                 constants.AliceAccAddress.String(),
 			ownerTotalShares:      50,
@@ -76,7 +81,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 			expectedOwnerShares:   40,  // 50 - 10
 		},
 		"Success: Withdraw all unlocked shares (8% of total), No sub-vaults, Redeemed quantums > Min quantums": {
-			mainVaultBalance:      1_234,
+			mainVaultBalance:      big.NewInt(1_234),
 			totalShares:           500,
 			owner:                 constants.BobAccAddress.String(),
 			ownerTotalShares:      47,
@@ -89,7 +94,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 			expectedOwnerShares:   7,   // 47 - 40
 		},
 		"Success: Withdraw all shares (100% of total), No sub-vaults, Redeemed quantums = Min quantums": {
-			mainVaultBalance:      654_321,
+			mainVaultBalance:      big.NewInt(654_321),
 			totalShares:           787_565,
 			owner:                 constants.CarlAccAddress.String(),
 			ownerTotalShares:      787_565,
@@ -101,21 +106,21 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 			expectedTotalShares:   0,
 			expectedOwnerShares:   0,
 		},
-		"Success: Withdraw some unlocked shares (1% of total), No sub-vaults, Redeemed quantums rounds down to 0": {
-			mainVaultBalance:      99,
+		"Failure: Withdraw some unlocked shares (1% of total), No sub-vaults, Redeemed quantums rounds down to 0": {
+			mainVaultBalance:      big.NewInt(99),
 			totalShares:           200,
 			owner:                 constants.AliceAccAddress.String(),
 			ownerTotalShares:      10,
 			ownerLockedShares:     5,
 			sharesToWithdraw:      2,
-			minQuoteQuantums:      -1,
+			minQuoteQuantums:      0,
 			deliverTxFails:        true,
 			redeemedQuoteQuantums: 0,   // 99 * 2 / 200 = 0.99 ~= 0 (rounded down)
 			expectedTotalShares:   200, // unchanged
 			expectedOwnerShares:   10,  // unchanged
 		},
 		"Failure: Withdraw more than locked shares": {
-			mainVaultBalance:    100,
+			mainVaultBalance:    big.NewInt(100),
 			totalShares:         500,
 			owner:               constants.AliceAccAddress.String(),
 			ownerTotalShares:    100,
@@ -127,31 +132,33 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 			expectedOwnerShares: 100, // unchanged
 		},
 		"Failure: Withdraw zero shares": {
-			mainVaultBalance:    100,
-			totalShares:         500,
-			owner:               constants.AliceAccAddress.String(),
-			ownerTotalShares:    100,
-			ownerLockedShares:   20,
-			sharesToWithdraw:    0,
-			minQuoteQuantums:    1,
-			deliverTxFails:      true,
-			expectedTotalShares: 500, // unchanged
-			expectedOwnerShares: 100, // unchanged
+			mainVaultBalance:        big.NewInt(100),
+			totalShares:             500,
+			owner:                   constants.AliceAccAddress.String(),
+			ownerTotalShares:        100,
+			ownerLockedShares:       20,
+			sharesToWithdraw:        0,
+			minQuoteQuantums:        1,
+			checkTxResponseContains: vaulttypes.ErrNonPositiveShares.Error(),
+			checkTxFails:            true,
+			expectedTotalShares:     500, // unchanged
+			expectedOwnerShares:     100, // unchanged
 		},
 		"Failure: Withdraw negative shares": {
-			mainVaultBalance:    100,
-			totalShares:         500,
-			owner:               constants.AliceAccAddress.String(),
-			ownerTotalShares:    100,
-			ownerLockedShares:   20,
-			sharesToWithdraw:    -1,
-			minQuoteQuantums:    1,
-			deliverTxFails:      true,
-			expectedTotalShares: 500, // unchanged
-			expectedOwnerShares: 100, // unchanged
+			mainVaultBalance:        big.NewInt(100),
+			totalShares:             500,
+			owner:                   constants.AliceAccAddress.String(),
+			ownerTotalShares:        100,
+			ownerLockedShares:       20,
+			sharesToWithdraw:        -1,
+			minQuoteQuantums:        1,
+			checkTxResponseContains: vaulttypes.ErrNonPositiveShares.Error(),
+			checkTxFails:            true,
+			expectedTotalShares:     500, // unchanged
+			expectedOwnerShares:     100, // unchanged
 		},
 		"Failure: Withdraw some unlocked shares (8% of total), one sub-vault, Redeemed quantums < Min quantums": {
-			mainVaultBalance:  1_234,
+			mainVaultBalance:  big.NewInt(1_234),
 			totalShares:       500,
 			owner:             constants.BobAccAddress.String(),
 			ownerTotalShares:  47,
@@ -180,7 +187,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 		},
 		"Success: Withdraw some unlocked shares (0.4444% of total), 888_888 quantums in main vault, " +
 			"one quoting sub-vault with negative equity": {
-			mainVaultBalance:  888_888,
+			mainVaultBalance:  big.NewInt(888_888),
 			totalShares:       1_000_000,
 			owner:             constants.AliceAccAddress.String(),
 			ownerTotalShares:  9999,
@@ -201,7 +208,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 				},
 			},
 			sharesToWithdraw:      4444,
-			minQuoteQuantums:      -1,
+			minQuoteQuantums:      123,
 			deliverTxFails:        false,
 			redeemedQuoteQuantums: 3_950,   // 888_888 * 4444 / 1_000_000 ~= 3950 (sub-vault is skipped)
 			expectedTotalShares:   995_556, // 1_000_000 - 4444
@@ -209,7 +216,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 		},
 		"Success: Withdraw some unlocked shares (~0.67% of total), 0 quantums in main vault, " +
 			"one quoting sub-vault with 0 leverage": {
-			mainVaultBalance:  0,
+			mainVaultBalance:  big.NewInt(0),
 			totalShares:       987_654,
 			owner:             constants.AliceAccAddress.String(),
 			ownerTotalShares:  9999,
@@ -238,7 +245,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 		},
 		"Success: Withdraw some unlocked shares (10% of total), 500 quantums in main vault, " +
 			"one stand-by sub-vault with 0 leverage, one close-only sub-vault with 1.5 leverage": {
-			mainVaultBalance:  500,
+			mainVaultBalance:  big.NewInt(500),
 			totalShares:       1_000,
 			owner:             constants.AliceAccAddress.String(),
 			ownerTotalShares:  120,
@@ -295,7 +302,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 		},
 		"Success: Withdraw all shares (100% of total), 500 quantums in main vault, " +
 			"one close-only sub-vault with 1.5 leverage": {
-			mainVaultBalance:  500,
+			mainVaultBalance:  big.NewInt(500),
 			totalShares:       1_000,
 			owner:             constants.AliceAccAddress.String(),
 			ownerTotalShares:  1_000,
@@ -327,6 +334,22 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 			expectedTotalShares:   0,
 			expectedOwnerShares:   0,
 		},
+		"Failure: Withdraw more than max uint64": {
+			mainVaultBalance: new(big.Int).Add(
+				new(big.Int).SetUint64(math.MaxUint64),
+				new(big.Int).SetUint64(1),
+			),
+			totalShares:       155,
+			owner:             constants.CarlAccAddress.String(),
+			ownerTotalShares:  155,
+			ownerLockedShares: 0,
+			sharesToWithdraw:  155,
+			minQuoteQuantums:  1,
+			// fails as owner redeems more than max uint64 quote quantums.
+			deliverTxFails:      true,
+			expectedTotalShares: 155, // unchanged
+			expectedOwnerShares: 155, // unchanged
+		},
 	}
 
 	for name, tc := range tests {
@@ -343,7 +366,7 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 								AssetPositions: []*satypes.AssetPosition{
 									{
 										AssetId:  assetstypes.AssetUsdc.Id,
-										Quantums: dtypes.NewIntFromUint64(tc.mainVaultBalance),
+										Quantums: dtypes.NewIntFromBigInt(tc.mainVaultBalance),
 									},
 								},
 							},
@@ -479,6 +502,15 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 				&msgWithdrawFromMegavault,
 			)
 			checkTxResp := tApp.CheckTx(CheckTx_MsgWithdrawFromMegavault)
+			// Check that CheckTx response log contains expected string, if any.
+			if tc.checkTxResponseContains != "" {
+				require.Contains(t, checkTxResp.Log, tc.checkTxResponseContains)
+			}
+			// Check that CheckTx succeeds or errors out as expected.
+			if tc.checkTxFails {
+				require.Conditionf(t, checkTxResp.IsErr, "Expected CheckTx to error. Response: %+v", checkTxResp)
+				return
+			}
 			require.Conditionf(t, checkTxResp.IsOK, "Expected CheckTx to succeed. Response: %+v", checkTxResp)
 
 			// Advance to next block (and check that DeliverTx is as expected).

--- a/protocol/x/vault/keeper/withdraw.go
+++ b/protocol/x/vault/keeper/withdraw.go
@@ -11,6 +11,7 @@ import (
 	assetstypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
@@ -225,12 +226,25 @@ func (k Keeper) WithdrawFromMegavault(
 		redeemedFromSubVault.Mul(redeemedFromSubVault, new(big.Rat).Sub(lib.BigRat1(), slippage))
 		quantumsToTransfer := new(big.Int).Quo(redeemedFromSubVault.Num(), redeemedFromSubVault.Denom())
 
-		err = k.subaccountsKeeper.TransferFundsFromSubaccountToSubaccount(
+		if quantumsToTransfer.Sign() <= 0 || !quantumsToTransfer.IsUint64() {
+			log.InfoLog(
+				ctx,
+				"Megavault withdrawal: quantums to transfer is invalid. Skipping this vault",
+				"Vault ID",
+				vaultId,
+				"Quantums",
+				quantumsToTransfer,
+			)
+			continue
+		}
+		err = k.sendingKeeper.ProcessTransfer(
 			ctx,
-			*vaultId.ToSubaccountId(),
-			types.MegavaultMainSubaccount,
-			assetstypes.AssetUsdc.Id,
-			quantumsToTransfer,
+			&sendingtypes.Transfer{
+				Sender:    *vaultId.ToSubaccountId(),
+				Recipient: types.MegavaultMainSubaccount,
+				AssetId:   assetstypes.AssetUsdc.Id,
+				Amount:    quantumsToTransfer.Uint64(), // validated above.
+			},
 		)
 		if err != nil {
 			log.ErrorLogWithError(
@@ -250,8 +264,9 @@ func (k Keeper) WithdrawFromMegavault(
 		megavaultEquity.Add(megavaultEquity, equity)
 	}
 
-	// 4. Return error if redeemed quantums are non-positive or less than min quantums.
-	if redeemedQuoteQuantums.Sign() <= 0 || redeemedQuoteQuantums.Cmp(minQuoteQuantums) < 0 {
+	// 4. Return error if redeemed quantums is invalid.
+	if redeemedQuoteQuantums.Sign() <= 0 || !redeemedQuoteQuantums.IsUint64() ||
+		redeemedQuoteQuantums.Cmp(minQuoteQuantums) < 0 {
 		return nil, errorsmod.Wrapf(
 			types.ErrInsufficientRedeemedQuoteQuantums,
 			"redeemed quote quantums: %s, min quote quantums: %s",
@@ -261,12 +276,14 @@ func (k Keeper) WithdrawFromMegavault(
 	}
 
 	// 5. Transfer from main vault to destination subaccount.
-	err = k.subaccountsKeeper.TransferFundsFromSubaccountToSubaccount(
+	err = k.sendingKeeper.ProcessTransfer(
 		ctx,
-		types.MegavaultMainSubaccount,
-		toSubaccount,
-		assetstypes.AssetUsdc.Id,
-		redeemedQuoteQuantums,
+		&sendingtypes.Transfer{
+			Sender:    types.MegavaultMainSubaccount,
+			Recipient: toSubaccount,
+			AssetId:   assetstypes.AssetUsdc.Id,
+			Amount:    redeemedQuoteQuantums.Uint64(), // validated above.
+		},
 	)
 	if err != nil {
 		log.ErrorLogWithError(

--- a/protocol/x/vault/types/errors.go
+++ b/protocol/x/vault/types/errors.go
@@ -20,10 +20,10 @@ var (
 		3,
 		"MarketParam not found",
 	)
-	ErrInvalidDepositAmount = errorsmod.Register(
+	ErrInvalidQuoteQuantums = errorsmod.Register(
 		ModuleName,
 		4,
-		"Deposit amount is invalid",
+		"QuoteQuantums must be positive and less than 2^64",
 	)
 	ErrNonPositiveEquity = errorsmod.Register(
 		ModuleName,
@@ -149,5 +149,10 @@ var (
 		ModuleName,
 		29,
 		"Cannot deactivate vaults with positive equity",
+	)
+	ErrNonPositiveShares = errorsmod.Register(
+		ModuleName,
+		30,
+		"Shares must be positive",
 	)
 )

--- a/protocol/x/vault/types/expected_keepers.go
+++ b/protocol/x/vault/types/expected_keepers.go
@@ -111,11 +111,4 @@ type SubaccountsKeeper interface {
 		ctx sdk.Context,
 		id satypes.SubaccountId,
 	) satypes.Subaccount
-	TransferFundsFromSubaccountToSubaccount(
-		ctx sdk.Context,
-		senderSubaccountId satypes.SubaccountId,
-		recipientSubaccountId satypes.SubaccountId,
-		assetId uint32,
-		quantums *big.Int,
-	) error
 }

--- a/protocol/x/vault/types/msg_allocate_to_vault.go
+++ b/protocol/x/vault/types/msg_allocate_to_vault.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ types.Msg = &MsgAllocateToVault{}
+
+// ValidateBasic performs stateless validation on a MsgAllocateToVault.
+func (msg *MsgAllocateToVault) ValidateBasic() error {
+	if msg.Authority == "" {
+		return ErrInvalidAuthority
+	}
+
+	// Validate that quote quantums is positive and an uint64.
+	quoteQuantums := msg.QuoteQuantums.BigInt()
+	if quoteQuantums.Sign() <= 0 || !quoteQuantums.IsUint64() {
+		return ErrInvalidQuoteQuantums
+	}
+
+	return nil
+}

--- a/protocol/x/vault/types/msg_allocate_to_vault_test.go
+++ b/protocol/x/vault/types/msg_allocate_to_vault_test.go
@@ -1,0 +1,82 @@
+package types_test
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgAllocateToVault_ValidateBasic(t *testing.T) {
+	tests := map[string]struct {
+		msg         types.MsgAllocateToVault
+		expectedErr error
+	}{
+		"Success": {
+			msg: types.MsgAllocateToVault{
+				Authority:     constants.AliceAccAddress.String(),
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewInt(1),
+			},
+		},
+		"Success: max uint64 quote quantums": {
+			msg: types.MsgAllocateToVault{
+				Authority:     constants.GovAuthority,
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewIntFromUint64(math.MaxUint64),
+			},
+		},
+		"Failure: quote quantums greater than max uint64": {
+			msg: types.MsgAllocateToVault{
+				Authority: constants.GovAuthority,
+				VaultId:   constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewIntFromBigInt(
+					new(big.Int).Add(
+						new(big.Int).SetUint64(math.MaxUint64),
+						new(big.Int).SetUint64(1),
+					),
+				),
+			},
+			expectedErr: types.ErrInvalidQuoteQuantums,
+		},
+		"Failure: zero quote quantums": {
+			msg: types.MsgAllocateToVault{
+				Authority:     constants.GovAuthority,
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewInt(0),
+			},
+			expectedErr: types.ErrInvalidQuoteQuantums,
+		},
+		"Failure: negative quote quantums": {
+			msg: types.MsgAllocateToVault{
+				Authority:     constants.GovAuthority,
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewInt(-1),
+			},
+			expectedErr: types.ErrInvalidQuoteQuantums,
+		},
+		"Failure: empty authority": {
+			msg: types.MsgAllocateToVault{
+				Authority:     "",
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewInt(0),
+			},
+			expectedErr: types.ErrInvalidAuthority,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/protocol/x/vault/types/msg_deposit_to_megavault.go
+++ b/protocol/x/vault/types/msg_deposit_to_megavault.go
@@ -21,7 +21,10 @@ func (msg *MsgDepositToMegavault) ValidateBasic() error {
 	// Validate that quote quantums is positive and an uint64.
 	quoteQuantums := msg.QuoteQuantums.BigInt()
 	if quoteQuantums.Sign() <= 0 || !quoteQuantums.IsUint64() {
-		return errors.Wrap(ErrInvalidDepositAmount, "quote quantums must be strictly positive and less than 2^64")
+		return errors.Wrap(
+			ErrInvalidQuoteQuantums,
+			"quote quantums must be strictly positive and less than 2^64",
+		)
 	}
 
 	return nil

--- a/protocol/x/vault/types/msg_deposit_to_megavault_test.go
+++ b/protocol/x/vault/types/msg_deposit_to_megavault_test.go
@@ -39,21 +39,21 @@ func TestMsgDepositToMegavault_ValidateBasic(t *testing.T) {
 					),
 				),
 			},
-			expectedErr: "Deposit amount is invalid",
+			expectedErr: types.ErrInvalidQuoteQuantums.Error(),
 		},
 		"Failure: zero quote quantums": {
 			msg: types.MsgDepositToMegavault{
 				SubaccountId:  &constants.Alice_Num0,
 				QuoteQuantums: dtypes.NewInt(0),
 			},
-			expectedErr: "Deposit amount is invalid",
+			expectedErr: types.ErrInvalidQuoteQuantums.Error(),
 		},
 		"Failure: negative quote quantums": {
 			msg: types.MsgDepositToMegavault{
 				SubaccountId:  &constants.Alice_Num0,
 				QuoteQuantums: dtypes.NewInt(-1),
 			},
-			expectedErr: "Deposit amount is invalid",
+			expectedErr: types.ErrInvalidQuoteQuantums.Error(),
 		},
 		"Failure: invalid subaccount owner": {
 			msg: types.MsgDepositToMegavault{

--- a/protocol/x/vault/types/msg_retrieve_from_vault.go
+++ b/protocol/x/vault/types/msg_retrieve_from_vault.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ types.Msg = &MsgRetrieveFromVault{}
+
+// ValidateBasic performs stateless validation on a MsgRetrieveFromVault.
+func (msg *MsgRetrieveFromVault) ValidateBasic() error {
+	if msg.Authority == "" {
+		return ErrInvalidAuthority
+	}
+
+	// Validate that quote quantums is positive and an uint64.
+	quoteQuantums := msg.QuoteQuantums.BigInt()
+	if quoteQuantums.Sign() <= 0 || !quoteQuantums.IsUint64() {
+		return ErrInvalidQuoteQuantums
+	}
+
+	return nil
+}

--- a/protocol/x/vault/types/msg_retrieve_from_vault_test.go
+++ b/protocol/x/vault/types/msg_retrieve_from_vault_test.go
@@ -1,0 +1,82 @@
+package types_test
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgRetrieveFromVault_ValidateBasic(t *testing.T) {
+	tests := map[string]struct {
+		msg         types.MsgRetrieveFromVault
+		expectedErr error
+	}{
+		"Success": {
+			msg: types.MsgRetrieveFromVault{
+				Authority:     constants.AliceAccAddress.String(),
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewInt(1),
+			},
+		},
+		"Success: max uint64 quote quantums": {
+			msg: types.MsgRetrieveFromVault{
+				Authority:     constants.GovAuthority,
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewIntFromUint64(math.MaxUint64),
+			},
+		},
+		"Failure: quote quantums greater than max uint64": {
+			msg: types.MsgRetrieveFromVault{
+				Authority: constants.GovAuthority,
+				VaultId:   constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewIntFromBigInt(
+					new(big.Int).Add(
+						new(big.Int).SetUint64(math.MaxUint64),
+						new(big.Int).SetUint64(1),
+					),
+				),
+			},
+			expectedErr: types.ErrInvalidQuoteQuantums,
+		},
+		"Failure: zero quote quantums": {
+			msg: types.MsgRetrieveFromVault{
+				Authority:     constants.GovAuthority,
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewInt(0),
+			},
+			expectedErr: types.ErrInvalidQuoteQuantums,
+		},
+		"Failure: negative quote quantums": {
+			msg: types.MsgRetrieveFromVault{
+				Authority:     constants.GovAuthority,
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewInt(-1),
+			},
+			expectedErr: types.ErrInvalidQuoteQuantums,
+		},
+		"Failure: empty authority": {
+			msg: types.MsgRetrieveFromVault{
+				Authority:     "",
+				VaultId:       constants.Vault_Clob0,
+				QuoteQuantums: dtypes.NewInt(0),
+			},
+			expectedErr: types.ErrInvalidAuthority,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/protocol/x/vault/types/msg_withdraw_from_megavault.go
+++ b/protocol/x/vault/types/msg_withdraw_from_megavault.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ types.Msg = &MsgWithdrawFromMegavault{}
+
+// ValidateBasic performs stateless validation on a MsgWithdrawFromMegavault.
+func (msg *MsgWithdrawFromMegavault) ValidateBasic() error {
+	// Validate subaccount to withdraw to.
+	if err := msg.SubaccountId.Validate(); err != nil {
+		return err
+	}
+
+	// Validate that shares is positive.
+	if msg.Shares.NumShares.Sign() <= 0 {
+		return ErrNonPositiveShares
+	}
+
+	// Validate that min quote quantums is non-negative and an uint64.
+	quoteQuantums := msg.MinQuoteQuantums.BigInt()
+	if quoteQuantums.Sign() < 0 || !quoteQuantums.IsUint64() {
+		return errors.Wrap(
+			ErrInvalidQuoteQuantums,
+			"min quote quantums must be non-negative and less than 2^64",
+		)
+	}
+
+	return nil
+}

--- a/protocol/x/vault/types/msg_withdraw_from_megavault_test.go
+++ b/protocol/x/vault/types/msg_withdraw_from_megavault_test.go
@@ -1,0 +1,117 @@
+package types_test
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgWithdrawFromMegavault_ValidateBasic(t *testing.T) {
+	tests := map[string]struct {
+		msg         types.MsgWithdrawFromMegavault
+		expectedErr string
+	}{
+		"Success": {
+			msg: types.MsgWithdrawFromMegavault{
+				SubaccountId: constants.Alice_Num0,
+				Shares: types.NumShares{
+					NumShares: dtypes.NewInt(1),
+				},
+				MinQuoteQuantums: dtypes.NewInt(1),
+			},
+		},
+		"Success: zero quote quantums": {
+			msg: types.MsgWithdrawFromMegavault{
+				SubaccountId: constants.Alice_Num0,
+				Shares: types.NumShares{
+					NumShares: dtypes.NewInt(1),
+				},
+				MinQuoteQuantums: dtypes.NewInt(0),
+			},
+		},
+		"Success: max uint64 quote quantums": {
+			msg: types.MsgWithdrawFromMegavault{
+				SubaccountId: constants.Alice_Num0,
+				Shares: types.NumShares{
+					NumShares: dtypes.NewInt(1),
+				},
+				MinQuoteQuantums: dtypes.NewIntFromUint64(math.MaxUint64),
+			},
+		},
+		"Failure: quote quantums greater than max uint64": {
+			msg: types.MsgWithdrawFromMegavault{
+				SubaccountId: constants.Alice_Num0,
+				Shares: types.NumShares{
+					NumShares: dtypes.NewInt(1),
+				},
+				MinQuoteQuantums: dtypes.NewIntFromBigInt(
+					new(big.Int).Add(
+						new(big.Int).SetUint64(math.MaxUint64),
+						new(big.Int).SetUint64(1),
+					),
+				),
+			},
+			expectedErr: types.ErrInvalidQuoteQuantums.Error(),
+		},
+		"Failure: negative quote quantums": {
+			msg: types.MsgWithdrawFromMegavault{
+				SubaccountId: constants.Alice_Num0,
+				Shares: types.NumShares{
+					NumShares: dtypes.NewInt(1),
+				},
+				MinQuoteQuantums: dtypes.NewInt(-1),
+			},
+			expectedErr: types.ErrInvalidQuoteQuantums.Error(),
+		},
+		"Failure: zero shares": {
+			msg: types.MsgWithdrawFromMegavault{
+				SubaccountId: constants.Alice_Num0,
+				Shares: types.NumShares{
+					NumShares: dtypes.NewInt(0),
+				},
+				MinQuoteQuantums: dtypes.NewInt(0),
+			},
+			expectedErr: types.ErrNonPositiveShares.Error(),
+		},
+		"Failure: negative shares": {
+			msg: types.MsgWithdrawFromMegavault{
+				SubaccountId: constants.Alice_Num0,
+				Shares: types.NumShares{
+					NumShares: dtypes.NewInt(-1),
+				},
+				MinQuoteQuantums: dtypes.NewInt(0),
+			},
+			expectedErr: types.ErrNonPositiveShares.Error(),
+		},
+		"Failure: invalid subaccount owner": {
+			msg: types.MsgWithdrawFromMegavault{
+				SubaccountId: satypes.SubaccountId{
+					Owner:  "invalid-owner",
+					Number: 0,
+				},
+				Shares: types.NumShares{
+					NumShares: dtypes.NewInt(1),
+				},
+				MinQuoteQuantums: dtypes.NewInt(0),
+			},
+			expectedErr: "subaccount id owner is an invalid address",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for positive `QuoteQuantums` in vault allocation and retrieval processes.
	- Introduced a structured transfer mechanism for fund transfers, improving clarity and reliability.
	- Added new message types for vault operations, including `MsgAllocateToVault`, `MsgRetrieveFromVault`, and `MsgWithdrawFromMegavault`.

- **Bug Fixes**
	- Updated error handling for scenarios with zero or negative `QuoteQuantums`, ensuring invalid operations are prevented.

- **Tests**
	- Expanded test cases for error handling in allocation and retrieval processes, ensuring robustness against invalid inputs.
	- Introduced comprehensive tests for new message types to validate their functionality and error handling.

- **Chores**
	- Added a new error variable for improved error handling related to `QuoteQuantums`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->