### PR TITLE
Update GetAllRevshare to handle liquidations

### DIFF
--- a/protocol/x/affiliates/abci.go
+++ b/protocol/x/affiliates/abci.go
@@ -1,8 +1,6 @@
 package affiliates
 
 import (
-	"runtime/debug"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/log"
 	"github.com/dydxprotocol/v4-chain/protocol/x/affiliates/keeper"
@@ -13,7 +11,6 @@ func EndBlocker(
 	keeper *keeper.Keeper,
 ) {
 	if err := keeper.AggregateAffiliateReferredVolumeForFills(ctx); err != nil {
-		log.ErrorLog(ctx, "error aggregating affiliate volume for fills", "error",
-			err, "stack", string(debug.Stack()))
+		log.ErrorLogWithError(ctx, "error aggregating affiliate volume for fills", err)
 	}
 }

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -467,7 +467,7 @@ func (k Keeper) persistMatchedOrders(
 	revSharesForFill, err := k.revshareKeeper.GetAllRevShares(ctx, fillForProcess, affiliatesWhitelistMap)
 	if err != nil {
 		revSharesForFill = revsharetypes.RevSharesForFill{}
-		log.ErrorLog(ctx, "error getting rev shares for fill", "error", err)
+		log.ErrorLogWithError(ctx, "error getting rev shares for fill", err)
 	}
 	if revSharesForFill.AffiliateRevShare != nil {
 		affiliateRevSharesQuoteQuantums = revSharesForFill.AffiliateRevShare.QuoteQuantums

--- a/protocol/x/revshare/keeper/revshare.go
+++ b/protocol/x/revshare/keeper/revshare.go
@@ -175,6 +175,11 @@ func (k Keeper) GetAllRevShares(
 	makerFees := fill.MakerFeeQuoteQuantums
 	netFees := big.NewInt(0).Add(takerFees, makerFees)
 
+	// net fees is 0 in case of liquidations where maker and taker fees are 0
+	if netFees.Sign() == 0 {
+		return types.RevSharesForFill{}, nil
+	}
+
 	affiliateRevShares, affiliateFeesShared, err := k.getAffiliateRevShares(ctx, fill, affiliatesWhitelistMap)
 	if err != nil {
 		return types.RevSharesForFill{}, err

--- a/protocol/x/revshare/keeper/revshare_test.go
+++ b/protocol/x/revshare/keeper/revshare_test.go
@@ -768,6 +768,82 @@ func TestKeeper_GetAllRevShares_Valid(t *testing.T) {
 				require.NoError(t, err)
 			},
 		},
+		{
+			name: "Valid revenue share with 0 taker fee and positive maker fees",
+			expectedRevSharesForFill: types.RevSharesForFill{
+				AllRevShares: []types.RevShare{
+					{
+						Recipient:         constants.BobAccAddress.String(),
+						RevShareFeeSource: types.REV_SHARE_FEE_SOURCE_NET_PROTOCOL_REVENUE,
+						RevShareType:      types.REV_SHARE_TYPE_UNCONDITIONAL,
+						QuoteQuantums:     big.NewInt(400_000),
+						RevSharePpm:       200_000,
+					},
+					{
+						Recipient:         constants.AliceAccAddress.String(),
+						RevShareFeeSource: types.REV_SHARE_FEE_SOURCE_NET_PROTOCOL_REVENUE,
+						RevShareType:      types.REV_SHARE_TYPE_UNCONDITIONAL,
+						QuoteQuantums:     big.NewInt(600_000),
+						RevSharePpm:       300_000,
+					},
+					{
+						Recipient:         constants.AliceAccAddress.String(),
+						RevShareFeeSource: types.REV_SHARE_FEE_SOURCE_NET_PROTOCOL_REVENUE,
+						RevShareType:      types.REV_SHARE_TYPE_MARKET_MAPPER,
+						QuoteQuantums:     big.NewInt(200_000),
+						RevSharePpm:       100_000,
+					},
+				},
+				AffiliateRevShare: nil,
+				FeeSourceToQuoteQuantums: map[types.RevShareFeeSource]*big.Int{
+					types.REV_SHARE_FEE_SOURCE_TAKER_FEE: big.NewInt(0),
+					// unconditional + market mapper rev shares fees
+					types.REV_SHARE_FEE_SOURCE_NET_PROTOCOL_REVENUE: big.NewInt(1_200_000),
+				},
+				FeeSourceToRevSharePpm: map[types.RevShareFeeSource]uint32{
+					types.REV_SHARE_FEE_SOURCE_TAKER_FEE:            0,
+					types.REV_SHARE_FEE_SOURCE_NET_PROTOCOL_REVENUE: 600_000,
+				},
+			},
+			fill: clobtypes.FillForProcess{
+				TakerAddr:                         constants.AliceAccAddress.String(),
+				TakerFeeQuoteQuantums:             big.NewInt(0),
+				MakerAddr:                         constants.BobAccAddress.String(),
+				MakerFeeQuoteQuantums:             big.NewInt(2_000_000),
+				FillQuoteQuantums:                 big.NewInt(100_000_000_000),
+				ProductId:                         perpetualId,
+				MonthlyRollingTakerVolumeQuantums: 1_000_000_000_000,
+				MarketId:                          marketId,
+			},
+			setup: func(tApp *testapp.TestApp, ctx sdk.Context, keeper *keeper.Keeper,
+				affiliatesKeeper *affiliateskeeper.Keeper) {
+				err := keeper.SetMarketMapperRevenueShareParams(ctx, types.MarketMapperRevenueShareParams{
+					Address:         constants.AliceAccAddress.String(),
+					RevenueSharePpm: 100_000, // 10%
+					ValidDays:       1,
+				})
+				require.NoError(t, err)
+
+				keeper.SetUnconditionalRevShareConfigParams(ctx, types.UnconditionalRevShareConfig{
+					Configs: []types.UnconditionalRevShareConfig_RecipientConfig{
+						{
+							Address:  constants.BobAccAddress.String(),
+							SharePpm: 200_000, // 20%
+						},
+						{
+							Address:  constants.AliceAccAddress.String(),
+							SharePpm: 300_000, // 30%
+						},
+					},
+				})
+
+				err = affiliatesKeeper.UpdateAffiliateTiers(ctx, affiliatetypes.DefaultAffiliateTiers)
+				require.NoError(t, err)
+				err = affiliatesKeeper.RegisterAffiliate(ctx, constants.AliceAccAddress.String(),
+					constants.BobAccAddress.String())
+				require.NoError(t, err)
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/protocol/x/revshare/types/errors.go
+++ b/protocol/x/revshare/types/errors.go
@@ -39,6 +39,6 @@ var (
 	ErrAffiliateFeesSharedGreaterThanOrEqualToNetFees = errorsmod.Register(
 		ModuleName,
 		7,
-		"net fees minus affiliate fee share is not larger than zero",
+		"affiliate fees shared greater than or equal to net fees",
 	)
 )

--- a/protocol/x/revshare/types/errors.go
+++ b/protocol/x/revshare/types/errors.go
@@ -36,9 +36,9 @@ var (
 		6,
 		"total fees shared exceeds net fees",
 	)
-	ErrAffiliateFeesSharedExceedsNetFees = errorsmod.Register(
+	ErrAffiliateFeesSharedGreaterThanOrEqualToNetFees = errorsmod.Register(
 		ModuleName,
 		7,
-		"affiliate fees shared exceeds net fees",
+		"net fees minus affiliate fee share is not larger than zero",
 	)
 )


### PR DESCRIPTION
### Changelist
[Failure error logs](https://app.datadoghq.com/logs?query=issue.id%3Ab70fa6d4-7d6d-11ef-909c-da7ad0900002%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1727507763000&to_ts=1727512431724&live=false) when going through liquidations since maker and taker fees are 0. This handles that case

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced revenue sharing functionality with improved checks for net fees.
	- Refined logic for calculating affiliate revenue shares based on specified thresholds.
	- Clarified error messages related to affiliate fees.

- **Bug Fixes**
	- Improved error handling for revenue share calculations to prevent exceeding defined limits.

- **Tests**
	- Added new test cases to validate behavior with zero fees and refined existing tests for accuracy in revenue share calculations.
	- Standardized setup functions for consistency across test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->