### PR TITLE
[CT-1307] Make pnl ticks computation consistent within a transaction.

### DIFF
--- a/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
+++ b/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
@@ -1,6 +1,8 @@
 import { logger, stats } from '@dydxprotocol-indexer/base';
 import {
   AssetPositionTable,
+  BlockFromDatabase,
+  BlockTable,
   FundingIndexMap,
   FundingIndexUpdatesTable,
   helpers,
@@ -50,11 +52,15 @@ export function normalizeStartTime(
  * @param blockHeight: consider transfers up until this block height.
  */
 export async function getPnlTicksCreateObjects(
-  blockHeight: string,
-  blockTime: IsoString,
   txId: number,
 ): Promise<PnlTicksCreateObject[]> {
   const startGetPnlTicksCreateObjects: number = Date.now();
+  const latestBlock: BlockFromDatabase = await BlockTable.getLatest({
+    readReplica: true,
+    txId,
+  });
+  const blockHeight: string = latestBlock.blockHeight;
+  const blockTime: string = latestBlock.time;
   const pnlTicksToBeCreatedAt: DateTime = DateTime.utc();
   const [
     mostRecentPnlTicks,

--- a/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
+++ b/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
@@ -55,7 +55,7 @@ export default async function runTask(): Promise<void> {
   let newTicksToCreate: PnlTicksCreateObject[] = [];
   try {
     await perpetualMarketRefresher.updatePerpetualMarkets();
-    newTicksToCreate = await getPnlTicksCreateObjects(latestBlockHeight, latestBlockTime, txId);
+    newTicksToCreate = await getPnlTicksCreateObjects(txId);
   } catch (error) {
     logger.error({
       at: 'create-pnl-ticks#runTask',


### PR DESCRIPTION
### Changelist
Fetch the latest block within the same transaction as other PnL tick data to avoid race conditions.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
