### PR TITLE
fix(affiliates): Check address is valid in `ReferredBy` query [OTE-896]

### DIFF
--- a/protocol/x/affiliates/keeper/grpc_query.go
+++ b/protocol/x/affiliates/keeper/grpc_query.go
@@ -59,6 +59,13 @@ func (k Keeper) ReferredBy(ctx context.Context,
 	req *types.ReferredByRequest) (*types.ReferredByResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
+	// Check req.Address is a valid bech32 address
+	_, err := sdk.AccAddressFromBech32(req.GetAddress())
+	if err != nil {
+		return nil, errorsmod.Wrapf(types.ErrInvalidAddress, "address: %s, error: %s",
+			req.GetAddress(), err.Error())
+	}
+
 	affiliateAddr, exists := k.GetReferredBy(sdkCtx, req.GetAddress())
 	if !exists {
 		return &types.ReferredByResponse{}, nil

--- a/protocol/x/affiliates/keeper/grpc_query_test.go
+++ b/protocol/x/affiliates/keeper/grpc_query_test.go
@@ -190,6 +190,14 @@ func TestReferredBy(t *testing.T) {
 			expected:    nil,
 			expectError: nil,
 		},
+		"Invalid bech32 address": {
+			req: &types.ReferredByRequest{
+				Address: "Foo",
+			},
+			setup:       func(ctx sdk.Context, k keeper.Keeper) {},
+			expected:    nil,
+			expectError: types.ErrInvalidAddress,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
### Changelist
`ReferredBy` query returns error if input address is not valid bech32 address. Prevents confusion when user/client typos the address

### Test Plan
Test on localnet
```
% dydxprotocold query affiliates referred-by dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4
affiliate_address: dydx1q54yvrslnu0xp4drpde6f4e0k2ap9efss5hpsd
% dydxprotocold query affiliates referred-by dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju
Error: rpc error: code = Unknown desc = address: dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju, error: decoding bech32 failed: invalid checksum (expected w8faqe got jrknju): Invalid address: unknown request
```

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for invalid addresses in the referral process.
  
- **Bug Fixes**
	- Added validation for bech32 address format to prevent processing of invalid addresses.

- **Tests**
	- Introduced a new test case for handling invalid bech32 addresses in the referral method.
	- Improved existing tests to ensure comprehensive coverage of various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->