### PR TITLE
fix(affiliates): Generate username with address, not subaccount id

### DIFF
--- a/indexer/services/roundtable/__tests__/helpers/usernames-helper.test.ts
+++ b/indexer/services/roundtable/__tests__/helpers/usernames-helper.test.ts
@@ -13,6 +13,10 @@ describe('usernames-helper', () => {
       'dydx1df84hz7y0dd3mrqcv3vrhw9wdttelul8edqmvp',
       'dydx16h7p7f4dysrgtzptxx2gtpt5d8t834g9dj830z',
       'dydx15u9tppy5e2pdndvlrvafxqhuurj9mnpdstzj6z',
+      'dydx1q54yvrslnu0xp4drpde6f4e0k2ap9efss5hpsd',
+      'dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4',
+      'dydx1n88uc38xhjgxzw9nwre4ep2c8ga4fjxc565lnf',
+      'dydx1n88uc38xhjgxzw9nwre4ep2c8ga4fjxc575lnf',
     ];
 
     const expectedUsernames = [
@@ -24,6 +28,10 @@ describe('usernames-helper', () => {
       'BoldGapOGY',
       'ZoomEraQE0',
       'WiryFernLEC',
+      'RudeFuel59E',
+      'MacroMealFK5',
+      'HappySnapWTT',
+      'BumpyEdgeH5Y',
     ];
 
     for (let i = 0; i < addresses.length; i++) {

--- a/indexer/services/roundtable/__tests__/tasks/subaccount-username-generator.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/subaccount-username-generator.test.ts
@@ -48,6 +48,14 @@ describe('subaccount-username-generator', () => {
     SubaccountUsernamesTable.findAll(
       {}, [], {});
 
+    const expectedUsernames = [
+      'BumpyEdgeH5Y', // dydx1n88uc38xhjgxzw9nwre4ep2c8ga4fjxc575lnf
+      'HappySnapWTT', // dydx1n88uc38xhjgxzw9nwre4ep2c8ga4fjxc565lnf
+      'MacroMealFK5', // dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4
+    ];
     expect(subaccountsWithUsernamesAfter.length).toEqual(subaccountsLength);
+    for (let i = 0; i < expectedUsernames.length; i++) {
+      expect(subaccountsWithUsernamesAfter[i].username).toEqual(expectedUsernames[i]);
+    }
   });
 });

--- a/indexer/services/roundtable/src/helpers/usernames-helper.ts
+++ b/indexer/services/roundtable/src/helpers/usernames-helper.ts
@@ -7,11 +7,11 @@ import nouns from './nouns.json';
 const suffixCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
 export function generateUsernameForSubaccount(
-  subaccountId: string,
+  address: string,
   subaccountNum: number,
   nounce: number = 0, // incremented in case of collision
 ): string {
-  const rng = seedrandom(`${subaccountId}/${subaccountNum}/${nounce}`);
+  const rng = seedrandom(`${address}/${subaccountNum}/${nounce}`);
   const randomAdjective: string = adjectives[Math.floor(rng() * adjectives.length)];
   const randomNoun: string = nouns[Math.floor(rng() * nouns.length)];
   const randomSuffix: string = Array.from(

--- a/indexer/services/roundtable/src/tasks/subaccount-username-generator.ts
+++ b/indexer/services/roundtable/src/tasks/subaccount-username-generator.ts
@@ -20,7 +20,7 @@ export default async function runTask(): Promise<void> {
   for (const subaccount of subaccountZerosWithoutUsername) {
     for (let i = 0; i < config.ATTEMPT_PER_SUBACCOUNT; i++) {
       const username: string = generateUsernameForSubaccount(
-        subaccount.subaccountId,
+        subaccount.address,
         // Always use subaccountNum 0 for generation. Effectively we are
         // generating one username per address. The fact that we are storing
         // in the `subaccount_usernames` table is a tech debt.


### PR DESCRIPTION
### Changelist
 Generate username with address, not subaccount id

### Test Plan
Improved roundtable task to check generated username

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Usernames are now generated based on subaccount addresses instead of IDs, enhancing the accuracy of username generation.
  
- **Tests**
	- Added new test cases to validate username generation for additional addresses and ensure correctness across all subaccounts.
	- Enhanced test coverage for the `subaccount-username-generator` functionality to verify generated usernames against expected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->