### PR TITLE
fix(affiliates): Reject self referral in `RegisterAffiliate`

### DIFF
--- a/protocol/x/affiliates/keeper/keeper.go
+++ b/protocol/x/affiliates/keeper/keeper.go
@@ -61,6 +61,12 @@ func (k Keeper) RegisterAffiliate(
 	referee string,
 	affiliateAddr string,
 ) error {
+	if referee == affiliateAddr {
+		return errorsmod.Wrapf(
+			types.ErrSelfReferral, "referee: %s, affiliate: %s",
+			referee, affiliateAddr,
+		)
+	}
 	if _, err := sdk.AccAddressFromBech32(referee); err != nil {
 		return errorsmod.Wrapf(types.ErrInvalidAddress, "referee: %s", referee)
 	}

--- a/protocol/x/affiliates/keeper/keeper_test.go
+++ b/protocol/x/affiliates/keeper/keeper_test.go
@@ -88,6 +88,15 @@ func TestRegisterAffiliate_GetReferredBy(t *testing.T) {
 				// No setup needed for this test case
 			},
 		},
+		{
+			name:        "Self referral",
+			referee:     constants.AliceAccAddress.String(),
+			affiliate:   constants.AliceAccAddress.String(),
+			expectError: types.ErrSelfReferral,
+			setup: func(t *testing.T, ctx sdk.Context, k *keeper.Keeper) {
+				// No setup needed for this test case
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/protocol/x/affiliates/types/errors.go
+++ b/protocol/x/affiliates/types/errors.go
@@ -16,4 +16,5 @@ var (
 		ModuleName, 8, "Duplicate affiliate address for whitelist")
 	ErrAffiliateTiersNotSet = errorsmod.Register(ModuleName, 9,
 		"Affiliate tiers not set (affiliate program is not active)")
+	ErrSelfReferral = errorsmod.Register(ModuleName, 10, "Self referral not allowed")
 )


### PR DESCRIPTION
### Changelist
This is already prevented at indexer level, but updating protocol behavior to be consistent

### Test Plan
Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced error handling for self-referral during affiliate registration.
	- Added a new error message: "Self referral not allowed".

- **Bug Fixes**
	- Enhanced validation logic to prevent users from registering themselves as affiliates.

- **Tests**
	- Added a new test case to verify self-referral error handling in the affiliate registration process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->