### PR TITLE
exclude deactivated vaults from megavault equity

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/vault.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/vault/vault.ts
@@ -55,7 +55,10 @@ export enum VaultStatus {
   /** VAULT_STATUS_UNSPECIFIED - Default value, invalid and unused. */
   VAULT_STATUS_UNSPECIFIED = 0,
 
-  /** VAULT_STATUS_DEACTIVATED - Don’t place orders. Does not count toward global vault balances. */
+  /**
+   * VAULT_STATUS_DEACTIVATED - Don’t place orders. Does not count toward global vault balances.
+   * A vault can only be set to this status if its equity is non-positive.
+   */
   VAULT_STATUS_DEACTIVATED = 1,
 
   /** VAULT_STATUS_STAND_BY - Don’t place orders. Does count towards global vault balances. */
@@ -74,7 +77,10 @@ export enum VaultStatusSDKType {
   /** VAULT_STATUS_UNSPECIFIED - Default value, invalid and unused. */
   VAULT_STATUS_UNSPECIFIED = 0,
 
-  /** VAULT_STATUS_DEACTIVATED - Don’t place orders. Does not count toward global vault balances. */
+  /**
+   * VAULT_STATUS_DEACTIVATED - Don’t place orders. Does not count toward global vault balances.
+   * A vault can only be set to this status if its equity is non-positive.
+   */
   VAULT_STATUS_DEACTIVATED = 1,
 
   /** VAULT_STATUS_STAND_BY - Don’t place orders. Does count towards global vault balances. */

--- a/proto/dydxprotocol/vault/vault.proto
+++ b/proto/dydxprotocol/vault/vault.proto
@@ -27,6 +27,7 @@ enum VaultStatus {
   VAULT_STATUS_UNSPECIFIED = 0;
 
   // Don’t place orders. Does not count toward global vault balances.
+  // A vault can only be set to this status if its equity is non-positive.
   VAULT_STATUS_DEACTIVATED = 1;
 
   // Don’t place orders. Does count towards global vault balances.

--- a/protocol/x/vault/keeper/msg_server_withdraw_from_megavault_test.go
+++ b/protocol/x/vault/keeper/msg_server_withdraw_from_megavault_test.go
@@ -185,6 +185,34 @@ func TestMsgWithdrawFromMegavault(t *testing.T) {
 			expectedTotalShares:   500, // unchanged
 			expectedOwnerShares:   47,  // unchanged
 		},
+		"Success: Withdraw some unlocked shares (8% of total), one deactivated sub-vault is excluded": {
+			mainVaultBalance:  big.NewInt(1_234),
+			totalShares:       500,
+			owner:             constants.DaveAccAddress.String(),
+			ownerTotalShares:  47,
+			ownerLockedShares: 7,
+			vaults: []VaultSetup{
+				{
+					id: constants.Vault_Clob0,
+					params: vaulttypes.VaultParams{
+						Status: vaulttypes.VaultStatus_VAULT_STATUS_DEACTIVATED,
+					},
+					assetQuoteQuantums:   big.NewInt(-400),
+					positionBaseQuantums: big.NewInt(0),
+					clobPair:             constants.ClobPair_Btc,
+					perpetual:            constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+					marketParam:          constants.TestMarketParams[0],
+					marketPrice:          constants.TestMarketPrices[0],
+					postWithdrawalEquity: big.NewInt(-400), // unchanged
+				},
+			},
+			sharesToWithdraw:      40,
+			minQuoteQuantums:      50,
+			deliverTxFails:        false,
+			redeemedQuoteQuantums: 98,  // 1234 * 0.08 = 98.72 ~= 98 (rounded down)
+			expectedTotalShares:   460, // 500 - 40
+			expectedOwnerShares:   7,   // 47 - 40
+		},
 		"Success: Withdraw some unlocked shares (0.4444% of total), 888_888 quantums in main vault, " +
 			"one quoting sub-vault with negative equity": {
 			mainVaultBalance:  big.NewInt(888_888),

--- a/protocol/x/vault/keeper/vault.go
+++ b/protocol/x/vault/keeper/vault.go
@@ -18,7 +18,7 @@ import (
 
 // GetMegavaultEquity returns the equity of the megavault (in quote quantums), which consists of
 // - equity of the megavault main subaccount
-// - equity of all vaults (if positive)
+// - equity of all vaults (if not-deactivated and positive)
 func (k Keeper) GetMegavaultEquity(ctx sdk.Context) (*big.Int, error) {
 	megavaultEquity, err := k.GetSubaccountEquity(ctx, types.MegavaultMainSubaccount)
 	if err != nil {
@@ -31,6 +31,10 @@ func (k Keeper) GetMegavaultEquity(ctx sdk.Context) (*big.Int, error) {
 	for ; vaultParamsIterator.Valid(); vaultParamsIterator.Next() {
 		var vaultParams types.VaultParams
 		k.cdc.MustUnmarshal(vaultParamsIterator.Value(), &vaultParams)
+
+		if vaultParams.Status == types.VaultStatus_VAULT_STATUS_DEACTIVATED {
+			continue
+		}
 
 		vaultId, err := types.GetVaultIdFromStateKey(vaultParamsIterator.Key())
 		if err != nil {

--- a/protocol/x/vault/keeper/vault_test.go
+++ b/protocol/x/vault/keeper/vault_test.go
@@ -484,7 +484,7 @@ func TestGetMegavaultEquity(t *testing.T) {
 				big.NewInt(345),
 				big.NewInt(-5),
 			},
-			expectedMegavaultEquity: big.NewInt(1_345),
+			expectedMegavaultEquity: big.NewInt(1_345), // deactivated vault is not counted.
 		},
 	}
 	for name, tc := range tests {

--- a/protocol/x/vault/types/vault.pb.go
+++ b/protocol/x/vault/types/vault.pb.go
@@ -57,6 +57,7 @@ const (
 	// Default value, invalid and unused.
 	VaultStatus_VAULT_STATUS_UNSPECIFIED VaultStatus = 0
 	// Don’t place orders. Does not count toward global vault balances.
+	// A vault can only be set to this status if its equity is non-positive.
 	VaultStatus_VAULT_STATUS_DEACTIVATED VaultStatus = 1
 	// Don’t place orders. Does count towards global vault balances.
 	VaultStatus_VAULT_STATUS_STAND_BY VaultStatus = 2


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for `VAULT_STATUS_DEACTIVATED`, clarifying conditions for vault deactivation.
	- Added a new test case for withdrawing shares from a megavault, excluding deactivated sub-vaults.

- **Bug Fixes**
	- Improved logic in equity calculations to exclude deactivated vaults.

- **Documentation**
	- Updated comments to reflect changes in vault processing and equity calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->