### PR TITLE
[OTE-784] Compliance roundtable address filter

### DIFF
--- a/indexer/packages/compliance/src/clients/elliptic-provider.ts
+++ b/indexer/packages/compliance/src/clients/elliptic-provider.ts
@@ -26,6 +26,7 @@ export const API_PATH: string = '/v2/wallet/synchronous';
 export const API_URI: string = `https://aml-api.elliptic.co${API_PATH}`;
 export const RISK_SCORE_KEY: string = 'risk_score';
 export const NO_RULES_TRIGGERED_RISK_SCORE: number = -1;
+export const NOT_IN_BLOCKCHAIN_RISK_SCORE: number = -2;
 
 export class EllipticProviderClient extends ComplianceClient {
   private apiKey: string;
@@ -98,7 +99,7 @@ export class EllipticProviderClient extends ComplianceClient {
           `${config.SERVICE_NAME}.get_elliptic_risk_score.status_code`,
           { status: '404' },
         );
-        return NO_RULES_TRIGGERED_RISK_SCORE;
+        return NOT_IN_BLOCKCHAIN_RISK_SCORE;
       }
 
       if (error?.response?.status === 429) {

--- a/indexer/packages/compliance/src/clients/elliptic-provider.ts
+++ b/indexer/packages/compliance/src/clients/elliptic-provider.ts
@@ -26,6 +26,7 @@ export const API_PATH: string = '/v2/wallet/synchronous';
 export const API_URI: string = `https://aml-api.elliptic.co${API_PATH}`;
 export const RISK_SCORE_KEY: string = 'risk_score';
 export const NO_RULES_TRIGGERED_RISK_SCORE: number = -1;
+// We use different negative values of risk score to represent different elliptic response states
 export const NOT_IN_BLOCKCHAIN_RISK_SCORE: number = -2;
 
 export class EllipticProviderClient extends ComplianceClient {

--- a/indexer/packages/compliance/src/index.ts
+++ b/indexer/packages/compliance/src/index.ts
@@ -5,3 +5,4 @@ export * from './geoblocking/util';
 export * from './types';
 export * from './config';
 export * from './constants';
+export * from './clients/elliptic-provider';

--- a/indexer/packages/postgres/__tests__/stores/compliance-data-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/compliance-data-table.test.ts
@@ -1,5 +1,6 @@
 import { ComplianceDataFromDatabase, ComplianceProvider } from '../../src/types';
 import * as ComplianceDataTable from '../../src/stores/compliance-table';
+import * as WalletTable from '../../src/stores/wallet-table';
 import {
   clearData,
   migrate,
@@ -9,6 +10,7 @@ import {
   blockedComplianceData,
   blockedAddress,
   nonBlockedComplianceData,
+  defaultWallet,
 } from '../helpers/constants';
 import { DateTime } from 'luxon';
 
@@ -137,6 +139,29 @@ describe('Compliance data store', () => {
 
     expect(complianceData).toBeDefined();
     expect(complianceData).toEqual(blockedComplianceData);
+  });
+
+  it('Successfully filters by onlyDydxAddressWithDeposit', async () => {
+    // Create two compliance entries, one with a corresponding wallet entry and another without
+    await Promise.all([
+      WalletTable.create(defaultWallet),
+      ComplianceDataTable.create(nonBlockedComplianceData),
+      ComplianceDataTable.create({
+        ...nonBlockedComplianceData,
+        address: 'not_dydx_address',
+      }),
+    ]);
+
+    const complianceData: ComplianceDataFromDatabase[] = await ComplianceDataTable.findAll(
+      {
+        onlyAddressInWalletsTable: true,
+      },
+      [],
+      { readReplica: true },
+    );
+
+    expect(complianceData.length).toEqual(1);
+    expect(complianceData[0]).toEqual(nonBlockedComplianceData);
   });
 
   it('Unable finds compliance data', async () => {

--- a/indexer/packages/postgres/__tests__/stores/compliance-data-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/compliance-data-table.test.ts
@@ -154,7 +154,7 @@ describe('Compliance data store', () => {
 
     const complianceData: ComplianceDataFromDatabase[] = await ComplianceDataTable.findAll(
       {
-        onlyAddressInWalletsTable: true,
+        addressInWalletsTable: true,
       },
       [],
       { readReplica: true },

--- a/indexer/packages/postgres/src/stores/compliance-table.ts
+++ b/indexer/packages/postgres/src/stores/compliance-table.ts
@@ -13,6 +13,7 @@ import {
 } from '../helpers/stores-helpers';
 import Transaction from '../helpers/transaction';
 import ComplianceDataModel from '../models/compliance-data-model';
+import WalletModel from '../models/wallet-model';
 import {
   ComplianceDataFromDatabase,
   ComplianceDataQueryConfig,
@@ -34,6 +35,7 @@ export async function findAll(
     provider,
     blocked,
     limit,
+    onlyAddressInWalletsTable,
   }: ComplianceDataQueryConfig,
   requiredFields: QueryableField[],
   options: Options = DEFAULT_POSTGRES_OPTIONS,
@@ -45,6 +47,7 @@ export async function findAll(
       provider,
       blocked,
       limit,
+      onlyAddressInWalletsTable,
     } as QueryConfig,
     requiredFields,
   );
@@ -68,6 +71,14 @@ export async function findAll(
 
   if (blocked !== undefined) {
     baseQuery = baseQuery.where(ComplianceDataColumns.blocked, blocked);
+  }
+
+  if (onlyAddressInWalletsTable === true) {
+    baseQuery = baseQuery.innerJoin(
+      WalletModel.tableName,
+      `${ComplianceDataModel.tableName}.${ComplianceDataColumns.address}`,
+      '=',
+      `${WalletModel.tableName}.${WalletModel.idColumn}`);
   }
 
   if (options.orderBy !== undefined) {

--- a/indexer/packages/postgres/src/stores/compliance-table.ts
+++ b/indexer/packages/postgres/src/stores/compliance-table.ts
@@ -35,7 +35,7 @@ export async function findAll(
     provider,
     blocked,
     limit,
-    onlyAddressInWalletsTable,
+    addressInWalletsTable,
   }: ComplianceDataQueryConfig,
   requiredFields: QueryableField[],
   options: Options = DEFAULT_POSTGRES_OPTIONS,
@@ -47,7 +47,7 @@ export async function findAll(
       provider,
       blocked,
       limit,
-      onlyAddressInWalletsTable,
+      addressInWalletsTable,
     } as QueryConfig,
     requiredFields,
   );
@@ -73,7 +73,7 @@ export async function findAll(
     baseQuery = baseQuery.where(ComplianceDataColumns.blocked, blocked);
   }
 
-  if (onlyAddressInWalletsTable === true) {
+  if (addressInWalletsTable === true) {
     baseQuery = baseQuery.innerJoin(
       WalletModel.tableName,
       `${ComplianceDataModel.tableName}.${ComplianceDataColumns.address}`,

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -92,7 +92,7 @@ export enum QueryableField {
   REFEREE_ADDRESS = 'refereeAddress',
   KEY = 'key',
   TOKEN = 'token',
-  ONLY_ADDRESS_IN_WALLETS_TABLE = 'onlyAddressInWalletsTable',
+  ADDRESS_IN_WALLETS_TABLE = 'addressInWalletsTable',
 }
 
 export interface QueryConfig {
@@ -292,7 +292,7 @@ export interface ComplianceDataQueryConfig extends QueryConfig {
   [QueryableField.UPDATED_BEFORE_OR_AT]?: string,
   [QueryableField.PROVIDER]?: string,
   [QueryableField.BLOCKED]?: boolean,
-  [QueryableField.ONLY_ADDRESS_IN_WALLETS_TABLE]?: boolean,
+  [QueryableField.ADDRESS_IN_WALLETS_TABLE]?: boolean,
 }
 
 export interface ComplianceStatusQueryConfig extends QueryConfig {

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -92,6 +92,7 @@ export enum QueryableField {
   REFEREE_ADDRESS = 'refereeAddress',
   KEY = 'key',
   TOKEN = 'token',
+  ONLY_ADDRESS_IN_WALLETS_TABLE = 'onlyAddressInWalletsTable',
 }
 
 export interface QueryConfig {
@@ -291,6 +292,7 @@ export interface ComplianceDataQueryConfig extends QueryConfig {
   [QueryableField.UPDATED_BEFORE_OR_AT]?: string,
   [QueryableField.PROVIDER]?: string,
   [QueryableField.BLOCKED]?: boolean,
+  [QueryableField.ONLY_ADDRESS_IN_WALLETS_TABLE]?: boolean,
 }
 
 export interface ComplianceStatusQueryConfig extends QueryConfig {

--- a/indexer/services/roundtable/src/tasks/update-compliance-data.ts
+++ b/indexer/services/roundtable/src/tasks/update-compliance-data.ts
@@ -151,7 +151,7 @@ export default async function runTask(
         blocked: false,
         provider: complianceProvider.provider,
         updatedBeforeOrAt: ageThreshold,
-        onlyAddressInWalletsTable: true,
+        addressInWalletsTable: true,
       },
       [],
       { readReplica: true },

--- a/indexer/services/roundtable/src/tasks/update-compliance-data.ts
+++ b/indexer/services/roundtable/src/tasks/update-compliance-data.ts
@@ -319,10 +319,11 @@ async function getComplianceData(
         return result.value;
       },
     ));
-    const responses404:
+    const addressNotFoundResponses:
     PromiseFulfilledResult<ComplianceClientResponse>[] = successResponses.filter(
       (result: PromiseSettledResult<ComplianceClientResponse>):
       result is PromiseFulfilledResult<ComplianceClientResponse> => {
+        // riskScore = NOT_IN_BLOCKCHAIN_RISK_SCORE denotes elliptic 404 responses
         return result.status === 'fulfilled' && result.value.riskScore === NOT_IN_BLOCKCHAIN_RISK_SCORE.toString();
       },
     );
@@ -347,8 +348,8 @@ async function getComplianceData(
       });
     }
 
-    if (responses404.length > 0) {
-      const addresses404 = responses404.map((result) => result.value.address);
+    if (addressNotFoundResponses.length > 0) {
+      const notFoundAddresses = addressNotFoundResponses.map((result) => result.value.address);
 
       stats.increment(
         `${config.SERVICE_NAME}.${taskName}.get_compliance_data_404`,
@@ -359,7 +360,7 @@ async function getComplianceData(
       logger.error({
         at: 'updated-compliance-data#getComplianceData',
         message: 'Failed to retrieve compliance data for the addresses due to elliptic 404',
-        addresses: addresses404,
+        addresses: notFoundAddresses,
       });
     }
     stats.timing(


### PR DESCRIPTION
### Changelist
Restrict comlink compliance screen from upserting when address is not a dydx wallet with deposit
Restrict compliance check during compliance update roundtable to dydx wallet with depoit + add logging

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new risk score constant for enhanced error handling in compliance checks.
	- Added a new parameter to improve compliance data retrieval based on wallet addresses.
	- Enhanced filtering capability for identifying addresses that returned a 404 error.

- **Bug Fixes**
	- Improved handling of invalid addresses in compliance checks to prevent unnecessary data entries.

- **Tests**
	- Implemented new test cases to verify compliance data filtering and address handling logic.

- **Documentation**
	- Updated method signatures and interfaces to reflect new parameters and functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->