### PR TITLE
Use vault table rather than placeholder config flags to fetch vaults.

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
@@ -17,7 +17,6 @@ import {
 import { RequestMethod, VaultHistoricalPnl } from '../../../../src/types';
 import request from 'supertest';
 import { getFixedRepresentation, sendRequest } from '../../../helpers/helpers';
-import config from '../../../../src/config';
 import { DateTime } from 'luxon';
 import Big from 'big.js';
 

--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -56,11 +56,6 @@ export const configSchema = {
   // Expose setting compliance status, only set to true in dev/staging.
   EXPOSE_SET_COMPLIANCE_ENDPOINT: parseBoolean({ default: false }),
 
-  // TODO(TRA-570): Placeholder data for vaults and matching set of markets for each vault until
-  // vaults table is added.
-  EXPERIMENT_VAULTS: parseString({ default: '' }),
-  EXPERIMENT_VAULT_MARKETS: parseString({ default: '' }),
-
   // Affiliates config
   VOLUME_ELIGIBILITY_THRESHOLD: parseInteger({ default: 10_000 }),
 

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -459,15 +459,15 @@ async function getVaultMapping(): Promise<VaultMapping> {
   const vaults: VaultFromDatabase[] = await VaultTable.findAll(
     {},
     [],
-    {}
+    {},
   );
-  return  _.zipObject(
+  return _.zipObject(
     vaults.map((vault: VaultFromDatabase): string => {
       return SubaccountTable.uuid(vault.address, 0);
     }),
     vaults.map((vault: VaultFromDatabase): string => {
       return vault.clobPairId;
-    }), 
+    }),
   );
 }
 

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -22,6 +22,8 @@ import {
   BlockFromDatabase,
   FundingIndexUpdatesTable,
   PnlTickInterval,
+  VaultTable,
+  VaultFromDatabase,
 } from '@dydxprotocol-indexer/postgres';
 import Big from 'big.js';
 import express from 'express';
@@ -57,8 +59,6 @@ import {
 const router: express.Router = express.Router();
 const controllerName: string = 'vault-controller';
 
-// TODO(TRA-570): Placeholder interface for mapping of vault subaccounts to tickers until vaults
-// table is added.
 interface VaultMapping {
   [subaccountId: string]: string,
 }
@@ -69,7 +69,7 @@ class VaultController extends Controller {
   async getMegavaultHistoricalPnl(
     @Query() resolution?: PnlTickInterval,
   ): Promise<MegavaultHistoricalPnlResponse> {
-    const vaultSubaccounts: VaultMapping = getVaultSubaccountsFromConfig();
+    const vaultSubaccounts: VaultMapping = await getVaultMapping();
     const [
       vaultPnlTicks,
       vaultPositions,
@@ -79,7 +79,7 @@ class VaultController extends Controller {
       Map<string, VaultPosition>,
       BlockFromDatabase,
     ] = await Promise.all([
-      getVaultSubaccountPnlTicks(resolution),
+      getVaultSubaccountPnlTicks(vaultSubaccounts, resolution),
       getVaultPositions(vaultSubaccounts),
       BlockTable.getLatest(),
     ]);
@@ -111,7 +111,7 @@ class VaultController extends Controller {
   async getVaultsHistoricalPnl(
     @Query() resolution?: PnlTickInterval,
   ): Promise<VaultsHistoricalPnlResponse> {
-    const vaultSubaccounts: VaultMapping = getVaultSubaccountsFromConfig();
+    const vaultSubaccounts: VaultMapping = await getVaultMapping();
     const [
       vaultPnlTicks,
       vaultPositions,
@@ -121,7 +121,7 @@ class VaultController extends Controller {
       Map<string, VaultPosition>,
       BlockFromDatabase,
     ] = await Promise.all([
-      getVaultSubaccountPnlTicks(resolution),
+      getVaultSubaccountPnlTicks(vaultSubaccounts, resolution),
       getVaultPositions(vaultSubaccounts),
       BlockTable.getLatest(),
     ]);
@@ -163,7 +163,7 @@ class VaultController extends Controller {
 
   @Get('/megavault/positions')
   async getMegavaultPositions(): Promise<MegavaultPositionResponse> {
-    const vaultSubaccounts: VaultMapping = getVaultSubaccountsFromConfig();
+    const vaultSubaccounts: VaultMapping = await getVaultMapping();
 
     const vaultPositions: Map<string, VaultPosition> = await getVaultPositions(vaultSubaccounts);
 
@@ -286,9 +286,10 @@ router.get(
   });
 
 async function getVaultSubaccountPnlTicks(
+  vaultSubaccounts: VaultMapping,
   resolution?: PnlTickInterval,
 ): Promise<PnlTicksFromDatabase[]> {
-  const vaultSubaccountIds: string[] = _.keys(getVaultSubaccountsFromConfig());
+  const vaultSubaccountIds: string[] = _.keys(vaultSubaccounts);
   if (vaultSubaccountIds.length === 0) {
     return [];
   }
@@ -454,19 +455,19 @@ function getPnlTicksWithCurrentTick(
   return pnlTicks.concat([currentTick]);
 }
 
-// TODO(TRA-570): Placeholder for getting vault subaccount ids until vault table is added.
-function getVaultSubaccountsFromConfig(): VaultMapping {
-  if (config.EXPERIMENT_VAULTS === '' && config.EXPERIMENT_VAULT_MARKETS === '') {
-    return {};
-  }
-  const vaultSubaccountIds: string[] = config.EXPERIMENT_VAULTS.split(',');
-  const vaultClobPairIds: string[] = config.EXPERIMENT_VAULT_MARKETS.split(',');
-  if (vaultSubaccountIds.length !== vaultClobPairIds.length) {
-    throw new Error('Expected number of vaults to match number of markets');
-  }
-  return _.zipObject(
-    vaultSubaccountIds,
-    vaultClobPairIds,
+async function getVaultMapping(): Promise<VaultMapping> {
+  const vaults: VaultFromDatabase[] = await VaultTable.findAll(
+    {},
+    [],
+    {}
+  );
+  return  _.zipObject(
+    vaults.map((vault: VaultFromDatabase): string => {
+      return SubaccountTable.uuid(vault.address, 0);
+    }),
+    vaults.map((vault: VaultFromDatabase): string => {
+      return vault.clobPairId;
+    }), 
   );
 }
 


### PR DESCRIPTION
### Changelist
Fetch vaults from the database rather than using the placeholder flags.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new asynchronous function for retrieving vault subaccount mappings directly from the database, improving data accuracy and reliability.
- **Bug Fixes**
	- Removed outdated configuration properties related to vaults, streamlining the setup process and enhancing test clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->