### PR TITLE
[CT-1326] send price updates after block is finalized

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1010,6 +1010,7 @@ func New(
 		},
 		app.RevShareKeeper,
 		&app.MarketMapKeeper,
+		app.FullNodeStreamingManager,
 	)
 	pricesModule := pricesmodule.NewAppModule(
 		appCodec,

--- a/protocol/lib/metrics/metric_keys.go
+++ b/protocol/lib/metrics/metric_keys.go
@@ -74,6 +74,7 @@ const (
 	GrpcSendOrderbookUpdatesLatency               = "grpc_send_orderbook_updates_latency"
 	GrpcSendOrderbookSnapshotLatency              = "grpc_send_orderbook_snapshot_latency"
 	GrpcSendSubaccountUpdateCount                 = "grpc_send_subaccount_update_count"
+	GrpcSendPriceUpdateCount                      = "grpc_send_price_update_count"
 	GrpcSendOrderbookFillsLatency                 = "grpc_send_orderbook_fills_latency"
 	GrpcAddUpdateToBufferCount                    = "grpc_add_update_to_buffer_count"
 	GrpcAddToSubscriptionChannelCount             = "grpc_add_to_subscription_channel_count"

--- a/protocol/streaming/full_node_streaming_manager.go
+++ b/protocol/streaming/full_node_streaming_manager.go
@@ -504,7 +504,7 @@ func (sm *FullNodeStreamingManagerImpl) SendPriceUpdate(
 	}
 
 	metrics.IncrCounter(
-		metrics.GrpcSendSubaccountUpdateCount,
+		metrics.GrpcSendPriceUpdateCount,
 		1,
 	)
 
@@ -1044,6 +1044,10 @@ func (sm *FullNodeStreamingManagerImpl) cacheStreamUpdatesByMarketIdWithLock(
 	streamUpdates []clobtypes.StreamUpdate,
 	marketIds []uint32,
 ) {
+	if len(streamUpdates) != len(marketIds) {
+		sm.logger.Error("Mismatch between stream updates and market IDs lengths")
+		return
+	}
 	sm.streamUpdateCache = append(sm.streamUpdateCache, streamUpdates...)
 	for _, marketId := range marketIds {
 		sm.streamUpdateSubscriptionCache = append(

--- a/protocol/streaming/noop_streaming_manager.go
+++ b/protocol/streaming/noop_streaming_manager.go
@@ -54,6 +54,10 @@ func (sm *NoopGrpcStreamingManager) TracksSubaccountId(id satypes.SubaccountId) 
 	return false
 }
 
+func (sm *NoopGrpcStreamingManager) TracksMarketId(id uint32) bool {
+	return false
+}
+
 func (sm *NoopGrpcStreamingManager) GetSubaccountSnapshotsForInitStreams(
 	getSubaccountSnapshot func(subaccountId satypes.SubaccountId) *satypes.StreamSubaccountUpdate,
 ) map[satypes.SubaccountId]*satypes.StreamSubaccountUpdate {
@@ -87,6 +91,12 @@ func (sm *NoopGrpcStreamingManager) GetStagedFinalizeBlockEvents(
 func (sm *NoopGrpcStreamingManager) SendSubaccountUpdate(
 	ctx sdk.Context,
 	subaccountUpdate satypes.StreamSubaccountUpdate,
+) {
+}
+
+func (sm *NoopGrpcStreamingManager) SendPriceUpdate(
+	ctx sdk.Context,
+	priceUpdate pricestypes.StreamPriceUpdate,
 ) {
 }
 

--- a/protocol/streaming/types/interface.go
+++ b/protocol/streaming/types/interface.go
@@ -52,10 +52,15 @@ type FullNodeStreamingManager interface {
 		ctx sdk.Context,
 		subaccountUpdate satypes.StreamSubaccountUpdate,
 	)
+	SendPriceUpdate(
+		ctx sdk.Context,
+		priceUpdate pricestypes.StreamPriceUpdate,
+	)
 	GetStagedFinalizeBlockEvents(
 		ctx sdk.Context,
 	) []clobtypes.StagedFinalizeBlockEvent
 	TracksSubaccountId(id satypes.SubaccountId) bool
+	TracksMarketId(marketId uint32) bool
 	StreamBatchUpdatesAfterFinalizeBlock(
 		ctx sdk.Context,
 		orderBookUpdatesToSyncLocalOpsQueue *clobtypes.OffchainUpdates,

--- a/protocol/testutil/keeper/prices.go
+++ b/protocol/testutil/keeper/prices.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	streaming "github.com/dydxprotocol/v4-chain/protocol/streaming"
 	revsharetypes "github.com/dydxprotocol/v4-chain/protocol/x/revshare/types"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -124,6 +125,7 @@ func createPricesKeeper(
 		},
 		revShareKeeper,
 		marketMapKeeper,
+		streaming.NewNoopGrpcStreamingManager(),
 	)
 
 	return k, storeKey, indexPriceCache, mockTimeProvider

--- a/protocol/x/prices/keeper/keeper.go
+++ b/protocol/x/prices/keeper/keeper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	libtime "github.com/dydxprotocol/v4-chain/protocol/lib/time"
+	streamingtypes "github.com/dydxprotocol/v4-chain/protocol/streaming/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 )
 
@@ -24,6 +25,8 @@ type (
 		authorities         map[string]struct{}
 		RevShareKeeper      types.RevShareKeeper
 		MarketMapKeeper     types.MarketMapKeeper
+
+		streamingManager streamingtypes.FullNodeStreamingManager
 	}
 )
 
@@ -38,6 +41,7 @@ func NewKeeper(
 	authorities []string,
 	revShareKeeper types.RevShareKeeper,
 	marketMapKeeper types.MarketMapKeeper,
+	streamingManager streamingtypes.FullNodeStreamingManager,
 ) *Keeper {
 	return &Keeper{
 		cdc:                 cdc,
@@ -48,6 +52,7 @@ func NewKeeper(
 		authorities:         lib.UniqueSliceToSet(authorities),
 		RevShareKeeper:      revShareKeeper,
 		MarketMapKeeper:     marketMapKeeper,
+		streamingManager:    streamingManager,
 	}
 }
 
@@ -65,4 +70,8 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) HasAuthority(authority string) bool {
 	_, ok := k.authorities[authority]
 	return ok
+}
+
+func (k Keeper) GetFullNodeStreamingManager() streamingtypes.FullNodeStreamingManager {
+	return k.streamingManager
 }

--- a/protocol/x/prices/keeper/market_price.go
+++ b/protocol/x/prices/keeper/market_price.go
@@ -96,6 +96,20 @@ func (k Keeper) UpdateMarketPrices(
 				pricefeedmetrics.GetLabelForMarketId(marketPrice.Id),
 			},
 		)
+
+		// If GRPC streaming is on, emit a price update to stream.
+		if k.GetFullNodeStreamingManager().Enabled() {
+			if k.GetFullNodeStreamingManager().TracksMarketId(marketPrice.Id) {
+				k.GetFullNodeStreamingManager().SendPriceUpdate(
+					ctx,
+					types.StreamPriceUpdate{
+						MarketId: marketPrice.Id,
+						Price:    marketPrice,
+						Snapshot: false,
+					},
+				)
+			}
+		}
 	}
 
 	// Generate indexer events.


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced full node streaming capabilities, enhancing real-time data handling.
  - Added support for sending price updates through the streaming manager.
  - Improved subscription management with stricter validation requirements.
  - Expanded metrics to include a new key for tracking gRPC price update counts.

- **Bug Fixes**
  - Enhanced error handling during initialization and market price retrieval.

These changes significantly improve the application's functionality and user experience by enabling better data streaming and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->