### PR TITLE
feat: usdt protection in antehandler

### DIFF
--- a/protocol/app/ante.go
+++ b/protocol/app/ante.go
@@ -103,6 +103,10 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrLogic, "prices keeper is required for ante builder")
 	}
 
+	if options.MarketMapKeeper == nil {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrLogic, "market map keeper is required for ante builder")
+	}
+
 	h := &lockingAnteHandler{
 		authStoreKey:             options.AuthStoreKey,
 		setupContextDecorator:    ante.NewSetUpContextDecorator(),

--- a/protocol/app/ante/market_update.go
+++ b/protocol/app/ante/market_update.go
@@ -15,8 +15,8 @@ import (
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
-var ErrNoCrossMarketUpdates = errors.New("cannot call MsgUpdateMarkets or MsgUpsertMarkets " +
-	"on a market listed as cross margin")
+var ErrRestrictedMarketUpdates = errors.New("cannot call MsgUpdateMarkets or MsgUpsertMarkets " +
+	"on a restricted market")
 
 type MarketMapKeeper interface {
 	GetAllMarkets(ctx sdk.Context) (map[string]mmtypes.Market, error)
@@ -89,7 +89,7 @@ func (d ValidateMarketUpdateDecorator) AnteHandle(
 	}
 
 	if contains, ticker := d.doMarketsContainRestrictedMarket(ctx, markets); contains {
-		return ctx, fmt.Errorf("%w: %s", ErrNoCrossMarketUpdates, ticker)
+		return ctx, fmt.Errorf("%w: %s", ErrRestrictedMarketUpdates, ticker)
 	}
 
 	// check if the market updates are safe

--- a/protocol/app/ante/market_update.go
+++ b/protocol/app/ante/market_update.go
@@ -76,8 +76,6 @@ func (d ValidateMarketUpdateDecorator) AnteHandle(
 		markets = msg.UpdateMarkets
 	case *mmtypes.MsgUpsertMarkets:
 		markets = msg.Markets
-	case *mmtypes.MsgCreateMarkets:
-		markets = msg.CreateMarkets
 	default:
 		return ctx, fmt.Errorf("unrecognized message type: %T", msg)
 	}

--- a/protocol/app/ante/market_update.go
+++ b/protocol/app/ante/market_update.go
@@ -92,7 +92,10 @@ func (d ValidateMarketUpdateDecorator) AnteHandle(
 	return next(ctx, tx, simulate)
 }
 
-func (d ValidateMarketUpdateDecorator) doMarketsContainRestrictedMarket(ctx sdk.Context, markets []mmtypes.Market) bool {
+func (d ValidateMarketUpdateDecorator) doMarketsContainRestrictedMarket(
+	ctx sdk.Context,
+	markets []mmtypes.Market,
+) bool {
 	// Grab all the perpetuals markets
 	perps := d.perpKeeper.GetAllPerpetuals(ctx)
 	restrictedMap := make(map[string]bool, len(perps))
@@ -107,7 +110,8 @@ func (d ValidateMarketUpdateDecorator) doMarketsContainRestrictedMarket(ctx sdk.
 		if err != nil {
 			continue
 		}
-		restrictedMap[cp.String()] = perp.Params.MarketType == perpetualstypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS
+		restrictedMap[cp.String()] = perp.Params.MarketType == perpetualstypes.
+			PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS
 	}
 
 	// add usdt/usd market to be restricted

--- a/protocol/app/ante/market_update_test.go
+++ b/protocol/app/ante/market_update_test.go
@@ -745,7 +745,7 @@ func TestValidateMarketUpdateDecorator_AnteHandle(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "always reject USDT/USD - simulate",
+			name: "always reject USDT/USD - simulate - upsert",
 			args: args{
 				msgs: []sdk.Msg{
 					&mmtypes.MsgUpsertMarkets{
@@ -760,7 +760,37 @@ func TestValidateMarketUpdateDecorator_AnteHandle(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "always reject USDT/USD",
+			name: "always reject USDT/USD - upsert",
+			args: args{
+				msgs: []sdk.Msg{
+					&mmtypes.MsgUpsertMarkets{
+						Authority: constants.BobAccAddress.String(),
+						Markets: []mmtypes.Market{
+							testUSDTUSDMarket,
+						},
+					},
+				},
+				simulate: false,
+			},
+			wantErr: true,
+		},
+		{
+			name: "always reject USDT/USD - simulate - update",
+			args: args{
+				msgs: []sdk.Msg{
+					&mmtypes.MsgUpdateMarkets{
+						Authority: constants.BobAccAddress.String(),
+						UpdateMarkets: []mmtypes.Market{
+							testUSDTUSDMarket,
+						},
+					},
+				},
+				simulate: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "always reject USDT/USD - update",
 			args: args{
 				msgs: []sdk.Msg{
 					&mmtypes.MsgUpdateMarkets{

--- a/protocol/app/ante/market_update_test.go
+++ b/protocol/app/ante/market_update_test.go
@@ -211,6 +211,25 @@ var (
 		},
 	}
 
+	testUSDTUSDMarket = mmtypes.Market{
+		Ticker: mmtypes.Ticker{
+			CurrencyPair: types.CurrencyPair{
+				Base:  "USDT",
+				Quote: "USD",
+			},
+			Decimals:         1,
+			MinProviderCount: 1,
+			Enabled:          true,
+			Metadata_JSON:    "",
+		},
+		ProviderConfigs: []mmtypes.ProviderConfig{
+			{
+				Name:           "test_provider",
+				OffChainTicker: "USDT/USD",
+			},
+		},
+	}
+
 	enabledTestMarketWithProviderConfig = mmtypes.Market{
 		Ticker: mmtypes.Ticker{
 			CurrencyPair: types.CurrencyPair{
@@ -724,6 +743,36 @@ func TestValidateMarketUpdateDecorator_AnteHandle(t *testing.T) {
 				marketMapMarkets: []mmtypes.Market{testMarket},
 			},
 			wantErr: false,
+		},
+		{
+			name: "always reject USDT/USD - simulate",
+			args: args{
+				msgs: []sdk.Msg{
+					&mmtypes.MsgUpsertMarkets{
+						Authority: constants.BobAccAddress.String(),
+						Markets: []mmtypes.Market{
+							testUSDTUSDMarket,
+						},
+					},
+				},
+				simulate: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "always reject USDT/USD",
+			args: args{
+				msgs: []sdk.Msg{
+					&mmtypes.MsgUpdateMarkets{
+						Authority: constants.BobAccAddress.String(),
+						UpdateMarkets: []mmtypes.Market{
+							testUSDTUSDMarket,
+						},
+					},
+				},
+				simulate: false,
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/protocol/app/ante/market_update_test.go
+++ b/protocol/app/ante/market_update_test.go
@@ -1,32 +1,31 @@
 package ante_test
 
 import (
-	storetypes "cosmossdk.io/store/types"
 	"math/rand"
 	"testing"
 
 	sdkmath "cosmossdk.io/math"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
-	assets "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
-	perpetualtypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
-	prices_types "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
-	"github.com/skip-mev/slinky/pkg/types"
-	mmtypes "github.com/skip-mev/slinky/x/marketmap/types"
-
+	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/skip-mev/slinky/pkg/types"
+	mmtypes "github.com/skip-mev/slinky/x/marketmap/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dydxprotocol/v4-chain/protocol/app/ante"
+	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	slinkylib "github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
 	testante "github.com/dydxprotocol/v4-chain/protocol/testutil/ante"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	assets "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
+	perpetualtypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	prices_types "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
 func TestIsMarketUpdateTx(t *testing.T) {

--- a/protocol/app/ante_test.go
+++ b/protocol/app/ante_test.go
@@ -29,6 +29,7 @@ func newHandlerOptions() app.HandlerOptions {
 		AuthStoreKey:      dydxApp.CommitMultiStore().(*rootmulti.Store).StoreKeysByName()[authtypes.StoreKey],
 		PerpetualsKeeper:  dydxApp.PerpetualsKeeper,
 		PricesKeeper:      dydxApp.PricesKeeper,
+		MarketMapKeeper:   &dydxApp.MarketMapKeeper,
 	}
 }
 
@@ -59,6 +60,10 @@ func TestNewAnteHandler_Error(t *testing.T) {
 		"nil PricesKeeper": {
 			handlerMutation: func(options *app.HandlerOptions) { options.PricesKeeper = nil },
 			errorMsg:        "prices keeper is required for ante builder",
+		},
+		"nil MarketMapKeeper": {
+			handlerMutation: func(options *app.HandlerOptions) { options.MarketMapKeeper = nil },
+			errorMsg:        "market map keeper is required for ante builder",
 		},
 		"nil handlerOptions.SignModeHandler": {
 			handlerMutation: func(options *app.HandlerOptions) { options.SignModeHandler = nil },


### PR DESCRIPTION
### Changelist
- Update the `doMarketsContainCrossMarket` to `doMarketsContainRestrictedMarket` where USDT/USD is additional restricted market (regardless of having a CROSS perp on it or not).
- Require the MarketMapKeeper to be passed to the antehandler (previously did not have a check)

### Test Plan

- Tested in antehandler tests
- full e2e test can be made with a market update transaction against a node

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added validation for the presence of the MarketMapKeeper in the ante handler.
	- Introduced a new variable for the USDT/USD currency pair and updated market validation logic to identify restricted markets.

- **Bug Fixes**
	- Enhanced error reporting for restricted markets in the ante handling process.

- **Tests**
	- Added test cases to validate market updates for the USDT/USD currency pair, ensuring proper rejection logic is in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->