### PR TITLE
[OTE-839] add query for unconditional revshare

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/revshare/query.lcd.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/revshare/query.lcd.ts
@@ -1,5 +1,5 @@
 import { LCDClient } from "@osmonauts/lcd";
-import { QueryMarketMapperRevenueShareParams, QueryMarketMapperRevenueShareParamsResponseSDKType, QueryMarketMapperRevShareDetails, QueryMarketMapperRevShareDetailsResponseSDKType } from "./query";
+import { QueryMarketMapperRevenueShareParams, QueryMarketMapperRevenueShareParamsResponseSDKType, QueryMarketMapperRevShareDetails, QueryMarketMapperRevShareDetailsResponseSDKType, QueryUnconditionalRevShareConfig, QueryUnconditionalRevShareConfigResponseSDKType } from "./query";
 export class LCDQueryClient {
   req: LCDClient;
 
@@ -11,6 +11,7 @@ export class LCDQueryClient {
     this.req = requestClient;
     this.marketMapperRevenueShareParams = this.marketMapperRevenueShareParams.bind(this);
     this.marketMapperRevShareDetails = this.marketMapperRevShareDetails.bind(this);
+    this.unconditionalRevShareConfig = this.unconditionalRevShareConfig.bind(this);
   }
   /* MarketMapperRevenueShareParams queries the revenue share params for the
    market mapper */
@@ -26,6 +27,13 @@ export class LCDQueryClient {
   async marketMapperRevShareDetails(params: QueryMarketMapperRevShareDetails): Promise<QueryMarketMapperRevShareDetailsResponseSDKType> {
     const endpoint = `dydxprotocol/revshare/market_mapper_rev_share_details/${params.marketId}`;
     return await this.req.get<QueryMarketMapperRevShareDetailsResponseSDKType>(endpoint);
+  }
+  /* Queries unconditional revenue share config */
+
+
+  async unconditionalRevShareConfig(_params: QueryUnconditionalRevShareConfig = {}): Promise<QueryUnconditionalRevShareConfigResponseSDKType> {
+    const endpoint = `dydxprotocol/revshare/unconditional_rev_share`;
+    return await this.req.get<QueryUnconditionalRevShareConfigResponseSDKType>(endpoint);
   }
 
 }

--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/revshare/query.rpc.Query.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/revshare/query.rpc.Query.ts
@@ -1,7 +1,7 @@
 import { Rpc } from "../../helpers";
 import * as _m0 from "protobufjs/minimal";
 import { QueryClient, createProtobufRpcClient } from "@cosmjs/stargate";
-import { QueryMarketMapperRevenueShareParams, QueryMarketMapperRevenueShareParamsResponse, QueryMarketMapperRevShareDetails, QueryMarketMapperRevShareDetailsResponse } from "./query";
+import { QueryMarketMapperRevenueShareParams, QueryMarketMapperRevenueShareParamsResponse, QueryMarketMapperRevShareDetails, QueryMarketMapperRevShareDetailsResponse, QueryUnconditionalRevShareConfig, QueryUnconditionalRevShareConfigResponse } from "./query";
 /** Query defines the gRPC querier service. */
 
 export interface Query {
@@ -13,6 +13,9 @@ export interface Query {
   /** Queries market mapper revenue share details for a specific market */
 
   marketMapperRevShareDetails(request: QueryMarketMapperRevShareDetails): Promise<QueryMarketMapperRevShareDetailsResponse>;
+  /** Queries unconditional revenue share config */
+
+  unconditionalRevShareConfig(request?: QueryUnconditionalRevShareConfig): Promise<QueryUnconditionalRevShareConfigResponse>;
 }
 export class QueryClientImpl implements Query {
   private readonly rpc: Rpc;
@@ -21,6 +24,7 @@ export class QueryClientImpl implements Query {
     this.rpc = rpc;
     this.marketMapperRevenueShareParams = this.marketMapperRevenueShareParams.bind(this);
     this.marketMapperRevShareDetails = this.marketMapperRevShareDetails.bind(this);
+    this.unconditionalRevShareConfig = this.unconditionalRevShareConfig.bind(this);
   }
 
   marketMapperRevenueShareParams(request: QueryMarketMapperRevenueShareParams = {}): Promise<QueryMarketMapperRevenueShareParamsResponse> {
@@ -35,6 +39,12 @@ export class QueryClientImpl implements Query {
     return promise.then(data => QueryMarketMapperRevShareDetailsResponse.decode(new _m0.Reader(data)));
   }
 
+  unconditionalRevShareConfig(request: QueryUnconditionalRevShareConfig = {}): Promise<QueryUnconditionalRevShareConfigResponse> {
+    const data = QueryUnconditionalRevShareConfig.encode(request).finish();
+    const promise = this.rpc.request("dydxprotocol.revshare.Query", "UnconditionalRevShareConfig", data);
+    return promise.then(data => QueryUnconditionalRevShareConfigResponse.decode(new _m0.Reader(data)));
+  }
+
 }
 export const createRpcQueryExtension = (base: QueryClient) => {
   const rpc = createProtobufRpcClient(base);
@@ -46,6 +56,10 @@ export const createRpcQueryExtension = (base: QueryClient) => {
 
     marketMapperRevShareDetails(request: QueryMarketMapperRevShareDetails): Promise<QueryMarketMapperRevShareDetailsResponse> {
       return queryService.marketMapperRevShareDetails(request);
+    },
+
+    unconditionalRevShareConfig(request?: QueryUnconditionalRevShareConfig): Promise<QueryUnconditionalRevShareConfigResponse> {
+      return queryService.unconditionalRevShareConfig(request);
     }
 
   };

--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/revshare/query.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/revshare/query.ts
@@ -1,5 +1,5 @@
 import { MarketMapperRevenueShareParams, MarketMapperRevenueShareParamsSDKType } from "./params";
-import { MarketMapperRevShareDetails, MarketMapperRevShareDetailsSDKType } from "./revshare";
+import { MarketMapperRevShareDetails, MarketMapperRevShareDetailsSDKType, UnconditionalRevShareConfig, UnconditionalRevShareConfigSDKType } from "./revshare";
 import * as _m0 from "protobufjs/minimal";
 import { DeepPartial } from "../../helpers";
 /** Queries for the default market mapper revenue share params */
@@ -39,6 +39,22 @@ export interface QueryMarketMapperRevShareDetailsResponse {
 
 export interface QueryMarketMapperRevShareDetailsResponseSDKType {
   details?: MarketMapperRevShareDetailsSDKType;
+}
+/** Queries unconditional revenue share details */
+
+export interface QueryUnconditionalRevShareConfig {}
+/** Queries unconditional revenue share details */
+
+export interface QueryUnconditionalRevShareConfigSDKType {}
+/** Response type for QueryUnconditionalRevShareConfig */
+
+export interface QueryUnconditionalRevShareConfigResponse {
+  config?: UnconditionalRevShareConfig;
+}
+/** Response type for QueryUnconditionalRevShareConfig */
+
+export interface QueryUnconditionalRevShareConfigResponseSDKType {
+  config?: UnconditionalRevShareConfigSDKType;
 }
 
 function createBaseQueryMarketMapperRevenueShareParams(): QueryMarketMapperRevenueShareParams {
@@ -205,6 +221,85 @@ export const QueryMarketMapperRevShareDetailsResponse = {
   fromPartial(object: DeepPartial<QueryMarketMapperRevShareDetailsResponse>): QueryMarketMapperRevShareDetailsResponse {
     const message = createBaseQueryMarketMapperRevShareDetailsResponse();
     message.details = object.details !== undefined && object.details !== null ? MarketMapperRevShareDetails.fromPartial(object.details) : undefined;
+    return message;
+  }
+
+};
+
+function createBaseQueryUnconditionalRevShareConfig(): QueryUnconditionalRevShareConfig {
+  return {};
+}
+
+export const QueryUnconditionalRevShareConfig = {
+  encode(_: QueryUnconditionalRevShareConfig, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryUnconditionalRevShareConfig {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryUnconditionalRevShareConfig();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(_: DeepPartial<QueryUnconditionalRevShareConfig>): QueryUnconditionalRevShareConfig {
+    const message = createBaseQueryUnconditionalRevShareConfig();
+    return message;
+  }
+
+};
+
+function createBaseQueryUnconditionalRevShareConfigResponse(): QueryUnconditionalRevShareConfigResponse {
+  return {
+    config: undefined
+  };
+}
+
+export const QueryUnconditionalRevShareConfigResponse = {
+  encode(message: QueryUnconditionalRevShareConfigResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.config !== undefined) {
+      UnconditionalRevShareConfig.encode(message.config, writer.uint32(10).fork()).ldelim();
+    }
+
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryUnconditionalRevShareConfigResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryUnconditionalRevShareConfigResponse();
+
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+
+      switch (tag >>> 3) {
+        case 1:
+          message.config = UnconditionalRevShareConfig.decode(reader, reader.uint32());
+          break;
+
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+
+    return message;
+  },
+
+  fromPartial(object: DeepPartial<QueryUnconditionalRevShareConfigResponse>): QueryUnconditionalRevShareConfigResponse {
+    const message = createBaseQueryUnconditionalRevShareConfigResponse();
+    message.config = object.config !== undefined && object.config !== null ? UnconditionalRevShareConfig.fromPartial(object.config) : undefined;
     return message;
   }
 

--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/revshare/tx.rpc.msg.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/revshare/tx.rpc.msg.ts
@@ -15,7 +15,7 @@ export interface Msg {
    */
 
   setMarketMapperRevShareDetailsForMarket(request: MsgSetMarketMapperRevShareDetailsForMarket): Promise<MsgSetMarketMapperRevShareDetailsForMarketResponse>;
-  /** SetUnconditionalRevShareConfig sets the unconditional revshare config */
+  /** UpdateUnconditionalRevShareConfig sets the unconditional revshare config */
 
   updateUnconditionalRevShareConfig(request: MsgUpdateUnconditionalRevShareConfig): Promise<MsgUpdateUnconditionalRevShareConfigResponse>;
 }

--- a/proto/dydxprotocol/revshare/query.proto
+++ b/proto/dydxprotocol/revshare/query.proto
@@ -25,6 +25,13 @@ service Query {
     option (google.api.http).get =
         "/dydxprotocol/revshare/market_mapper_rev_share_details/{market_id}";
   }
+
+  // Queries unconditional revenue share config
+  rpc UnconditionalRevShareConfig(QueryUnconditionalRevShareConfig)
+      returns (QueryUnconditionalRevShareConfigResponse) {
+    option (google.api.http).get =
+        "/dydxprotocol/revshare/unconditional_rev_share";
+  }
 }
 
 // Queries for the default market mapper revenue share params
@@ -41,4 +48,12 @@ message QueryMarketMapperRevShareDetails { uint32 market_id = 1; }
 // Response type for QueryMarketMapperRevShareDetails
 message QueryMarketMapperRevShareDetailsResponse {
   MarketMapperRevShareDetails details = 1 [ (gogoproto.nullable) = false ];
+}
+
+// Queries unconditional revenue share details
+message QueryUnconditionalRevShareConfig {}
+
+// Response type for QueryUnconditionalRevShareConfig
+message QueryUnconditionalRevShareConfigResponse {
+  UnconditionalRevShareConfig config = 1 [ (gogoproto.nullable) = false ];
 }

--- a/proto/dydxprotocol/revshare/tx.proto
+++ b/proto/dydxprotocol/revshare/tx.proto
@@ -21,7 +21,7 @@ service Msg {
   rpc SetMarketMapperRevShareDetailsForMarket(
       MsgSetMarketMapperRevShareDetailsForMarket)
       returns (MsgSetMarketMapperRevShareDetailsForMarketResponse);
-  // SetUnconditionalRevShareConfig sets the unconditional revshare config
+  // UpdateUnconditionalRevShareConfig sets the unconditional revshare config
   rpc UpdateUnconditionalRevShareConfig(MsgUpdateUnconditionalRevShareConfig)
       returns (MsgUpdateUnconditionalRevShareConfigResponse);
 }

--- a/protocol/x/revshare/client/cli/query.go
+++ b/protocol/x/revshare/client/cli/query.go
@@ -22,6 +22,7 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 
 	cmd.AddCommand(CmdQueryRevShareParams())
 	cmd.AddCommand(CmdQueryRevShareDetailsForMarket())
+	cmd.AddCommand(CmdQueryUnconditionalRevShareConfig())
 
 	return cmd
 }

--- a/protocol/x/revshare/client/cli/query_params.go
+++ b/protocol/x/revshare/client/cli/query_params.go
@@ -66,3 +66,26 @@ func CmdQueryRevShareDetailsForMarket() *cobra.Command {
 
 	return cmd
 }
+
+func CmdQueryUnconditionalRevShareConfig() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unconditional-revshare-config",
+		Short: "unconditional revshare config",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			queryClient := types.NewQueryClient(clientCtx)
+			res, err := queryClient.UnconditionalRevShareConfig(
+				context.Background(),
+				&types.QueryUnconditionalRevShareConfig{},
+			)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/protocol/x/revshare/keeper/grpc_query_unconditional_revshare.go
+++ b/protocol/x/revshare/keeper/grpc_query_unconditional_revshare.go
@@ -1,0 +1,21 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/revshare/types"
+)
+
+func (k Keeper) UnconditionalRevShareConfig(
+	ctx context.Context,
+	req *types.QueryUnconditionalRevShareConfig,
+) (*types.QueryUnconditionalRevShareConfigResponse, error) {
+	config, err := k.GetUnconditionalRevShareConfigParams(sdk.UnwrapSDKContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return &types.QueryUnconditionalRevShareConfigResponse{
+		Config: config,
+	}, nil
+}

--- a/protocol/x/revshare/keeper/grpc_query_unconditional_revshare_test.go
+++ b/protocol/x/revshare/keeper/grpc_query_unconditional_revshare_test.go
@@ -1,0 +1,58 @@
+package keeper_test
+
+import (
+	"testing"
+
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	"github.com/dydxprotocol/v4-chain/protocol/x/revshare/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryUnconditionalRevShare(t *testing.T) {
+	testCases := map[string]struct {
+		config types.UnconditionalRevShareConfig
+	}{
+		"Single recipient": {
+			config: types.UnconditionalRevShareConfig{
+				Configs: []types.UnconditionalRevShareConfig_RecipientConfig{
+					{
+						Address:  constants.AliceAccAddress.String(),
+						SharePpm: 100_000,
+					},
+				},
+			},
+		},
+		"Multiple recipients": {
+			config: types.UnconditionalRevShareConfig{
+				Configs: []types.UnconditionalRevShareConfig_RecipientConfig{
+					{
+						Address:  constants.AliceAccAddress.String(),
+						SharePpm: 50_000,
+					},
+					{
+						Address:  constants.BobAccAddress.String(),
+						SharePpm: 30_000,
+					},
+				},
+			},
+		},
+		"Empty config": {
+			config: types.UnconditionalRevShareConfig{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tApp := testapp.NewTestAppBuilder(t).Build()
+			ctx := tApp.InitChain()
+			k := tApp.App.RevShareKeeper
+
+			k.SetUnconditionalRevShareConfigParams(ctx, tc.config)
+
+			resp, err := k.UnconditionalRevShareConfig(ctx, &types.QueryUnconditionalRevShareConfig{})
+			require.NoError(t, err)
+			require.Equal(t, tc.config, resp.Config)
+		})
+	}
+}

--- a/protocol/x/revshare/types/query.pb.go
+++ b/protocol/x/revshare/types/query.pb.go
@@ -207,44 +207,134 @@ func (m *QueryMarketMapperRevShareDetailsResponse) GetDetails() MarketMapperRevS
 	return MarketMapperRevShareDetails{}
 }
 
+// Queries unconditional revenue share details
+type QueryUnconditionalRevShareConfig struct {
+}
+
+func (m *QueryUnconditionalRevShareConfig) Reset()         { *m = QueryUnconditionalRevShareConfig{} }
+func (m *QueryUnconditionalRevShareConfig) String() string { return proto.CompactTextString(m) }
+func (*QueryUnconditionalRevShareConfig) ProtoMessage()    {}
+func (*QueryUnconditionalRevShareConfig) Descriptor() ([]byte, []int) {
+	return fileDescriptor_13d50c6e3048e744, []int{4}
+}
+func (m *QueryUnconditionalRevShareConfig) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryUnconditionalRevShareConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryUnconditionalRevShareConfig.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryUnconditionalRevShareConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryUnconditionalRevShareConfig.Merge(m, src)
+}
+func (m *QueryUnconditionalRevShareConfig) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryUnconditionalRevShareConfig) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryUnconditionalRevShareConfig.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryUnconditionalRevShareConfig proto.InternalMessageInfo
+
+// Response type for QueryUnconditionalRevShareConfig
+type QueryUnconditionalRevShareConfigResponse struct {
+	Config UnconditionalRevShareConfig `protobuf:"bytes,1,opt,name=config,proto3" json:"config"`
+}
+
+func (m *QueryUnconditionalRevShareConfigResponse) Reset() {
+	*m = QueryUnconditionalRevShareConfigResponse{}
+}
+func (m *QueryUnconditionalRevShareConfigResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryUnconditionalRevShareConfigResponse) ProtoMessage()    {}
+func (*QueryUnconditionalRevShareConfigResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_13d50c6e3048e744, []int{5}
+}
+func (m *QueryUnconditionalRevShareConfigResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryUnconditionalRevShareConfigResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryUnconditionalRevShareConfigResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryUnconditionalRevShareConfigResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryUnconditionalRevShareConfigResponse.Merge(m, src)
+}
+func (m *QueryUnconditionalRevShareConfigResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryUnconditionalRevShareConfigResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryUnconditionalRevShareConfigResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryUnconditionalRevShareConfigResponse proto.InternalMessageInfo
+
+func (m *QueryUnconditionalRevShareConfigResponse) GetConfig() UnconditionalRevShareConfig {
+	if m != nil {
+		return m.Config
+	}
+	return UnconditionalRevShareConfig{}
+}
+
 func init() {
 	proto.RegisterType((*QueryMarketMapperRevenueShareParams)(nil), "dydxprotocol.revshare.QueryMarketMapperRevenueShareParams")
 	proto.RegisterType((*QueryMarketMapperRevenueShareParamsResponse)(nil), "dydxprotocol.revshare.QueryMarketMapperRevenueShareParamsResponse")
 	proto.RegisterType((*QueryMarketMapperRevShareDetails)(nil), "dydxprotocol.revshare.QueryMarketMapperRevShareDetails")
 	proto.RegisterType((*QueryMarketMapperRevShareDetailsResponse)(nil), "dydxprotocol.revshare.QueryMarketMapperRevShareDetailsResponse")
+	proto.RegisterType((*QueryUnconditionalRevShareConfig)(nil), "dydxprotocol.revshare.QueryUnconditionalRevShareConfig")
+	proto.RegisterType((*QueryUnconditionalRevShareConfigResponse)(nil), "dydxprotocol.revshare.QueryUnconditionalRevShareConfigResponse")
 }
 
 func init() { proto.RegisterFile("dydxprotocol/revshare/query.proto", fileDescriptor_13d50c6e3048e744) }
 
 var fileDescriptor_13d50c6e3048e744 = []byte{
-	// 420 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x4c, 0xa9, 0x4c, 0xa9,
-	0x28, 0x28, 0xca, 0x2f, 0xc9, 0x4f, 0xce, 0xcf, 0xd1, 0x2f, 0x4a, 0x2d, 0x2b, 0xce, 0x48, 0x2c,
-	0x4a, 0xd5, 0x2f, 0x2c, 0x4d, 0x2d, 0xaa, 0xd4, 0x03, 0x8b, 0x0b, 0x89, 0x22, 0x2b, 0xd1, 0x83,
-	0x29, 0x91, 0x12, 0x49, 0xcf, 0x4f, 0xcf, 0x07, 0x0b, 0xeb, 0x83, 0x58, 0x10, 0xc5, 0x52, 0x32,
-	0xe9, 0xf9, 0xf9, 0xe9, 0x39, 0xa9, 0xfa, 0x89, 0x05, 0x99, 0xfa, 0x89, 0x79, 0x79, 0xf9, 0x25,
-	0x89, 0x25, 0x99, 0xf9, 0x79, 0xc5, 0x50, 0x59, 0x25, 0xec, 0xb6, 0x15, 0x24, 0x16, 0x25, 0xe6,
-	0xc2, 0xd4, 0xa8, 0x60, 0x57, 0x03, 0x63, 0x40, 0x54, 0x29, 0xa9, 0x72, 0x29, 0x07, 0x82, 0xdc,
-	0xe8, 0x9b, 0x58, 0x94, 0x9d, 0x5a, 0xe2, 0x9b, 0x58, 0x50, 0x90, 0x5a, 0x14, 0x94, 0x5a, 0x96,
-	0x9a, 0x57, 0x9a, 0x1a, 0x0c, 0x52, 0x16, 0x00, 0x36, 0x52, 0xa9, 0x89, 0x91, 0x4b, 0x9b, 0x08,
-	0x75, 0x41, 0xa9, 0xc5, 0x05, 0xf9, 0x79, 0xc5, 0xa9, 0x42, 0xc1, 0x5c, 0x6c, 0x10, 0xc7, 0x48,
-	0x30, 0x2a, 0x30, 0x6a, 0x70, 0x1b, 0x99, 0xea, 0x61, 0xf5, 0xbc, 0x1e, 0x7e, 0xe3, 0x9c, 0x58,
-	0x4e, 0xdc, 0x93, 0x67, 0x08, 0x82, 0x1a, 0xa5, 0x64, 0xcf, 0xa5, 0x80, 0xcd, 0x0d, 0x60, 0x0d,
-	0x2e, 0xa9, 0x25, 0x89, 0x99, 0x39, 0xc5, 0x42, 0xd2, 0x5c, 0x9c, 0xb9, 0x60, 0xe9, 0xf8, 0xcc,
-	0x14, 0xb0, 0xdd, 0xbc, 0x41, 0x1c, 0x10, 0x01, 0xcf, 0x14, 0xa5, 0x3a, 0x2e, 0x0d, 0x42, 0x06,
-	0xc0, 0x7d, 0x10, 0xc4, 0xc5, 0x9e, 0x02, 0x11, 0x82, 0x7a, 0xc1, 0x88, 0x38, 0x2f, 0x20, 0x1b,
-	0x06, 0x75, 0x3f, 0xcc, 0x20, 0xa3, 0xf3, 0xcc, 0x5c, 0xac, 0x60, 0x07, 0x08, 0xdd, 0x67, 0xe4,
-	0x92, 0xc3, 0xef, 0x77, 0x21, 0x2b, 0x1c, 0xf6, 0x11, 0x11, 0x0d, 0x52, 0x4e, 0xe4, 0xeb, 0x85,
-	0x05, 0x80, 0x92, 0x6d, 0xd3, 0xe5, 0x27, 0x93, 0x99, 0xcc, 0x85, 0x4c, 0xf5, 0xb1, 0x27, 0x24,
-	0x68, 0x30, 0xe7, 0x82, 0xcd, 0x89, 0x2f, 0x4a, 0x2d, 0x8b, 0x07, 0x8b, 0xc7, 0x43, 0x22, 0x4b,
-	0xe8, 0x31, 0x23, 0x97, 0x34, 0xbe, 0x88, 0x32, 0x27, 0xc1, 0x89, 0xc8, 0x1a, 0xa5, 0xec, 0xc9,
-	0xd4, 0x08, 0xf7, 0x98, 0x17, 0xd8, 0x63, 0x2e, 0x42, 0x4e, 0x24, 0x7a, 0x0c, 0x1a, 0x8b, 0xfa,
-	0xd5, 0xf0, 0x04, 0x56, 0xeb, 0x14, 0x72, 0xe2, 0x91, 0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f,
-	0x1e, 0xc9, 0x31, 0x4e, 0x78, 0x2c, 0xc7, 0x70, 0xe1, 0xb1, 0x1c, 0xc3, 0x8d, 0xc7, 0x72, 0x0c,
-	0x51, 0x56, 0xe9, 0x99, 0x25, 0x19, 0xa5, 0x49, 0x7a, 0xc9, 0xf9, 0xb9, 0xa8, 0xf6, 0x94, 0x99,
-	0xe8, 0x26, 0x67, 0x24, 0x66, 0xe6, 0xe9, 0xc3, 0x45, 0x2a, 0x10, 0x76, 0x97, 0x54, 0x16, 0xa4,
-	0x16, 0x27, 0xb1, 0x81, 0xa5, 0x8c, 0x01, 0x01, 0x00, 0x00, 0xff, 0xff, 0x31, 0xa4, 0xeb, 0xf4,
-	0x55, 0x04, 0x00, 0x00,
+	// 496 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x93, 0x4f, 0x6b, 0xd4, 0x40,
+	0x18, 0xc6, 0x77, 0xc4, 0xae, 0x3a, 0xe2, 0x65, 0x50, 0x90, 0x5d, 0x89, 0x75, 0x54, 0x28, 0x88,
+	0x19, 0x59, 0xad, 0x85, 0x82, 0x14, 0xd6, 0x5e, 0x14, 0x0a, 0x35, 0xd5, 0x8b, 0x97, 0x65, 0x9a,
+	0x8c, 0xd9, 0xc1, 0xdd, 0x99, 0x38, 0xc9, 0x86, 0x2e, 0xfe, 0x39, 0xf4, 0x13, 0x08, 0x7e, 0x02,
+	0xbf, 0x4d, 0x6f, 0x16, 0xbc, 0x78, 0x52, 0xd9, 0xf8, 0x41, 0x24, 0x93, 0x49, 0x9a, 0x42, 0x3a,
+	0x4d, 0x7b, 0x1b, 0xde, 0x79, 0xde, 0xe7, 0x7d, 0x7e, 0x99, 0x37, 0xf0, 0x4e, 0x30, 0x0f, 0xf6,
+	0x22, 0x25, 0x13, 0xe9, 0xcb, 0x09, 0x51, 0x2c, 0x8d, 0xc7, 0x54, 0x31, 0xf2, 0x61, 0xc6, 0xd4,
+	0xdc, 0xd5, 0x75, 0x74, 0xa3, 0x2e, 0x71, 0x4b, 0x49, 0xef, 0x7a, 0x28, 0x43, 0xa9, 0xcb, 0x24,
+	0x3f, 0x15, 0xe2, 0xde, 0xad, 0x50, 0xca, 0x70, 0xc2, 0x08, 0x8d, 0x38, 0xa1, 0x42, 0xc8, 0x84,
+	0x26, 0x5c, 0x8a, 0xd8, 0xdc, 0xe2, 0xe6, 0x69, 0x11, 0x55, 0x74, 0x5a, 0x6a, 0xee, 0x35, 0x6b,
+	0xca, 0x43, 0xa1, 0xc2, 0xf7, 0xe1, 0xdd, 0x57, 0x79, 0xc6, 0x2d, 0xaa, 0xde, 0xb3, 0x64, 0x8b,
+	0x46, 0x11, 0x53, 0x1e, 0x4b, 0x99, 0x98, 0xb1, 0x9d, 0x5c, 0xb6, 0xad, 0x2d, 0xf1, 0x3e, 0x80,
+	0x0f, 0x5a, 0xe8, 0x3c, 0x16, 0x47, 0x52, 0xc4, 0x0c, 0xed, 0xc0, 0x6e, 0x11, 0xe6, 0x26, 0x58,
+	0x06, 0x2b, 0x57, 0x07, 0xab, 0x6e, 0x23, 0xbc, 0x6b, 0xb7, 0x1b, 0x5e, 0x3c, 0xf8, 0x7d, 0xbb,
+	0xe3, 0x19, 0x2b, 0xbc, 0x01, 0x97, 0x9b, 0x32, 0xe8, 0x86, 0x4d, 0x96, 0x50, 0x3e, 0x89, 0x51,
+	0x1f, 0x5e, 0x99, 0xea, 0xeb, 0x11, 0x0f, 0xf4, 0xec, 0x6b, 0xde, 0xe5, 0xa2, 0xf0, 0x22, 0xc0,
+	0x5f, 0xe0, 0xca, 0x69, 0x06, 0x15, 0x81, 0x07, 0x2f, 0x05, 0x45, 0xc9, 0x20, 0x0c, 0xda, 0x21,
+	0xd4, 0xcd, 0x4c, 0xfe, 0xd2, 0x08, 0x63, 0x03, 0xf0, 0x46, 0xf8, 0x52, 0x04, 0x3c, 0x7f, 0x51,
+	0x3a, 0x29, 0x7b, 0x9e, 0x4b, 0xf1, 0x8e, 0x87, 0xf8, 0x93, 0xc9, 0x68, 0xd1, 0x54, 0x19, 0xb7,
+	0x61, 0xd7, 0xd7, 0x95, 0x53, 0x22, 0x5a, 0xbc, 0xca, 0x4f, 0x5c, 0xf8, 0x0c, 0xbe, 0x2f, 0xc1,
+	0x25, 0x3d, 0x1e, 0xfd, 0x01, 0xd0, 0xb1, 0xbf, 0x0e, 0x5a, 0x3f, 0x61, 0x5c, 0x8b, 0x45, 0xe9,
+	0x0d, 0xcf, 0xdf, 0x5b, 0xe2, 0xe3, 0x67, 0xfb, 0x3f, 0xff, 0x7d, 0xbb, 0xb0, 0x86, 0x56, 0x49,
+	0xf3, 0xaa, 0x9b, 0x45, 0x98, 0x6a, 0x9f, 0x91, 0x62, 0xe9, 0x48, 0xd7, 0x47, 0xc5, 0x3a, 0xa1,
+	0x0c, 0xc0, 0xbe, 0x6d, 0x95, 0xd6, 0xce, 0x10, 0xb1, 0xde, 0xd8, 0xdb, 0x38, 0x67, 0x63, 0x05,
+	0xf6, 0x52, 0x83, 0x6d, 0xa2, 0xe1, 0x19, 0xc1, 0xcc, 0x9e, 0x91, 0x8f, 0xd5, 0x2f, 0xf0, 0x19,
+	0xfd, 0x00, 0xb0, 0x6f, 0x79, 0x7f, 0x3b, 0xa5, 0xa5, 0xd1, 0x4e, 0xd9, 0x62, 0x7b, 0xf1, 0x53,
+	0x4d, 0xf9, 0x08, 0xb9, 0x27, 0x50, 0xce, 0xea, 0x1e, 0x47, 0x94, 0xc3, 0xd7, 0x07, 0x0b, 0x07,
+	0x1c, 0x2e, 0x1c, 0xf0, 0x77, 0xe1, 0x80, 0xaf, 0x99, 0xd3, 0x39, 0xcc, 0x9c, 0xce, 0xaf, 0xcc,
+	0xe9, 0xbc, 0x5d, 0x0f, 0x79, 0x32, 0x9e, 0xed, 0xba, 0xbe, 0x9c, 0x1e, 0xf7, 0x4c, 0x9f, 0x3c,
+	0xf4, 0xc7, 0x94, 0x0b, 0x52, 0x55, 0xf6, 0x8e, 0xe6, 0x24, 0xf3, 0x88, 0xc5, 0xbb, 0x5d, 0x7d,
+	0xf5, 0xf8, 0x7f, 0x00, 0x00, 0x00, 0xff, 0xff, 0xf2, 0x34, 0xdf, 0xbf, 0xc9, 0x05, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -264,6 +354,8 @@ type QueryClient interface {
 	MarketMapperRevenueShareParams(ctx context.Context, in *QueryMarketMapperRevenueShareParams, opts ...grpc.CallOption) (*QueryMarketMapperRevenueShareParamsResponse, error)
 	// Queries market mapper revenue share details for a specific market
 	MarketMapperRevShareDetails(ctx context.Context, in *QueryMarketMapperRevShareDetails, opts ...grpc.CallOption) (*QueryMarketMapperRevShareDetailsResponse, error)
+	// Queries unconditional revenue share config
+	UnconditionalRevShareConfig(ctx context.Context, in *QueryUnconditionalRevShareConfig, opts ...grpc.CallOption) (*QueryUnconditionalRevShareConfigResponse, error)
 }
 
 type queryClient struct {
@@ -292,6 +384,15 @@ func (c *queryClient) MarketMapperRevShareDetails(ctx context.Context, in *Query
 	return out, nil
 }
 
+func (c *queryClient) UnconditionalRevShareConfig(ctx context.Context, in *QueryUnconditionalRevShareConfig, opts ...grpc.CallOption) (*QueryUnconditionalRevShareConfigResponse, error) {
+	out := new(QueryUnconditionalRevShareConfigResponse)
+	err := c.cc.Invoke(ctx, "/dydxprotocol.revshare.Query/UnconditionalRevShareConfig", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// MarketMapperRevenueShareParams queries the revenue share params for the
@@ -299,6 +400,8 @@ type QueryServer interface {
 	MarketMapperRevenueShareParams(context.Context, *QueryMarketMapperRevenueShareParams) (*QueryMarketMapperRevenueShareParamsResponse, error)
 	// Queries market mapper revenue share details for a specific market
 	MarketMapperRevShareDetails(context.Context, *QueryMarketMapperRevShareDetails) (*QueryMarketMapperRevShareDetailsResponse, error)
+	// Queries unconditional revenue share config
+	UnconditionalRevShareConfig(context.Context, *QueryUnconditionalRevShareConfig) (*QueryUnconditionalRevShareConfigResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -310,6 +413,9 @@ func (*UnimplementedQueryServer) MarketMapperRevenueShareParams(ctx context.Cont
 }
 func (*UnimplementedQueryServer) MarketMapperRevShareDetails(ctx context.Context, req *QueryMarketMapperRevShareDetails) (*QueryMarketMapperRevShareDetailsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method MarketMapperRevShareDetails not implemented")
+}
+func (*UnimplementedQueryServer) UnconditionalRevShareConfig(ctx context.Context, req *QueryUnconditionalRevShareConfig) (*QueryUnconditionalRevShareConfigResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UnconditionalRevShareConfig not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -352,6 +458,24 @@ func _Query_MarketMapperRevShareDetails_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_UnconditionalRevShareConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryUnconditionalRevShareConfig)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).UnconditionalRevShareConfig(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/dydxprotocol.revshare.Query/UnconditionalRevShareConfig",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).UnconditionalRevShareConfig(ctx, req.(*QueryUnconditionalRevShareConfig))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "dydxprotocol.revshare.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -363,6 +487,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "MarketMapperRevShareDetails",
 			Handler:    _Query_MarketMapperRevShareDetails_Handler,
+		},
+		{
+			MethodName: "UnconditionalRevShareConfig",
+			Handler:    _Query_UnconditionalRevShareConfig_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -486,6 +614,62 @@ func (m *QueryMarketMapperRevShareDetailsResponse) MarshalToSizedBuffer(dAtA []b
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryUnconditionalRevShareConfig) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryUnconditionalRevShareConfig) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryUnconditionalRevShareConfig) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryUnconditionalRevShareConfigResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryUnconditionalRevShareConfigResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryUnconditionalRevShareConfigResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Config.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -536,6 +720,26 @@ func (m *QueryMarketMapperRevShareDetailsResponse) Size() (n int) {
 	var l int
 	_ = l
 	l = m.Details.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryUnconditionalRevShareConfig) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryUnconditionalRevShareConfigResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.Config.Size()
 	n += 1 + l + sovQuery(uint64(l))
 	return n
 }
@@ -807,6 +1011,139 @@ func (m *QueryMarketMapperRevShareDetailsResponse) Unmarshal(dAtA []byte) error 
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.Details.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryUnconditionalRevShareConfig) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryUnconditionalRevShareConfig: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryUnconditionalRevShareConfig: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryUnconditionalRevShareConfigResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryUnconditionalRevShareConfigResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryUnconditionalRevShareConfigResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Config", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Config.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/protocol/x/revshare/types/query.pb.gw.go
+++ b/protocol/x/revshare/types/query.pb.gw.go
@@ -105,6 +105,24 @@ func local_request_Query_MarketMapperRevShareDetails_0(ctx context.Context, mars
 
 }
 
+func request_Query_UnconditionalRevShareConfig_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryUnconditionalRevShareConfig
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.UnconditionalRevShareConfig(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_UnconditionalRevShareConfig_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryUnconditionalRevShareConfig
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.UnconditionalRevShareConfig(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -154,6 +172,29 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_MarketMapperRevShareDetails_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_UnconditionalRevShareConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_UnconditionalRevShareConfig_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_UnconditionalRevShareConfig_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -238,6 +279,26 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_UnconditionalRevShareConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_UnconditionalRevShareConfig_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_UnconditionalRevShareConfig_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -245,10 +306,14 @@ var (
 	pattern_Query_MarketMapperRevenueShareParams_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"dydxprotocol", "revshare", "market_mapper_rev_share_params"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_Query_MarketMapperRevShareDetails_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"dydxprotocol", "revshare", "market_mapper_rev_share_details", "market_id"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_UnconditionalRevShareConfig_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"dydxprotocol", "revshare", "unconditional_rev_share"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (
 	forward_Query_MarketMapperRevenueShareParams_0 = runtime.ForwardResponseMessage
 
 	forward_Query_MarketMapperRevShareDetails_0 = runtime.ForwardResponseMessage
+
+	forward_Query_UnconditionalRevShareConfig_0 = runtime.ForwardResponseMessage
 )

--- a/protocol/x/revshare/types/tx.pb.go
+++ b/protocol/x/revshare/types/tx.pb.go
@@ -394,7 +394,7 @@ type MsgClient interface {
 	// SetMarketMapperRevenueShareDetails sets the revenue share details for a
 	// market mapper.
 	SetMarketMapperRevShareDetailsForMarket(ctx context.Context, in *MsgSetMarketMapperRevShareDetailsForMarket, opts ...grpc.CallOption) (*MsgSetMarketMapperRevShareDetailsForMarketResponse, error)
-	// SetUnconditionalRevShareConfig sets the unconditional revshare config
+	// UpdateUnconditionalRevShareConfig sets the unconditional revshare config
 	UpdateUnconditionalRevShareConfig(ctx context.Context, in *MsgUpdateUnconditionalRevShareConfig, opts ...grpc.CallOption) (*MsgUpdateUnconditionalRevShareConfigResponse, error)
 }
 
@@ -441,7 +441,7 @@ type MsgServer interface {
 	// SetMarketMapperRevenueShareDetails sets the revenue share details for a
 	// market mapper.
 	SetMarketMapperRevShareDetailsForMarket(context.Context, *MsgSetMarketMapperRevShareDetailsForMarket) (*MsgSetMarketMapperRevShareDetailsForMarketResponse, error)
-	// SetUnconditionalRevShareConfig sets the unconditional revshare config
+	// UpdateUnconditionalRevShareConfig sets the unconditional revshare config
 	UpdateUnconditionalRevShareConfig(context.Context, *MsgUpdateUnconditionalRevShareConfig) (*MsgUpdateUnconditionalRevShareConfigResponse, error)
 }
 


### PR DESCRIPTION
### Changelist
Add query to get unconditional revshare

### Test Plan
Tested locally

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new command to query unconditional revenue share configurations via the command line interface.
	- Added methods to retrieve unconditional revenue share configurations through the application and gRPC services.

- **Bug Fixes**
	- Enhanced error handling for retrieving unconditional revenue share configurations.

- **Tests**
	- Implemented a test suite to validate the functionality of querying unconditional revenue share configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->