### PR TITLE
Improve query to find candles map.

### DIFF
--- a/indexer/services/ender/src/caches/block-cache.ts
+++ b/indexer/services/ender/src/caches/block-cache.ts
@@ -107,6 +107,7 @@ function isNextBlock(blockHeight: string): boolean {
  * All caches must be initialized in a Transaction to ensure consistency
  */
 export async function initializeAllCaches(): Promise<void> {
+  const start: number = Date.now();
   const txId: number = await Transaction.start();
   await Transaction.setIsolationLevel(txId, IsolationLevel.READ_COMMITTED);
 
@@ -120,6 +121,10 @@ export async function initializeAllCaches(): Promise<void> {
   ]);
 
   await Transaction.rollback(txId);
+  stats.timing(
+    `${config.SERVICE_NAME}.initialize_caches`,
+    Date.now() - start,
+  );
 }
 
 export function resetBlockCache(): void {

--- a/indexer/services/ender/src/caches/candle-cache.ts
+++ b/indexer/services/ender/src/caches/candle-cache.ts
@@ -23,8 +23,6 @@ export async function startCandleCache(txId?: number): Promise<void> {
 
   candlesMap = await CandleTable.findCandlesMap(
     tickers,
-    Object.values(CandleResolution),
-    { txId },
   );
 }
 


### PR DESCRIPTION
### Changelist
Optimize queries to find initial map for candles by limiting the time period to search over for latest candles, and using a single query to get all the latest candles rather than repeated querying for a single ticker's candles.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced candle retrieval logic using raw SQL queries for improved performance.
	- Added performance monitoring for cache initialization.

- **Bug Fixes**
	- Improved error handling in block cache refresh functionality for clearer logging.

- **Tests**
	- Updated test suite for `CandlesGenerator` to handle new date management with `luxon`.
	- Adjusted test cases to ensure compatibility with changes in date handling.

- **Refactor**
	- Removed unnecessary parameters in candle retrieval functions for streamlined logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->