### PR TITLE
Bump SDK - Always Reset OE

### DIFF
--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -470,7 +470,7 @@ replace (
 	// Use dYdX fork of CometBFT
 	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20241001172045-cfee87f3abbf
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20240808180557-4b1c1dc17703
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241022180223-cc8c850952c5
 	github.com/cosmos/iavl => github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85
 )
 

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -961,8 +961,8 @@ github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dydxprotocol/cometbft v0.38.6-0.20241001172045-cfee87f3abbf h1:pdKqF/qshVtVxcCfpK93QSUIIV3UjR/zj0RfPuqFPwU=
 github.com/dydxprotocol/cometbft v0.38.6-0.20241001172045-cfee87f3abbf/go.mod h1:EBEod7kZfNr4W0VooOrTEMSiXNrSyiQ/M2FL/rOcPCs=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20240808180557-4b1c1dc17703 h1:4bNZ3j0dhbxWfqyEKc0sC2377m+t+wFuFDocqig9VLo=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20240808180557-4b1c1dc17703/go.mod h1:TWUDGvgHJ49+QI6WOf03km3TuUOoAplzgnsjGQH3L7s=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241022180223-cc8c850952c5 h1:C1WxxDRbNMrX8U57IsiTZuEp5R5i/nsEtGhPyU1TIQI=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241022180223-cc8c850952c5/go.mod h1:TWUDGvgHJ49+QI6WOf03km3TuUOoAplzgnsjGQH3L7s=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d h1:HgLu1FD2oDFzlKW6/+SFXlH5Os8cwNTbplQIrQOWx8w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85 h1:5B/yGZyTBX/OZASQQMnk6Ms/TZja56MYd8OBaVc0Mho=


### PR DESCRIPTION
### Changelist
Bump SDK to adopt this [change](https://github.com/dydxprotocol/cosmos-sdk/pull/57). Non-breaking change for OE, completely no-op for nodes not enabling OE. 

### Test Plan
Stably running on prod FNS full node 

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
