### PR TITLE
[TRA-890] Return nearest hour PnL as final data point for vaults pnl.

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
@@ -298,13 +298,14 @@ describe('vault-controller#V4', () => {
     });
 
     it.each([
-      ['no resolution', '', [1, 2]],
-      ['daily resolution', '?resolution=day', [1, 2]],
-      ['hourly resolution', '?resolution=hour', [1, 2, 3, 4]],
+      ['no resolution', '', [1, 2], 4],
+      ['daily resolution', '?resolution=day', [1, 2], 4],
+      ['hourly resolution', '?resolution=hour', [1, 2, 3, 4], 4],
     ])('Get /vaults/historicalPnl with single vault subaccount (%s)', async (
       _name: string,
       queryParam: string,
       expectedTicksIndex: number[],
+      currentTickIndex: number,
     ) => {
       await VaultTable.create({
         ...testConstants.defaultVault,
@@ -313,7 +314,7 @@ describe('vault-controller#V4', () => {
       });
       const createdPnlTicks: PnlTicksFromDatabase[] = await createPnlTicks();
       const finalTick: PnlTicksFromDatabase = {
-        ...createdPnlTicks[expectedTicksIndex[expectedTicksIndex.length - 1]],
+        ...createdPnlTicks[currentTickIndex],
         equity: Big(vault1Equity).toFixed(),
         blockHeight: latestBlockHeight,
         blockTime: latestTime.toISO(),
@@ -338,14 +339,16 @@ describe('vault-controller#V4', () => {
     });
 
     it.each([
-      ['no resolution', '', [1, 2], [6, 7]],
-      ['daily resolution', '?resolution=day', [1, 2], [6, 7]],
-      ['hourly resolution', '?resolution=hour', [1, 2, 3, 4], [6, 7, 8, 9]],
+      ['no resolution', '', [1, 2], [6, 7], 4, 9],
+      ['daily resolution', '?resolution=day', [1, 2], [6, 7], 4, 9],
+      ['hourly resolution', '?resolution=hour', [1, 2, 3, 4], [6, 7, 8, 9], 4, 9],
     ])('Get /vaults/historicalPnl with 2 vault subaccounts (%s)', async (
       _name: string,
       queryParam: string,
       expectedTicksIndex1: number[],
       expectedTicksIndex2: number[],
+      curerntTickIndex1: number,
+      currentTickIndex2: number,
     ) => {
       await Promise.all([
         VaultTable.create({
@@ -361,14 +364,14 @@ describe('vault-controller#V4', () => {
       ]);
       const createdPnlTicks: PnlTicksFromDatabase[] = await createPnlTicks();
       const finalTick1: PnlTicksFromDatabase = {
-        ...createdPnlTicks[expectedTicksIndex1[expectedTicksIndex1.length - 1]],
+        ...createdPnlTicks[curerntTickIndex1],
         equity: Big(vault1Equity).toFixed(),
         blockHeight: latestBlockHeight,
         blockTime: latestTime.toISO(),
         createdAt: latestTime.toISO(),
       };
       const finalTick2: PnlTicksFromDatabase = {
-        ...createdPnlTicks[expectedTicksIndex2[expectedTicksIndex2.length - 1]],
+        ...createdPnlTicks[currentTickIndex2],
         equity: Big(vault2Equity).toFixed(),
         blockHeight: latestBlockHeight,
         blockTime: latestTime.toISO(),

--- a/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
@@ -21,7 +21,7 @@ import {
 import { RequestMethod, VaultHistoricalPnl } from '../../../../src/types';
 import request from 'supertest';
 import { getFixedRepresentation, sendRequest } from '../../../helpers/helpers';
-import { DateTime } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 import Big from 'big.js';
 import config from '../../../../src/config';
 
@@ -124,6 +124,7 @@ describe('vault-controller#V4', () => {
           effectiveAtHeight: twoDayBlockHeight,
         }),
       ]);
+      Settings.now = () => latestTime.valueOf();
     });
 
     afterEach(async () => {
@@ -133,6 +134,7 @@ describe('vault-controller#V4', () => {
       config.VAULT_PNL_HISTORY_HOURS = vaultPnlHistoryHoursPrev;
       config.VAULT_LATEST_PNL_TICK_WINDOW_HOURS = vaultPnlLastPnlWindowPrev;
       config.VAULT_PNL_START_DATE = vaultPnlStartDatePrev;
+      Settings.now = () => new Date().valueOf();
     });
 
     it.each([

--- a/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
@@ -347,7 +347,7 @@ describe('vault-controller#V4', () => {
       queryParam: string,
       expectedTicksIndex1: number[],
       expectedTicksIndex2: number[],
-      curerntTickIndex1: number,
+      currentTickIndex1: number,
       currentTickIndex2: number,
     ) => {
       await Promise.all([
@@ -364,7 +364,7 @@ describe('vault-controller#V4', () => {
       ]);
       const createdPnlTicks: PnlTicksFromDatabase[] = await createPnlTicks();
       const finalTick1: PnlTicksFromDatabase = {
-        ...createdPnlTicks[curerntTickIndex1],
+        ...createdPnlTicks[currentTickIndex1],
         equity: Big(vault1Equity).toFixed(),
         blockHeight: latestBlockHeight,
         blockTime: latestTime.toISO(),

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -358,13 +358,13 @@ async function getVaultSubaccountPnlTicks(
     VaultPnlTicksView.getVaultsPnl(
       resolution,
       windowSeconds,
-      getVautlPnlStartDate(),
+      getVaultPnlStartDate(),
     ),
     PnlTicksTable.getLatestPnlTick(
       vaultSubaccountIds,
       // Add a buffer of 10 minutes to get the first PnL tick for PnL data as PnL ticks aren't
       // created exactly on the hour.
-      getVautlPnlStartDate().plus({ minutes: 10 }),
+      getVaultPnlStartDate().plus({ minutes: 10 }),
     ),
   ]);
 
@@ -577,7 +577,7 @@ export async function getLatestPnlTicks(
       vaultSubaccountIds,
       // Add a buffer of 10 minutes to get the first PnL tick for PnL data as PnL ticks aren't
       // created exactly on the hour.
-      getVautlPnlStartDate().plus({ minutes: 10 }),
+      getVaultPnlStartDate().plus({ minutes: 10 }),
     ),
   ]);
   const adjustedPnlTicks: PnlTicksFromDatabase[] = adjustVaultPnlTicks(
@@ -601,13 +601,13 @@ export async function getLatestPnlTick(
     VaultPnlTicksView.getVaultsPnl(
       PnlTickInterval.hour,
       config.VAULT_LATEST_PNL_TICK_WINDOW_HOURS * 60 * 60,
-      getVautlPnlStartDate(),
+      getVaultPnlStartDate(),
     ),
     PnlTicksTable.getLatestPnlTick(
       vaultSubaccountIds,
       // Add a buffer of 10 minutes to get the first PnL tick for PnL data as PnL ticks aren't
       // created exactly on the hour.
-      getVautlPnlStartDate().plus({ minutes: 10 }),
+      getVaultPnlStartDate().plus({ minutes: 10 }),
     ),
   ]);
   const adjustedPnlTicks: PnlTicksFromDatabase[] = adjustVaultPnlTicks(
@@ -834,7 +834,7 @@ async function getVaultMapping(): Promise<VaultMapping> {
   return validVaultMapping;
 }
 
-function getVautlPnlStartDate(): DateTime {
+function getVaultPnlStartDate(): DateTime {
   const startDate: DateTime = DateTime.fromISO(config.VAULT_PNL_START_DATE).toUTC();
   return startDate;
 }

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -571,7 +571,7 @@ export async function getLatestPnlTicks(
   ] = await Promise.all([
     PnlTicksTable.getLatestPnlTick(
       vaultSubaccountIds,
-      DateTime.utc(),
+      DateTime.now().toUTC(),
     ),
     PnlTicksTable.getLatestPnlTick(
       vaultSubaccountIds,


### PR DESCRIPTION
### Changelist
Fetch the latest pnl ticks for all sub-vaults when returning historical pnl.

### Test Plan
Unit tests, deployed onto test env.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve the latest Profit and Loss (PnL) ticks for vault subaccounts, enhancing historical PnL data accuracy.

- **Bug Fixes**
	- Updated test cases to ensure correct handling of historical PnL data with precise tick references.
	- Corrected a typo in the method name for retrieving vault PnL start dates.

- **Documentation**
	- Enhanced clarity in the logic for determining final ticks in test cases, ensuring alignment with updated response structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->