### PR TITLE
[OTE-876] update roundtable loop timings for instrumentation and uncrossing

### DIFF
--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -208,7 +208,7 @@ export const configSchema = {
   AGGREGATE_TRADING_REWARDS_CHUNK_SIZE: parseInteger({ default: 50 }),
 
   // Uncross orderbook
-  STALE_ORDERBOOK_LEVEL_THRESHOLD_SECONDS:  parseInteger({ default: 10 }),
+  STALE_ORDERBOOK_LEVEL_THRESHOLD_SECONDS: parseInteger({ default: 10 }),
 
   // Subaccount username generator
   SUBACCOUNT_USERNAME_NUM_RANDOM_DIGITS: parseInteger({ default: 3 }),

--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -70,7 +70,7 @@ export const configSchema = {
     default: 2 * ONE_MINUTE_IN_MILLISECONDS,
   }),
   LOOPS_INTERVAL_MS_UNCROSS_ORDERBOOK: parseInteger({
-    default: THIRTY_SECONDS_IN_MILLISECONDS,
+    default: 15 * ONE_SECOND_IN_MILLISECONDS,
   }),
   LOOPS_INTERVAL_MS_PNL_TICKS: parseInteger({
     default: THIRTY_SECONDS_IN_MILLISECONDS,
@@ -79,7 +79,7 @@ export const configSchema = {
     default: 2 * ONE_MINUTE_IN_MILLISECONDS,
   }),
   LOOPS_INTERVAL_MS_ORDERBOOK_INSTRUMENTATION: parseInteger({
-    default: 5 * ONE_SECOND_IN_MILLISECONDS,
+    default: 1 * ONE_MINUTE_IN_MILLISECONDS,
   }),
   LOOPS_INTERVAL_MS_PNL_INSTRUMENTATION: parseInteger({
     default: ONE_HOUR_IN_MILLISECONDS,
@@ -208,7 +208,7 @@ export const configSchema = {
   AGGREGATE_TRADING_REWARDS_CHUNK_SIZE: parseInteger({ default: 50 }),
 
   // Uncross orderbook
-  STALE_ORDERBOOK_LEVEL_THRESHOLD_SECONDS: parseInteger({ default: 10 }),
+  STALE_ORDERBOOK_LEVEL_THRESHOLD_SECONDS:  parseInteger({ default: 10 }),
 
   // Subaccount username generator
   SUBACCOUNT_USERNAME_NUM_RANDOM_DIGITS: parseInteger({ default: 3 }),


### PR DESCRIPTION
### Changelist
Updating values of loop timing so that uncrossing happens more frequently than instrumentation

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated default values for operational loop intervals to enhance performance.
	- Improved timing configurations for order book management.
- **Bug Fixes**
	- Adjusted whitespace for better readability in configuration declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->