### PR TITLE
Add event for swept funds.

### DIFF
--- a/protocol/x/vault/keeper/sweep_funds.go
+++ b/protocol/x/vault/keeper/sweep_funds.go
@@ -45,4 +45,10 @@ func (k Keeper) SweepMainVaultBankBalance(
 		)
 		return
 	}
+
+	ctx.EventManager().EmitEvent(
+		types.NewSweepToMegavaultEvent(
+			mainVaultBalance.Amount.BigInt().Uint64(),
+		),
+	)
 }

--- a/protocol/x/vault/types/events.go
+++ b/protocol/x/vault/types/events.go
@@ -19,6 +19,9 @@ const (
 	AttributeKeyTotalShares           = "total_shares"
 	AttributeKeyMegavaultEquity       = "megavault_equity"
 	AttributeKeyRedeemedQuoteQuantums = "redeemed_quote_quantums"
+
+	EventTypeSweepToMegavault      = "sweep_to_megavault"
+	AttributeKeySweptQuoteQuantums = "swept_quote_quantums"
 )
 
 // NewDepositToMegavaultEvent constructs a new deposit_to_megavault sdk.Event.
@@ -50,5 +53,14 @@ func NewWithdrawFromMegavaultEvent(
 		sdk.NewAttribute(AttributeKeyTotalShares, fmt.Sprintf("%d", totalShares)),
 		sdk.NewAttribute(AttributeKeyMegavaultEquity, fmt.Sprintf("%d", megavaultEquity)),
 		sdk.NewAttribute(AttributeKeyRedeemedQuoteQuantums, fmt.Sprintf("%d", redeemedQuoteQuantums)),
+	)
+}
+
+func NewSweepToMegavaultEvent(
+	quoteQuantums uint64,
+) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeSweepToMegavault,
+		sdk.NewAttribute(AttributeKeySweptQuoteQuantums, fmt.Sprintf("%d", quoteQuantums)),
 	)
 }


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced event emission for fund sweeping to the megavault, enhancing notification capabilities.
	- Added a new event type for sweeping quote quantums to the megavault, improving event handling.

- **Bug Fixes**
	- No specific bug fixes noted in this release. 

- **Documentation**
	- Updated documentation to reflect new event types and attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->