### PR TITLE
Optimize query for latest pnl tick at specific time.

### DIFF
--- a/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
+++ b/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
@@ -538,7 +538,7 @@ export async function getLatestPnlTick(
     WHERE
       "subaccountId" in (${subaccountIds.map((id: string) => { return `'${id}'`; }).join(',')}) AND
       "blockTime" <= '${beforeOrAt.toUTC().toISO()}'::timestamp AND
-      "blockTime" >= '${beforeOrAt.toUTC().minus({ day: 1}).toISO()}'::timestamp
+      "blockTime" >= '${beforeOrAt.toUTC().minus({ hours: 4}).toISO()}'::timestamp
     ORDER BY
       "subaccountId",
       "blockTime" DESC

--- a/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
+++ b/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
@@ -537,7 +537,8 @@ export async function getLatestPnlTick(
       pnl_ticks
     WHERE
       "subaccountId" in (${subaccountIds.map((id: string) => { return `'${id}'`; }).join(',')}) AND
-      "blockTime" <= '${beforeOrAt.toUTC().toISO()}'::timestamp
+      "blockTime" <= '${beforeOrAt.toUTC().toISO()}'::timestamp AND
+      "blockTime" >= '${beforeOrAt.toUTC().minus({ day: 1}).toISO()}'::timestamp
     ORDER BY
       "subaccountId",
       "blockTime" DESC

--- a/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
+++ b/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
@@ -538,7 +538,7 @@ export async function getLatestPnlTick(
     WHERE
       "subaccountId" in (${subaccountIds.map((id: string) => { return `'${id}'`; }).join(',')}) AND
       "blockTime" <= '${beforeOrAt.toUTC().toISO()}'::timestamp AND
-      "blockTime" >= '${beforeOrAt.toUTC().minus({ hours: 4}).toISO()}'::timestamp
+      "blockTime" >= '${beforeOrAt.toUTC().minus({ hours: 4 }).toISO()}'::timestamp
     ORDER BY
       "subaccountId",
       "blockTime" DESC


### PR DESCRIPTION
### Changelist
Simple optimization of the query to get the latest pnl tick at a specific time by limiting the query to looking at pnl ticks for a 4 hour time period rather than all time.

Query plan before:
```
                                                                               QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=89139.08..91537.27 rows=22464 width=72) (actual time=766.967..825.231 rows=118 loops=1)
   ->  Sort  (cost=89139.08..90338.17 rows=479638 width=72) (actual time=766.966..805.466 rows=261952 loops=1)
         Sort Key: pnl_ticks."subaccountId", pnl_ticks."blockTime" DESC
         Sort Method: external merge  Disk: 23272kB
         ->  Nested Loop  (cost=308.27..32639.43 rows=479638 width=72) (actual time=1.158..306.101 rows=261952 loops=1)
               ->  HashAggregate  (cost=307.70..309.01 rows=131 width=16) (actual time=1.140..1.283 rows=130 loops=1)
                     Group Key: subaccounts.id
                     ->  Nested Loop  (cost=0.41..307.37 rows=131 width=16) (actual time=0.052..1.104 rows=130 loops=1)
                           ->  Seq Scan on vaults  (cost=0.00..3.29 rows=129 width=44) (actual time=0.030..0.049 rows=130 loops=1)
                           ->  Index Scan using subaccounts_address_index on subaccounts  (cost=0.41..2.35 rows=1 width=60) (actual time=0.008..0.008 rows=1 loops=130)
                                 Index Cond: ((address)::text = (vaults.address)::text)
                                 Filter: ("subaccountNumber" = 0)
               ->  Index Scan using pnl_ticks_subaccountid_index on pnl_ticks  (cost=0.57..193.55 rows=5325 width=72) (actual time=0.015..2.115 rows=2015 loops=130)
                     Index Cond: ("subaccountId" = subaccounts.id)
                     Filter: ("blockTime" <= '2024-11-15 14:00:00'::timestamp without time zone)
                     Rows Removed by Filter: 161
 Planning Time: 0.413 ms
 Execution Time: 843.384 ms
```

Query plan after change:
```
                                                                                     QUERY PLAN                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=6926.89..6930.50 rows=722 width=72) (actual time=27.540..28.902 rows=118 loops=1)
   ->  Sort  (cost=6926.89..6928.70 rows=722 width=72) (actual time=27.539..28.852 rows=472 loops=1)
         Sort Key: pnl_ticks."subaccountId", pnl_ticks."blockTime" DESC
         Sort Method: quicksort  Memory: 91kB
         ->  Gather  (cost=1309.59..6892.61 rows=722 width=72) (actual time=3.600..28.527 rows=472 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Hash Semi Join  (cost=309.59..5820.41 rows=301 width=72) (actual time=2.104..24.354 rows=157 loops=3)
                     Hash Cond: (pnl_ticks."subaccountId" = subaccounts.id)
                     ->  Parallel Index Scan using pnl_ticks_blocktime_index on pnl_ticks  (cost=0.57..5312.44 rows=74513 width=72) (actual time=0.840..19.248 rows=40406 loops=3)
                           Index Cond: (("blockTime" <= '2024-11-15 14:00:00'::timestamp without time zone) AND ("blockTime" >= '2024-11-15 10:00:00'::timestamp without time zone))
                     ->  Hash  (cost=307.37..307.37 rows=132 width=16) (actual time=1.003..1.005 rows=130 loops=3)
                           Buckets: 1024  Batches: 1  Memory Usage: 15kB
                           ->  Nested Loop  (cost=0.41..307.37 rows=132 width=16) (actual time=0.033..0.975 rows=130 loops=3)
                                 ->  Seq Scan on vaults  (cost=0.00..3.29 rows=129 width=44) (actual time=0.008..0.030 rows=130 loops=3)
                                 ->  Index Scan using subaccounts_address_index on subaccounts  (cost=0.41..2.35 rows=1 width=60) (actual time=0.007..0.007 rows=1 loops=390)
                                       Index Cond: ((address)::text = (vaults.address)::text)
                                       Filter: ("subaccountNumber" = 0)
 Planning Time: 0.640 ms
 Execution Time: 28.947 ms
(20 rows)
```

### Test Plan
Unit tests. 

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced query logic to filter results within a specific four-hour time window for improved data accuracy. 

- **Bug Fixes**
	- Refined data retrieval process to ensure more relevant results based on the updated time conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->