### PR TITLE
Use Rust proto crate name as `dydx-proto`

### DIFF
--- a/v4-proto-rs/Cargo.toml
+++ b/v4-proto-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dydx-proto-rust"
+name = "dydx-proto"
 version = "0.1.0"
 edition = "2021"
 description = "Compiled dYdX protobuf files"

--- a/v4-proto-rs/README.md
+++ b/v4-proto-rs/README.md
@@ -6,7 +6,7 @@ Cargo.toml
 
 ```toml
 [dependencies]
-dydx-proto-rust = "0.1"
+dydx-proto = "0.1"
 ```
 
 *Note:* by default, rust stub files are not rebuilt (see Q&A below)

--- a/v4-proto-rs/deny.toml
+++ b/v4-proto-rs/deny.toml
@@ -31,7 +31,7 @@ confidence-threshold = 0.8
 exceptions = []
 
 [[licenses.clarify]]
-crate = "dydx-proto-rust"
+crate = "dydx-proto"
 expression = "LicenseRef-dYdX-Custom"
 license-files = [
     { path = "LICENSE", hash = 0x30bcd1e3 },


### PR DESCRIPTION
### Changelist
Changes Rust protocol buffers crate name to `dydx-proto`, removing the `-rust`, since the crate name is available and using `-rust` is redundant in Rust code.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The project has been rebranded from `dydx-proto-rust` to `dydx-proto`, simplifying the package name for better clarity.
  
- **Documentation**
	- Updated README to reflect the new dependency name, enhancing consistency across project documentation. 

- **Configuration**
	- Adjusted license clarification in configuration files to align with the new package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->