### PR TITLE
Start refresh vault PnL task.

### DIFF
--- a/indexer/services/roundtable/src/index.ts
+++ b/indexer/services/roundtable/src/index.ts
@@ -20,6 +20,7 @@ import marketUpdaterTask from './tasks/market-updater';
 import orderbookInstrumentationTask from './tasks/orderbook-instrumentation';
 import performComplianceStatusTransitionsTask from './tasks/perform-compliance-status-transitions';
 import pnlInstrumentationTask from './tasks/pnl-instrumentation';
+import refreshVaultPnlTask from './tasks/refresh-vault-pnl';
 import removeExpiredOrdersTask from './tasks/remove-expired-orders';
 import removeOldOrderUpdatesTask from './tasks/remove-old-order-updates';
 import subaccountUsernameGeneratorTask from './tasks/subaccount-username-generator';
@@ -270,6 +271,13 @@ async function start(): Promise<void> {
       deleteOldFirebaseNotificationTokensTask,
       'delete-old-firebase-notification-tokens',
       config.LOOPS_INTERVAL_MS_DELETE_FIREBASE_NOTIFICATION_TOKENS_MONTHLY,
+    );
+  }
+  if (config.LOOPS_ENABLED_REFRESH_VAULT_PNL) {
+    startLoop(
+      refreshVaultPnlTask,
+      'refresh-vault-pnl',
+      config.LOOPS_INTERVAL_MS_REFRESH_VAULT_PNL,
     );
   }
 


### PR DESCRIPTION
### Changelist
Missed adding the task to `index.ts` to be started when `roundtable` starts.

### Test Plan
Unit tests, deployed to test-net env.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new task to refresh the vault's Profit and Loss (PnL) based on user-defined configurations.
	- Enhanced service functionality with improved task management and scheduling.

- **Bug Fixes**
	- Maintained existing error handling and logging for a seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->