### PR TITLE
Add cumulativeEntryPrice migration

### DIFF
--- a/indexer/packages/postgres/__tests__/db/helpers.test.ts
+++ b/indexer/packages/postgres/__tests__/db/helpers.test.ts
@@ -32,6 +32,7 @@ describe('helpers', () => {
       entryPrice: defaultPerpetualPosition.entryPrice as string,
       sumOpen: defaultPerpetualPosition.sumOpen as string,
       sumClose: defaultPerpetualPosition.sumClose as string,
+      cumulativeEntryPrice: defaultPerpetualPosition.cumulativeEntryPrice as string,
     };
 
     it('compute unsettled funding for long position', () => {

--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -518,6 +518,7 @@ export const defaultPerpetualPosition: PerpetualPositionCreateObject = {
   openEventId: defaultTendermintEventId,
   lastEventId: defaultTendermintEventId2,
   settledFunding: '200000',
+  cumulativeEntryPrice: '20000',
 };
 
 export const defaultPerpetualPositionId: string = PerpetualPositionTable.uuid(
@@ -540,6 +541,7 @@ export const isolatedPerpetualPosition: PerpetualPositionCreateObject = {
   openEventId: defaultTendermintEventId,
   lastEventId: defaultTendermintEventId2,
   settledFunding: '200000',
+  cumulativeEntryPrice: '1.5',
 };
 
 export const isolatedPerpetualPositionId: string = PerpetualPositionTable.uuid(

--- a/indexer/packages/postgres/__tests__/stores/perpetual-position-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/perpetual-position-table.test.ts
@@ -419,6 +419,7 @@ describe('PerpetualPosition store', () => {
           maxSize: tinyMaxSize,
           sumOpen: tinySize,
           entryPrice: tinyPrice,
+          cumulativeEntryPrice: tinyPrice,
         });
 
         const closedAt: IsoString = DateTime.utc().toISO();

--- a/indexer/packages/postgres/src/db/helpers.ts
+++ b/indexer/packages/postgres/src/db/helpers.ts
@@ -90,7 +90,7 @@ export function getUnrealizedPnl(
   }
   return (
     Big(position.size).times(
-      Big(market.oraclePrice!).minus(position.entryPrice),
+      Big(market.oraclePrice!).minus(position.cumulativeEntryPrice),
     )
   ).toFixed();
 }

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20241022151729_add_perpetual_positions_cumulative_entry_price.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20241022151729_add_perpetual_positions_cumulative_entry_price.ts
@@ -1,0 +1,17 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex
+    .schema
+    .alterTable('perpetual_positions', (table) => {
+      table.decimal('cumulativeEntryPrice', null).defaultTo(0).notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex
+    .schema
+    .alterTable('perpetual_positions', (table) => {
+      table.dropColumn('cumulativeEntryPrice');
+    });
+}

--- a/indexer/packages/postgres/src/models/perpetual-position-model.ts
+++ b/indexer/packages/postgres/src/models/perpetual-position-model.ts
@@ -79,6 +79,7 @@ export default class PerpetualPositionModel extends Model {
         'openEventId',
         'lastEventId',
         'settledFunding',
+        'cumulativeEntryPrice',
       ],
       properties: {
         id: { type: 'string', format: 'uuid' },
@@ -97,6 +98,7 @@ export default class PerpetualPositionModel extends Model {
         createdAtHeight: { type: 'string', pattern: IntegerPattern },
         closedAtHeight: { type: ['string', 'null'], default: null, pattern: IntegerPattern },
         settledFunding: { type: 'string', pattern: NumericPattern },
+        cumulativeEntryPrice: { type: 'string', pattern: NonNegativeNumericPattern, default: '0' },
       },
     };
   }
@@ -128,6 +130,7 @@ export default class PerpetualPositionModel extends Model {
       closeEventId: 'hex-string',
       lastEventId: 'hex-string',
       settledFunding: 'string',
+      cumulativeEntryPrice: 'string',
     };
   }
 
@@ -168,4 +171,6 @@ export default class PerpetualPositionModel extends Model {
   lastEventId!: Buffer;
 
   settledFunding!: string;
+
+  cumulativeEntryPrice!: string;
 }

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -52,6 +52,7 @@ export interface PerpetualPositionFromDatabase extends IdBasedModelFromDatabase 
   closeEventId?: Buffer,
   lastEventId: Buffer,
   settledFunding: string,
+  cumulativeEntryPrice: string,
 }
 
 export interface OrderFromDatabase extends IdBasedModelFromDatabase {

--- a/indexer/packages/postgres/src/types/perpetual-position-types.ts
+++ b/indexer/packages/postgres/src/types/perpetual-position-types.ts
@@ -34,6 +34,7 @@ export interface PerpetualPositionCreateObject {
   closedAtHeight?: string,
   closeEventId?: Buffer,
   exitPrice?: string,
+  cumulativeEntryPrice?: string,
 }
 
 export interface PerpetualPositionUpdateObject {
@@ -53,6 +54,7 @@ export interface PerpetualPositionUpdateObject {
   closeEventId?: Buffer | null,
   lastEventId?: Buffer,
   settledFunding?: string,
+  cumulativeEntryPrice?: string,
 }
 
 // Object used to update a subaccount's perpetual position in the SubaccountUpdateHandler
@@ -93,6 +95,7 @@ export interface UpdatedPerpetualPositionSubaccountKafkaObject {
   settledFunding: string,
   realizedPnl?: string,
   unrealizedPnl?: string,
+  cumulativeEntryPrice: string,
 }
 
 export interface PerpetualPositionCloseObject {
@@ -123,4 +126,5 @@ export enum PerpetualPositionColumns {
   closeEventId = 'closeEventId',
   lastEventId = 'lastEventId',
   settledFunding = 'settledFunding',
+  cumulativeEntryPrice = 'cumulativeEntryPrice',
 }

--- a/indexer/packages/postgres/src/types/websocket-message-types.ts
+++ b/indexer/packages/postgres/src/types/websocket-message-types.ts
@@ -56,6 +56,7 @@ export interface PerpetualPositionSubaccountMessageContents {
   sumClose: string,
   realizedPnl?: string,
   unrealizedPnl?: string,
+  cumulativeEntryPrice: string,
 }
 
 export interface AssetPositionSubaccountMessageContents {


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new property, `cumulativeEntryPrice`, to enhance tracking of entry prices in perpetual positions across various interfaces and models.
  
- **Bug Fixes**
  - Improved error handling in tests related to closing positions, ensuring system robustness.

- **Tests**
  - Expanded test coverage for perpetual position functionalities, including new scenarios for closing positions and handling edge cases.

- **Chores**
  - Added migration for the `cumulativeEntryPrice` column in the database, ensuring data integrity and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->