### PR TITLE
Use repeatable read for pnl tick generation.

### DIFF
--- a/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
+++ b/indexer/services/roundtable/src/tasks/create-pnl-ticks.ts
@@ -2,6 +2,7 @@ import { logger, stats } from '@dydxprotocol-indexer/base';
 import {
   BlockFromDatabase,
   BlockTable,
+  IsolationLevel,
   PnlTicksCreateObject,
   PnlTicksTable,
   Transaction,
@@ -50,8 +51,10 @@ export default async function runTask(): Promise<void> {
     return;
   }
 
-  // Start a transaction to ensure different table reads are consistent.
+  // Start a transaction to ensure different table reads are consistent. Use a repeatable read
+  // to ensure all reads within the transaction are consistent.
   const txId: number = await Transaction.start();
+  await Transaction.setIsolationLevel(txId, IsolationLevel.REPEATABLE_READ);
   let newTicksToCreate: PnlTicksCreateObject[] = [];
   try {
     await perpetualMarketRefresher.updatePerpetualMarkets();


### PR DESCRIPTION
### Changelist
By default all transactions in postgres use the `read committed` isolation level. This means that any `SELECT` within a transaction will only see data that was committed before the select was run. However, this means that `SELECT`s within a transaction done at different times may see different data. This is an issue for the PnL task which gets data from the `transfers` table and the `perpetual_positions` table to determine the PnL snapshot of a subaccount, as there can be a race condition between reading the transfers and perpetual positions if `ender` is updating both tables.
Instead we should use the `repeatable read` transaction isolation level, that guarantees within a transaction all `SELECT`s will read the same snapshot of data. We only use this for the read-only transaction in the pnl task to ensure no rollbacks / retries need to be added.

[Transaction isolation level reference](https://www.postgresql.org/docs/current/transaction-iso.html)

### Test Plan
Unit tests, running in a deployed environment.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction management for creating PNL ticks, ensuring more consistent data reads.
  
- **Bug Fixes**
	- Improved error handling during the fetching of PNL ticks to ensure better logging and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->