### PR TITLE
feat(oe): Enable OE by default (target: v8.0+)

### DIFF
--- a/protocol/app/flags/flags.go
+++ b/protocol/app/flags/flags.go
@@ -80,7 +80,7 @@ const (
 
 	DefaultVEOracleEnabled = true
 
-	DefaultOptimisticExecutionEnabled       = false
+	DefaultOptimisticExecutionEnabled       = true
 	DefaultOptimisticExecutionTestAbortRate = 0
 )
 

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -1308,6 +1308,8 @@ func launchValidatorInDir(
 		"--oracle.enabled=false",
 		"--oracle.metrics_enabled=false",
 		"--log_level=error",
+		// TODO(CT-1329): Currently, the TestApp framework does not work well with OE,
+		// since the non-deterministic test app instances does not handle go routines.
 		"--optimistic-execution-enabled=false",
 	})
 

--- a/protocol/testutil/app/app.go
+++ b/protocol/testutil/app/app.go
@@ -1308,6 +1308,7 @@ func launchValidatorInDir(
 		"--oracle.enabled=false",
 		"--oracle.metrics_enabled=false",
 		"--log_level=error",
+		"--optimistic-execution-enabled=false",
 	})
 
 	ctx := svrcmd.CreateExecuteContext(parentCtx)


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The default setting for optimistic execution is now enabled, enhancing performance for users without requiring manual configuration.
  - Improved configurability for launching the validator application with additional command-line arguments.

- **Bug Fixes**
  - No bug fixes were included in this release.

- **Documentation**
  - No updates to documentation were made in this release.

- **Chores**
  - Minor internal adjustments to flag settings were performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->