### PR TITLE
set each megavault share to be worth 0.001 usdc on 7.x upgrade

### DIFF
--- a/protocol/app/upgrades/v7.0.0/upgrade.go
+++ b/protocol/app/upgrades/v7.0.0/upgrade.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	// Each megavault share is worth 0.01 USDC.
-	QUOTE_QUANTUMS_PER_MEGAVAULT_SHARE = 10_000
+	// Each megavault share is worth 0.001 USDC.
+	QUOTE_QUANTUMS_PER_MEGAVAULT_SHARE = 1_000
 )
 
 var (

--- a/protocol/app/upgrades/v7.0.0/upgrade.go
+++ b/protocol/app/upgrades/v7.0.0/upgrade.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	// Each megavault share is worth 1 USDC.
-	QUOTE_QUANTUMS_PER_MEGAVAULT_SHARE = 1_000_000
+	// Each megavault share is worth 0.01 USDC.
+	QUOTE_QUANTUMS_PER_MEGAVAULT_SHARE = 10_000
 )
 
 var (

--- a/protocol/app/upgrades/v7.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v7.0.0/upgrade_container_test.go
@@ -115,21 +115,21 @@ func checkVaultParams(
 func postUpgradeMegavaultSharesCheck(node *containertest.Node, t *testing.T) {
 	// Alice equity = vault_0_equity * 1 + vault_1_equity * 1/3 + vault_2_equity * 123_456/556_677
 	// = 1_000 + 2_000 * 1/3 + 3_000 * 123_456/556_677
-	// ~= 2331.99
+	// ~= 2331.986
 	// Bob equity = vault_1_equity * 1/3 + vault_2_equity * 433_221/556_677
 	// = 2_000 * 1/3 + 3_000 * 433_221/556_677
-	// ~= 3001.35
+	// ~= 3001.347
 	// Carl equity = vault_1_equity * 1/3
 	// = 2_000 * 1/3
-	// ~= 666.67
-	// 1 USDC in equity should be granted 1 megavault share and round down to nearest integer.
+	// ~= 666.667
+	// 0.01 USDC in equity should be granted 1 megavault share and round down to nearest integer.
 	expectedOwnerShares := map[string]*big.Int{
-		constants.AliceAccAddress.String(): big.NewInt(2_331),
-		constants.BobAccAddress.String():   big.NewInt(3_001),
-		constants.CarlAccAddress.String():  big.NewInt(666),
+		constants.AliceAccAddress.String(): big.NewInt(233_198),
+		constants.BobAccAddress.String():   big.NewInt(300_134),
+		constants.CarlAccAddress.String():  big.NewInt(66_666),
 	}
-	// 2331 + 3001 + 666 = 5998
-	expectedTotalShares := big.NewInt(5_998)
+	// 233_198 + 300_134 + 66_666 = 599_998
+	expectedTotalShares := big.NewInt(599_998)
 
 	// Check MegaVault total shares.
 	resp, err := containertest.Query(

--- a/protocol/app/upgrades/v7.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v7.0.0/upgrade_container_test.go
@@ -115,18 +115,18 @@ func checkVaultParams(
 func postUpgradeMegavaultSharesCheck(node *containertest.Node, t *testing.T) {
 	// Alice equity = vault_0_equity * 1 + vault_1_equity * 1/3 + vault_2_equity * 123_456/556_677
 	// = 1_000 + 2_000 * 1/3 + 3_000 * 123_456/556_677
-	// ~= 2331.986
+	// ~= 2331.98605
 	// Bob equity = vault_1_equity * 1/3 + vault_2_equity * 433_221/556_677
 	// = 2_000 * 1/3 + 3_000 * 433_221/556_677
-	// ~= 3001.347
+	// ~= 3001.34728
 	// Carl equity = vault_1_equity * 1/3
 	// = 2_000 * 1/3
-	// ~= 666.667
-	// 0.01 USDC in equity should be granted 1 megavault share and round down to nearest integer.
+	// ~= 666.66667
+	// 0.001 USDC in equity should be granted 1 megavault share and round down to nearest integer.
 	expectedOwnerShares := map[string]*big.Int{
-		constants.AliceAccAddress.String(): big.NewInt(233_198),
-		constants.BobAccAddress.String():   big.NewInt(300_134),
-		constants.CarlAccAddress.String():  big.NewInt(66_666),
+		constants.AliceAccAddress.String(): big.NewInt(2_331_986),
+		constants.BobAccAddress.String():   big.NewInt(3_001_347),
+		constants.CarlAccAddress.String():  big.NewInt(666_666),
 	}
 	// 233_198 + 300_134 + 66_666 = 599_998
 	expectedTotalShares := big.NewInt(599_998)

--- a/protocol/app/upgrades/v7.0.0/upgrade_container_test.go
+++ b/protocol/app/upgrades/v7.0.0/upgrade_container_test.go
@@ -128,8 +128,8 @@ func postUpgradeMegavaultSharesCheck(node *containertest.Node, t *testing.T) {
 		constants.BobAccAddress.String():   big.NewInt(3_001_347),
 		constants.CarlAccAddress.String():  big.NewInt(666_666),
 	}
-	// 233_198 + 300_134 + 66_666 = 599_998
-	expectedTotalShares := big.NewInt(599_998)
+	// 2_331_986 + 3_001_347 + 666_666 = 5_999_999
+	expectedTotalShares := big.NewInt(5_999_999)
 
 	// Check MegaVault total shares.
 	resp, err := containertest.Query(


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a migration strategy for vault shares, adjusting how owner equities are calculated and managed.
  
- **Bug Fixes**
  - Refined expected equity calculations for users, ensuring more accurate share distributions post-upgrade.

- **Documentation**
  - Updated comments for clarity on new equity calculations and share rounding processes. 

- **Changes**
  - Updated valuation of megavault shares from 1 USDC to 0.001 USDC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->