### PR TITLE
[CT-629] Fix entryPrice calc

### DIFF
--- a/indexer/services/ender/__tests__/handlers/order-fills/liquidation-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/liquidation-handler.test.ts
@@ -137,7 +137,7 @@ describe('LiquidationHandler', () => {
     perpetualId: testConstants.defaultPerpetualMarket.id,
     side: PositionSide.LONG,
     status: PerpetualPositionStatus.OPEN,
-    size: '10',
+    size: '5',
     maxSize: '25',
     sumOpen: '10',
     entryPrice: '15000',
@@ -392,7 +392,7 @@ describe('LiquidationHandler', () => {
             defaultPerpetualPosition.openEventId,
           ),
           {
-            sumOpen: Big(defaultPerpetualPosition.size).plus(totalFilled).toFixed(),
+            sumOpen: Big(defaultPerpetualPosition.sumOpen!).plus(totalFilled).toFixed(),
             entryPrice: getWeightedAverage(
               defaultPerpetualPosition.entryPrice!,
               defaultPerpetualPosition.size,

--- a/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
@@ -212,6 +212,7 @@ describe('OrderHandler', () => {
       {
         goodTilBlock: 15,
       },
+      false,
     ],
     [
       'goodTilBlockTime',
@@ -221,6 +222,17 @@ describe('OrderHandler', () => {
       {
         goodTilBlockTime: 1_000_005_000,
       },
+      false,
+    ],
+    [
+      'goodTilBlock',
+      {
+        goodTilBlock: 10,
+      },
+      {
+        goodTilBlock: 15,
+      },
+      true,
     ],
   ])(
     'creates fills and orders (with %s), sends vulcan messages for order updates and order ' +
@@ -229,6 +241,7 @@ describe('OrderHandler', () => {
       _name: string,
       makerGoodTilOneof: Partial<IndexerOrder>,
       takerGoodTilOneof: Partial<IndexerOrder>,
+      useNegativeSize: boolean,
     ) => {
       const transactionIndex: number = 0;
       const eventIndex: number = 0;
@@ -284,7 +297,10 @@ describe('OrderHandler', () => {
 
       // create PerpetualPositions
       await Promise.all([
-        PerpetualPositionTable.create(defaultPerpetualPosition),
+        PerpetualPositionTable.create({
+          ...defaultPerpetualPosition,
+          size: useNegativeSize ? '-5' : defaultPerpetualPosition.size,
+        }),
         PerpetualPositionTable.create({
           ...defaultPerpetualPosition,
           subaccountId: testConstants.defaultSubaccountId2,

--- a/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
@@ -138,7 +138,7 @@ describe('OrderHandler', () => {
     perpetualId: testConstants.defaultPerpetualMarket.id,
     side: PositionSide.LONG,
     status: PerpetualPositionStatus.OPEN,
-    size: '10',
+    size: '5',
     maxSize: '25',
     sumOpen: '10',
     entryPrice: '15000',
@@ -439,7 +439,7 @@ describe('OrderHandler', () => {
             defaultPerpetualPosition.openEventId,
           ),
           {
-            sumOpen: Big(defaultPerpetualPosition.size).plus(totalFilled).toFixed(),
+            sumOpen: Big(defaultPerpetualPosition.sumOpen!).plus(totalFilled).toFixed(),
             entryPrice: getWeightedAverage(
               defaultPerpetualPosition.entryPrice!,
               defaultPerpetualPosition.size,

--- a/indexer/services/ender/src/scripts/helpers/dydx_liquidation_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/helpers/dydx_liquidation_fill_handler_per_order.sql
@@ -200,7 +200,7 @@ BEGIN
                 perpetual_position_record."side", order_side) THEN
             sum_open = dydx_trim_scale(perpetual_position_record."sumOpen" + fill_amount);
             entry_price = dydx_get_weighted_average(
-                    perpetual_position_record."entryPrice", perpetual_position_record."size",
+                    perpetual_position_record."entryPrice", ABS(perpetual_position_record."size"),
                     maker_price, fill_amount);
             perpetual_position_record."sumOpen" = sum_open;
             perpetual_position_record."entryPrice" = entry_price;

--- a/indexer/services/ender/src/scripts/helpers/dydx_liquidation_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/helpers/dydx_liquidation_fill_handler_per_order.sql
@@ -200,7 +200,7 @@ BEGIN
                 perpetual_position_record."side", order_side) THEN
             sum_open = dydx_trim_scale(perpetual_position_record."sumOpen" + fill_amount);
             entry_price = dydx_get_weighted_average(
-                    perpetual_position_record."entryPrice", perpetual_position_record."sumOpen",
+                    perpetual_position_record."entryPrice", perpetual_position_record."size",
                     maker_price, fill_amount);
             perpetual_position_record."sumOpen" = sum_open;
             perpetual_position_record."entryPrice" = entry_price;

--- a/indexer/services/ender/src/scripts/helpers/dydx_update_perpetual_position_aggregate_fields.sql
+++ b/indexer/services/ender/src/scripts/helpers/dydx_update_perpetual_position_aggregate_fields.sql
@@ -44,7 +44,7 @@ BEGIN
     IF dydx_perpetual_position_and_order_side_matching(perpetual_position_record."side", side) THEN
         sum_open := dydx_trim_scale(perpetual_position_record."sumOpen" + size);
         entry_price := dydx_get_weighted_average(
-            perpetual_position_record."entryPrice", perpetual_position_record."size", price, size
+            perpetual_position_record."entryPrice", ABS(perpetual_position_record."size"), price, size
         );
         perpetual_position_record."sumOpen" = sum_open;
         perpetual_position_record."entryPrice" = entry_price;

--- a/indexer/services/ender/src/scripts/helpers/dydx_update_perpetual_position_aggregate_fields.sql
+++ b/indexer/services/ender/src/scripts/helpers/dydx_update_perpetual_position_aggregate_fields.sql
@@ -44,7 +44,7 @@ BEGIN
     IF dydx_perpetual_position_and_order_side_matching(perpetual_position_record."side", side) THEN
         sum_open := dydx_trim_scale(perpetual_position_record."sumOpen" + size);
         entry_price := dydx_get_weighted_average(
-            perpetual_position_record."entryPrice", perpetual_position_record."sumOpen", price, size
+            perpetual_position_record."entryPrice", perpetual_position_record."size", price, size
         );
         perpetual_position_record."sumOpen" = sum_open;
         perpetual_position_record."entryPrice" = entry_price;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted test cases for `LiquidationHandler` and `OrderHandler` to reflect changes in the `defaultPerpetualPosition` size, ensuring accurate validation of liquidation orders and order fills.
	- Updated calculations in tests to align with the new expected values for `sumOpen` and position size.

- **Chores**
	- Refined SQL functions for handling entry price calculations, improving accuracy in order fill processing and perpetual position updates.
	- Enhanced test suite by adding new scenarios for order fills, ensuring thorough validation of order handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->