### PR TITLE
[TRA-671] Prevent connect messages in x/authz

### DIFF
--- a/protocol/lib/ante/nested_msg.go
+++ b/protocol/lib/ante/nested_msg.go
@@ -12,6 +12,7 @@ import (
 )
 
 const DYDX_MSG_PREFIX = "/" + constants.AppName
+const CONNECT_MSG_PREFIX = "/connect"
 
 // IsNestedMsg returns true if the given msg is a nested msg.
 func IsNestedMsg(msg sdk.Msg) bool {
@@ -30,6 +31,11 @@ func IsNestedMsg(msg sdk.Msg) bool {
 // IsDydxMsg returns true if the given msg is a dYdX custom msg.
 func IsDydxMsg(msg sdk.Msg) bool {
 	return strings.HasPrefix(sdk.MsgTypeURL(msg), DYDX_MSG_PREFIX)
+}
+
+// IsConnectMsg returns true if the given msg is a Connect custom msg.
+func IsConnectMsg(msg sdk.Msg) bool {
+	return strings.HasPrefix(sdk.MsgTypeURL(msg), CONNECT_MSG_PREFIX)
 }
 
 // ValidateNestedMsg returns err if the given msg is an invalid nested msg.
@@ -79,6 +85,9 @@ func validateInnerMsg(msg sdk.Msg) error {
 			)
 			if IsDydxMsg(inner) {
 				return fmt.Errorf("Invalid nested msg for MsgExec: dydx msg type")
+			}
+			if IsConnectMsg(inner) {
+				return fmt.Errorf("Invalid nested msg for MsgExec: Connect msg type")
 			}
 		}
 

--- a/protocol/testutil/msgs/nested_msgs.go
+++ b/protocol/testutil/msgs/nested_msgs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/encoding"
 	prices "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	sending "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
+	marketmap "github.com/skip-mev/connect/v2/x/marketmap/types"
 )
 
 func init() {
@@ -45,6 +46,9 @@ func init() {
 
 	_ = testTxBuilder.SetMsgs(&MsgExecWithDydxMessage)
 	MsgExecWithDydxMessageTxBytes, _ = testEncodingCfg.TxConfig.TxEncoder()(testTxBuilder.GetTx())
+
+	_ = testTxBuilder.SetMsgs(&MsgExecWithConnectMessage)
+	MsgExecWithConnectMessageTxBytes, _ = testEncodingCfg.TxConfig.TxEncoder()(testTxBuilder.GetTx())
 
 	_ = testTxBuilder.SetMsgs(MsgSubmitProposalWithUpgrade)
 	MsgSubmitProposalWithUpgradeTxBytes, _ = testEncodingCfg.TxConfig.TxEncoder()(testTxBuilder.GetTx())
@@ -119,6 +123,12 @@ var (
 		[]sdk.Msg{&sending.MsgCreateTransfer{}},
 	)
 	MsgExecWithDydxMessageTxBytes []byte
+
+	MsgExecWithConnectMessage = authz.NewMsgExec(
+		constants.AliceAccAddress,
+		[]sdk.Msg{&marketmap.MsgUpsertMarkets{}},
+	)
+	MsgExecWithConnectMessageTxBytes []byte
 
 	// Valid MsgSubmitProposals
 	MsgSubmitProposalWithUpgrade, _ = gov.NewMsgSubmitProposal(


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to identify and validate "Connect" messages within the messaging system.
	- Added a new message type, `MsgExecWithConnectMessage`, to handle specific transaction scenarios.

- **Bug Fixes**
	- Enhanced error handling for invalid "Connect" messages in nested message validation.

- **Tests**
	- Expanded test coverage with new tests for validating "Connect" messages, ensuring accurate identification and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->