### PR TITLE
Add endpoint to fetch mid prices for perpetual markets

### DIFF
--- a/indexer/packages/postgres/src/stores/perpetual-market-table.ts
+++ b/indexer/packages/postgres/src/stores/perpetual-market-table.ts
@@ -31,6 +31,7 @@ export async function findAll(
     id,
     marketId,
     liquidityTierId,
+    tickers,
     limit,
   }: PerpetualMarketQueryConfig,
   requiredFields: QueryableField[],
@@ -57,6 +58,10 @@ export async function findAll(
 
   if (marketId !== undefined) {
     baseQuery = baseQuery.whereIn(PerpetualMarketColumns.marketId, marketId);
+  }
+
+  if (tickers !== undefined) {
+    baseQuery = baseQuery.whereIn(PerpetualMarketColumns.ticker, tickers);
   }
 
   if (liquidityTierId !== undefined) {

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -60,6 +60,7 @@ export enum QueryableField {
   GOOD_TIL_BLOCK_BEFORE_OR_AT = 'goodTilBlockBeforeOrAt',
   GOOD_TIL_BLOCK_TIME_BEFORE_OR_AT = 'goodTilBlockTimeBeforeOrAt',
   TICKER = 'ticker',
+  TICKERS = 'tickers',
   RESOLUTION = 'resolution',
   FROM_ISO = 'fromISO',
   TO_ISO = 'toISO',
@@ -149,6 +150,7 @@ export interface OrderQueryConfig extends QueryConfig {
 export interface PerpetualMarketQueryConfig extends QueryConfig {
   [QueryableField.ID]?: string[],
   [QueryableField.MARKET_ID]?: number[],
+  [QueryableField.TICKERS]?: string[],
   [QueryableField.LIQUIDITY_TIER_ID]?: number[],
 }
 

--- a/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-markets-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-markets-controller.test.ts
@@ -11,11 +11,21 @@ import {
   LiquidityTiersTable,
   liquidityTierRefresher,
 } from '@dydxprotocol-indexer/postgres';
+import {
+  OrderbookMidPricesCache,
+} from '@dydxprotocol-indexer/redis';
 import { RequestMethod } from '../../../../src/types';
 import request from 'supertest';
 import { getQueryString, sendRequest } from '../../../helpers/helpers';
 import _ from 'lodash';
 import { perpetualMarketToResponseObject } from '../../../../src/request-helpers/request-transformer';
+
+jest.mock('@dydxprotocol-indexer/redis', () => ({
+  ...jest.requireActual('@dydxprotocol-indexer/redis'),
+  OrderbookMidPricesCache: {
+    getMedianPrice: jest.fn(),
+  },
+}));
 
 describe('perpetual-markets-controller#V4', () => {
   beforeAll(async () => {
@@ -30,10 +40,12 @@ describe('perpetual-markets-controller#V4', () => {
 
   afterAll(async () => {
     await dbHelpers.teardown();
+    jest.resetAllMocks();
   });
 
   afterEach(async () => {
     await dbHelpers.clearData();
+    jest.clearAllMocks();
   });
 
   describe('/', () => {
@@ -126,6 +138,132 @@ describe('perpetual-markets-controller#V4', () => {
       expect(response.body.errors[0]).toEqual(expect.objectContaining({
         msg: 'ticker must be a valid ticker (BTC-USD, etc)',
       }));
+    });
+  });
+
+  describe('GET /v4/perpetualMarkets/orderbookMidPrices', () => {
+    it('returns mid prices for all markets when no tickers are specified', async () => {
+      (OrderbookMidPricesCache.getMedianPrice as jest.Mock).mockImplementation((client, ticker) => {
+        const prices: {[key: string]: string} = {
+          'BTC-USD': '30000.5',
+          'ETH-USD': '2000.25',
+          'SHIB-USD': '5.75',
+        };
+        return Promise.resolve(prices[ticker]);
+      });
+
+      const response = await sendRequest({
+        type: RequestMethod.GET,
+        path: '/v4/perpetualMarkets/orderbookMidPrices',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        'BTC-USD': '30000.5',
+        'ETH-USD': '2000.25',
+        'SHIB-USD': '5.75',
+      });
+      const numMarkets = (await PerpetualMarketTable.findAll({}, [])).length;
+      expect(OrderbookMidPricesCache.getMedianPrice).toHaveBeenCalledTimes(numMarkets);
+    });
+
+    it('returns mid prices for multiple specified tickers', async () => {
+      (OrderbookMidPricesCache.getMedianPrice as jest.Mock).mockImplementation((client, ticker) => {
+        const prices: {[key: string]: string} = {
+          'BTC-USD': '30000.5',
+          'ETH-USD': '2000.25',
+        };
+        return Promise.resolve(prices[ticker]);
+      });
+
+      const response = await sendRequest({
+        type: RequestMethod.GET,
+        path: '/v4/perpetualMarkets/orderbookMidPrices?tickers=BTC-USD&tickers=ETH-USD',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        'BTC-USD': '30000.5',
+        'ETH-USD': '2000.25',
+      });
+
+      expect(OrderbookMidPricesCache.getMedianPrice).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns mid prices for one specified ticker', async () => {
+      (OrderbookMidPricesCache.getMedianPrice as jest.Mock).mockImplementation((client, ticker) => {
+        const prices: {[key: string]: string} = {
+          'BTC-USD': '30000.5',
+          'ETH-USD': '2000.25',
+        };
+        return Promise.resolve(prices[ticker]);
+      });
+
+      const response = await sendRequest({
+        type: RequestMethod.GET,
+        path: '/v4/perpetualMarkets/orderbookMidPrices?tickers=BTC-USD',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        'BTC-USD': '30000.5',
+      });
+
+      expect(OrderbookMidPricesCache.getMedianPrice).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits markets with no mid price', async () => {
+      (OrderbookMidPricesCache.getMedianPrice as jest.Mock).mockImplementation((client, ticker) => {
+        const prices: {[key: string]: string | null} = {
+          'BTC-USD': '30000.5',
+          'ETH-USD': null,
+          'SHIB-USD': '5.75',
+        };
+        return Promise.resolve(prices[ticker]);
+      });
+
+      const response = await sendRequest({
+        type: RequestMethod.GET,
+        path: '/v4/perpetualMarkets/orderbookMidPrices',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        'BTC-USD': '30000.5',
+        'SHIB-USD': '5.75',
+      });
+    });
+
+    it('returns an empty object when no markets have mid prices', async () => {
+      (OrderbookMidPricesCache.getMedianPrice as jest.Mock).mockResolvedValue(null);
+
+      const response = await sendRequest({
+        type: RequestMethod.GET,
+        path: '/v4/perpetualMarkets/orderbookMidPrices',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({});
+    });
+
+    it('returns prices only for valid tickers and ignores invalid tickers', async () => {
+      (OrderbookMidPricesCache.getMedianPrice as jest.Mock).mockImplementation((client, ticker) => {
+        const prices: {[key: string]: string} = {
+          'BTC-USD': '30000.5',
+        };
+        return Promise.resolve(prices[ticker]);
+      });
+
+      const response = await sendRequest({
+        type: RequestMethod.GET,
+        path: '/v4/perpetualMarkets/orderbookMidPrices?tickers=BTC-USD&tickers=INVALID-TICKER',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        'BTC-USD': '30000.5',
+      });
+      expect(OrderbookMidPricesCache.getMedianPrice).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -2542,6 +2542,89 @@ fetch(`${baseURL}/perpetualMarkets`,
 This operation does not require authentication
 </aside>
 
+## GetOrderbookMidPrices
+
+<a id="opIdGetOrderbookMidPrices"></a>
+
+> Code samples
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+# For the deployment by DYDX token holders, use
+# baseURL = 'https://indexer.dydx.trade/v4'
+baseURL = 'https://dydx-testnet.imperator.co/v4'
+
+r = requests.get(f'{baseURL}/perpetualMarkets/orderbookMidPrices', headers = headers)
+
+print(r.json())
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+};
+
+// For the deployment by DYDX token holders, use
+// const baseURL = 'https://indexer.dydx.trade/v4';
+const baseURL = 'https://dydx-testnet.imperator.co/v4';
+
+fetch(`${baseURL}/perpetualMarkets/orderbookMidPrices`,
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+`GET /perpetualMarkets/orderbookMidPrices`
+
+### Parameters
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|tickers|query|array[string]|false|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "property1": "string",
+  "property2": "string"
+}
+```
+
+### Responses
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Ok|Inline|
+
+### Response Schema
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» **additionalProperties**|string|false|none|none|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
 ## ListPositions
 
 <a id="opIdListPositions"></a>

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -2925,6 +2925,41 @@
         ]
       }
     },
+    "/perpetualMarkets/orderbookMidPrices": {
+      "get": {
+        "operationId": "GetOrderbookMidPrices",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {},
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "tickers",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    },
     "/perpetualPositions": {
       "get": {
         "operationId": "ListPositions",

--- a/indexer/services/comlink/src/controllers/api/v4/perpetual-markets-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/perpetual-markets-controller.ts
@@ -9,6 +9,7 @@ import {
   LiquidityTiersMap,
   LiquidityTiersFromDatabase,
 } from '@dydxprotocol-indexer/postgres';
+import { OrderbookMidPricesCache } from '@dydxprotocol-indexer/redis';
 import express from 'express';
 import {
   matchedData,
@@ -20,12 +21,13 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
+import { redisClient } from '../../../helpers/redis/redis-controller';
 import { NotFoundError } from '../../../lib/errors';
 import {
   handleControllerError,
 } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
-import { CheckLimitSchema, CheckTickerOptionalQuerySchema } from '../../../lib/validation/schemas';
+import { CheckLimitSchema, CheckTickerOptionalQuerySchema, CheckTickersQuerySchema } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { perpetualMarketToResponseObject } from '../../../request-helpers/request-transformer';
@@ -108,6 +110,28 @@ class PerpetualMarketsController extends Controller {
         .value(),
     };
   }
+
+  @Get('/orderbookMidPrices')
+  async getOrderbookMidPrices(
+    @Query() tickers?: string[],
+  ): Promise<{ [ticker: string]: string }> {
+    // Convert tickers to an array if it's a single string
+    const tickersArray: string[] = typeof tickers === 'string' ? [tickers] : tickers || [];
+
+    const perpetualMarkets: PerpetualMarketFromDatabase[] = tickersArray.length > 0
+      ? await PerpetualMarketTable.findAll({ tickers: tickersArray }, [])
+      : await PerpetualMarketTable.findAll({}, []);
+
+    const orderbookMidPrices: { [ticker: string]: string } = {};
+    for (const market of perpetualMarkets) {
+      const price = await OrderbookMidPricesCache.getMedianPrice(redisClient, market.ticker);
+      if (price !== null) {
+        orderbookMidPrices[market.ticker] = price;
+      }
+    }
+
+    return orderbookMidPrices;
+  }
 }
 
 router.get(
@@ -146,6 +170,38 @@ router.get(
     } finally {
       stats.timing(
         `${config.SERVICE_NAME}.${controllerName}.get_perpetual_markets.timing`,
+        Date.now() - start,
+      );
+    }
+  },
+);
+
+router.get(
+  '/orderbookMidPrices',
+  rateLimiterMiddleware(getReqRateLimiter),
+  ...CheckTickersQuerySchema,
+  handleValidationErrors,
+  ExportResponseCodeStats({ controllerName }),
+  async (req: express.Request, res: express.Response) => {
+    const start: number = Date.now();
+    const { tickers }: { tickers?: string[] } = matchedData(req);
+
+    try {
+      const controller: PerpetualMarketsController = new PerpetualMarketsController();
+      const response = await controller.getOrderbookMidPrices(tickers);
+
+      return res.send(response);
+    } catch (error) {
+      return handleControllerError(
+        'PerpetualMarketController GET /orderbookMidPrices',
+        'OrderbookMidPrices error',
+        error,
+        req,
+        res,
+      );
+    } finally {
+      stats.timing(
+        `${config.SERVICE_NAME}.${controllerName}.get_orderbook_mid_prices.timing`,
         Date.now() - start,
       );
     }

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -212,6 +212,25 @@ export const CheckHistoricalBlockTradingRewardsSchema = checkSchema({
   },
 });
 
+export const CheckTickersQuerySchema = checkSchema({
+  tickers: {
+    in: ['query'],
+    optional: true,
+    custom: {
+      options: (value: string | string[]) => {
+        if (typeof value === 'string') {
+          return true; // Accept a single string
+        }
+        if (Array.isArray(value)) {
+          return value.every((ticker) => typeof ticker === 'string');
+        }
+        return false; // Reject anything else
+      },
+      errorMessage: 'tickers must be a string or an array of strings',
+    },
+  },
+});
+
 export const CheckTransferBetweenSchema = checkSchema(transferBetweenSchemaRecord);
 
 export const RegisterTokenValidationSchema = [


### PR DESCRIPTION
### Changelist
Adds an endpoint to fetch perpetual market mid orderbook prices for an array of markets. This enables "close all positions at mid market price" as currently the frontend only subscribes to one market's orderbook at a time.

### Test Plan
- Added unit tests
- Tested manually in dev
