### PR TITLE
[OTE-852] Register rpc routes in module

### DIFF
--- a/protocol/x/revshare/module.go
+++ b/protocol/x/revshare/module.go
@@ -1,6 +1,7 @@
 package revshare
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -75,7 +76,12 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 }
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
-func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {}
+func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
+	err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	if err != nil {
+		panic(err)
+	}
+}
 
 // GetTxCmd returns the root Tx command for the module. The subcommands of this root command are used by end-users to
 // generate new transactions containing messages defined in the module.


### PR DESCRIPTION
### Changelist

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced gRPC Gateway route registration for improved query handling capabilities. 

- **Bug Fixes**
	- Addressed the issue of unregistered routes in the previous implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->