### PR TITLE
Increase orderbook mid price cache duration to 60 seconds

### DIFF
--- a/indexer/packages/redis/__tests__/caches/orderbook-mid-prices-cache.test.ts
+++ b/indexer/packages/redis/__tests__/caches/orderbook-mid-prices-cache.test.ts
@@ -136,7 +136,7 @@ describe('orderbook-mid-prices-cache', () => {
       expect(result).toEqual({ 'BTC-USD': '50500' });
     });
 
-    it('returns the correct median price after 30 seconds', async () => {
+    it('returns the correct median price after 60 seconds', async () => {
       jest.useFakeTimers();
       // Mock the getOrderBookMidPrice function for the ticker
       const mockPrices: string[] = ['50000', '51000', '49000', '48000', '52000', '53000'];
@@ -154,7 +154,7 @@ describe('orderbook-mid-prices-cache', () => {
       expect(OrderbookLevelsCache.getOrderBookMidPrice).toHaveBeenCalledTimes(2);
 
       // Advance time and fetch more prices
-      jest.advanceTimersByTime(31000); // Advance time by 31 seconds
+      jest.advanceTimersByTime(61000); // Advance time by 61 seconds
       await fetchAndCacheOrderbookMidPrices(
         client,
         [defaultTicker, defaultTicker, defaultTicker, defaultTicker],

--- a/indexer/packages/redis/src/scripts/add_orderbook_mid_prices.lua
+++ b/indexer/packages/redis/src/scripts/add_orderbook_mid_prices.lua
@@ -7,8 +7,8 @@ local numArgs = #ARGV
 -- Get the timestamp from the last argument
 local timestamp = tonumber(ARGV[numArgs])
 
--- Time window (30 seconds)
-local thirtySeconds = 30
+-- Time window (60 seconds)
+local sixtySeconds = 60
 
 -- Validate the timestamp
 if not timestamp then
@@ -16,7 +16,7 @@ if not timestamp then
 end
 
 -- Calculate the cutoff time for removing old prices
-local cutoffTime = timestamp - thirtySeconds
+local cutoffTime = timestamp - sixtySeconds
 
 -- Iterate through each key (market) and corresponding price
 for i = 1, numKeys do
@@ -31,7 +31,7 @@ for i = 1, numKeys do
   -- Add the price to the sorted set with the current timestamp as the score
   redis.call("ZADD", priceCacheKey, timestamp, price)
 
-  -- Remove entries older than the cutoff time (older than 30 seconds)
+  -- Remove entries older than the cutoff time (older than 60 seconds)
   redis.call("ZREMRANGEBYSCORE", priceCacheKey, "-inf", cutoffTime)
 end
 


### PR DESCRIPTION
Increases the amount of time we store orderbook mid price data from 30 to 60 seconds. This is to remedy spikes in candle data that we continue to see with 30 seconds of data. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the timing in the `getMedianPrice` test case from 30 seconds to 60 seconds to ensure accurate median price verification.

- **Chores**
	- Updated the time window for processing market prices from 30 seconds to 60 seconds in the relevant Lua script, including necessary comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->