### PR TITLE
Include getting main subaccount equity / pnl for megavault PnL query.

### DIFF
--- a/indexer/packages/postgres/src/constants.ts
+++ b/indexer/packages/postgres/src/constants.ts
@@ -23,7 +23,7 @@ import {
   PerpetualMarketStatus,
   TimeInForce,
 } from './types';
-import { uuid } from './stores/subaccount-table';
+import { SubaccountTable } from '.';
 
 export const BUFFER_ENCODING_UTF_8: BufferEncoding = 'utf-8';
 
@@ -133,4 +133,5 @@ export const CHILD_SUBACCOUNT_MULTIPLIER: number = 1000;
 
 // From https://github.com/dydxprotocol/v4-chain/blob/protocol/v7.0.0-dev0/protocol/app/module_accounts_test.go#L41
 export const MEGAVAULT_MODULE_ADDRESS: string = 'dydx18tkxrnrkqc2t0lr3zxr5g6a4hdvqksylxqje4r';
-export const MEGAVAULT_SUBACCOUNT_ID: string = uuid(MEGAVAULT_MODULE_ADDRESS, 0);
+// Generated from the module address + subaccount number 0.
+export const MEGAVAULT_SUBACCOUNT_ID: string = 'c7169f81-0c80-54c5-a41f-9cbb6a538fdf';

--- a/indexer/packages/postgres/src/constants.ts
+++ b/indexer/packages/postgres/src/constants.ts
@@ -23,6 +23,7 @@ import {
   PerpetualMarketStatus,
   TimeInForce,
 } from './types';
+import { uuid } from './stores/subaccount-table';
 
 export const BUFFER_ENCODING_UTF_8: BufferEncoding = 'utf-8';
 
@@ -129,3 +130,7 @@ export const DEFAULT_POSTGRES_OPTIONS : Options = config.USE_READ_REPLICA
 export const MAX_PARENT_SUBACCOUNTS: number = 128;
 
 export const CHILD_SUBACCOUNT_MULTIPLIER: number = 1000;
+
+// From https://github.com/dydxprotocol/v4-chain/blob/protocol/v7.0.0-dev0/protocol/app/module_accounts_test.go#L41
+export const MEGAVAULT_MODULE_ADDRESS: string = 'dydx18tkxrnrkqc2t0lr3zxr5g6a4hdvqksylxqje4r';
+export const MEGAVAULT_SUBACCOUNT_ID: string = uuid(MEGAVAULT_MODULE_ADDRESS, 0);

--- a/indexer/packages/postgres/src/constants.ts
+++ b/indexer/packages/postgres/src/constants.ts
@@ -23,7 +23,6 @@ import {
   PerpetualMarketStatus,
   TimeInForce,
 } from './types';
-import { SubaccountTable } from '.';
 
 export const BUFFER_ENCODING_UTF_8: BufferEncoding = 'utf-8';
 

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -444,6 +444,7 @@ async function getVaultPositions(
 }
 
 async function getMainSubaccountEquity(): Promise<string> {
+  // Main vault subaccount should only ever hold a USDC and never any perpetuals.
   const usdcBalance: {[subaccountId: string]: Big} = await AssetPositionTable
     .findUsdcPositionForSubaccounts(
       [MEGAVAULT_SUBACCOUNT_ID],

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -24,6 +24,7 @@ import {
   PnlTickInterval,
   VaultTable,
   VaultFromDatabase,
+  MEGAVAULT_SUBACCOUNT_ID,
 } from '@dydxprotocol-indexer/postgres';
 import Big from 'big.js';
 import express from 'express';
@@ -70,18 +71,24 @@ class VaultController extends Controller {
     @Query() resolution?: PnlTickInterval,
   ): Promise<MegavaultHistoricalPnlResponse> {
     const vaultSubaccounts: VaultMapping = await getVaultMapping();
+    const vaultSubaccountIdsWithMainSubaccount: string[] = _
+      .keys(vaultSubaccounts)
+      .concat([MEGAVAULT_SUBACCOUNT_ID]);
     const [
       vaultPnlTicks,
       vaultPositions,
       latestBlock,
+      mainSubaccountEquity,
     ] : [
       PnlTicksFromDatabase[],
       Map<string, VaultPosition>,
       BlockFromDatabase,
+      string,
     ] = await Promise.all([
-      getVaultSubaccountPnlTicks(vaultSubaccounts, resolution),
+      getVaultSubaccountPnlTicks(vaultSubaccountIdsWithMainSubaccount, resolution),
       getVaultPositions(vaultSubaccounts),
       BlockTable.getLatest(),
+      getMainSubaccountEquity(),
     ]);
 
     // aggregate pnlTicks for all vault subaccounts grouped by blockHeight
@@ -92,7 +99,7 @@ class VaultController extends Controller {
         return position.equity;
       }).reduce((acc: string, curr: string): string => {
         return (Big(acc).add(Big(curr))).toFixed();
-      }, '0');
+      }, mainSubaccountEquity);
     const pnlTicksWithCurrentTick: PnlTicksFromDatabase[] = getPnlTicksWithCurrentTick(
       currentEquity,
       Array.from(aggregatedPnlTicks.values()),
@@ -100,7 +107,7 @@ class VaultController extends Controller {
     );
 
     return {
-      megavaultPnl: pnlTicksWithCurrentTick.map(
+      megavaultPnl: _.sortBy(pnlTicksWithCurrentTick, 'blockTime').map(
         (pnlTick: PnlTicksFromDatabase) => {
           return pnlTicksToResponseObject(pnlTick);
         }),
@@ -121,7 +128,7 @@ class VaultController extends Controller {
       Map<string, VaultPosition>,
       BlockFromDatabase,
     ] = await Promise.all([
-      getVaultSubaccountPnlTicks(vaultSubaccounts, resolution),
+      getVaultSubaccountPnlTicks(_.keys(vaultSubaccounts), resolution),
       getVaultPositions(vaultSubaccounts),
       BlockTable.getLatest(),
     ]);
@@ -286,10 +293,9 @@ router.get(
   });
 
 async function getVaultSubaccountPnlTicks(
-  vaultSubaccounts: VaultMapping,
+  vaultSubaccountIds: string[],
   resolution?: PnlTickInterval,
 ): Promise<PnlTicksFromDatabase[]> {
-  const vaultSubaccountIds: string[] = _.keys(vaultSubaccounts);
   if (vaultSubaccountIds.length === 0) {
     return [];
   }
@@ -435,6 +441,14 @@ async function getVaultPositions(
       ];
     },
   ));
+}
+
+async function getMainSubaccountEquity(): Promise<string> {
+  const usdcBalance: {[subaccountId: string]: Big} = await AssetPositionTable
+    .findUsdcPositionForSubaccounts(
+      [MEGAVAULT_SUBACCOUNT_ID],
+    );
+  return usdcBalance[MEGAVAULT_SUBACCOUNT_ID]?.toFixed() || '0';
 }
 
 function getPnlTicksWithCurrentTick(


### PR DESCRIPTION
### Changelist
Get main subaccount PnL ticks + main subaccount USDC balance for equity calculations.
Misc.
- add ordering for aggregated Pnl ticks by time

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced constants for `MEGAVAULT_MODULE_ADDRESS` and `MEGAVAULT_SUBACCOUNT_ID` to enhance vault functionality.
	- Added a new function to fetch the equity of the main vault subaccount, improving financial metrics accuracy.
	- Updated the vault controller to include main subaccount equity in calculations.

- **Bug Fixes**
	- Adjusted test cases to reflect changes in equity calculations for the main vault subaccount.

- **Refactor**
	- Enhanced logic for aggregating equity from vault positions to include main subaccount data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->