### PR TITLE
[CT-1203] add clob pair id and subaccount num filters

### DIFF
--- a/protocol/x/accountplus/authenticator/clob_pair_id_filter.go
+++ b/protocol/x/accountplus/authenticator/clob_pair_id_filter.go
@@ -1,0 +1,118 @@
+package authenticator
+
+import (
+	"strconv"
+	"strings"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+)
+
+var _ Authenticator = &ClobPairIdFilter{}
+
+// ClobPairIdFilter filters incoming messages based on a predefined JSON pattern.
+// It allows for complex pattern matching to support advanced authentication flows.
+type ClobPairIdFilter struct {
+	whitelist []uint32
+}
+
+// NewClobPairIdFilter creates a new ClobPairIdFilter with the provided EncodingConfig.
+func NewClobPairIdFilter() ClobPairIdFilter {
+	return ClobPairIdFilter{}
+}
+
+// Type returns the type of the authenticator.
+func (m ClobPairIdFilter) Type() string {
+	return "ClobPairIdFilter"
+}
+
+// StaticGas returns the static gas amount for the authenticator. Currently, it's set to zero.
+func (m ClobPairIdFilter) StaticGas() uint64 {
+	return 0
+}
+
+// Initialize sets up the authenticator with the given data, which should be a valid JSON pattern for message filtering.
+func (m ClobPairIdFilter) Initialize(config []byte) (Authenticator, error) {
+	strSlice := strings.Split(string(config), SEPARATOR)
+
+	m.whitelist = make([]uint32, len(strSlice))
+	for i, str := range strSlice {
+		num, err := strconv.ParseUint(str, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		m.whitelist[i] = uint32(num)
+	}
+	return m, nil
+}
+
+// Track is a no-op in this implementation but can be used to track message handling.
+func (m ClobPairIdFilter) Track(ctx sdk.Context, request AuthenticationRequest) error {
+	return nil
+}
+
+// Authenticate checks if the provided message conforms to the set JSON pattern.
+// It returns an AuthenticationResult based on the evaluation.
+func (m ClobPairIdFilter) Authenticate(ctx sdk.Context, request AuthenticationRequest) error {
+	// Collect the clob pair ids from the request.
+	requestOrderIds := make([]uint32, 0)
+	switch msg := request.Msg.(type) {
+	case *clobtypes.MsgPlaceOrder:
+		requestOrderIds = append(requestOrderIds, msg.Order.OrderId.ClobPairId)
+	case *clobtypes.MsgCancelOrder:
+		requestOrderIds = append(requestOrderIds, msg.OrderId.ClobPairId)
+	case *clobtypes.MsgBatchCancel:
+		for _, batch := range msg.ShortTermCancels {
+			requestOrderIds = append(requestOrderIds, batch.ClobPairId)
+		}
+	}
+
+	// Make sure all the clob pair ids are in the whitelist.
+	for _, clobPairId := range requestOrderIds {
+		whitelisted := false
+		for _, whitelistId := range m.whitelist {
+			if clobPairId == whitelistId {
+				whitelisted = true
+				break
+			}
+		}
+
+		if !whitelisted {
+			return errorsmod.Wrapf(
+				sdkerrors.ErrUnauthorized,
+				"order id %d not in whitelist %v",
+				clobPairId,
+				m.whitelist,
+			)
+		}
+	}
+	return nil
+}
+
+// ConfirmExecution confirms the execution of a message. Currently, it always confirms.
+func (m ClobPairIdFilter) ConfirmExecution(ctx sdk.Context, request AuthenticationRequest) error {
+	return nil
+}
+
+// OnAuthenticatorAdded performs additional checks when an authenticator is added.
+// Specifically, it ensures numbers in JSON are encoded as strings.
+func (m ClobPairIdFilter) OnAuthenticatorAdded(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return nil
+}
+
+// OnAuthenticatorRemoved is a no-op in this implementation but can be used when an authenticator is removed.
+func (m ClobPairIdFilter) OnAuthenticatorRemoved(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return nil
+}

--- a/protocol/x/accountplus/authenticator/clob_pair_id_filter_test.go
+++ b/protocol/x/accountplus/authenticator/clob_pair_id_filter_test.go
@@ -21,7 +21,7 @@ type ClobPairIdFilterTest struct {
 }
 
 func TestClobPairIdFilterTest(t *testing.T) {
-	suite.Run(t, new(MessageFilterTest))
+	suite.Run(t, new(ClobPairIdFilterTest))
 }
 
 func (s *ClobPairIdFilterTest) SetupTest() {
@@ -89,8 +89,8 @@ func (s *ClobPairIdFilterTest) TestFilter() {
 				s.tApp.App.AppCodec(),
 				ak,
 				sigModeHandler,
-				s.TestAccAddress[0],
-				s.TestAccAddress[0],
+				constants.AliceAccAddress,
+				constants.AliceAccAddress,
 				nil,
 				sdk.NewCoins(),
 				tt.msg,

--- a/protocol/x/accountplus/authenticator/clob_pair_id_filter_test.go
+++ b/protocol/x/accountplus/authenticator/clob_pair_id_filter_test.go
@@ -1,0 +1,111 @@
+package authenticator_test
+
+import (
+	"os"
+	"testing"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/authenticator"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ClobPairIdFilterTest struct {
+	BaseAuthenticatorSuite
+
+	ClobPairIdFilter authenticator.ClobPairIdFilter
+}
+
+func TestClobPairIdFilterTest(t *testing.T) {
+	suite.Run(t, new(MessageFilterTest))
+}
+
+func (s *ClobPairIdFilterTest) SetupTest() {
+	s.SetupKeys()
+	s.ClobPairIdFilter = authenticator.NewClobPairIdFilter()
+}
+
+func (s *ClobPairIdFilterTest) TearDownTest() {
+	os.RemoveAll(s.HomeDir)
+}
+
+// TestFilter tests the ClobPairIdFilter with multiple clob messages
+func (s *ClobPairIdFilterTest) TestFilter() {
+	tests := map[string]struct {
+		whitelist string
+		msg       sdk.Msg
+
+		match bool
+	}{
+		"order place": {
+			whitelist: "0",
+			msg:       constants.Msg_PlaceOrder_LongTerm,
+			match:     true,
+		},
+		"order cancel": {
+			whitelist: "0",
+			msg:       constants.Msg_CancelOrder_LongTerm,
+			match:     true,
+		},
+		"order batch cancel": {
+			whitelist: "0",
+			msg:       constants.Msg_BatchCancel,
+			match:     true,
+		},
+		"order place - fail": {
+			whitelist: "1",
+			msg:       constants.Msg_PlaceOrder_LongTerm,
+			match:     false,
+		},
+		"order cancel - fail": {
+			whitelist: "1",
+			msg:       constants.Msg_CancelOrder_LongTerm,
+			match:     false,
+		},
+		"order batch cancel - fail": {
+			whitelist: "1",
+			msg:       constants.Msg_BatchCancel,
+			match:     false,
+		},
+	}
+
+	for name, tt := range tests {
+		s.Run(name, func() {
+			err := s.ClobPairIdFilter.OnAuthenticatorAdded(s.Ctx, sdk.AccAddress{}, []byte(tt.whitelist), "1")
+			s.Require().NoError(err)
+			filter, err := s.ClobPairIdFilter.Initialize([]byte(tt.whitelist))
+			s.Require().NoError(err)
+
+			ak := s.tApp.App.AccountKeeper
+			sigModeHandler := s.EncodingConfig.TxConfig.SignModeHandler()
+			tx, err := s.GenSimpleTx([]sdk.Msg{tt.msg}, []cryptotypes.PrivKey{s.TestPrivKeys[0]})
+			s.Require().NoError(err)
+			request, err := authenticator.GenerateAuthenticationRequest(
+				s.Ctx,
+				s.tApp.App.AppCodec(),
+				ak,
+				sigModeHandler,
+				s.TestAccAddress[0],
+				s.TestAccAddress[0],
+				nil,
+				sdk.NewCoins(),
+				tt.msg,
+				tx,
+				0,
+				false,
+			)
+			s.Require().NoError(err)
+
+			err = filter.Authenticate(s.Ctx, request)
+			if tt.match {
+				s.Require().NoError(err)
+			} else {
+				s.Require().ErrorIs(err, sdkerrors.ErrUnauthorized)
+			}
+		})
+	}
+}

--- a/protocol/x/accountplus/authenticator/composition_test.go
+++ b/protocol/x/accountplus/authenticator/composition_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 
@@ -665,9 +664,6 @@ func (s *AggregatedAuthenticatorsTest) TestNestedAuthenticatorCalls() {
 			Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
 		}
 
-		encodedMsg, err := codectypes.NewAnyWithValue(msg)
-		s.Require().NoError(err, "Should encode Any value successfully")
-
 		// mock the authentication request
 		authReq := authenticator.AuthenticationRequest{
 			AuthenticatorId: tc.id,
@@ -675,7 +671,7 @@ func (s *AggregatedAuthenticatorsTest) TestNestedAuthenticatorCalls() {
 			FeePayer:        s.TestAccAddress[0],
 			FeeGranter:      nil,
 			Fee:             sdk.NewCoins(),
-			Msg:             authenticator.LocalAny{TypeURL: encodedMsg.TypeUrl, Value: encodedMsg.Value},
+			Msg:             msg,
 			MsgIndex:        0,
 			Signature:       []byte{1, 1, 1, 1, 1},
 			SignModeTxData:  authenticator.SignModeData{Direct: []byte{1, 1, 1, 1, 1}},
@@ -834,15 +830,12 @@ func (s *AggregatedAuthenticatorsTest) TestAnyOfNotWritingFailedSubAuthState() {
 			Amount:      sdk.NewCoins(sdk.NewInt64Coin("foo", 1)),
 		}
 
-		encodedMsg, err := codectypes.NewAnyWithValue(msg)
-		s.Require().NoError(err, "Should encode Any value successfully")
-
 		// mock the authentication request
 		authReq := authenticator.AuthenticationRequest{
 			AuthenticatorId: "1",
 			Account:         s.TestAccAddress[0],
 			FeePayer:        s.TestAccAddress[0],
-			Msg:             authenticator.LocalAny{TypeURL: encodedMsg.TypeUrl, Value: encodedMsg.Value},
+			Msg:             msg,
 			MsgIndex:        0,
 			Signature:       []byte{1, 1, 1, 1, 1},
 			SignModeTxData:  authenticator.SignModeData{Direct: []byte{1, 1, 1, 1, 1}},

--- a/protocol/x/accountplus/authenticator/constants.go
+++ b/protocol/x/accountplus/authenticator/constants.go
@@ -1,0 +1,5 @@
+package authenticator
+
+// SEPARATOR is the separator used to split the configuration string.
+// This is used by MessageFilter, SubaccountFilter, and ClobPairIdFilter.
+const SEPARATOR = ","

--- a/protocol/x/accountplus/authenticator/message_filter.go
+++ b/protocol/x/accountplus/authenticator/message_filter.go
@@ -49,14 +49,14 @@ func (m MessageFilter) Track(ctx sdk.Context, request AuthenticationRequest) err
 // It returns an AuthenticationResult based on the evaluation.
 func (m MessageFilter) Authenticate(ctx sdk.Context, request AuthenticationRequest) error {
 	for _, msgType := range m.msgTypes {
-		if request.Msg.TypeURL == msgType {
+		if sdk.MsgTypeURL(request.Msg) == msgType {
 			return nil
 		}
 	}
 	return errorsmod.Wrapf(
 		sdkerrors.ErrUnauthorized,
 		"message types do not match. Got %s, Expected %v",
-		request.Msg.TypeURL,
+		sdk.MsgTypeURL(request.Msg),
 		m.msgTypes,
 	)
 }

--- a/protocol/x/accountplus/authenticator/message_filter.go
+++ b/protocol/x/accountplus/authenticator/message_filter.go
@@ -9,8 +9,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const SEPARATOR = ","
-
 var _ Authenticator = &MessageFilter{}
 
 // MessageFilter filters incoming messages based on a predefined JSON pattern.

--- a/protocol/x/accountplus/authenticator/requests.go
+++ b/protocol/x/accountplus/authenticator/requests.go
@@ -10,7 +10,7 @@ type TrackRequest struct {
 	FeePayer            sdk.AccAddress `json:"fee_payer"`
 	FeeGranter          sdk.AccAddress `json:"fee_granter,omitempty"`
 	Fee                 sdk.Coins      `json:"fee"`
-	Msg                 LocalAny       `json:"msg"`
+	Msg                 sdk.Msg        `json:"msg"`
 	MsgIndex            uint64         `json:"msg_index"`
 	AuthenticatorParams []byte         `json:"authenticator_params,omitempty"`
 }
@@ -21,7 +21,7 @@ type ConfirmExecutionRequest struct {
 	FeePayer            sdk.AccAddress `json:"fee_payer"`
 	FeeGranter          sdk.AccAddress `json:"fee_granter,omitempty"`
 	Fee                 sdk.Coins      `json:"fee"`
-	Msg                 LocalAny       `json:"msg"`
+	Msg                 sdk.Msg        `json:"msg"`
 	MsgIndex            uint64         `json:"msg_index"`
 	AuthenticatorParams []byte         `json:"authenticator_params,omitempty"`
 }
@@ -32,7 +32,7 @@ type AuthenticationRequest struct {
 	FeePayer        sdk.AccAddress `json:"fee_payer"`
 	FeeGranter      sdk.AccAddress `json:"fee_granter,omitempty"`
 	Fee             sdk.Coins      `json:"fee"`
-	Msg             LocalAny       `json:"msg"`
+	Msg             sdk.Msg        `json:"msg"`
 
 	// Since array size is int, and size depends on the system architecture,
 	// we use uint64 to cover all available architectures.

--- a/protocol/x/accountplus/authenticator/subaccount_filter.go
+++ b/protocol/x/accountplus/authenticator/subaccount_filter.go
@@ -1,0 +1,116 @@
+package authenticator
+
+import (
+	"strconv"
+	"strings"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+)
+
+var _ Authenticator = &SubaccountFilter{}
+
+// SubaccountFilter filters incoming messages based on a predefined JSON pattern.
+// It allows for complex pattern matching to support advanced authentication flows.
+type SubaccountFilter struct {
+	whitelist []uint32
+}
+
+// NewSubaccountFilter creates a new SubaccountFilter with the provided EncodingConfig.
+func NewSubaccountFilter() SubaccountFilter {
+	return SubaccountFilter{}
+}
+
+// Type returns the type of the authenticator.
+func (m SubaccountFilter) Type() string {
+	return "SubaccountFilter"
+}
+
+// StaticGas returns the static gas amount for the authenticator. Currently, it's set to zero.
+func (m SubaccountFilter) StaticGas() uint64 {
+	return 0
+}
+
+// Initialize sets up the authenticator with the given data, which should be a valid JSON pattern for message filtering.
+func (m SubaccountFilter) Initialize(config []byte) (Authenticator, error) {
+	strSlice := strings.Split(string(config), SEPARATOR)
+
+	m.whitelist = make([]uint32, len(strSlice))
+	for i, str := range strSlice {
+		num, err := strconv.ParseUint(str, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		m.whitelist[i] = uint32(num)
+	}
+	return m, nil
+}
+
+// Track is a no-op in this implementation but can be used to track message handling.
+func (m SubaccountFilter) Track(ctx sdk.Context, request AuthenticationRequest) error {
+	return nil
+}
+
+// Authenticate checks if the provided message conforms to the set JSON pattern.
+// It returns an AuthenticationResult based on the evaluation.
+func (m SubaccountFilter) Authenticate(ctx sdk.Context, request AuthenticationRequest) error {
+	// Collect the clob pair ids from the request.
+	requestSubaccountNums := make([]uint32, 0)
+	switch msg := request.Msg.(type) {
+	case *clobtypes.MsgPlaceOrder:
+		requestSubaccountNums = append(requestSubaccountNums, msg.Order.OrderId.SubaccountId.Number)
+	case *clobtypes.MsgCancelOrder:
+		requestSubaccountNums = append(requestSubaccountNums, msg.OrderId.SubaccountId.Number)
+	case *clobtypes.MsgBatchCancel:
+		requestSubaccountNums = append(requestSubaccountNums, msg.SubaccountId.Number)
+	}
+
+	// Make sure all the subaccount numbers are in the whitelist.
+	for _, subaccountNum := range requestSubaccountNums {
+		whitelisted := false
+		for _, whitelistId := range m.whitelist {
+			if subaccountNum == whitelistId {
+				whitelisted = true
+				break
+			}
+		}
+
+		if !whitelisted {
+			return errorsmod.Wrapf(
+				sdkerrors.ErrUnauthorized,
+				"subaccount number %d not in whitelist %v",
+				subaccountNum,
+				m.whitelist,
+			)
+		}
+	}
+	return nil
+}
+
+// ConfirmExecution confirms the execution of a message. Currently, it always confirms.
+func (m SubaccountFilter) ConfirmExecution(ctx sdk.Context, request AuthenticationRequest) error {
+	return nil
+}
+
+// OnAuthenticatorAdded performs additional checks when an authenticator is added.
+// Specifically, it ensures numbers in JSON are encoded as strings.
+func (m SubaccountFilter) OnAuthenticatorAdded(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return nil
+}
+
+// OnAuthenticatorRemoved is a no-op in this implementation but can be used when an authenticator is removed.
+func (m SubaccountFilter) OnAuthenticatorRemoved(
+	ctx sdk.Context,
+	account sdk.AccAddress,
+	config []byte,
+	authenticatorId string,
+) error {
+	return nil
+}

--- a/protocol/x/accountplus/authenticator/subaccount_filter_test.go
+++ b/protocol/x/accountplus/authenticator/subaccount_filter_test.go
@@ -21,7 +21,7 @@ type SubaccountFilterTest struct {
 }
 
 func TestSubaccountFilterTest(t *testing.T) {
-	suite.Run(t, new(MessageFilterTest))
+	suite.Run(t, new(SubaccountFilterTest))
 }
 
 func (s *SubaccountFilterTest) SetupTest() {
@@ -89,8 +89,8 @@ func (s *SubaccountFilterTest) TestFilter() {
 				s.tApp.App.AppCodec(),
 				ak,
 				sigModeHandler,
-				s.TestAccAddress[0],
-				s.TestAccAddress[0],
+				constants.AliceAccAddress,
+				constants.AliceAccAddress,
 				nil,
 				sdk.NewCoins(),
 				tt.msg,

--- a/protocol/x/accountplus/authenticator/subaccount_filter_test.go
+++ b/protocol/x/accountplus/authenticator/subaccount_filter_test.go
@@ -1,0 +1,111 @@
+package authenticator_test
+
+import (
+	"os"
+	"testing"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+
+	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/authenticator"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SubaccountFilterTest struct {
+	BaseAuthenticatorSuite
+
+	SubaccountFilter authenticator.SubaccountFilter
+}
+
+func TestSubaccountFilterTest(t *testing.T) {
+	suite.Run(t, new(MessageFilterTest))
+}
+
+func (s *SubaccountFilterTest) SetupTest() {
+	s.SetupKeys()
+	s.SubaccountFilter = authenticator.NewSubaccountFilter()
+}
+
+func (s *SubaccountFilterTest) TearDownTest() {
+	os.RemoveAll(s.HomeDir)
+}
+
+// TestFilter tests the SubaccountFilter with multiple clob messages
+func (s *SubaccountFilterTest) TestFilter() {
+	tests := map[string]struct {
+		whitelist string
+		msg       sdk.Msg
+
+		match bool
+	}{
+		"order place": {
+			whitelist: "0",
+			msg:       constants.Msg_PlaceOrder_LongTerm,
+			match:     true,
+		},
+		"order cancel": {
+			whitelist: "0",
+			msg:       constants.Msg_CancelOrder_LongTerm,
+			match:     true,
+		},
+		"order batch cancel": {
+			whitelist: "0",
+			msg:       constants.Msg_BatchCancel,
+			match:     true,
+		},
+		"order place - fail": {
+			whitelist: "1",
+			msg:       constants.Msg_PlaceOrder_LongTerm,
+			match:     false,
+		},
+		"order cancel - fail": {
+			whitelist: "1",
+			msg:       constants.Msg_CancelOrder_LongTerm,
+			match:     false,
+		},
+		"order batch cancel - fail": {
+			whitelist: "1",
+			msg:       constants.Msg_BatchCancel,
+			match:     false,
+		},
+	}
+
+	for name, tt := range tests {
+		s.Run(name, func() {
+			err := s.SubaccountFilter.OnAuthenticatorAdded(s.Ctx, sdk.AccAddress{}, []byte(tt.whitelist), "1")
+			s.Require().NoError(err)
+			filter, err := s.SubaccountFilter.Initialize([]byte(tt.whitelist))
+			s.Require().NoError(err)
+
+			ak := s.tApp.App.AccountKeeper
+			sigModeHandler := s.EncodingConfig.TxConfig.SignModeHandler()
+			tx, err := s.GenSimpleTx([]sdk.Msg{tt.msg}, []cryptotypes.PrivKey{s.TestPrivKeys[0]})
+			s.Require().NoError(err)
+			request, err := authenticator.GenerateAuthenticationRequest(
+				s.Ctx,
+				s.tApp.App.AppCodec(),
+				ak,
+				sigModeHandler,
+				s.TestAccAddress[0],
+				s.TestAccAddress[0],
+				nil,
+				sdk.NewCoins(),
+				tt.msg,
+				tx,
+				0,
+				false,
+			)
+			s.Require().NoError(err)
+
+			err = filter.Authenticate(s.Ctx, request)
+			if tt.match {
+				s.Require().NoError(err)
+			} else {
+				s.Require().ErrorIs(err, sdkerrors.ErrUnauthorized)
+			}
+		})
+	}
+}

--- a/protocol/x/accountplus/testutils/spy_authenticator.go
+++ b/protocol/x/accountplus/testutils/spy_authenticator.go
@@ -15,10 +15,10 @@ import (
 var _ authenticator.Authenticator = &SpyAuthenticator{}
 
 type SpyTrackRequest struct {
-	AuthenticatorId string                 `json:"authenticator_id"`
-	Account         sdk.AccAddress         `json:"account"`
-	Msg             authenticator.LocalAny `json:"msg"`
-	MsgIndex        uint64                 `json:"msg_index"`
+	AuthenticatorId string         `json:"authenticator_id"`
+	Account         sdk.AccAddress `json:"account"`
+	Msg             sdk.Msg        `json:"msg"`
+	MsgIndex        uint64         `json:"msg_index"`
 }
 
 type SpyAddRequest struct {


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `ClobPairIdFilter` and `SubaccountFilter` for enhanced message filtering based on whitelisted IDs.
- **Improvements**
	- Streamlined message handling by directly using `sdk.Msg` instead of `LocalAny` across various structures and methods.
	- Simplified encoding processes for messages, reducing complexity in authentication flows.
- **Tests**
	- Added comprehensive test suites for `ClobPairIdFilter` and `SubaccountFilter` to validate functionality against various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->