### PR TITLE
Add config var to exclude specific stateful order ids from being processed.

### DIFF
--- a/indexer/services/ender/src/config.ts
+++ b/indexer/services/ender/src/config.ts
@@ -6,6 +6,7 @@ import {
   parseSchema,
   baseConfigSchema,
   parseBoolean,
+  parseString,
 } from '@dydxprotocol-indexer/base';
 import {
   kafkaConfigSchema,
@@ -22,6 +23,13 @@ export const configSchema = {
   ...kafkaConfigSchema,
   SEND_WEBSOCKET_MESSAGES: parseBoolean({
     default: true,
+  }),
+  // Config var to skip processing stateful order events with specific uuids.
+  // Order UUIDs should be in a string delimited by commas.
+  // Only set if invalid order events are being included in a block and preventing ender from
+  // progressing.
+  SKIP_STATEFUL_ORDER_UUIDS: parseString({
+    default: '',
   }),
 };
 

--- a/indexer/services/ender/src/lib/types.ts
+++ b/indexer/services/ender/src/lib/types.ts
@@ -61,6 +61,8 @@ export enum DydxIndexerSubtypes {
   UPSERT_VAULT = 'upsert_vault',
 }
 
+export const SKIPPED_EVENT_SUBTYPE = 'skipped_event';
+
 // Generic interface used for creating the Handler objects
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EventMessage = any;

--- a/indexer/services/ender/src/scripts/handlers/dydx_block_processor_ordered_handlers.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_block_processor_ordered_handlers.sql
@@ -69,6 +69,8 @@ BEGIN
                 rval[i] = dydx_funding_handler(block_height, block_time, event_data, event_index, transaction_index);
             WHEN '"upsert_vault"'::jsonb THEN
                 rval[i] = dydx_vault_upsert_handler(block_time, event_data);
+            WHEN '"skipped_event"'::jsonb THEN
+                rval[i] = jsonb_build_object();
             ELSE
                 NULL;
             END CASE;

--- a/indexer/services/ender/src/scripts/handlers/dydx_block_processor_unordered_handlers.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_block_processor_unordered_handlers.sql
@@ -67,6 +67,8 @@ BEGIN
                 rval[i] = dydx_trading_rewards_handler(block_height, block_time, event_data, event_index, transaction_index, jsonb_array_element_text(block->'txHashes', transaction_index));
             WHEN '"register_affiliate"'::jsonb THEN
                 rval[i] = dydx_register_affiliate_handler(block_height, event_data);
+            WHEN '"skipped_event"'::jsonb THEN
+                rval[i] = jsonb_build_object();
             ELSE
                 NULL;
             END CASE;

--- a/indexer/services/ender/src/validators/validator.ts
+++ b/indexer/services/ender/src/validators/validator.ts
@@ -58,4 +58,13 @@ export abstract class Validator<T extends object> {
     txId: number,
     messageReceivedTimestamp: string,
   ): Handler<EventMessage>[];
+
+  /**
+   * Allows aribtrary logic to exclude events from being processed.
+   * Defaults to no events being excluded.
+   * @returns
+   */
+  public shouldExcludeEvent(): boolean {
+    return false;
+  }
 }


### PR DESCRIPTION
### Changelist
Add a way to specify order uuid of stateful order events to skip.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration variable to manage skipped order UUIDs, enhancing order processing.
	- Added functionality to exclude specific events from processing based on order UUIDs.
	- Enhanced event handling in SQL scripts to accommodate skipped events.

- **Bug Fixes**
	- Improved test coverage for scenarios involving skipped orders to ensure correct behavior.

- **Documentation**
	- Updated test suites to maintain configuration integrity across tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->