### PR TITLE
Fix test flakiness due to using inconsistent time.

### DIFF
--- a/indexer/services/comlink/__tests__/lib/helpers.test.ts
+++ b/indexer/services/comlink/__tests__/lib/helpers.test.ts
@@ -868,7 +868,7 @@ describe('helpers', () => {
         ),
       };
       const blockHeight2: string = '80';
-      const blockTime2: string = DateTime.fromISO(pnlTick.createdAt).plus({ hour: 1 }).toISO();
+      const blockTime2: string = DateTime.fromISO(pnlTick.createdAt).startOf('hour').plus({ minute: 61 }).toISO();
       const pnlTick3: PnlTicksFromDatabase = {
         ...testConstants.defaultPnlTick,
         id: PnlTicksTable.uuid(
@@ -880,7 +880,7 @@ describe('helpers', () => {
         createdAt: blockTime2,
       };
       const blockHeight3: string = '81';
-      const blockTime3: string = DateTime.fromISO(pnlTick.createdAt).plus({ minute: 61 }).toISO();
+      const blockTime3: string = DateTime.fromISO(pnlTick.createdAt).startOf('hour').plus({ minute: 62 }).toISO();
       const pnlTick4: PnlTicksFromDatabase = {
         ...testConstants.defaultPnlTick,
         id: PnlTicksTable.uuid(


### PR DESCRIPTION
### Changelist
Use start of hour in tests to fix flaky test issues.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the calculation of `blockTime` for specific `PnlTicks`, ensuring accurate aggregation based on hourly timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->