### PR TITLE
[CT-1327] place post only orders first in prepare check state

### DIFF
--- a/protocol/mocks/MemClob.go
+++ b/protocol/mocks/MemClob.go
@@ -578,17 +578,17 @@ func (_m *MemClob) RemoveOrderIfFilled(ctx types.Context, orderId clobtypes.Orde
 	_m.Called(ctx, orderId)
 }
 
-// ReplayOperations provides a mock function with given fields: ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates
-func (_m *MemClob) ReplayOperations(ctx types.Context, localOperations []clobtypes.InternalOperation, shortTermOrderTxBytes map[clobtypes.OrderHash][]byte, existingOffchainUpdates *clobtypes.OffchainUpdates) *clobtypes.OffchainUpdates {
-	ret := _m.Called(ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates)
+// ReplayOperations provides a mock function with given fields: ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, onlyPlacePostOnly
+func (_m *MemClob) ReplayOperations(ctx types.Context, localOperations []clobtypes.InternalOperation, shortTermOrderTxBytes map[clobtypes.OrderHash][]byte, existingOffchainUpdates *clobtypes.OffchainUpdates, onlyPlacePostOnly bool) *clobtypes.OffchainUpdates {
+	ret := _m.Called(ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, onlyPlacePostOnly)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ReplayOperations")
 	}
 
 	var r0 *clobtypes.OffchainUpdates
-	if rf, ok := ret.Get(0).(func(types.Context, []clobtypes.InternalOperation, map[clobtypes.OrderHash][]byte, *clobtypes.OffchainUpdates) *clobtypes.OffchainUpdates); ok {
-		r0 = rf(ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates)
+	if rf, ok := ret.Get(0).(func(types.Context, []clobtypes.InternalOperation, map[clobtypes.OrderHash][]byte, *clobtypes.OffchainUpdates, bool) *clobtypes.OffchainUpdates); ok {
+		r0 = rf(ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, onlyPlacePostOnly)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*clobtypes.OffchainUpdates)

--- a/protocol/mocks/MemClob.go
+++ b/protocol/mocks/MemClob.go
@@ -578,9 +578,9 @@ func (_m *MemClob) RemoveOrderIfFilled(ctx types.Context, orderId clobtypes.Orde
 	_m.Called(ctx, orderId)
 }
 
-// ReplayOperations provides a mock function with given fields: ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, onlyPlacePostOnly
-func (_m *MemClob) ReplayOperations(ctx types.Context, localOperations []clobtypes.InternalOperation, shortTermOrderTxBytes map[clobtypes.OrderHash][]byte, existingOffchainUpdates *clobtypes.OffchainUpdates, onlyPlacePostOnly bool) *clobtypes.OffchainUpdates {
-	ret := _m.Called(ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, onlyPlacePostOnly)
+// ReplayOperations provides a mock function with given fields: ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, postOnlyFilter
+func (_m *MemClob) ReplayOperations(ctx types.Context, localOperations []clobtypes.InternalOperation, shortTermOrderTxBytes map[clobtypes.OrderHash][]byte, existingOffchainUpdates *clobtypes.OffchainUpdates, postOnlyFilter bool) *clobtypes.OffchainUpdates {
+	ret := _m.Called(ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, postOnlyFilter)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ReplayOperations")
@@ -588,7 +588,7 @@ func (_m *MemClob) ReplayOperations(ctx types.Context, localOperations []clobtyp
 
 	var r0 *clobtypes.OffchainUpdates
 	if rf, ok := ret.Get(0).(func(types.Context, []clobtypes.InternalOperation, map[clobtypes.OrderHash][]byte, *clobtypes.OffchainUpdates, bool) *clobtypes.OffchainUpdates); ok {
-		r0 = rf(ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, onlyPlacePostOnly)
+		r0 = rf(ctx, localOperations, shortTermOrderTxBytes, existingOffchainUpdates, postOnlyFilter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*clobtypes.OffchainUpdates)

--- a/protocol/testutil/constants/stateful_orders.go
+++ b/protocol/testutil/constants/stateful_orders.go
@@ -1308,6 +1308,19 @@ var (
 	}
 
 	// Long-Term post-only orders.
+	LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO = clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: Alice_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:         clobtypes.Order_SIDE_BUY,
+		Quantums:     5,
+		Subticks:     10,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 5},
+		TimeInForce:  clobtypes.Order_TIME_IN_FORCE_POST_ONLY,
+	}
 	LongTermOrder_Alice_Num0_Id0_Clob0_Buy100_Price10_GTBT15_PO = clobtypes.Order{
 		OrderId: clobtypes.OrderId{
 			SubaccountId: Alice_Num0,
@@ -1356,6 +1369,19 @@ var (
 		},
 		Side:         clobtypes.Order_SIDE_BUY,
 		Quantums:     100_000_000,
+		Subticks:     50_000_000_000,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+		TimeInForce:  clobtypes.Order_TIME_IN_FORCE_POST_ONLY,
+	}
+	LongTermOrder_Dave_Num0_Id0_Clob0_Sell025BTC_Price50000_GTBT10_PO = clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: Dave_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:         clobtypes.Order_SIDE_SELL,
+		Quantums:     25_000_000,
 		Subticks:     50_000_000_000,
 		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
 		TimeInForce:  clobtypes.Order_TIME_IN_FORCE_POST_ONLY,

--- a/protocol/x/clob/e2e/conditional_orders_test.go
+++ b/protocol/x/clob/e2e/conditional_orders_test.go
@@ -705,7 +705,7 @@ func TestConditionalOrder(t *testing.T) {
 				constants.Dave_Num0_500000USD,
 			},
 			orders: []clobtypes.Order{
-				constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell025BTC_Price50000_GTBT10,
+				constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell025BTC_Price50000_GTBT10_PO,
 				constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Buy05BTC_Price50000_GTBT10_TP_49999_PO,
 			},
 			priceUpdateForFirstBlock: &prices.MsgUpdateMarketPrices{

--- a/protocol/x/clob/e2e/conditional_orders_test.go
+++ b/protocol/x/clob/e2e/conditional_orders_test.go
@@ -1869,7 +1869,7 @@ func TestConditionalOrder_TriggeringUsingMatchedPrice(t *testing.T) {
 				constants.Order_Dave_Num1_Id0_Clob0_Sell1BTC_Price49997_GTB10,
 				constants.Order_Carl_Num1_Id0_Clob0_Buy1BTC_Price50003_GTB10,
 				// Place the conditional order.
-				constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell025BTC_Price50000_GTBT10,
+				constants.LongTermOrder_Dave_Num0_Id0_Clob0_Sell025BTC_Price50000_GTBT10_PO,
 				constants.ConditionalOrder_Carl_Num0_Id0_Clob0_Buy05BTC_Price50000_GTBT10_TP_49999_PO,
 			},
 			expectedInTriggeredStateAfterBlock: map[uint32]map[clobtypes.OrderId]bool{

--- a/protocol/x/clob/e2e/order_removal_test.go
+++ b/protocol/x/clob/e2e/order_removal_test.go
@@ -43,7 +43,7 @@ func TestConditionalOrderRemoval(t *testing.T) {
 				constants.Bob_Num0_10_000USD,
 			},
 			orders: []clobtypes.Order{
-				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5,
+				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO,
 				constants.ConditionalOrder_Bob_Num0_Id0_Clob0_Sell10_Price10_GTBT10_PO_SL_15,
 			},
 
@@ -629,7 +629,7 @@ func TestOrderRemoval(t *testing.T) {
 				constants.Alice_Num0_10_000USD,
 				constants.Bob_Num0_10_000USD,
 			},
-			firstOrder:  constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5,
+			firstOrder:  constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO,
 			secondOrder: constants.LongTermOrder_Bob_Num0_Id0_Clob0_Sell10_Price10_GTBT10_PO,
 
 			expectedFirstOrderRemoved:  false,

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -523,8 +523,8 @@ func (k Keeper) PlaceStatefulOrdersFromLastBlock(
 
 		order := orderPlacement.GetOrder()
 
-		// Prioritize placing post-only orders if the flag is set.
-		if onlyPlacePostOnly && !order.IsPostOnlyOrder() {
+		// Skip the order if it is a post-only order and we are only placing post-only orders.
+		if onlyPlacePostOnly != order.IsPostOnlyOrder() {
 			continue
 		}
 

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -487,6 +487,9 @@ func (k Keeper) AddPreexistingStatefulOrder(
 // PlaceStatefulOrdersFromLastBlock validates and places stateful orders from the last block onto the memclob.
 // Note that stateful orders could fail to be placed due to various reasons such as collateralization
 // check failures, self-trade errors, etc. In these cases the `checkState` will not be written to.
+// Note that this function also takes in a postOnlyFilter variable and only places post-only orders if
+// postOnlyFilter is true and non-post-only orders if postOnlyFilter is false.
+//
 // This function is used in:
 // 1. `PrepareCheckState` to place newly placed long term orders from the last
 // block from ProcessProposerMatchesEvents.PlacedStatefulOrderIds. This is step 3 in PrepareCheckState.
@@ -496,7 +499,7 @@ func (k Keeper) PlaceStatefulOrdersFromLastBlock(
 	ctx sdk.Context,
 	placedStatefulOrderIds []types.OrderId,
 	existingOffchainUpdates *types.OffchainUpdates,
-	onlyPlacePostOnly bool,
+	postOnlyFilter bool,
 ) (
 	offchainUpdates *types.OffchainUpdates,
 ) {
@@ -523,8 +526,8 @@ func (k Keeper) PlaceStatefulOrdersFromLastBlock(
 
 		order := orderPlacement.GetOrder()
 
-		// Skip the order if it is a post-only order and we are only placing post-only orders.
-		if onlyPlacePostOnly != order.IsPostOnlyOrder() {
+		// Skip post-only orders if postOnlyFilter is false or non-post-only orders if postOnlyFilter is true.
+		if postOnlyFilter != order.IsPostOnlyOrder() {
 			continue
 		}
 
@@ -582,11 +585,14 @@ func (k Keeper) PlaceStatefulOrdersFromLastBlock(
 // PlaceConditionalOrdersTriggeredInLastBlock takes in a list of conditional order ids that were triggered
 // in the last block, verifies they are conditional orders, verifies they are in triggered state, and places
 // the orders on the memclob.
+//
+// Note that this function also takes in a postOnlyFilter variable and only places post-only orders if
+// postOnlyFilter is true and non-post-only orders if postOnlyFilter is false.
 func (k Keeper) PlaceConditionalOrdersTriggeredInLastBlock(
 	ctx sdk.Context,
 	conditionalOrderIdsTriggeredInLastBlock []types.OrderId,
 	existingOffchainUpdates *types.OffchainUpdates,
-	onlyPlacePostOnly bool,
+	postOnlyFilter bool,
 ) (
 	offchainUpdates *types.OffchainUpdates,
 ) {
@@ -620,7 +626,7 @@ func (k Keeper) PlaceConditionalOrdersTriggeredInLastBlock(
 		ctx,
 		conditionalOrderIdsTriggeredInLastBlock,
 		existingOffchainUpdates,
-		onlyPlacePostOnly,
+		postOnlyFilter,
 	)
 }
 

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -496,6 +496,7 @@ func (k Keeper) PlaceStatefulOrdersFromLastBlock(
 	ctx sdk.Context,
 	placedStatefulOrderIds []types.OrderId,
 	existingOffchainUpdates *types.OffchainUpdates,
+	onlyPlacePostOnly bool,
 ) (
 	offchainUpdates *types.OffchainUpdates,
 ) {
@@ -521,6 +522,12 @@ func (k Keeper) PlaceStatefulOrdersFromLastBlock(
 		}
 
 		order := orderPlacement.GetOrder()
+
+		// Prioritize placing post-only orders if the flag is set.
+		if onlyPlacePostOnly && !order.IsPostOnlyOrder() {
+			continue
+		}
+
 		// Validate and place order.
 		_, orderStatus, placeOrderOffchainUpdates, err := k.AddPreexistingStatefulOrder(
 			ctx,
@@ -579,6 +586,7 @@ func (k Keeper) PlaceConditionalOrdersTriggeredInLastBlock(
 	ctx sdk.Context,
 	conditionalOrderIdsTriggeredInLastBlock []types.OrderId,
 	existingOffchainUpdates *types.OffchainUpdates,
+	onlyPlacePostOnly bool,
 ) (
 	offchainUpdates *types.OffchainUpdates,
 ) {
@@ -608,7 +616,12 @@ func (k Keeper) PlaceConditionalOrdersTriggeredInLastBlock(
 		}
 	}
 
-	return k.PlaceStatefulOrdersFromLastBlock(ctx, conditionalOrderIdsTriggeredInLastBlock, existingOffchainUpdates)
+	return k.PlaceStatefulOrdersFromLastBlock(
+		ctx,
+		conditionalOrderIdsTriggeredInLastBlock,
+		existingOffchainUpdates,
+		onlyPlacePostOnly,
+	)
 }
 
 // PerformOrderCancellationStatefulValidation performs stateful validation on an order cancellation.

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -2218,7 +2218,8 @@ func TestPlaceStatefulOrdersFromLastBlock(t *testing.T) {
 			for _, order := range tc.orders {
 				orderIds = append(orderIds, order.OrderId)
 			}
-			ks.ClobKeeper.PlaceStatefulOrdersFromLastBlock(ctx, orderIds, offchainUpdates)
+			ks.ClobKeeper.PlaceStatefulOrdersFromLastBlock(ctx, orderIds, offchainUpdates, true)
+			ks.ClobKeeper.PlaceStatefulOrdersFromLastBlock(ctx, orderIds, offchainUpdates, false)
 
 			// PlaceStatefulOrdersFromLastBlock utilizes the memclob's PlaceOrder flow, but we
 			// do not want to emit PlaceMessages in offchain events for stateful orders. This assertion
@@ -2376,13 +2377,15 @@ func TestPlaceConditionalOrdersTriggeredInLastBlock(t *testing.T) {
 					t,
 					tc.expectedPanic,
 					func() {
-						ks.ClobKeeper.PlaceConditionalOrdersTriggeredInLastBlock(ctx, orderIds, offchainUpdates)
+						ks.ClobKeeper.PlaceConditionalOrdersTriggeredInLastBlock(ctx, orderIds, offchainUpdates, true)
+						ks.ClobKeeper.PlaceConditionalOrdersTriggeredInLastBlock(ctx, orderIds, offchainUpdates, false)
 					},
 				)
 				return
 			}
 
-			ks.ClobKeeper.PlaceConditionalOrdersTriggeredInLastBlock(ctx, orderIds, offchainUpdates)
+			ks.ClobKeeper.PlaceConditionalOrdersTriggeredInLastBlock(ctx, orderIds, offchainUpdates, true)
+			ks.ClobKeeper.PlaceConditionalOrdersTriggeredInLastBlock(ctx, orderIds, offchainUpdates, false)
 
 			// PlaceStatefulOrdersFromLastBlock utilizes the memclob's PlaceOrder flow, but we
 			// do not want to emit PlaceMessages in offchain events for stateful orders. This assertion

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -2250,13 +2250,13 @@ func TestPlaceStatefulOrdersFromLastBlock(t *testing.T) {
 
 func TestPlaceStatefulOrdersFromLastBlock_PostOnly(t *testing.T) {
 	tests := map[string]struct {
-		orders            []types.Order
-		onlyPlacePostOnly bool
+		orders         []types.Order
+		postOnlyFilter bool
 
 		expectedOrderPlacementCalls []types.Order
 	}{
-		"places PO stateful orders from last block when onlyPlacePostOnly = true": {
-			onlyPlacePostOnly: true,
+		"places PO stateful orders from last block when postOnlyFilter = true": {
+			postOnlyFilter: true,
 			orders: []types.Order{
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO,
 			},
@@ -2264,22 +2264,22 @@ func TestPlaceStatefulOrdersFromLastBlock_PostOnly(t *testing.T) {
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO,
 			},
 		},
-		"does not places non-PO stateful orders when onlyPlacePostOnly = true": {
-			onlyPlacePostOnly: true,
+		"does not places non-PO stateful orders when postOnlyFilter = true": {
+			postOnlyFilter: true,
 			orders: []types.Order{
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5,
 			},
 			expectedOrderPlacementCalls: []types.Order{},
 		},
-		"does not places PO stateful orders from last block, when onlyPlacePostOnly = false": {
-			onlyPlacePostOnly: false,
+		"does not places PO stateful orders from last block, when postOnlyFilter = false": {
+			postOnlyFilter: false,
 			orders: []types.Order{
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO,
 			},
 			expectedOrderPlacementCalls: []types.Order{},
 		},
-		"places non-PO stateful orders from last block when onlyPlacePostOnly = false": {
-			onlyPlacePostOnly: false,
+		"places non-PO stateful orders from last block when postOnlyFilter = false": {
+			postOnlyFilter: false,
 			orders: []types.Order{
 				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5,
 			},
@@ -2350,7 +2350,7 @@ func TestPlaceStatefulOrdersFromLastBlock_PostOnly(t *testing.T) {
 			for _, order := range tc.orders {
 				orderIds = append(orderIds, order.OrderId)
 			}
-			ks.ClobKeeper.PlaceStatefulOrdersFromLastBlock(ctx, orderIds, offchainUpdates, tc.onlyPlacePostOnly)
+			ks.ClobKeeper.PlaceStatefulOrdersFromLastBlock(ctx, orderIds, offchainUpdates, tc.postOnlyFilter)
 
 			// PlaceStatefulOrdersFromLastBlock utilizes the memclob's PlaceOrder flow, but we
 			// do not want to emit PlaceMessages in offchain events for stateful orders. This assertion

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -2248,6 +2248,137 @@ func TestPlaceStatefulOrdersFromLastBlock(t *testing.T) {
 	}
 }
 
+func TestPlaceStatefulOrdersFromLastBlock_PostOnly(t *testing.T) {
+	tests := map[string]struct {
+		orders            []types.Order
+		onlyPlacePostOnly bool
+
+		expectedOrderPlacementCalls []types.Order
+	}{
+		"places PO stateful orders from last block when onlyPlacePostOnly = true": {
+			onlyPlacePostOnly: true,
+			orders: []types.Order{
+				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO,
+			},
+			expectedOrderPlacementCalls: []types.Order{
+				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO,
+			},
+		},
+		"does not places non-PO stateful orders when onlyPlacePostOnly = true": {
+			onlyPlacePostOnly: true,
+			orders: []types.Order{
+				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5,
+			},
+			expectedOrderPlacementCalls: []types.Order{},
+		},
+		"does not places PO stateful orders from last block, when onlyPlacePostOnly = false": {
+			onlyPlacePostOnly: false,
+			orders: []types.Order{
+				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5_PO,
+			},
+			expectedOrderPlacementCalls: []types.Order{},
+		},
+		"places non-PO stateful orders from last block when onlyPlacePostOnly = false": {
+			onlyPlacePostOnly: false,
+			orders: []types.Order{
+				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5,
+			},
+			expectedOrderPlacementCalls: []types.Order{
+				constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT5,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Setup state.
+			memClob := &mocks.MemClob{}
+
+			memClob.On("SetClobKeeper", mock.Anything).Return()
+
+			ks := keepertest.NewClobKeepersTestContext(
+				t,
+				memClob,
+				&mocks.BankKeeper{},
+				indexer_manager.NewIndexerEventManagerNoop(),
+			)
+
+			ks.MarketMapKeeper.InitGenesis(ks.Ctx, constants.MarketMap_DefaultGenesisState)
+			prices.InitGenesis(ks.Ctx, *ks.PricesKeeper, constants.Prices_DefaultGenesisState)
+			perpetuals.InitGenesis(ks.Ctx, *ks.PerpetualsKeeper, constants.Perpetuals_DefaultGenesisState)
+
+			ctx := ks.Ctx.WithBlockHeight(int64(100)).WithBlockTime(time.Unix(5, 0))
+			ctx = ctx.WithIsCheckTx(true)
+			ks.BlockTimeKeeper.SetPreviousBlockInfo(ctx, &blocktimetypes.BlockInfo{
+				Height:    100,
+				Timestamp: time.Unix(int64(2), 0),
+			})
+
+			// Create CLOB pair.
+			memClob.On("CreateOrderbook", constants.ClobPair_Btc).Return()
+			_, err := ks.ClobKeeper.CreatePerpetualClobPairAndMemStructs(
+				ctx,
+				constants.ClobPair_Btc.Id,
+				clobtest.MustPerpetualId(constants.ClobPair_Btc),
+				satypes.BaseQuantums(constants.ClobPair_Btc.StepBaseQuantums),
+				constants.ClobPair_Btc.QuantumConversionExponent,
+				constants.ClobPair_Btc.SubticksPerTick,
+				constants.ClobPair_Btc.Status,
+			)
+			require.NoError(t, err)
+
+			// Create each stateful order placement in state
+			for i, order := range tc.orders {
+				require.True(t, order.IsStatefulOrder())
+
+				ks.ClobKeeper.SetLongTermOrderPlacement(ctx.WithIsCheckTx(false), order, uint32(i))
+			}
+
+			// Assert expected order placement memclob calls.
+			for _, order := range tc.expectedOrderPlacementCalls {
+				memClob.On("PlaceOrder", mock.Anything, order).Return(
+					satypes.BaseQuantums(0),
+					types.Success,
+					constants.TestOffchainUpdates,
+					nil,
+				).Once()
+			}
+
+			// Run the test and verify expectations.
+			offchainUpdates := types.NewOffchainUpdates()
+			orderIds := make([]types.OrderId, 0)
+			for _, order := range tc.orders {
+				orderIds = append(orderIds, order.OrderId)
+			}
+			ks.ClobKeeper.PlaceStatefulOrdersFromLastBlock(ctx, orderIds, offchainUpdates, tc.onlyPlacePostOnly)
+
+			// PlaceStatefulOrdersFromLastBlock utilizes the memclob's PlaceOrder flow, but we
+			// do not want to emit PlaceMessages in offchain events for stateful orders. This assertion
+			// verifies that we call `ClearPlaceMessages()` on the offchain updates before returning.
+			require.Equal(t, 0, memclobtest.MessageCountOfType(offchainUpdates, types.PlaceMessageType))
+
+			// Verify that all removed orders have an associated off-chain update.
+			orderMap := make(map[types.OrderId]bool)
+			for _, order := range tc.orders {
+				orderMap[order.OrderId] = true
+			}
+
+			removedOrders := lib.FilterSlice(tc.expectedOrderPlacementCalls, func(order types.Order) bool {
+				return !orderMap[order.OrderId]
+			})
+
+			for _, order := range removedOrders {
+				require.True(
+					t,
+					memclobtest.HasMessage(offchainUpdates, order.OrderId, types.RemoveMessageType),
+				)
+			}
+
+			memClob.AssertExpectations(t)
+		})
+	}
+}
+
 func TestPlaceConditionalOrdersTriggeredInLastBlock(t *testing.T) {
 	tests := map[string]struct {
 		triggeredOrders             []types.Order

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -1019,6 +1019,11 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 				continue
 			}
 
+			// Skip the order if it is a post-only order and we are only replaying post-only orders.
+			if onlyPlacePostOnly && !statefulOrderPlacement.Order.IsPostOnlyOrder() {
+				continue
+			}
+
 			// TODO(DEC-998): Research whether it's fine for two post-only orders to be matched. Currently they are dropped.
 			_, orderStatus, placeOrderOffchainUpdates, err := m.clobKeeper.AddPreexistingStatefulOrder(
 				ctx,
@@ -1069,6 +1074,11 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 
 			// if not in state anymore, this means it was removed in the previous block. No-op.
 			if !found {
+				continue
+			}
+
+			// Skip the order if it is a post-only order and we are only replaying post-only orders.
+			if onlyPlacePostOnly && !statefulOrderPlacement.Order.IsPostOnlyOrder() {
 				continue
 			}
 

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -925,7 +925,7 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 			order := operation.GetShortTermOrderPlacement().Order
 
 			// Skip the order if it is a post-only order and we are only replaying post-only orders.
-			if onlyPlacePostOnly && !order.IsPostOnlyOrder() {
+			if onlyPlacePostOnly != order.IsPostOnlyOrder() {
 				continue
 			}
 
@@ -1020,7 +1020,7 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 			}
 
 			// Skip the order if it is a post-only order and we are only replaying post-only orders.
-			if onlyPlacePostOnly && !statefulOrderPlacement.Order.IsPostOnlyOrder() {
+			if onlyPlacePostOnly != statefulOrderPlacement.Order.IsPostOnlyOrder() {
 				continue
 			}
 
@@ -1078,7 +1078,7 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 			}
 
 			// Skip the order if it is a post-only order and we are only replaying post-only orders.
-			if onlyPlacePostOnly && !statefulOrderPlacement.Order.IsPostOnlyOrder() {
+			if onlyPlacePostOnly != statefulOrderPlacement.Order.IsPostOnlyOrder() {
 				continue
 			}
 

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -874,12 +874,15 @@ func (m *MemClobPriceTimePriority) matchOrder(
 // - Pre-existing stateful orders.
 // - Stateful cancelations.
 // Note that match operations are no-op.
+//
+// Note that this function also takes in a postOnlyFilter variable and only places post-only orders if
+// postOnlyFilter is true and non-post-only orders if postOnlyFilter is false.
 func (m *MemClobPriceTimePriority) ReplayOperations(
 	ctx sdk.Context,
 	localOperations []types.InternalOperation,
 	shortTermOrderTxBytes map[types.OrderHash][]byte,
 	existingOffchainUpdates *types.OffchainUpdates,
-	onlyPlacePostOnly bool,
+	postOnlyFilter bool,
 ) *types.OffchainUpdates {
 	lib.AssertCheckTxMode(ctx)
 
@@ -924,8 +927,8 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 		case *types.InternalOperation_ShortTermOrderPlacement:
 			order := operation.GetShortTermOrderPlacement().Order
 
-			// Skip the order if it is a post-only order and we are only replaying post-only orders.
-			if onlyPlacePostOnly != order.IsPostOnlyOrder() {
+			// Skip post-only orders if postOnlyFilter is false or non-post-only orders if postOnlyFilter is true.
+			if postOnlyFilter != order.IsPostOnlyOrder() {
 				continue
 			}
 
@@ -1019,8 +1022,8 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 				continue
 			}
 
-			// Skip the order if it is a post-only order and we are only replaying post-only orders.
-			if onlyPlacePostOnly != statefulOrderPlacement.Order.IsPostOnlyOrder() {
+			// Skip post-only orders if postOnlyFilter is false or non-post-only orders if postOnlyFilter is true.
+			if postOnlyFilter != statefulOrderPlacement.Order.IsPostOnlyOrder() {
 				continue
 			}
 
@@ -1077,8 +1080,8 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 				continue
 			}
 
-			// Skip the order if it is a post-only order and we are only replaying post-only orders.
-			if onlyPlacePostOnly != statefulOrderPlacement.Order.IsPostOnlyOrder() {
+			// Skip post-only orders if postOnlyFilter is false or non-post-only orders if postOnlyFilter is true.
+			if postOnlyFilter != statefulOrderPlacement.Order.IsPostOnlyOrder() {
 				continue
 			}
 

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -879,6 +879,7 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 	localOperations []types.InternalOperation,
 	shortTermOrderTxBytes map[types.OrderHash][]byte,
 	existingOffchainUpdates *types.OffchainUpdates,
+	onlyPlacePostOnly bool,
 ) *types.OffchainUpdates {
 	lib.AssertCheckTxMode(ctx)
 
@@ -922,6 +923,11 @@ func (m *MemClobPriceTimePriority) ReplayOperations(
 		// Replay all short-term and stateful order placements.
 		case *types.InternalOperation_ShortTermOrderPlacement:
 			order := operation.GetShortTermOrderPlacement().Order
+
+			// Skip the order if it is a post-only order and we are only replaying post-only orders.
+			if onlyPlacePostOnly && !order.IsPostOnlyOrder() {
+				continue
+			}
 
 			// Set underlying tx bytes so OperationsToPropose may access it and
 			// store the tx bytes on OperationHashToTxBytes data structure

--- a/protocol/x/clob/types/memclob.go
+++ b/protocol/x/clob/types/memclob.go
@@ -110,7 +110,7 @@ type MemClob interface {
 		localOperations []InternalOperation,
 		shortTermOrderTxBytes map[OrderHash][]byte,
 		existingOffchainUpdates *OffchainUpdates,
-		onlyPlacePostOnly bool,
+		postOnlyFilter bool,
 	) (offchainUpdates *OffchainUpdates)
 	SetMemclobGauges(
 		ctx sdk.Context,

--- a/protocol/x/clob/types/memclob.go
+++ b/protocol/x/clob/types/memclob.go
@@ -110,6 +110,7 @@ type MemClob interface {
 		localOperations []InternalOperation,
 		shortTermOrderTxBytes map[OrderHash][]byte,
 		existingOffchainUpdates *OffchainUpdates,
+		onlyPlacePostOnly bool,
 	) (offchainUpdates *OffchainUpdates)
 	SetMemclobGauges(
 		ctx sdk.Context,

--- a/protocol/x/clob/types/order.go
+++ b/protocol/x/clob/types/order.go
@@ -180,6 +180,11 @@ func (o *Order) IsConditionalOrder() bool {
 	return o.OrderId.IsConditionalOrder()
 }
 
+// IsPostOnlyOrder returns whether this order is a post only order.
+func (o *Order) IsPostOnlyOrder() bool {
+	return o.GetTimeInForce() == Order_TIME_IN_FORCE_POST_ONLY
+}
+
 // CanTrigger returns if a condition order is eligible to be triggered based on a given
 // subticks value. Function will panic if order is not a conditional order.
 func (o *Order) CanTrigger(subticks Subticks) bool {


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method `IsPostOnlyOrder` to determine if an order is post-only.
	- Enhanced order placement logic with a new parameter `postOnlyFilter` for conditional processing of orders.
	- Updated replay operations to conditionally skip non-post-only orders based on the new parameter.
	- Added new long-term orders with a "post-only" time-in-force option.

- **Bug Fixes**
	- Improved error handling and telemetry for order placement and removal processes.

- **Tests**
	- Updated test cases to cover new functionality related to post-only order processing and ensure robustness against edge cases.
	- Expanded tests for conditional order removals to reflect new business logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->