### PR TITLE
fix(affiliates): Fix logic in affiliate referred volume aggregation

### DIFF
--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -343,34 +343,42 @@ func (k Keeper) GetAffiliateWhitelist(ctx sdk.Context) (types.AffiliateWhitelist
 	}
 	return affiliateWhitelist, nil
 }
+
 func (k Keeper) AggregateAffiliateReferredVolumeForFills(
 	ctx sdk.Context,
 ) error {
 	blockStats := k.statsKeeper.GetBlockStats(ctx)
 	referredByCache := make(map[string]string)
+
 	for _, fill := range blockStats.Fills {
-		// Add taker's referred volume to the cache
-		if _, ok := referredByCache[fill.Taker]; !ok {
-			referredByAddrTaker, found := k.GetReferredBy(ctx, fill.Taker)
-			if !found {
-				continue
+		// Process taker's referred volume
+		referredByAddrTaker, cached := referredByCache[fill.Taker]
+		if !cached {
+			var found bool
+			referredByAddrTaker, found = k.GetReferredBy(ctx, fill.Taker)
+			if found {
+				referredByCache[fill.Taker] = referredByAddrTaker
 			}
-			referredByCache[fill.Taker] = referredByAddrTaker
 		}
-		if err := k.AddReferredVolume(ctx, referredByCache[fill.Taker], lib.BigU(fill.Notional)); err != nil {
-			return err
+		if referredByAddrTaker != "" {
+			if err := k.AddReferredVolume(ctx, referredByAddrTaker, lib.BigU(fill.Notional)); err != nil {
+				return err
+			}
 		}
 
-		// Add maker's referred volume to the cache
-		if _, ok := referredByCache[fill.Maker]; !ok {
-			referredByAddrMaker, found := k.GetReferredBy(ctx, fill.Maker)
-			if !found {
-				continue
+		// Process maker's referred volume
+		referredByAddrMaker, cached := referredByCache[fill.Maker]
+		if !cached {
+			var found bool
+			referredByAddrMaker, found = k.GetReferredBy(ctx, fill.Maker)
+			if found {
+				referredByCache[fill.Maker] = referredByAddrMaker
 			}
-			referredByCache[fill.Maker] = referredByAddrMaker
 		}
-		if err := k.AddReferredVolume(ctx, referredByCache[fill.Maker], lib.BigU(fill.Notional)); err != nil {
-			return err
+		if referredByAddrMaker != "" {
+			if err := k.AddReferredVolume(ctx, referredByAddrMaker, lib.BigU(fill.Notional)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/protocol/x/affiliates/keeper/keeper_test.go
+++ b/protocol/x/affiliates/keeper/keeper_test.go
@@ -781,6 +781,29 @@ func TestAggregateAffiliateReferredVolumeForFills(t *testing.T) {
 				})
 			},
 		},
+		{
+			name:           "2 referrals, takers not referred, maker referred",
+			referrals:      2,
+			expectedVolume: big.NewInt(300_000_000_000),
+			setup: func(t *testing.T, ctx sdk.Context, k *keeper.Keeper, statsKeeper *statskeeper.Keeper) {
+				err := k.RegisterAffiliate(ctx, maker, affiliate)
+				require.NoError(t, err)
+				statsKeeper.SetBlockStats(ctx, &statstypes.BlockStats{
+					Fills: []*statstypes.BlockStats_Fill{
+						{
+							Taker:    referee1,
+							Maker:    maker,
+							Notional: 100_000_000_000,
+						},
+						{
+							Taker:    referee2,
+							Maker:    maker,
+							Notional: 200_000_000_000,
+						},
+					},
+				})
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Changelist
Currently, when calculating referred volumes from new fills, if the taker is not referred, the fill is skipped directly so the maker volume (even if referred) does not count towards the affiliate's referred volume.
Fixed by independently adding volume from taker/maker. 

This bug may result in protocol-view of affiliate referred volume being smaller than actual, potentially leading to lower than expected affiliate tier. 

### Test Plan
Unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to aggregate referred volumes for affiliates, improving efficiency in processing referrals.
  
- **Bug Fixes**
	- Enhanced testing coverage for the affiliate referral system with a new test case for aggregating referred volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->