### PR TITLE
[OTE-823] Fix FNS onchain events staging + retrieval logic

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -2095,6 +2095,7 @@ func getFullNodeStreamingManagerFromOptions(
 			appFlags.GrpcStreamingMaxChannelBufferSize,
 			appFlags.FullNodeStreamingSnapshotInterval,
 			streamingManagerTransientStoreKey,
+			cdc,
 		)
 
 		// Start websocket server.

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -163,10 +163,6 @@ func (f *Flags) Validate() error {
 
 	// Grpc streaming
 	if f.GrpcStreamingEnabled {
-		if f.OptimisticExecutionEnabled {
-			// TODO(OTE-456): Finish gRPC streaming x OE integration.
-			return fmt.Errorf("grpc streaming cannot be enabled together with optimistic execution")
-		}
 		if !f.GrpcEnable {
 			return fmt.Errorf("grpc.enable must be set to true - grpc streaming requires gRPC server")
 		}

--- a/protocol/app/flags/flags_test.go
+++ b/protocol/app/flags/flags_test.go
@@ -113,14 +113,17 @@ func TestValidate(t *testing.T) {
 				OptimisticExecutionEnabled: true,
 			},
 		},
-		"failure - optimistic execution cannot be enabled with gRPC streaming": {
+		"success - optimistic execution canbe  enabled with gRPC streaming": {
 			flags: flags.Flags{
-				NonValidatingFullNode:      false,
-				GrpcEnable:                 true,
-				GrpcStreamingEnabled:       true,
-				OptimisticExecutionEnabled: true,
+				NonValidatingFullNode:             false,
+				GrpcEnable:                        true,
+				GrpcStreamingEnabled:              true,
+				OptimisticExecutionEnabled:        true,
+				GrpcStreamingMaxBatchSize:         2000,
+				GrpcStreamingFlushIntervalMs:      100,
+				GrpcStreamingMaxChannelBufferSize: 2000,
+				WebsocketStreamingPort:            8989,
 			},
-			expectedErr: fmt.Errorf("grpc streaming cannot be enabled together with optimistic execution"),
 		},
 		"failure - gRPC disabled": {
 			flags: flags.Flags{

--- a/protocol/x/clob/module.go
+++ b/protocol/x/clob/module.go
@@ -178,6 +178,16 @@ func (am AppModule) PreBlock(ctx context.Context) (appmodule.ResponsePreBlock, e
 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the clob module.
+func (am AppModule) Precommit(ctx context.Context) error {
+	defer telemetry.ModuleMeasureSince(am.Name(), time.Now(), telemetry.MetricKeyPrecommiter)
+	Precommit(
+		lib.UnwrapSDKContext(ctx, types.ModuleName),
+		*am.keeper,
+	)
+	return nil
+}
+
+// BeginBlock executes all ABCI BeginBlock logic respective to the clob module.
 func (am AppModule) BeginBlock(ctx context.Context) error {
 	defer telemetry.ModuleMeasureSince(am.Name(), time.Now(), telemetry.MetricKeyBeginBlocker)
 	BeginBlocker(


### PR DESCRIPTION
### Changelist
Fix FNS onchain events staging + retrieval logic. 

### Test Plan
Tested by running FNS + load-testing locally. 

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method `Precommit` for enhanced ABCI Precommit logic in the clob module.
	- Updated streaming manager to utilize a new codec for improved event serialization and deserialization.
  
- **Bug Fixes**
	- Removed restrictions allowing gRPC streaming to work with optimistic execution enabled.

- **Tests**
	- Updated test cases to reflect changes in flag validation, allowing optimistic execution with gRPC streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->