### PR TITLE
[OTE-849] Add metrics to track revenue shares

### DIFF
--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -305,8 +305,7 @@ const (
 	UpdateSubaccounts                     = "update_subaccounts"
 	SubaccountOwner                       = "subaccount_owner"
 	MarketMapperRevenueDistribution       = "market_mapper_revenue_distribution"
-	AffiliateRevenueShareDistribution     = "affiliate_revenue_share_distribution"
-	UnconditionalRevenueShareDistribution = "unconditional_revenue_share_distribution"
+	RevenueShareDistribution              = "revenue_share_distribution"
 	NetFeesPostRevenueShareDistribution   = "net_fees_post_revenue_share_distribution"
 
 	// Liquidation Daemon.
@@ -412,6 +411,9 @@ const (
 	ValidatorNumFills              = "validator_num_fills"
 	ValidatorNumMatchedTakerOrders = "validator_num_matched_taker_orders"
 	ValidatorVolumeQuoteQuantums   = "validator_volume_quote_quantums"
+
+	// x/revshare
+	RevShareType = "rev_share_type"
 
 	// x/acocuntplus
 	TimestampNonce = "timestamp_nonce"

--- a/protocol/lib/metrics/constants.go
+++ b/protocol/lib/metrics/constants.go
@@ -305,6 +305,9 @@ const (
 	UpdateSubaccounts                     = "update_subaccounts"
 	SubaccountOwner                       = "subaccount_owner"
 	MarketMapperRevenueDistribution       = "market_mapper_revenue_distribution"
+	AffiliateRevenueShareDistribution     = "affiliate_revenue_share_distribution"
+	UnconditionalRevenueShareDistribution = "unconditional_revenue_share_distribution"
+	NetFeesPostRevenueShareDistribution   = "net_fees_post_revenue_share_distribution"
 
 	// Liquidation Daemon.
 	CheckCollateralizationForSubaccounts     = "check_collateralization_for_subaccounts"

--- a/protocol/x/revshare/types/types.go
+++ b/protocol/x/revshare/types/types.go
@@ -60,3 +60,18 @@ type RevSharesForFill struct {
 	FeeSourceToRevSharePpm   map[RevShareFeeSource]uint32
 	AllRevShares             []RevShare
 }
+
+func (r RevShareType) String() string {
+	switch r {
+	case REV_SHARE_TYPE_UNSPECIFIED:
+		return "REV_SHARE_TYPE_UNSPECIFIED"
+	case REV_SHARE_TYPE_MARKET_MAPPER:
+		return "REV_SHARE_TYPE_MARKET_MAPPER"
+	case REV_SHARE_TYPE_UNCONDITIONAL:
+		return "REV_SHARE_TYPE_UNCONDITIONAL"
+	case REV_SHARE_TYPE_AFFILIATE:
+		return "REV_SHARE_TYPE_AFFILIATE"
+	default:
+		return "UNKNOWN"
+	}
+}


### PR DESCRIPTION
### Changelist
Adding metrics to track unconditional and affiliate rev shares
Also added metrics to track remaining fees after revshare is subtracted

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new constants for tracking affiliate and unconditional revenue share distributions.
	- Enhanced metrics for revenue share processing, allowing for more detailed tracking of different revenue share types.
	- Added new metric for tracking net fees post-revenue share distribution.
	- Added a new metric emission for the fee collector share to improve visibility into fee distribution.

- **Bug Fixes**
	- Improved error handling for invalid revenue share types during asset transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->