### PR TITLE
Check for invalid addresses in `SetAffiliateWhitelist`

### DIFF
--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -310,8 +310,12 @@ func (k Keeper) SetAffiliateWhitelist(ctx sdk.Context, whitelist types.Affiliate
 				"taker fee share ppm %d is greater than the cap %d",
 				tier.TakerFeeSharePpm, types.AffiliatesRevSharePpmCap)
 		}
-		// Check for duplicate addresses.
 		for _, address := range tier.Addresses {
+			// Check for invalid addresses.
+			if _, err := sdk.AccAddressFromBech32(address); err != nil {
+				return errorsmod.Wrapf(types.ErrInvalidAddress, "address to whitelist: %s", address)
+			}
+			// Check for duplicate addresses.
 			if addressSet[address] {
 				return errorsmod.Wrapf(types.ErrDuplicateAffiliateAddressForWhitelist,
 					"address %s is duplicated in affiliate whitelist", address)

--- a/protocol/x/affiliates/keeper/keeper_test.go
+++ b/protocol/x/affiliates/keeper/keeper_test.go
@@ -484,6 +484,36 @@ func TestSetAffiliateWhitelist(t *testing.T) {
 			},
 			expectedError: types.ErrRevShareSafetyViolation,
 		},
+		{
+			name: "Invalid bech32 address present",
+			whitelist: types.AffiliateWhitelist{
+				Tiers: []types.AffiliateWhitelist_Tier{
+					{
+						Addresses: []string{
+							constants.AliceAccAddress.String(),
+							"dydxinvalidaddress",
+						},
+						TakerFeeSharePpm: 500_000, // 50%
+					},
+				},
+			},
+			expectedError: types.ErrInvalidAddress,
+		},
+		{
+			name: "Validator operator address not accepted",
+			whitelist: types.AffiliateWhitelist{
+				Tiers: []types.AffiliateWhitelist_Tier{
+					{
+						Addresses: []string{
+							constants.AliceAccAddress.String(),
+							"dydxvaloper1et2kxktzr6tav65uhrxsyr8gx82xvan6gl78xd",
+						},
+						TakerFeeSharePpm: 500_000, // 50%
+					},
+				},
+			},
+			expectedError: types.ErrInvalidAddress,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Changelist
Check input contains only valid `bech32` address in `SetAffiliateWhitelist`

### Test Plan
Unit test
### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for setting the affiliate whitelist to ensure only valid addresses are processed.
  
- **Bug Fixes**
	- Improved error handling for invalid addresses when setting the affiliate whitelist.

- **Tests**
	- Added new test cases to ensure robust handling of invalid addresses and duplicate entries in the affiliate whitelist. 
	- Updated existing tests to cover additional scenarios and ensure correct fallback behavior for non-whitelisted affiliates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->