### PR TITLE
fix transfers parent SA API for external addresses in transfers

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -645,6 +645,12 @@ export const defaultTransfer3: TransferCreateObject = {
   assetId: defaultAsset2.id,
 };
 
+export const defaultTransferWithAlternateAddress: TransferCreateObject = {
+  ...defaultTransfer,
+  senderSubaccountId: defaultSubaccountIdWithAlternateAddress,
+  recipientSubaccountId: defaultSubaccountId,
+};
+
 export const defaultTransferId: string = TransferTable.uuid(
   defaultTransfer.eventId,
   defaultTransfer.assetId,
@@ -652,6 +658,15 @@ export const defaultTransferId: string = TransferTable.uuid(
   defaultTransfer.recipientSubaccountId,
   defaultTransfer.senderWalletAddress,
   defaultTransfer.recipientWalletAddress,
+);
+
+export const defaultTransferWithAlternateAddressId: string = TransferTable.uuid(
+  defaultTransferWithAlternateAddress.eventId,
+  defaultTransferWithAlternateAddress.assetId,
+  defaultTransferWithAlternateAddress.senderSubaccountId,
+  defaultTransferWithAlternateAddress.recipientSubaccountId,
+  defaultTransferWithAlternateAddress.senderWalletAddress,
+  defaultTransferWithAlternateAddress.recipientWalletAddress,
 );
 
 export const defaultWithdrawal: TransferCreateObject = {

--- a/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
@@ -20,10 +20,9 @@ import request from 'supertest';
 import { getQueryString, sendRequest } from '../../../helpers/helpers';
 import {
   createdDateTime, createdHeight,
-  defaultAsset,
+  defaultAsset, defaultSubaccount2Num0,
   defaultTendermintEventId4,
-  defaultWalletAddress,
-  isolatedSubaccountId,
+  defaultWalletAddress, isolatedSubaccountId,
 } from '@dydxprotocol-indexer/postgres/build/__tests__/helpers/constants';
 import Big from 'big.js';
 
@@ -461,10 +460,14 @@ describe('transfers-controller#V4', () => {
       };
       await WalletTable.create(defaultWallet);
       await Promise.all([
+        SubaccountTable.create(defaultSubaccount2Num0),
+      ]);
+      await Promise.all([
         TransferTable.create(testConstants.defaultTransfer),
         TransferTable.create(transfer2),
         TransferTable.create(testConstants.defaultWithdrawal),
         TransferTable.create(testConstants.defaultDeposit),
+        TransferTable.create(testConstants.defaultTransferWithAlternateAddress),
       ]);
 
       const response: request.Response = await sendRequest({
@@ -550,6 +553,24 @@ describe('transfers-controller#V4', () => {
         transactionHash: testConstants.defaultWithdrawal.transactionHash,
       };
 
+      const expectedTransferWithAlternateAddressResponse: ParentSubaccountTransferResponseObject = {
+        id: testConstants.defaultTransferWithAlternateAddressId,
+        sender: {
+          address: testConstants.defaultAddress2,
+          parentSubaccountNumber: testConstants.defaultSubaccount2Num0.subaccountNumber,
+        },
+        recipient: {
+          address: testConstants.defaultAddress,
+          parentSubaccountNumber: testConstants.defaultSubaccount.subaccountNumber,
+        },
+        size: testConstants.defaultTransferWithAlternateAddress.size,
+        createdAt: testConstants.defaultTransferWithAlternateAddress.createdAt,
+        createdAtHeight: testConstants.defaultTransferWithAlternateAddress.createdAtHeight,
+        symbol: testConstants.defaultAsset.symbol,
+        type: TransferType.TRANSFER_IN,
+        transactionHash: testConstants.defaultTransferWithAlternateAddress.transactionHash,
+      };
+
       expect(response.body.transfers).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -563,6 +584,9 @@ describe('transfers-controller#V4', () => {
           }),
           expect.objectContaining({
             ...expectedDepositResponse,
+          }),
+          expect.objectContaining({
+            ...expectedTransferWithAlternateAddressResponse,
           }),
         ]),
       );

--- a/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
@@ -218,6 +218,7 @@ class TransfersController extends Controller {
           transfer,
           idToAsset,
           idToSubaccount,
+          address,
           parentSubaccountNumber);
       });
 
@@ -225,7 +226,8 @@ class TransfersController extends Controller {
     const transfersFiltered:
     ParentSubaccountTransferResponseObject[] = transfersWithParentSubaccount.filter(
       (transfer) => {
-        return transfer.sender.parentSubaccountNumber !== transfer.recipient.parentSubaccountNumber;
+        return transfer.sender.address !== transfer.recipient.address ||
+            transfer.sender.parentSubaccountNumber !== transfer.recipient.parentSubaccountNumber;
       });
 
     return {

--- a/indexer/services/comlink/src/request-helpers/request-transformer.ts
+++ b/indexer/services/comlink/src/request-helpers/request-transformer.ts
@@ -243,6 +243,7 @@ export function transferToParentSubaccountResponseObject(
   transfer: TransferFromDatabase,
   assetMap: AssetById,
   subaccountMap: SubaccountById,
+  address: string,
   parentSubaccountNumber: number,
 ): ParentSubaccountTransferResponseObject {
 
@@ -251,6 +252,9 @@ export function transferToParentSubaccountResponseObject(
     : parentSubaccountHelpers.getParentSubaccountNum(
       subaccountMap[transfer.senderSubaccountId!].subaccountNumber,
     );
+  const senderAddress = transfer.senderWalletAddress
+    ? transfer.senderWalletAddress
+    : subaccountMap[transfer.senderSubaccountId!].address;
 
   const recipientParentSubaccountNum = transfer.recipientWalletAddress
     ? undefined
@@ -260,13 +264,13 @@ export function transferToParentSubaccountResponseObject(
 
   // Determine transfer type based on parent subaccount number.
   let transferType: TransferType = TransferType.TRANSFER_IN;
-  if (senderParentSubaccountNum === parentSubaccountNumber) {
+  if (senderAddress === address && senderParentSubaccountNum === parentSubaccountNumber) {
     if (transfer.recipientSubaccountId) {
       transferType = TransferType.TRANSFER_OUT;
     } else {
       transferType = TransferType.WITHDRAWAL;
     }
-  } else if (recipientParentSubaccountNum === parentSubaccountNumber) {
+  } else { // if (recipientParentSubaccountNum === parentSubaccountNumber) {
     if (transfer.senderSubaccountId) {
       transferType = TransferType.TRANSFER_IN;
     } else {


### PR DESCRIPTION
### Changelist
The transfers parent subaccount API was filtering out transfers from different addresses if the parent subaccount number was the same. This fixes it

### Test Plan
Added tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new constants for creating transfer objects with alternate addresses, enhancing transfer flexibility.
  - Improved transfer handling for parent subaccounts, including new test scenarios for alternate addresses and pagination.

- **Bug Fixes**
  - Enhanced error handling for invalid addresses and subaccount numbers in transfer operations.

- **Improvements**
  - Refined filtering logic for transfer requests to ensure accurate results based on sender and recipient addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->