### PR TITLE
Add OE Abort rate test flag

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/big"
 	"net/http"
@@ -33,6 +34,7 @@ import (
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/baseapp/oe"
 	"github.com/cosmos/cosmos-sdk/client"
 	cosmosflags "github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
@@ -413,7 +415,17 @@ func New(
 	// Enable optimistic block execution.
 	if appFlags.OptimisticExecutionEnabled {
 		logger.Info("optimistic execution is enabled.")
-		baseAppOptions = append(baseAppOptions, baseapp.SetOptimisticExecution())
+		if appFlags.OptimisticExecutionTestAbortRate > 0 {
+			logger.Warn(fmt.Sprintf(
+				"Test flag optimistic-execution-test-abort-rate is set: %v\n",
+				appFlags.OptimisticExecutionTestAbortRate,
+			))
+		}
+		baseAppOptions = append(
+			baseAppOptions,
+			baseapp.SetOptimisticExecution(
+				oe.WithAbortRate(int(appFlags.OptimisticExecutionTestAbortRate)),
+			))
 	}
 
 	bApp := baseapp.NewBaseApp(appconstants.AppName, logger, db, txConfig.TxDecoder(), baseAppOptions...)

--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -31,7 +31,8 @@ type Flags struct {
 
 	VEOracleEnabled bool // Slinky Vote Extensions
 	// Optimistic block execution
-	OptimisticExecutionEnabled bool
+	OptimisticExecutionEnabled       bool
+	OptimisticExecutionTestAbortRate uint16
 }
 
 // List of CLI flags.
@@ -58,7 +59,8 @@ const (
 	VEOracleEnabled = "slinky-vote-extension-oracle-enabled"
 
 	// Enable optimistic block execution.
-	OptimisticExecutionEnabled = "optimistic-execution-enabled"
+	OptimisticExecutionEnabled       = "optimistic-execution-enabled"
+	OptimisticExecutionTestAbortRate = "optimistic-execution-test-abort-rate"
 )
 
 // Default values.
@@ -76,8 +78,10 @@ const (
 	DefaultWebsocketStreamingPort            = 9092
 	DefaultFullNodeStreamingSnapshotInterval = 0
 
-	DefaultVEOracleEnabled            = true
-	DefaultOptimisticExecutionEnabled = false
+	DefaultVEOracleEnabled = true
+
+	DefaultOptimisticExecutionEnabled       = false
+	DefaultOptimisticExecutionTestAbortRate = 0
 )
 
 // AddFlagsToCmd adds flags to app initialization.
@@ -152,6 +156,11 @@ func AddFlagsToCmd(cmd *cobra.Command) {
 		DefaultOptimisticExecutionEnabled,
 		"Whether to enable optimistic block execution",
 	)
+	cmd.Flags().Uint16(
+		OptimisticExecutionTestAbortRate,
+		DefaultOptimisticExecutionTestAbortRate,
+		"[Test only] Abort rate for optimistic execution",
+	)
 }
 
 // Validate checks that the flags are valid.
@@ -210,8 +219,9 @@ func GetFlagValuesFromOptions(
 		WebsocketStreamingPort:            DefaultWebsocketStreamingPort,
 		FullNodeStreamingSnapshotInterval: DefaultFullNodeStreamingSnapshotInterval,
 
-		VEOracleEnabled:            true,
-		OptimisticExecutionEnabled: DefaultOptimisticExecutionEnabled,
+		VEOracleEnabled:                  true,
+		OptimisticExecutionEnabled:       DefaultOptimisticExecutionEnabled,
+		OptimisticExecutionTestAbortRate: DefaultOptimisticExecutionTestAbortRate,
 	}
 
 	// Populate the flags if they exist.
@@ -302,6 +312,12 @@ func GetFlagValuesFromOptions(
 	if option := appOpts.Get(OptimisticExecutionEnabled); option != nil {
 		if v, err := cast.ToBoolE(option); err == nil {
 			result.OptimisticExecutionEnabled = v
+		}
+	}
+
+	if option := appOpts.Get(OptimisticExecutionTestAbortRate); option != nil {
+		if v, err := cast.ToUint16E(option); err == nil {
+			result.OptimisticExecutionTestAbortRate = v
 		}
 	}
 	return result


### PR DESCRIPTION
### Changelist
Add a test flag for OE abort rate (used to force OE to abort and re-run `FinalizeBlock` at the end of block

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line flag for configuring the optimistic execution test abort rate.
	- Enhanced configurability of optimistic execution with conditional logging based on the abort rate flag.

- **Bug Fixes**
	- Improved handling of optimistic execution settings to ensure proper initialization and logging. 

- **Documentation**
	- Updated flag declarations for clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->