### PR TITLE
Fix flaky vault test.

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
@@ -21,6 +21,7 @@ import request from 'supertest';
 import { getFixedRepresentation, sendRequest } from '../../../helpers/helpers';
 import { DateTime } from 'luxon';
 import Big from 'big.js';
+import config from '../../../../src/config';
 
 describe('vault-controller#V4', () => {
   const latestBlockHeight: string = '25';
@@ -37,6 +38,7 @@ describe('vault-controller#V4', () => {
   const vault1Equity: number = 159500;
   const vault2Equity: number = 10000;
   const mainVaultEquity: number = 10000;
+  const vaultPnlHistoryHoursPrev: number = config.VAULT_PNL_HISTORY_HOURS;
 
   beforeAll(async () => {
     await dbHelpers.migrate();
@@ -48,6 +50,8 @@ describe('vault-controller#V4', () => {
 
   describe('GET /v1', () => {
     beforeEach(async () => {
+      // Get a week of data for hourly pnl ticks.
+      config.VAULT_PNL_HISTORY_HOURS = 168;
       await testMocks.seedData();
       await perpetualMarketRefresher.updatePerpetualMarkets();
       await liquidityTierRefresher.updateLiquidityTiers();
@@ -109,6 +113,7 @@ describe('vault-controller#V4', () => {
 
     afterEach(async () => {
       await dbHelpers.clearData();
+      config.VAULT_PNL_HISTORY_HOURS = vaultPnlHistoryHoursPrev;
     });
 
     it('Get /megavault/historicalPnl with no vault subaccounts', async () => {


### PR DESCRIPTION
### Changelist
Data points in the unit tests can be filtered out due to the default limit of 3 days of hourly PnL ticks based on the day, causing the test to be flaky.

### Test Plan
Re-ran unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a configuration variable for vault PnL history hours to enhance testing flexibility.
	- Updated test setup and teardown processes to dynamically adjust and reset the configuration for historical PnL data retrieval.
	- Added comments for improved readability and maintainability of test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->