### PR TITLE
[CT-1321] subscribe to market prices streaming services

### DIFF
--- a/protocol/streaming/noop_streaming_manager.go
+++ b/protocol/streaming/noop_streaming_manager.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/streaming/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -22,6 +23,7 @@ func (sm *NoopGrpcStreamingManager) Enabled() bool {
 func (sm *NoopGrpcStreamingManager) Subscribe(
 	_ []uint32,
 	_ []*satypes.SubaccountId,
+	_ []uint32,
 	_ types.OutgoingMessageSender,
 ) (
 	err error,
@@ -58,9 +60,16 @@ func (sm *NoopGrpcStreamingManager) GetSubaccountSnapshotsForInitStreams(
 	return nil
 }
 
+func (sm *NoopGrpcStreamingManager) GetPriceSnapshotsForInitStreams(
+	_ func(_ uint32) *pricestypes.StreamPriceUpdate,
+) map[uint32]*pricestypes.StreamPriceUpdate {
+	return nil
+}
+
 func (sm *NoopGrpcStreamingManager) InitializeNewStreams(
 	getOrderbookSnapshot func(clobPairId clobtypes.ClobPairId) *clobtypes.OffchainUpdates,
 	subaccountSnapshots map[satypes.SubaccountId]*satypes.StreamSubaccountUpdate,
+	priceSnapshots map[uint32]*pricestypes.StreamPriceUpdate,
 	blockHeight uint32,
 	execMode sdk.ExecMode,
 ) {

--- a/protocol/streaming/types/interface.go
+++ b/protocol/streaming/types/interface.go
@@ -3,6 +3,7 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 )
 
@@ -14,6 +15,7 @@ type FullNodeStreamingManager interface {
 	Subscribe(
 		clobPairIds []uint32,
 		subaccountIds []*satypes.SubaccountId,
+		marketIds []uint32,
 		srv OutgoingMessageSender,
 	) (
 		err error,
@@ -23,12 +25,16 @@ type FullNodeStreamingManager interface {
 	InitializeNewStreams(
 		getOrderbookSnapshot func(clobPairId clobtypes.ClobPairId) *clobtypes.OffchainUpdates,
 		subaccountSnapshots map[satypes.SubaccountId]*satypes.StreamSubaccountUpdate,
+		priceSnapshots map[uint32]*pricestypes.StreamPriceUpdate,
 		blockHeight uint32,
 		execMode sdk.ExecMode,
 	)
 	GetSubaccountSnapshotsForInitStreams(
 		getSubaccountSnapshot func(subaccountId satypes.SubaccountId) *satypes.StreamSubaccountUpdate,
 	) map[satypes.SubaccountId]*satypes.StreamSubaccountUpdate
+	GetPriceSnapshotsForInitStreams(
+		getPriceSnapshot func(marketId uint32) *pricestypes.StreamPriceUpdate,
+	) map[uint32]*pricestypes.StreamPriceUpdate
 	SendOrderbookUpdates(
 		offchainUpdates *clobtypes.OffchainUpdates,
 		ctx sdk.Context,

--- a/protocol/x/clob/keeper/grpc_stream_orderbook.go
+++ b/protocol/x/clob/keeper/grpc_stream_orderbook.go
@@ -11,6 +11,7 @@ func (k Keeper) StreamOrderbookUpdates(
 	err := k.GetFullNodeStreamingManager().Subscribe(
 		req.GetClobPairId(),
 		req.GetSubaccountIds(),
+		req.GetMarketIds(),
 		stream,
 	)
 	if err != nil {

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -22,6 +22,7 @@ import (
 	flags "github.com/dydxprotocol/v4-chain/protocol/x/clob/flags"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/rate_limit"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
 type (
@@ -326,6 +327,25 @@ func (k Keeper) GetSubaccountSnapshotsForInitStreams(
 	)
 }
 
+func (k Keeper) GetPriceSnapshotsForInitStreams(
+	ctx sdk.Context,
+) (
+	priceSnapshots map[uint32]*pricestypes.StreamPriceUpdate,
+) {
+	lib.AssertCheckTxMode(ctx)
+
+	return k.GetFullNodeStreamingManager().GetPriceSnapshotsForInitStreams(
+		func(marketId uint32) *pricestypes.StreamPriceUpdate {
+			update := k.pricesKeeper.GetStreamPriceUpdate(
+				ctx,
+				marketId,
+				true,
+			)
+			return &update
+		},
+	)
+}
+
 // InitializeNewStreams initializes new streams for all uninitialized clob pairs
 // by sending the corresponding orderbook snapshots.
 func (k Keeper) InitializeNewStreams(
@@ -333,6 +353,8 @@ func (k Keeper) InitializeNewStreams(
 	subaccountSnapshots map[satypes.SubaccountId]*satypes.StreamSubaccountUpdate,
 ) {
 	streamingManager := k.GetFullNodeStreamingManager()
+
+	priceSnapshots := k.GetPriceSnapshotsForInitStreams(ctx)
 
 	streamingManager.InitializeNewStreams(
 		func(clobPairId types.ClobPairId) *types.OffchainUpdates {
@@ -342,6 +364,7 @@ func (k Keeper) InitializeNewStreams(
 			)
 		},
 		subaccountSnapshots,
+		priceSnapshots,
 		lib.MustConvertIntegerToUint32(ctx.BlockHeight()),
 		ctx.ExecMode(),
 	)

--- a/protocol/x/clob/types/expected_keepers.go
+++ b/protocol/x/clob/types/expected_keepers.go
@@ -141,6 +141,7 @@ type PerpetualsKeeper interface {
 
 type PricesKeeper interface {
 	GetMarketParam(ctx sdk.Context, id uint32) (param pricestypes.MarketParam, exists bool)
+	GetStreamPriceUpdate(ctx sdk.Context, id uint32, snapshot bool) (val pricestypes.StreamPriceUpdate)
 }
 
 type StatsKeeper interface {

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -193,3 +193,26 @@ func (k Keeper) GetMarketIdToValidIndexPrice(
 	}
 	return ret
 }
+
+// GetStreamPriceUpdate returns a stream price update from its id.
+func (k Keeper) GetStreamPriceUpdate(
+	ctx sdk.Context,
+	id uint32,
+	snapshot bool,
+) (
+	val types.StreamPriceUpdate,
+) {
+	price, err := k.GetMarketPrice(ctx, id)
+	if err != nil {
+		k.Logger(ctx).Error(
+			"failed to get market price for streaming",
+			"market id", id,
+			"error", err,
+		)
+	}
+	return types.StreamPriceUpdate{
+		MarketId: id,
+		Price:    price,
+		Snapshot: snapshot,
+	}
+}


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced subscription management to include market-specific subscriptions.
	- Added support for handling price snapshots in streaming updates.
	- WebSocket server now processes additional query parameters for improved subscription handling.

- **Bug Fixes**
	- Improved error handling in query parameter parsing for WebSocket requests.

- **Documentation**
	- Updated interfaces to reflect new methods for price snapshot retrieval.

These updates improve the streaming service's functionality, allowing for more precise and efficient data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->