### PR TITLE
[CT-1268] fix genesis for account plus

### DIFF
--- a/protocol/x/accountplus/genesis.go
+++ b/protocol/x/accountplus/genesis.go
@@ -18,7 +18,19 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	if err != nil {
 		panic(err)
 	}
+
+	params := k.GetParams(ctx)
+	nextAuthenticatorId := k.InitializeOrGetNextAuthenticatorId(ctx)
+
+	data, err := k.GetAllAuthenticatorData(ctx)
+	if err != nil {
+		panic(err)
+	}
+
 	return &types.GenesisState{
-		Accounts: accounts,
+		Accounts:            accounts,
+		Params:              params,
+		NextAuthenticatorId: nextAuthenticatorId,
+		AuthenticatorData:   data,
 	}
 }

--- a/protocol/x/accountplus/genesis_test.go
+++ b/protocol/x/accountplus/genesis_test.go
@@ -18,7 +18,10 @@ func TestImportExportGenesis(t *testing.T) {
 		// The order of this list may not match the order in GenesisState. We want our tests to be deterministic so
 		// order of expectedAccountStates was manually set based on test debug. This ordering should only be changed if
 		// additional accounts added to genesisState. If a feature breaks the existing ordering, should look into why.
-		expectedAccountStates []types.AccountState
+		expectedAccountStates       []types.AccountState
+		expectedParams              types.Params
+		expectedNextAuthenticatorId uint64
+		expectedAuthenticatorData   []types.AuthenticatorData
 	}{
 		"non-empty genesis": {
 			genesisState: &types.GenesisState{
@@ -45,6 +48,32 @@ func TestImportExportGenesis(t *testing.T) {
 						},
 					},
 				},
+				Params: types.Params{
+					IsSmartAccountActive: true,
+				},
+				NextAuthenticatorId: 100,
+				AuthenticatorData: []types.AuthenticatorData{
+					{
+						Address: constants.AliceAccAddress.String(),
+						Authenticators: []types.AccountAuthenticator{
+							{
+								Id:     1,
+								Type:   "MessageFilter",
+								Config: []byte("/cosmos.bank.v1beta1.MsgSend"),
+							},
+						},
+					},
+					{
+						Address: constants.BobAccAddress.String(),
+						Authenticators: []types.AccountAuthenticator{
+							{
+								Id:     1,
+								Type:   "ClobPairIdFilter",
+								Config: []byte("0,1,2"),
+							},
+						},
+					},
+				},
 			},
 			expectedAccountStates: []types.AccountState{
 				{
@@ -66,6 +95,32 @@ func TestImportExportGenesis(t *testing.T) {
 					TimestampNonceDetails: types.TimestampNonceDetails{
 						TimestampNonces: []uint64{baseTsNonce + 5, baseTsNonce + 6, baseTsNonce + 7},
 						MaxEjectedNonce: baseTsNonce + 1,
+					},
+				},
+			},
+			expectedParams: types.Params{
+				IsSmartAccountActive: true,
+			},
+			expectedNextAuthenticatorId: 100,
+			expectedAuthenticatorData: []types.AuthenticatorData{
+				{
+					Address: constants.BobAccAddress.String(),
+					Authenticators: []types.AccountAuthenticator{
+						{
+							Id:     1,
+							Type:   "ClobPairIdFilter",
+							Config: []byte("0,1,2"),
+						},
+					},
+				},
+				{
+					Address: constants.AliceAccAddress.String(),
+					Authenticators: []types.AccountAuthenticator{
+						{
+							Id:     1,
+							Type:   "MessageFilter",
+							Config: []byte("/cosmos.bank.v1beta1.MsgSend"),
+						},
 					},
 				},
 			},
@@ -95,11 +150,26 @@ func TestImportExportGenesis(t *testing.T) {
 				"Keeper account states do not match Genesis account states",
 			)
 
+			// Check that keeper params are correct
+			actualParams := k.GetParams(ctx)
+			require.Equal(t, tc.expectedParams, actualParams)
+
+			// Check that keeper next authenticator id is correct
+			actualNextAuthenticatorId := k.InitializeOrGetNextAuthenticatorId(ctx)
+			require.Equal(t, tc.expectedNextAuthenticatorId, actualNextAuthenticatorId)
+
+			// Check that keeper authenticator data is correct
+			actualAuthenticatorData, _ := k.GetAllAuthenticatorData(ctx)
+			require.Equal(t, tc.expectedAuthenticatorData, actualAuthenticatorData)
+
 			exportedGenesis := accountplus.ExportGenesis(ctx, k)
 
 			// Check that the exported state matches the expected state
 			expectedGenesis := &types.GenesisState{
-				Accounts: tc.expectedAccountStates,
+				Accounts:            tc.expectedAccountStates,
+				Params:              tc.expectedParams,
+				NextAuthenticatorId: tc.expectedNextAuthenticatorId,
+				AuthenticatorData:   tc.expectedAuthenticatorData,
 			}
 			require.Equal(t, *exportedGenesis, *expectedGenesis)
 		})

--- a/protocol/x/accountplus/keeper/authenticators.go
+++ b/protocol/x/accountplus/keeper/authenticators.go
@@ -96,19 +96,27 @@ func (k Keeper) AddAuthenticator(
 	}
 
 	k.SetNextAuthenticatorId(ctx, id+1)
-
-	store := prefix.NewStore(
-		ctx.KVStore(k.storeKey),
-		[]byte(types.AuthenticatorKeyPrefix),
-	)
 	authenticator := types.AccountAuthenticator{
 		Id:     id,
 		Type:   authenticatorType,
 		Config: config,
 	}
-	b := k.cdc.MustMarshal(&authenticator)
-	store.Set(types.KeyAccountId(account, id), b)
+	k.SetAuthenticator(ctx, account.String(), id, authenticator)
 	return id, nil
+}
+
+func (k Keeper) SetAuthenticator(
+	ctx sdk.Context,
+	account string,
+	authenticatorId uint64,
+	authenticator types.AccountAuthenticator,
+) {
+	store := prefix.NewStore(
+		ctx.KVStore(k.storeKey),
+		[]byte(types.AuthenticatorKeyPrefix),
+	)
+	b := k.cdc.MustMarshal(&authenticator)
+	store.Set(types.BuildKey(account, authenticatorId), b)
 }
 
 // RemoveAuthenticator removes an authenticator from an account

--- a/protocol/x/accountplus/keeper/keeper.go
+++ b/protocol/x/accountplus/keeper/keeper.go
@@ -105,7 +105,8 @@ func (k Keeper) GetAllAuthenticatorData(ctx sdk.Context) ([]types.AuthenticatorD
 			return err
 		}
 
-		// Extract account address from key
+		// Key is of format `SA/A/{accountAddr}/{authenticatorId}`.
+		// Extract account address from key.
 		accountAddr := strings.Split(string(key), "/")[2]
 
 		// Check if this entry is for a new address or the same as the last one processed

--- a/protocol/x/accountplus/keeper/keeper.go
+++ b/protocol/x/accountplus/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
@@ -53,7 +54,14 @@ func (k Keeper) GetAllAccountStates(ctx sdk.Context) ([]types.AccountState, erro
 
 	accounts := []types.AccountState{}
 	for ; iterator.Valid(); iterator.Next() {
-		accountState, found := k.GetAccountState(ctx, iterator.Key())
+		key := iterator.Key()
+
+		// Temporary workaround to exclude smart account kv pairs.
+		if strings.HasPrefix(string(key), types.SmartAccountKeyPrefix) {
+			continue
+		}
+
+		accountState, found := k.GetAccountState(ctx, key)
 		if !found {
 			return accounts, errors.New("Could not get account state for address: " + sdk.AccAddress(iterator.Key()).String())
 		}
@@ -73,7 +81,65 @@ func (k Keeper) SetGenesisState(ctx sdk.Context, data types.GenesisState) error 
 		k.SetAccountState(ctx, address, account)
 	}
 
+	k.SetParams(ctx, data.Params)
+	k.SetNextAuthenticatorId(ctx, data.NextAuthenticatorId)
+
+	for _, data := range data.GetAuthenticatorData() {
+		address := data.GetAddress()
+		for _, authenticator := range data.GetAuthenticators() {
+			k.SetAuthenticator(ctx, address, authenticator.Id, authenticator)
+		}
+	}
+
 	return nil
+}
+
+// GetAllAuthenticatorData is used in genesis export to export all the authenticator for all accounts
+func (k Keeper) GetAllAuthenticatorData(ctx sdk.Context) ([]types.AuthenticatorData, error) {
+	var accountAuthenticators []types.AuthenticatorData
+
+	parse := func(key []byte, value []byte) error {
+		var authenticator types.AccountAuthenticator
+		err := k.cdc.Unmarshal(value, &authenticator)
+		if err != nil {
+			return err
+		}
+
+		// Extract account address from key
+		accountAddr := strings.Split(string(key), "/")[2]
+
+		// Check if this entry is for a new address or the same as the last one processed
+		if len(accountAuthenticators) == 0 ||
+			accountAuthenticators[len(accountAuthenticators)-1].Address != accountAddr {
+			// If it's a new address, create a new AuthenticatorData entry
+			accountAuthenticators = append(accountAuthenticators, types.AuthenticatorData{
+				Address:        accountAddr,
+				Authenticators: []types.AccountAuthenticator{authenticator},
+			})
+		} else {
+			// If it's the same address, append the authenticator to the last entry in the list
+			lastIndex := len(accountAuthenticators) - 1
+			accountAuthenticators[lastIndex].Authenticators = append(
+				accountAuthenticators[lastIndex].Authenticators,
+				authenticator,
+			)
+		}
+
+		return nil
+	}
+
+	// Iterate over all entries in the store using a prefix iterator
+	iterator := storetypes.KVStorePrefixIterator(ctx.KVStore(k.storeKey), []byte(types.AuthenticatorKeyPrefix))
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		err := parse(iterator.Key(), iterator.Value())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return accountAuthenticators, nil
 }
 
 func GetAccountPlusStateWithTimestampNonceDetails(

--- a/protocol/x/accountplus/keeper/keeper.go
+++ b/protocol/x/accountplus/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -57,7 +58,7 @@ func (k Keeper) GetAllAccountStates(ctx sdk.Context) ([]types.AccountState, erro
 		key := iterator.Key()
 
 		// Temporary workaround to exclude smart account kv pairs.
-		if strings.HasPrefix(string(key), types.SmartAccountKeyPrefix) {
+		if bytes.HasPrefix(key, []byte(types.SmartAccountKeyPrefix)) {
 			continue
 		}
 


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced genesis state export with additional fields: parameters, next authenticator ID, and authenticator data.
	- Introduced a new method for setting authenticators, improving account management.
	- Added functionality to retrieve all authenticator data for accounts.

- **Bug Fixes**
	- Improved logic for retrieving account states by filtering out smart account key-value pairs.

- **Tests**
	- Expanded test coverage for genesis state validation, including new fields for parameters and authenticators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->