### PR TITLE
Improve vault endpoint performance.

### DIFF
--- a/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
+++ b/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
@@ -254,14 +254,14 @@ export async function findFundingIndexMaps(
       "funding_index_updates",
       unnest(ARRAY[?]) AS "searchHeight"
     WHERE
-      "effectiveAtHeight" > ? AND
+      "effectiveAtHeight" > ${Big(minHeight).minus(FOUR_HOUR_OF_BLOCKS).toFixed()} AND
       "effectiveAtHeight" <= "searchHeight"
     ORDER BY
       "perpetualId",
       "searchHeight",
       "effectiveAtHeight" DESC
     `,
-    [heightNumbers, Big(minHeight).minus(FOUR_HOUR_OF_BLOCKS).toFixed()],
+    [heightNumbers],
   ) as unknown as {
     rows: FundingIndexUpdatesFromDatabaseWithSearchHeight[],
   };

--- a/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
+++ b/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
@@ -252,7 +252,7 @@ export async function findFundingIndexMaps(
       "funding_index_updates".*
     FROM
       "funding_index_updates",
-      unnest(ARRAY[?]) AS "searchHeight"
+      unnest(ARRAY[${heightNumbers.join(',')}]) AS "searchHeight"
     WHERE
       "effectiveAtHeight" > ${Big(minHeight).minus(FOUR_HOUR_OF_BLOCKS).toFixed()} AND
       "effectiveAtHeight" <= "searchHeight"
@@ -261,7 +261,6 @@ export async function findFundingIndexMaps(
       "searchHeight",
       "effectiveAtHeight" DESC
     `,
-    [heightNumbers],
   ) as unknown as {
     rows: FundingIndexUpdatesFromDatabaseWithSearchHeight[],
   };

--- a/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
+++ b/indexer/packages/postgres/src/stores/funding-index-updates-table.ts
@@ -20,6 +20,15 @@ import {
   PerpetualMarketFromDatabase,
 } from '../types';
 import * as PerpetualMarketTable from './perpetual-market-table';
+import { knexReadReplica } from '../helpers/knex';
+
+// Assuming block time of 1 second, this should be 4 hours of blocks
+const FOUR_HOUR_OF_BLOCKS = Big(3600).times(4);
+// Type used for querying for funding index maps for multiple effective heights.
+interface FundingIndexUpdatesFromDatabaseWithSearchHeight extends FundingIndexUpdatesFromDatabase {
+  // max effective height being queried for
+  searchHeight: string,
+};
 
 export function uuid(
   blockHeight: string,
@@ -193,8 +202,6 @@ export async function findFundingIndexMap(
       options,
     );
 
-  // Assuming block time of 1 second, this should be 4 hours of blocks
-  const FOUR_HOUR_OF_BLOCKS = Big(3600).times(4);
   const fundingIndexUpdates: FundingIndexUpdatesFromDatabase[] = await baseQuery
     .distinctOn(FundingIndexUpdatesColumns.perpetualId)
     .where(FundingIndexUpdatesColumns.effectiveAtHeight, '<=', effectiveBeforeOrAtHeight)
@@ -215,4 +222,67 @@ export async function findFundingIndexMap(
     },
     initialFundingIndexMap,
   );
+}
+
+/**
+ * Finds funding index maps for multiple effective before or at heights. Uses a SQL query unnesting
+ * an array of effective before or at heights and cross-joining with the funding index updates table
+ * to find the closest funding index update per effective before or at height.
+ * @param effectiveBeforeOrAtHeights Heights to get funding index maps for.
+ * @param options 
+ * @returns Object mapping block heights to the respective funding index maps.
+ */
+export async function findFundingIndexMaps(
+  effectiveBeforeOrAtHeights: string[],
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
+): Promise<{[blockHeight: string]: FundingIndexMap}> {
+  const heightNumbers: number[] = effectiveBeforeOrAtHeights
+    .map((height: string) => parseInt(height, 10))
+    .sort();
+  // Get the min height to limit the search to blocks 4 hours or before the min height.
+  const minHeight: number = heightNumbers[0];
+
+  const result: {
+    rows: FundingIndexUpdatesFromDatabaseWithSearchHeight[]
+  } = await knexReadReplica.getConnection().raw(
+    `
+    SELECT
+      DISTINCT ON ("perpetualId", "searchHeight") "perpetualId", "searchHeight",
+      "funding_index_updates".*
+    FROM
+      "funding_index_updates",
+      unnest(ARRAY[${heightNumbers.join(',')}]) AS "searchHeight"
+    WHERE
+      "effectiveAtHeight" > ${Big(minHeight).minus(FOUR_HOUR_OF_BLOCKS).toFixed()} AND
+      "effectiveAtHeight" <= "searchHeight"
+    ORDER BY
+      "perpetualId",
+      "searchHeight",
+      "effectiveAtHeight" DESC
+    `,
+  ) as unknown as {
+    rows: FundingIndexUpdatesFromDatabaseWithSearchHeight[],
+  };
+
+  const perpetualMarkets: PerpetualMarketFromDatabase[] = await PerpetualMarketTable.findAll(
+    {},
+    [],
+    options,
+  );
+
+  const fundingIndexMaps:{[blockHeight: string]: FundingIndexMap} = {};
+  for (const height of effectiveBeforeOrAtHeights) {
+    fundingIndexMaps[height] = _.reduce(perpetualMarkets,
+      (acc: FundingIndexMap, perpetualMarket: PerpetualMarketFromDatabase): FundingIndexMap => {
+        acc[perpetualMarket.id] = Big(0);
+        return acc;
+      },
+      {},
+    );
+  }
+  for (const funding of result.rows) {
+    fundingIndexMaps[funding.searchHeight][funding.perpetualId] = Big(funding.fundingIndex)
+  }
+
+  return fundingIndexMaps;
 }


### PR DESCRIPTION
### Changelist
Fetch funding index update maps in bulk rather than one at a time per vault.

### Test Plan
Unit tests. 

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve funding index maps for multiple effective heights, enhancing data retrieval capabilities.

- **Bug Fixes**
	- Optimized the `getVaultPositions` function for improved performance in fetching funding index maps.

- **Documentation**
	- Updated method signatures and interfaces for better clarity and usability.

- **Refactor**
	- Streamlined data retrieval logic in the `VaultController` to enhance efficiency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->