### PR TITLE
Run account plus migration in v8 upgrade

### DIFF
--- a/protocol/app/upgrades.go
+++ b/protocol/app/upgrades.go
@@ -33,6 +33,7 @@ func (app *App) setupUpgradeHandlers() {
 			app.PricesKeeper,
 			app.PerpetualsKeeper,
 			app.ClobKeeper,
+			app.AccountPlusKeeper,
 		),
 	)
 }

--- a/protocol/app/upgrades/v8.0/upgrade.go
+++ b/protocol/app/upgrades/v8.0/upgrade.go
@@ -94,10 +94,13 @@ func CreateUpgradeHandler(
 	pricesKeeper pricestypes.PricesKeeper,
 	perpetualsKeeper perptypes.PerpetualsKeeper,
 	clobKeeper clobtypes.ClobKeeper,
+	accountplusKeeper accountpluskeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		sdkCtx := lib.UnwrapSDKContext(ctx, "app/upgrades")
 		sdkCtx.Logger().Info(fmt.Sprintf("Running %s Upgrade...", UpgradeName))
+
+		MigrateAccountplusAccountState(sdkCtx, accountplusKeeper)
 
 		// Set market, perpetual, and clob ids to a set number
 		setMarketListingBaseIds(sdkCtx, pricesKeeper, perpetualsKeeper, clobKeeper)


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced upgrade process to include migration of account states, ensuring better state management during upgrades.
	- Integrated logging for migration progress to provide users with feedback during the upgrade process.

- **Bug Fixes**
	- Addressed potential issues with account state handling by ensuring proper key structure during migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->