### PR TITLE
Get latest hourly tick to compute final tick for megavault PnL.

### DIFF
--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -62,6 +62,7 @@ export const configSchema = {
   // Vaults config
   VAULT_PNL_HISTORY_DAYS: parseInteger({ default: 90 }),
   VAULT_PNL_HISTORY_HOURS: parseInteger({ default: 72 }),
+  VAULT_LATEST_PNL_TICK_WINDOW_HOURS: parseInteger({ default: 1 }),
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Changelist
For all resolutions, get the latest hourly PnL tick to compute the final "current" tick. This ensures the final PnL tick when looking at daily resolution to have the most update to date PnL snapshot (computed hourly).

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter for vault settings, enhancing customization options.
	- Added functionality to retrieve the latest PnL tick for vault subaccounts, improving data granularity.
- **Bug Fixes**
	- Improved time and block height management in tests for the vault controller, ensuring accuracy.
- **Documentation**
	- Updated test cases to reflect changes in time handling and block height calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->