### PR TITLE
update migration to stop excessive consumption of computation

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240910101410_change_fills_affiliaterevshare_type.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240910101410_change_fills_affiliaterevshare_type.ts
@@ -2,15 +2,21 @@ import * as Knex from 'knex';
 
 // No data has been stored added at time of commit
 export async function up(knex: Knex): Promise<void> {
-  return knex.schema.alterTable('fills', (table) => {
-    // decimal('columnName') has is 8,2 precision and scale
-    // decimal('columnName', null) has variable precision and scale
-    table.decimal('affiliateRevShare', null).notNullable().defaultTo(0).alter();
+  // decimal('columnName') has is 8,2 precision and scale
+  // decimal('columnName', null) has variable precision and scale
+  await knex.schema.alterTable('fills', (table) => {
+    table.dropColumn('affiliateRevShare');
+  });
+  await knex.schema.alterTable('fills', (table) => {
+    table.decimal('affiliateRevShare', null).notNullable().defaultTo(0);
   });
 }
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema.alterTable('fills', (table) => {
-    table.string('affiliateRevShare').notNullable().defaultTo('0').alter();
+  await knex.schema.alterTable('fills', (table) => {
+    table.dropColumn('affiliateRevShare');
+  });
+  await knex.schema.alterTable('fills', (table) => {
+    table.string('affiliateRevShare').notNullable().defaultTo('0');
   });
 }


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `affiliateRevShare` column in the `fills` table to improve data accuracy by changing its type to decimal.

- **Bug Fixes**
	- Ensured that the `affiliateRevShare` column is not nullable and has a default value of 0 for better data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->