### PR TITLE
Fix: deterministically fetch perp info from state

### DIFF
--- a/protocol/testutil/constants/positions.go
+++ b/protocol/testutil/constants/positions.go
@@ -102,7 +102,7 @@ var (
 	// SOL positions
 	PerpetualPosition_OneSolLong = *testutil.CreateSinglePerpetualPosition(
 		2,
-		big.NewInt(10_000_000_000), // 0.1 SOL
+		big.NewInt(100_000_000_000), // 1 SOL
 		big.NewInt(0),
 		big.NewInt(0),
 	)

--- a/protocol/testutil/constants/positions.go
+++ b/protocol/testutil/constants/positions.go
@@ -99,6 +99,13 @@ var (
 		big.NewInt(0),
 		big.NewInt(0),
 	)
+	// SOL positions
+	PerpetualPosition_OneSolLong = *testutil.CreateSinglePerpetualPosition(
+		2,
+		big.NewInt(10_000_000_000), // 0.1 SOL
+		big.NewInt(0),
+		big.NewInt(0),
+	)
 	// Long position for arbitrary isolated market
 	PerpetualPosition_OneISOLong = *testutil.CreateSinglePerpetualPosition(
 		3,

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -770,33 +770,33 @@ func (k Keeper) GetAllRelevantPerpetuals(
 	perptypes.PerpInfos,
 	error,
 ) {
-	subaccountIdsMap := make(map[types.SubaccountId]struct{})
-	perpIdsMap := make(map[uint32]struct{})
+	subaccountIdsSet := make(map[types.SubaccountId]struct{})
+	perpIdsSet := make(map[uint32]struct{})
 
 	// Add all relevant perpetuals in every update.
 	for _, update := range updates {
 		// If this subaccount has not been processed already, get all of its existing perpetuals.
-		if _, exists := subaccountIdsMap[update.SubaccountId]; !exists {
+		if _, exists := subaccountIdsSet[update.SubaccountId]; !exists {
 			sa := k.GetSubaccount(ctx, update.SubaccountId)
 			for _, postition := range sa.PerpetualPositions {
-				perpIdsMap[postition.PerpetualId] = struct{}{}
+				perpIdsSet[postition.PerpetualId] = struct{}{}
 			}
-			subaccountIdsMap[update.SubaccountId] = struct{}{}
+			subaccountIdsSet[update.SubaccountId] = struct{}{}
 		}
 
 		// Add all perpetuals in the update.
 		for _, perpUpdate := range update.PerpetualUpdates {
-			perpIdsMap[perpUpdate.GetId()] = struct{}{}
+			perpIdsSet[perpUpdate.GetId()] = struct{}{}
 		}
 	}
 
 	// Important: Sort the perpIds to ensure determinism!
-	perpIdsOrdered := lib.GetSortedKeys[lib.Sortable[uint32]](perpIdsMap)
+	sortedPerpIds := lib.GetSortedKeys[lib.Sortable[uint32]](perpIdsSet)
 
 	// Get all perpetual information from state.
 	ltCache := make(map[uint32]perptypes.LiquidityTier)
-	perpInfos := make(perptypes.PerpInfos, len(perpIdsOrdered))
-	for _, perpId := range perpIdsOrdered {
+	perpInfos := make(perptypes.PerpInfos, len(sortedPerpIds))
+	for _, perpId := range sortedPerpIds {
 		perpetual, price, err := k.perpetualsKeeper.GetPerpetualAndMarketPrice(ctx, perpId)
 		if err != nil {
 			return nil, err

--- a/protocol/x/subaccounts/keeper/subaccount.go
+++ b/protocol/x/subaccounts/keeper/subaccount.go
@@ -770,30 +770,33 @@ func (k Keeper) GetAllRelevantPerpetuals(
 	perptypes.PerpInfos,
 	error,
 ) {
-	subaccountIds := make(map[types.SubaccountId]struct{})
-	perpIds := make(map[uint32]struct{})
+	subaccountIdsMap := make(map[types.SubaccountId]struct{})
+	perpIdsMap := make(map[uint32]struct{})
 
 	// Add all relevant perpetuals in every update.
 	for _, update := range updates {
 		// If this subaccount has not been processed already, get all of its existing perpetuals.
-		if _, exists := subaccountIds[update.SubaccountId]; !exists {
+		if _, exists := subaccountIdsMap[update.SubaccountId]; !exists {
 			sa := k.GetSubaccount(ctx, update.SubaccountId)
 			for _, postition := range sa.PerpetualPositions {
-				perpIds[postition.PerpetualId] = struct{}{}
+				perpIdsMap[postition.PerpetualId] = struct{}{}
 			}
-			subaccountIds[update.SubaccountId] = struct{}{}
+			subaccountIdsMap[update.SubaccountId] = struct{}{}
 		}
 
 		// Add all perpetuals in the update.
 		for _, perpUpdate := range update.PerpetualUpdates {
-			perpIds[perpUpdate.GetId()] = struct{}{}
+			perpIdsMap[perpUpdate.GetId()] = struct{}{}
 		}
 	}
 
+	// Important: Sort the perpIds to ensure determinism!
+	perpIdsOrdered := lib.GetSortedKeys[lib.Sortable[uint32]](perpIdsMap)
+
 	// Get all perpetual information from state.
 	ltCache := make(map[uint32]perptypes.LiquidityTier)
-	perpInfos := make(perptypes.PerpInfos, len(perpIds))
-	for perpId := range perpIds {
+	perpInfos := make(perptypes.PerpInfos, len(perpIdsOrdered))
+	for _, perpId := range perpIdsOrdered {
 		perpetual, price, err := k.perpetualsKeeper.GetPerpetualAndMarketPrice(ctx, perpId)
 		if err != nil {
 			return nil, err

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -10,6 +10,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 
+	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
@@ -6015,6 +6016,116 @@ func TestGetNetCollateralAndMarginRequirements(t *testing.T) {
 					require.Equal(t, tc.expectedMaintenanceMargin.String(), risk.MMR.String())
 				}
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetAllRelevantPerpetuals_Deterministic(t *testing.T) {
+	tests := map[string]struct {
+		// state
+		perpetuals []perptypes.Perpetual
+
+		// subaccount state
+		assetPositions     []*types.AssetPosition
+		perpetualPositions []*types.PerpetualPosition
+
+		// updates
+		assetUpdates     []types.AssetUpdate
+		perpetualUpdates []types.PerpetualUpdate
+
+		// expectations
+		expectedNetCollateral     *big.Int
+		expectedInitialMargin     *big.Int
+		expectedMaintenanceMargin *big.Int
+		expectedErr               error
+	}{
+		"Gas used is deterministic when erroring on gas usage": {
+			assetPositions: testutil.CreateUsdcAssetPositions(big.NewInt(10_000_000_001)), // $10,000.000001
+			perpetuals: []perptypes.Perpetual{
+				constants.BtcUsd_NoMarginRequirement,
+				constants.EthUsd_NoMarginRequirement,
+				constants.SolUsd_20PercentInitial_10PercentMaintenance,
+			},
+			perpetualPositions: []*types.PerpetualPosition{
+				&constants.PerpetualPosition_OneBTCLong,
+				&constants.PerpetualPosition_OneTenthEthLong,
+				&constants.PerpetualPosition_OneSolLong,
+			},
+			assetUpdates: []types.AssetUpdate{
+				{
+					AssetId:          constants.Usdc.Id,
+					BigQuantumsDelta: big.NewInt(1_000_000), // +1 USDC
+				},
+			},
+			perpetualUpdates: []types.PerpetualUpdate{
+				{
+					PerpetualId:      uint32(0),
+					BigQuantumsDelta: big.NewInt(-200_000_000), // -2 BTC
+				},
+				{
+					PerpetualId:      uint32(1),
+					BigQuantumsDelta: big.NewInt(250_000_000), // .25 ETH
+				},
+				{
+					PerpetualId:      uint32(2),
+					BigQuantumsDelta: big.NewInt(500_000_000), // .005 SOL
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Setup.
+			ctx, keeper, pricesKeeper, perpetualsKeeper, _, _, assetsKeeper, _, _, _, _ := keepertest.SubaccountsKeepers(
+				t,
+				true,
+			)
+			keepertest.CreateTestMarkets(t, ctx, pricesKeeper)
+			keepertest.CreateTestLiquidityTiers(t, ctx, perpetualsKeeper)
+			keepertest.CreateTestPerpetuals(t, ctx, perpetualsKeeper)
+			for _, p := range tc.perpetuals {
+				perpetualsKeeper.SetPerpetualForTest(ctx, p)
+			}
+			require.NoError(t, keepertest.CreateUsdcAsset(ctx, assetsKeeper))
+
+			subaccount := createNSubaccount(keeper, ctx, 1, big.NewInt(1_000))[0]
+			subaccount.PerpetualPositions = tc.perpetualPositions
+			subaccount.AssetPositions = tc.assetPositions
+			keeper.SetSubaccount(ctx, subaccount)
+			subaccountId := *subaccount.Id
+
+			update := types.Update{
+				SubaccountId:     subaccountId,
+				AssetUpdates:     tc.assetUpdates,
+				PerpetualUpdates: tc.perpetualUpdates,
+			}
+
+			// Execute.
+			gasUsedBefore := ctx.GasMeter().GasConsumed()
+			_, err := keeper.GetAllRelevantPerpetuals(ctx, []types.Update{update})
+			require.NoError(t, err)
+			gasUsedAfter := ctx.GasMeter().GasConsumed()
+
+			gasUsed := uint64(0)
+			for range 100 { // run 100 times since it's highly unlikely gas usage is deterministic over 100 times if there's non-determinism.
+				// divide by 2 so that the state read fails at least second to last time.
+				ctxWithLimitedGas := ctx.WithGasMeter(storetypes.NewGasMeter((gasUsedAfter - gasUsedBefore) / 2))
+
+				require.PanicsWithValue(
+					t,
+					storetypes.ErrorOutOfGas{Descriptor: "ReadFlat"},
+					func() {
+						keeper.GetAllRelevantPerpetuals(ctxWithLimitedGas, []types.Update{update})
+					},
+				)
+
+				if gasUsed == 0 {
+					gasUsed = ctxWithLimitedGas.GasMeter().GasConsumed()
+					require.Greater(t, gasUsed, uint64(0))
+				} else {
+					require.Equal(t, gasUsed, ctxWithLimitedGas.GasMeter().GasConsumed(), "Gas usage when out of gas is not deterministic")
+				}
 			}
 		})
 	}

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -6033,12 +6033,6 @@ func TestGetAllRelevantPerpetuals_Deterministic(t *testing.T) {
 		// updates
 		assetUpdates     []types.AssetUpdate
 		perpetualUpdates []types.PerpetualUpdate
-
-		// expectations
-		expectedNetCollateral     *big.Int
-		expectedInitialMargin     *big.Int
-		expectedMaintenanceMargin *big.Int
-		expectedErr               error
 	}{
 		"Gas used is deterministic when erroring on gas usage": {
 			assetPositions: testutil.CreateUsdcAssetPositions(big.NewInt(10_000_000_001)), // $10,000.000001

--- a/protocol/x/subaccounts/keeper/subaccount_test.go
+++ b/protocol/x/subaccounts/keeper/subaccount_test.go
@@ -6108,7 +6108,9 @@ func TestGetAllRelevantPerpetuals_Deterministic(t *testing.T) {
 			gasUsedAfter := ctx.GasMeter().GasConsumed()
 
 			gasUsed := uint64(0)
-			for range 100 { // run 100 times since it's highly unlikely gas usage is deterministic over 100 times if there's non-determinism.
+			// Run 100 times since it's highly unlikely gas usage is deterministic over 100 times if
+			// there's non-determinism.
+			for range 100 {
 				// divide by 2 so that the state read fails at least second to last time.
 				ctxWithLimitedGas := ctx.WithGasMeter(storetypes.NewGasMeter((gasUsedAfter - gasUsedBefore) / 2))
 
@@ -6116,7 +6118,7 @@ func TestGetAllRelevantPerpetuals_Deterministic(t *testing.T) {
 					t,
 					storetypes.ErrorOutOfGas{Descriptor: "ReadFlat"},
 					func() {
-						keeper.GetAllRelevantPerpetuals(ctxWithLimitedGas, []types.Update{update})
+						_, _ = keeper.GetAllRelevantPerpetuals(ctxWithLimitedGas, []types.Update{update})
 					},
 				)
 
@@ -6124,7 +6126,12 @@ func TestGetAllRelevantPerpetuals_Deterministic(t *testing.T) {
 					gasUsed = ctxWithLimitedGas.GasMeter().GasConsumed()
 					require.Greater(t, gasUsed, uint64(0))
 				} else {
-					require.Equal(t, gasUsed, ctxWithLimitedGas.GasMeter().GasConsumed(), "Gas usage when out of gas is not deterministic")
+					require.Equal(
+						t,
+						gasUsed,
+						ctxWithLimitedGas.GasMeter().GasConsumed(),
+						"Gas usage when out of gas is not deterministic",
+					)
 				}
 			}
 		})


### PR DESCRIPTION
### Changelist
Problem: The ordering a map iteration in go is not deterministic. If the iteration loop completes, the final result is the same. However, if the loop exits in the middle (ie goes over the gas limit -> abort), then the different sets of perp ids have been iterated on; therefore creates a non-deterministic behavior in terms of gas usage.

Fix: deterministically order the perp ids to iterate over by sorting first.

### Test Plan
Unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new perpetual position for SOL, enhancing the available options for users.

- **Bug Fixes**
	- Improved clarity in the naming of variables related to subaccount and perpetual IDs, ensuring better understanding and maintenance.

- **Tests**
	- Added a new test to validate consistent gas usage for the `GetAllRelevantPerpetuals` method, ensuring reliability under varying conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->