### PR TITLE
Fix bug with PnL aggregation.

### DIFF
--- a/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
@@ -19,7 +19,7 @@ import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import { NotFoundError } from '../../../lib/errors';
-import { aggregatePnlTicks, getChildSubaccountIds, handleControllerError } from '../../../lib/helpers';
+import { aggregateHourlyPnlTicks, getChildSubaccountIds, handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
 import {
   CheckLimitAndCreatedBeforeOrAtAndOnOrAfterSchema,
@@ -156,10 +156,10 @@ class HistoricalPnlController extends Controller {
     }
 
     // aggregate pnlTicks for all subaccounts grouped by blockHeight
-    const aggregatedPnlTicks: Map<number, PnlTicksFromDatabase> = aggregatePnlTicks(pnlTicks);
+    const aggregatedPnlTicks: PnlTicksFromDatabase[] = aggregateHourlyPnlTicks(pnlTicks);
 
     return {
-      historicalPnl: Array.from(aggregatedPnlTicks.values()).map(
+      historicalPnl: aggregatedPnlTicks.map(
         (pnlTick: PnlTicksFromDatabase) => {
           return pnlTicksToResponseObject(pnlTick);
         }),


### PR DESCRIPTION
### Changelist
PnL aggregation was by block, however PnL ticks can be generated for the same hour at separate block heights (seconds to minutes apart).
Instead, aggregate PnL ticks by hour.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced hourly aggregation for Profit and Loss (PnL) ticks, enhancing data granularity.
  
- **Bug Fixes**
	- Updated test cases to reflect new aggregation logic and ensure accurate results.

- **Documentation**
	- Improved comments and documentation within the code to clarify changes in aggregation methods and data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->