### PR TITLE
[TRA-654] add listing module state init into v7 upgrade handler

### DIFF
--- a/protocol/app/upgrades.go
+++ b/protocol/app/upgrades.go
@@ -33,6 +33,7 @@ func (app *App) setupUpgradeHandlers() {
 			app.AccountKeeper,
 			app.PricesKeeper,
 			app.VaultKeeper,
+			app.ListingKeeper,
 		),
 	)
 }

--- a/protocol/app/upgrades/v7.0.0/upgrade.go
+++ b/protocol/app/upgrades/v7.0.0/upgrade.go
@@ -199,7 +199,7 @@ func migrateVaultSharesToMegavaultShares(ctx sdk.Context, k vaultkeeper.Keeper) 
 
 func initListingModuleState(ctx sdk.Context, listingKeeper listingkeeper.Keeper) {
 	// Set hard cap on listed markets
-	err := listingKeeper.SetMarketsHardCap(ctx, 500)
+	err := listingKeeper.SetMarketsHardCap(ctx, listingtypes.DefaultMarketsHardCap)
 	if err != nil {
 		panic(fmt.Sprintf("failed to set markets hard cap: %s", err))
 	}

--- a/protocol/app/upgrades/v7.0.0/upgrade.go
+++ b/protocol/app/upgrades/v7.0.0/upgrade.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 
+	listingtypes "github.com/dydxprotocol/v4-chain/protocol/x/listing/types"
+
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -12,6 +14,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/slinky"
+	listingkeeper "github.com/dydxprotocol/v4-chain/protocol/x/listing/keeper"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	vaultkeeper "github.com/dydxprotocol/v4-chain/protocol/x/vault/keeper"
 	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
@@ -194,12 +197,30 @@ func migrateVaultSharesToMegavaultShares(ctx sdk.Context, k vaultkeeper.Keeper) 
 	ctx.Logger().Info("Successfully migrated vault shares to megavault shares")
 }
 
+func initListingModuleState(ctx sdk.Context, listingKeeper listingkeeper.Keeper) {
+	// Set hard cap on listed markets
+	err := listingKeeper.SetMarketsHardCap(ctx, 500)
+	if err != nil {
+		panic(fmt.Sprintf("failed to set markets hard cap: %s", err))
+	}
+
+	// Set listing vault deposit params
+	err = listingKeeper.SetListingVaultDepositParams(
+		ctx,
+		listingtypes.DefaultParams(),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("failed to set listing vault deposit params: %s", err))
+	}
+}
+
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
 	accountKeeper authkeeper.AccountKeeper,
 	pricesKeeper pricestypes.PricesKeeper,
 	vaultKeeper vaultkeeper.Keeper,
+	listingKeeper listingkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		sdkCtx := lib.UnwrapSDKContext(ctx, "app/upgrades")
@@ -216,6 +237,9 @@ func CreateUpgradeHandler(
 
 		// Migrate vault shares to megavault shares.
 		migrateVaultSharesToMegavaultShares(sdkCtx, vaultKeeper)
+
+		// Initialize listing module state.
+		initListingModuleState(sdkCtx, listingKeeper)
 
 		return mm.RunMigrations(ctx, configurator, vm)
 	}

--- a/protocol/app/upgrades/v7.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v7.0.0/upgrade_container_test.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"testing"
 
+	listingtypes "github.com/dydxprotocol/v4-chain/protocol/x/listing/types"
+
 	"github.com/cosmos/gogoproto/proto"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -58,6 +60,9 @@ func postUpgradeChecks(node *containertest.Node, t *testing.T) {
 
 	// Check that the affiliates module has been initialized with the default tiers.
 	postUpgradeAffiliatesModuleTiersCheck(node, t)
+
+	// Check that the listing module state has been initialized with the hard cap and default deposit params.
+	postUpgradeListingModuleStateCheck(node, t)
 }
 
 func postUpgradeVaultParamsCheck(node *containertest.Node, t *testing.T) {
@@ -202,4 +207,35 @@ func postUpgradeMegavaultModuleAccCheck(node *containertest.Node, t *testing.T) 
 	moduleAccResp := authtypes.QueryModuleAccountByNameResponse{}
 	err = proto.UnmarshalText(resp.String(), &moduleAccResp)
 	require.NoError(t, err)
+}
+
+func postUpgradeListingModuleStateCheck(node *containertest.Node, t *testing.T) {
+	// Check that the listing module state has been initialized with the hard cap and default deposit params.
+	resp, err := containertest.Query(
+		node,
+		listingtypes.NewQueryClient,
+		listingtypes.QueryClient.ListingVaultDepositParams,
+		&listingtypes.QueryListingVaultDepositParams{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	listingVaultDepositParamsResp := listingtypes.QueryListingVaultDepositParamsResponse{}
+	err = proto.UnmarshalText(resp.String(), &listingVaultDepositParamsResp)
+	require.NoError(t, err)
+	require.Equal(t, listingtypes.DefaultParams(), listingVaultDepositParamsResp.Params)
+
+	resp, err = containertest.Query(
+		node,
+		listingtypes.NewQueryClient,
+		listingtypes.QueryClient.MarketsHardCap,
+		&listingtypes.QueryMarketsHardCap{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	marketsHardCapResp := listingtypes.QueryMarketsHardCapResponse{}
+	err = proto.UnmarshalText(resp.String(), &marketsHardCapResp)
+	require.NoError(t, err)
+	require.Equal(t, uint32(500), marketsHardCapResp.HardCap)
 }

--- a/protocol/x/listing/types/constants.go
+++ b/protocol/x/listing/types/constants.go
@@ -14,4 +14,6 @@ const (
 	DefaultQuantumConversionExponent = -9
 
 	ResolutionOffset = -6
+
+	DefaultMarketsHardCap = 500
 )


### PR DESCRIPTION
### Changelist
Set markets hard cap and default listing vault params for the listing module state in v7 upgrade handler

### Test Plan
Existing tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated a new listing module into the upgrade process, enhancing state initialization during upgrades.
	- Added a hard cap on the number of listed markets and established deposit parameters for the listing vault.

- **Bug Fixes**
	- Implemented error handling to ensure proper initialization of the listing module's state.

- **Tests**
	- Introduced checks to validate the listing module's state after upgrades, ensuring correct setup and functionality.
	- Enhanced post-upgrade validation process with specific checks for the listing module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->