### PR TITLE
fix tsnonce preventing multisignature bug

### DIFF
--- a/protocol/x/accountplus/ante/timestampnonce.go
+++ b/protocol/x/accountplus/ante/timestampnonce.go
@@ -20,9 +20,14 @@ func IsTimestampNonceTx(ctx sdk.Context, tx sdk.Tx) (bool, error) {
 		return false, err
 	}
 
-	if len(signatures) != 1 {
-		return false, errorsmod.Wrap(sdkerrors.ErrTxDecode, "more than one signature")
+	// multi signature cannot contain timestamp nonce
+	if len(signatures) > 1 {
+		for _, sig := range signatures {
+			if accountpluskeeper.IsTimestampNonce(sig.Sequence) {
+				return false, errorsmod.Wrap(sdkerrors.ErrTxDecode, "multi signature contains timestampnonce")
+			}
+		}
 	}
 
-	return accountpluskeeper.IsTimestampNonce(signatures[0].Sequence), nil
+	return len(signatures) == 1 && accountpluskeeper.IsTimestampNonce(signatures[0].Sequence), nil
 }

--- a/protocol/x/accountplus/ante/timestampnonce_test.go
+++ b/protocol/x/accountplus/ante/timestampnonce_test.go
@@ -32,7 +32,12 @@ func TestIsTimestampNonceTx(t *testing.T) {
 			expectedResult: true,
 			expectedErr:    false,
 		},
-		"Returns error for more than one signature": {
+		"Returns false with no error if multisignature with regular seq number": {
+			seqs:           []uint64{1, 1},
+			expectedResult: false,
+			expectedErr:    false,
+		},
+		"Returns error for multisignature with timestamp nonce": {
 			seqs:           []uint64{keeper.TimestampNonceSequenceCutoff, keeper.TimestampNonceSequenceCutoff},
 			expectedResult: false,
 			expectedErr:    true,


### PR DESCRIPTION
### Changelist
in AnteHandle seq number is checked if it is a ts nonce via 
```
	if isTimestampNonce, err = accountplusante.IsTimestampNonceTx(ctx, tx); err != nil {
		return ctx, err
	}
```
However, IsTimestampNonce would return an error if len(signatures) != 1, causing AnteHandle to early return. Hence, multisignature would not be possible. This PR fixes the bug.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced logic for timestamp nonce transactions, allowing multiple signatures while preventing timestamp nonces.
	- Updated test cases to align with new expectations for multisignature scenarios, ensuring accurate validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->