### PR TITLE
Revert "[CT-629] Fix entryPrice calc (#2455)"

### DIFF
--- a/indexer/services/ender/__tests__/handlers/order-fills/liquidation-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/liquidation-handler.test.ts
@@ -137,7 +137,7 @@ describe('LiquidationHandler', () => {
     perpetualId: testConstants.defaultPerpetualMarket.id,
     side: PositionSide.LONG,
     status: PerpetualPositionStatus.OPEN,
-    size: '5',
+    size: '10',
     maxSize: '25',
     sumOpen: '10',
     entryPrice: '15000',
@@ -392,7 +392,7 @@ describe('LiquidationHandler', () => {
             defaultPerpetualPosition.openEventId,
           ),
           {
-            sumOpen: Big(defaultPerpetualPosition.sumOpen!).plus(totalFilled).toFixed(),
+            sumOpen: Big(defaultPerpetualPosition.size).plus(totalFilled).toFixed(),
             entryPrice: getWeightedAverage(
               defaultPerpetualPosition.entryPrice!,
               defaultPerpetualPosition.size,

--- a/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/order-fills/order-handler.test.ts
@@ -138,7 +138,7 @@ describe('OrderHandler', () => {
     perpetualId: testConstants.defaultPerpetualMarket.id,
     side: PositionSide.LONG,
     status: PerpetualPositionStatus.OPEN,
-    size: '5',
+    size: '10',
     maxSize: '25',
     sumOpen: '10',
     entryPrice: '15000',
@@ -212,7 +212,6 @@ describe('OrderHandler', () => {
       {
         goodTilBlock: 15,
       },
-      false,
     ],
     [
       'goodTilBlockTime',
@@ -222,17 +221,6 @@ describe('OrderHandler', () => {
       {
         goodTilBlockTime: 1_000_005_000,
       },
-      false,
-    ],
-    [
-      'goodTilBlock',
-      {
-        goodTilBlock: 10,
-      },
-      {
-        goodTilBlock: 15,
-      },
-      true,
     ],
   ])(
     'creates fills and orders (with %s), sends vulcan messages for order updates and order ' +
@@ -241,7 +229,6 @@ describe('OrderHandler', () => {
       _name: string,
       makerGoodTilOneof: Partial<IndexerOrder>,
       takerGoodTilOneof: Partial<IndexerOrder>,
-      useNegativeSize: boolean,
     ) => {
       const transactionIndex: number = 0;
       const eventIndex: number = 0;
@@ -297,10 +284,7 @@ describe('OrderHandler', () => {
 
       // create PerpetualPositions
       await Promise.all([
-        PerpetualPositionTable.create({
-          ...defaultPerpetualPosition,
-          size: useNegativeSize ? '-5' : defaultPerpetualPosition.size,
-        }),
+        PerpetualPositionTable.create(defaultPerpetualPosition),
         PerpetualPositionTable.create({
           ...defaultPerpetualPosition,
           subaccountId: testConstants.defaultSubaccountId2,
@@ -455,7 +439,7 @@ describe('OrderHandler', () => {
             defaultPerpetualPosition.openEventId,
           ),
           {
-            sumOpen: Big(defaultPerpetualPosition.sumOpen!).plus(totalFilled).toFixed(),
+            sumOpen: Big(defaultPerpetualPosition.size).plus(totalFilled).toFixed(),
             entryPrice: getWeightedAverage(
               defaultPerpetualPosition.entryPrice!,
               defaultPerpetualPosition.size,

--- a/indexer/services/ender/src/scripts/helpers/dydx_liquidation_fill_handler_per_order.sql
+++ b/indexer/services/ender/src/scripts/helpers/dydx_liquidation_fill_handler_per_order.sql
@@ -200,7 +200,7 @@ BEGIN
                 perpetual_position_record."side", order_side) THEN
             sum_open = dydx_trim_scale(perpetual_position_record."sumOpen" + fill_amount);
             entry_price = dydx_get_weighted_average(
-                    perpetual_position_record."entryPrice", ABS(perpetual_position_record."size"),
+                    perpetual_position_record."entryPrice", perpetual_position_record."sumOpen",
                     maker_price, fill_amount);
             perpetual_position_record."sumOpen" = sum_open;
             perpetual_position_record."entryPrice" = entry_price;

--- a/indexer/services/ender/src/scripts/helpers/dydx_update_perpetual_position_aggregate_fields.sql
+++ b/indexer/services/ender/src/scripts/helpers/dydx_update_perpetual_position_aggregate_fields.sql
@@ -44,7 +44,7 @@ BEGIN
     IF dydx_perpetual_position_and_order_side_matching(perpetual_position_record."side", side) THEN
         sum_open := dydx_trim_scale(perpetual_position_record."sumOpen" + size);
         entry_price := dydx_get_weighted_average(
-            perpetual_position_record."entryPrice", ABS(perpetual_position_record."size"), price, size
+            perpetual_position_record."entryPrice", perpetual_position_record."sumOpen", price, size
         );
         perpetual_position_record."sumOpen" = sum_open;
         perpetual_position_record."entryPrice" = entry_price;


### PR DESCRIPTION
This reverts commit c8f8a4a1f9ebc4f18742324a409f42fa6fdfdda3.

### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of liquidation and order fill events, improving robustness and accuracy in test scenarios.
	- Updated logic for calculating entry and exit prices in relation to perpetual positions.
  
- **Bug Fixes**
	- Refined validation logic for order fills and handling of edge cases, ensuring correct status updates for orders.

- **Documentation**
	- Improved clarity in test cases and assertions related to order sizes and statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->