### PR TITLE
Allow configuring day vault PnL starts.

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
@@ -460,7 +460,7 @@ describe('PnlTicks store', () => {
       interval,
       7 * 24 * 60 * 60, // 1 week
       [defaultSubaccountId, defaultSubaccountIdWithAlternateAddress],
-      DateTime.fromISO(createdTicks[0].blockTime).plus({ seconds: 1 }),
+      DateTime.fromISO(createdTicks[8].blockTime).plus({ seconds: 1 }),
     );
     // See setup function for created ticks.
     // Should exclude tick that is within the same hour except the first.

--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -62,8 +62,10 @@ export const configSchema = {
   // Vaults config
   VAULT_PNL_HISTORY_DAYS: parseInteger({ default: 90 }),
   VAULT_PNL_HISTORY_HOURS: parseInteger({ default: 72 }),
+  VAULT_PNL_START_DATE: parseString({ default: '2024-01-01T00:00:00Z' }),
   VAULT_LATEST_PNL_TICK_WINDOW_HOURS: parseInteger({ default: 1 }),
   VAULT_FETCH_FUNDING_INDEX_BLOCK_WINDOWS: parseInteger({ default: 250_000 }),
+
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Changelist
Allow setting a config var to determine the day vault PnL should start from.
Only queries for PnL data points created past the specified date, and adjusts the total pnl of each point by subtracting the pnl of the start date.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new function to retrieve the latest PnL ticks for subaccounts based on a specified date.
  - Added a configuration parameter for setting the vault PnL start date.

- **Improvements**
  - Enhanced PnL tick retrieval by incorporating date filtering and adjustment logic for accurate calculations.

- **Bug Fixes**
  - Updated test cases to better handle edge scenarios and ensure accurate PnL calculations based on the new start date parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->