### PR TITLE
allow megavault operator to set default quoting params

### DIFF
--- a/protocol/x/vault/keeper/msg_server_update_default_quoting_params.go
+++ b/protocol/x/vault/keeper/msg_server_update_default_quoting_params.go
@@ -5,7 +5,6 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 )
@@ -15,15 +14,18 @@ func (k msgServer) UpdateDefaultQuotingParams(
 	goCtx context.Context,
 	msg *types.MsgUpdateDefaultQuotingParams,
 ) (*types.MsgUpdateDefaultQuotingParamsResponse, error) {
-	if !k.HasAuthority(msg.Authority) {
+	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
+	operator := k.GetOperatorParams(ctx).Operator
+
+	// Check if authority is valid (must be a module authority or operator).
+	if !k.HasAuthority(msg.Authority) && msg.Authority != operator {
 		return nil, errorsmod.Wrapf(
-			govtypes.ErrInvalidSigner,
+			types.ErrInvalidAuthority,
 			"invalid authority %s",
 			msg.Authority,
 		)
 	}
 
-	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
 	if err := k.SetDefaultQuotingParams(ctx, msg.DefaultQuotingParams); err != nil {
 		return nil, err
 	}

--- a/protocol/x/vault/keeper/msg_server_update_default_quoting_params_test.go
+++ b/protocol/x/vault/keeper/msg_server_update_default_quoting_params_test.go
@@ -9,28 +9,39 @@ import (
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 
+	"github.com/cometbft/cometbft/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vault/keeper"
-	"github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
+	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMsgUpdateDefaultQuotingParams(t *testing.T) {
 	tests := map[string]struct {
 		// Msg.
-		msg *types.MsgUpdateDefaultQuotingParams
+		msg *vaulttypes.MsgUpdateDefaultQuotingParams
+		// Operator.
+		operator string
 		// Expected error
 		expectedErr string
 	}{
-		"Success. Update to default": {
-			msg: &types.MsgUpdateDefaultQuotingParams{
+		"Success. Update to default. Gov Authority": {
+			msg: &vaulttypes.MsgUpdateDefaultQuotingParams{
 				Authority:            lib.GovModuleAddress.String(),
-				DefaultQuotingParams: types.DefaultQuotingParams(),
+				DefaultQuotingParams: vaulttypes.DefaultQuotingParams(),
 			},
+			operator: constants.AliceAccAddress.String(),
+		},
+		"Success. Update to default. Operator Authority": {
+			msg: &vaulttypes.MsgUpdateDefaultQuotingParams{
+				Authority:            constants.CarlAccAddress.String(),
+				DefaultQuotingParams: vaulttypes.DefaultQuotingParams(),
+			},
+			operator: constants.CarlAccAddress.String(),
 		},
 		"Success. Update to non-default": {
-			msg: &types.MsgUpdateDefaultQuotingParams{
+			msg: &vaulttypes.MsgUpdateDefaultQuotingParams{
 				Authority: lib.GovModuleAddress.String(),
-				DefaultQuotingParams: types.QuotingParams{
+				DefaultQuotingParams: vaulttypes.QuotingParams{
 					Layers:                           3,
 					SpreadMinPpm:                     234_567,
 					SpreadBufferPpm:                  6_789,
@@ -40,18 +51,20 @@ func TestMsgUpdateDefaultQuotingParams(t *testing.T) {
 					ActivationThresholdQuoteQuantums: dtypes.NewInt(2_121_343_787),
 				},
 			},
+			operator: constants.AliceAccAddress.String(),
 		},
 		"Failure - Invalid Authority": {
-			msg: &types.MsgUpdateDefaultQuotingParams{
+			msg: &vaulttypes.MsgUpdateDefaultQuotingParams{
 				Authority:            constants.AliceAccAddress.String(),
-				DefaultQuotingParams: types.DefaultQuotingParams(),
+				DefaultQuotingParams: vaulttypes.DefaultQuotingParams(),
 			},
+			operator:    constants.BobAccAddress.String(),
 			expectedErr: "invalid authority",
 		},
 		"Failure - Invalid Params": {
-			msg: &types.MsgUpdateDefaultQuotingParams{
+			msg: &vaulttypes.MsgUpdateDefaultQuotingParams{
 				Authority: lib.GovModuleAddress.String(),
-				DefaultQuotingParams: types.QuotingParams{
+				DefaultQuotingParams: vaulttypes.QuotingParams{
 					Layers:                           3,
 					SpreadMinPpm:                     4_000,
 					SpreadBufferPpm:                  2_000,
@@ -61,13 +74,26 @@ func TestMsgUpdateDefaultQuotingParams(t *testing.T) {
 					ActivationThresholdQuoteQuantums: dtypes.NewInt(1_000_000_000),
 				},
 			},
-			expectedErr: types.ErrInvalidOrderSizePctPpm.Error(),
+			operator:    constants.AliceAccAddress.String(),
+			expectedErr: vaulttypes.ErrInvalidOrderSizePctPpm.Error(),
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tApp := testapp.NewTestAppBuilder(t).Build()
+			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+				genesis = testapp.DefaultGenesis()
+				// Set megavault operator.
+				testapp.UpdateGenesisDocWithAppStateForModule(
+					&genesis,
+					func(genesisState *vaulttypes.GenesisState) {
+						genesisState.OperatorParams = vaulttypes.OperatorParams{
+							Operator: tc.operator,
+						}
+					},
+				)
+				return genesis
+			}).Build()
 			ctx := tApp.InitChain()
 			k := tApp.App.VaultKeeper
 			ms := keeper.NewMsgServerImpl(k)
@@ -75,7 +101,7 @@ func TestMsgUpdateDefaultQuotingParams(t *testing.T) {
 			_, err := ms.UpdateDefaultQuotingParams(ctx, tc.msg)
 			if tc.expectedErr != "" {
 				require.ErrorContains(t, err, tc.expectedErr)
-				require.Equal(t, types.DefaultQuotingParams(), k.GetDefaultQuotingParams(ctx))
+				require.Equal(t, vaulttypes.DefaultQuotingParams(), k.GetDefaultQuotingParams(ctx))
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.msg.DefaultQuotingParams, k.GetDefaultQuotingParams(ctx))


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced authority validation for updating default quoting parameters.
	- Expanded test cases to cover both "Gov Authority" and "Operator Authority" scenarios.

- **Bug Fixes**
	- Updated error handling for invalid authority to improve clarity.

- **Documentation**
	- Improved test structure by explicitly defining operator roles and updating type references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->