### PR TITLE
Dont set default value for fills rows

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20240829161445_add_fills_affiliateearnedrevshare.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20240829161445_add_fills_affiliateearnedrevshare.ts
@@ -2,7 +2,7 @@ import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.table('fills', (table) => {
-    table.string('affiliateEarnedRevShare').notNullable().defaultTo('0');
+    table.string('affiliateEarnedRevShare');
   });
 }
 


### PR DESCRIPTION
### Changelist
- Remove setting default values during affiliatesEarnedRevShare migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `affiliateEarnedRevShare` column in the `fills` table to allow null values and removed the default setting.
  
- **Bug Fixes**
	- Ensured flexibility in data entry for the `affiliateEarnedRevShare` column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->