### PR TITLE
chore: Add EIGEN,BOME as isolatd market in default test genesis

### DIFF
--- a/protocol/scripts/genesis/prod_pregenesis.sh
+++ b/protocol/scripts/genesis/prod_pregenesis.sh
@@ -168,7 +168,10 @@ create_pregenesis_file() {
 	echo "Copying exchange config jsons to $TMP_EXCHANGE_CONFIG_JSON_DIR"
 	cp -R ./daemons/pricefeed/client/constants/testdata $TMP_EXCHANGE_CONFIG_JSON_DIR
 
+	echo "Running edit_genesis..."
 	edit_genesis "$VAL_CONFIG_DIR" "" "" "" "" "$TMP_EXCHANGE_CONFIG_JSON_DIR" "./testing/delaymsg_config" "STATUS_INITIALIZING" ""
+	
+	echo "Oerwriting genesis params for production..."
 	overwrite_genesis_production
 }
 

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -3952,9 +3952,9 @@
           "price": 4973000000
         },
         {
-          "exponent": -10,
+          "exponent": -12,
           "id": 301,
-          "price": 657992192
+          "price": 8695478191
         }
       ]
     },
@@ -4090,7 +4090,7 @@
       ]
     }
   },
-  "app_version": "7.0.0-dev0-148-g7da33a6b8",
+  "app_version": "7.0.0-dev0-149-g12cfb908b",
   "chain_id": "dydx-sample-1",
   "consensus": {
     "params": {

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -475,6 +475,26 @@
           "status": "STATUS_INITIALIZING",
           "step_base_quantums": 1000000,
           "subticks_per_tick": 1000000
+        },
+        {
+          "id": 300,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 300
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_INITIALIZING",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
+        },
+        {
+          "id": 301,
+          "perpetual_clob_metadata": {
+            "perpetual_id": 301
+          },
+          "quantum_conversion_exponent": -9,
+          "status": "STATUS_INITIALIZING",
+          "step_base_quantums": 1000000,
+          "subticks_per_tick": 1000000
         }
       ],
       "equity_tier_limit_config": {
@@ -1397,6 +1417,70 @@
               "min_provider_count": 3
             }
           },
+          "BOME/USD": {
+            "provider_configs": [
+              {
+                "invert": false,
+                "metadata_JSON": "",
+                "name": "kucoin_ws",
+                "normalize_by_pair": {
+                  "Base": "USDT",
+                  "Quote": "USD"
+                },
+                "off_chain_ticker": "BOME-USDT"
+              },
+              {
+                "invert": false,
+                "metadata_JSON": "",
+                "name": "huobi_ws",
+                "normalize_by_pair": {
+                  "Base": "USDT",
+                  "Quote": "USD"
+                },
+                "off_chain_ticker": "bomeusdt"
+              },
+              {
+                "invert": false,
+                "metadata_JSON": "",
+                "name": "bybit_ws",
+                "normalize_by_pair": {
+                  "Base": "USDT",
+                  "Quote": "USD"
+                },
+                "off_chain_ticker": "BOMEUSDT"
+              },
+              {
+                "invert": false,
+                "metadata_JSON": "{\"base_token_vault\":{\"token_vault_address\":\"FBba2XsQVhkoQDMfbNLVmo7dsvssdT39BMzVc2eFfE21\",\"token_decimals\":6},\"quote_token_vault\":{\"token_vault_address\":\"GuXKCb9ibwSeRSdSYqaCL3dcxBZ7jJcj6Y7rDwzmUBu9\",\"token_decimals\":9},\"amm_info_address\":\"DSUvc5qf5LJHHV5e2tD184ixotSnCnwj7i4jJa4Xsrmt\",\"open_orders_address\":\"38p42yoKFWgxw2LCbB96wAKa2LwAxiBArY3fc3eA9yWv\"}",
+                "name": "raydium_api",
+                "normalize_by_pair": {
+                  "Base": "SOL",
+                  "Quote": "USD"
+                },
+                "off_chain_ticker": "BOME,RAYDIUM,UKHH6C7MMYIWCF1B9PNWE25TSPKDDT3H5PQZGZ74J82/SOL,RAYDIUM,SO11111111111111111111111111111111111111112"
+              },
+              {
+                "invert": false,
+                "metadata_JSON": "",
+                "name": "okx_ws",
+                "normalize_by_pair": {
+                  "Base": "USDT",
+                  "Quote": "USD"
+                },
+                "off_chain_ticker": "BOME-USDT"
+              }
+            ],
+            "ticker": {
+              "currency_pair": {
+                "Base": "BOME",
+                "Quote": "USD"
+              },
+              "decimals": 12,
+              "enabled": true,
+              "metadata_JSON": "{\"reference_price\":6051284618,\"liquidity\":748591,\"aggregate_ids\":[{\"venue\":\"coinmarketcap\",\"ID\":\"29870\"}]}",
+              "min_provider_count": 1
+            }
+          },
           "BTC/USD": {
             "provider_configs": [
               {
@@ -1737,6 +1821,50 @@
               "decimals": 9,
               "enabled": true,
               "min_provider_count": 3
+            }
+          },
+          "EIGEN/USD": {
+            "provider_configs": [
+              {
+                "invert": false,
+                "name": "okx_ws",
+                "normalize_by_pair": {
+                  "Base": "USDT",
+                  "Quote": "USD"
+                },
+                "off_chain_ticker": "EIGEN-USDT"
+              },
+              {
+                "invert": false,
+                "name": "bybit_ws",
+                "normalize_by_pair": {
+                  "Base": "USDT",
+                  "Quote": "USD"
+                },
+                "off_chain_ticker": "EIGENUSDT"
+              },
+              {
+                "name": "crypto_dot_com_ws",
+                "off_chain_ticker": "EIGEN_USD"
+              },
+              {
+                "name": "coinbase_ws",
+                "off_chain_ticker": "EIGEN-USD"
+              },
+              {
+                "name": "kraken_api",
+                "off_chain_ticker": "EIGENUSD"
+              }
+            ],
+            "ticker": {
+              "currency_pair": {
+                "Base": "EIGEN",
+                "Quote": "USD"
+              },
+              "decimals": 9,
+              "enabled": true,
+              "metadata_JSON": "{\"reference_price\":3648941500,\"liquidity\":3099304,\"aggregate_ids\":[{\"venue\":\"coinmarketcap\",\"ID\":\"30494\"}]}",
+              "min_provider_count": 1
             }
           },
           "ETC/USD": {
@@ -3390,6 +3518,28 @@
             "market_type": 1,
             "ticker": "XRP-USD"
           }
+        },
+        {
+          "params": {
+            "atomic_resolution": -6,
+            "default_funding_ppm": 0,
+            "id": 300,
+            "liquidity_tier": 4,
+            "market_id": 300,
+            "market_type": 2,
+            "ticker": "EIGEN-USD"
+          }
+        },
+        {
+          "params": {
+            "atomic_resolution": -3,
+            "default_funding_ppm": 0,
+            "id": 301,
+            "liquidity_tier": 4,
+            "market_id": 301,
+            "market_type": 2,
+            "ticker": "BOME-USD"
+          }
         }
       ]
     },
@@ -3604,6 +3754,20 @@
           "id": 1000001,
           "min_price_change_ppm": 2500,
           "pair": "DYDX-USD"
+        },
+        {
+          "exponent": -9,
+          "id": 300,
+          "min_exchanges": 1,
+          "min_price_change_ppm": 800,
+          "pair": "EIGEN-USD"
+        },
+        {
+          "exponent": -12,
+          "id": 301,
+          "min_exchanges": 1,
+          "min_price_change_ppm": 800,
+          "pair": "BOME-USD"
         }
       ],
       "market_prices": [
@@ -3781,6 +3945,16 @@
           "exponent": -9,
           "id": 1000001,
           "price": 2050000000
+        },
+        {
+          "exponent": -9,
+          "id": 300,
+          "price": 4973000000
+        },
+        {
+          "exponent": -10,
+          "id": 301,
+          "price": 657992192
         }
       ]
     },
@@ -3916,7 +4090,7 @@
       ]
     }
   },
-  "app_version": "7.0.0-dev0-129-g2b9a6b6dd",
+  "app_version": "7.0.0-dev0-148-g7da33a6b8",
   "chain_id": "dydx-sample-1",
   "consensus": {
     "params": {

--- a/protocol/testing/genesis.sh
+++ b/protocol/testing/genesis.sh
@@ -542,6 +542,26 @@ function edit_genesis() {
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[32].params.liquidity_tier' -v '1'
 	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[32].params.market_type' -v '1'
 
+	# Perpetual (Isolated): EIGEN-USD
+	dasel put -t json -f "$GENESIS" '.app_state.perpetuals.perpetuals.[]' -v "{}"
+	dasel put -t string -f "$GENESIS" '.app_state.perpetuals.perpetuals.[33].params.ticker' -v 'EIGEN-USD'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[33].params.id' -v '300'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[33].params.market_id' -v '300'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[33].params.atomic_resolution' -v '-6'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[33].params.default_funding_ppm' -v '0'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[33].params.liquidity_tier' -v '4'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[33].params.market_type' -v '2' # Isolated
+
+	# Perpetual (Isolated): BOME-USD
+	dasel put -t json -f "$GENESIS" '.app_state.perpetuals.perpetuals.[]' -v "{}"
+	dasel put -t string -f "$GENESIS" '.app_state.perpetuals.perpetuals.[34].params.ticker' -v 'BOME-USD'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[34].params.id' -v '301'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[34].params.market_id' -v '301'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[34].params.atomic_resolution' -v '-3'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[34].params.default_funding_ppm' -v '0'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[34].params.liquidity_tier' -v '4'
+	dasel put -t int -f "$GENESIS" '.app_state.perpetuals.perpetuals.[34].params.market_type' -v '2' # Isolated
+
 	# Update MarketMap module.
 	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map' -v "{}"
 	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets' -v "{}"
@@ -1251,7 +1271,43 @@ function edit_genesis() {
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "kucoin_ws", "off_chain_ticker": "BTC-USDT", "normalize_by_pair": {"Base": "BTC", "Quote": "USD"}, "invert": true}'
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.USDT/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "USDC-USDT", "invert": true}'
 
+    # Marketmap: EIGEN-USD
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD' -v "{}"
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.ticker' -v "{}" 
 
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.ticker.currency_pair' -v "{}"
+    dasel put -t string -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.ticker.currency_pair.Base' -v 'EIGEN'
+    dasel put -t string -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.ticker.currency_pair.Quote' -v 'USD'
+
+    dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.ticker.decimals' -v '9'
+    dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.ticker.min_provider_count' -v '1'
+    dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.ticker.enabled' -v 'true'
+    dasel put -t string -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.ticker.metadata_JSON' -v '{"reference_price":3648941500,"liquidity":3099304,"aggregate_ids":[{"venue":"coinmarketcap","ID":"30494"}]}'
+
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.provider_configs.[]' -v '{"name": "okx_ws", "off_chain_ticker": "EIGEN-USDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}, "invert": false}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.provider_configs.[]' -v '{"name": "bybit_ws", "off_chain_ticker": "EIGENUSDT", "normalize_by_pair": {"Base": "USDT", "Quote": "USD"}, "invert": false}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.provider_configs.[]' -v '{"name": "crypto_dot_com_ws", "off_chain_ticker": "EIGEN_USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.provider_configs.[]' -v '{"name": "coinbase_ws", "off_chain_ticker": "EIGEN-USD"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.EIGEN/USD.provider_configs.[]' -v '{"name": "kraken_api", "off_chain_ticker": "EIGENUSD"}'
+
+	# Marketmap: BOME-USD
+	dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD' -v "{}"
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.ticker' -v "{}" 
+
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.ticker.currency_pair' -v "{}"
+    dasel put -t string -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.ticker.currency_pair.Base' -v 'BOME'
+    dasel put -t string -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.ticker.currency_pair.Quote' -v 'USD'
+
+    dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.ticker.decimals' -v '12'
+    dasel put -t int -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.ticker.min_provider_count' -v '1'
+    dasel put -t bool -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.ticker.enabled' -v 'true'
+    dasel put -t string -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.ticker.metadata_JSON' -v '{"reference_price":6051284618,"liquidity":748591,"aggregate_ids":[{"venue":"coinmarketcap","ID":"29870"}]}'
+
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.provider_configs.[]' -v '{"name":"kucoin_ws","off_chain_ticker":"BOME-USDT","normalize_by_pair":{"Base":"USDT","Quote":"USD"},"invert":false,"metadata_JSON":""}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.provider_configs.[]' -v '{"name":"huobi_ws","off_chain_ticker":"bomeusdt","normalize_by_pair":{"Base":"USDT","Quote":"USD"},"invert":false,"metadata_JSON":""}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.provider_configs.[]' -v '{"name":"bybit_ws","off_chain_ticker":"BOMEUSDT","normalize_by_pair":{"Base":"USDT","Quote":"USD"},"invert":false,"metadata_JSON":""}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.provider_configs.[]' -v '{"name":"raydium_api","off_chain_ticker":"BOME,RAYDIUM,UKHH6C7MMYIWCF1B9PNWE25TSPKDDT3H5PQZGZ74J82/SOL,RAYDIUM,SO11111111111111111111111111111111111111112","normalize_by_pair":{"Base":"SOL","Quote":"USD"},"invert":false,"metadata_JSON":"{\"base_token_vault\":{\"token_vault_address\":\"FBba2XsQVhkoQDMfbNLVmo7dsvssdT39BMzVc2eFfE21\",\"token_decimals\":6},\"quote_token_vault\":{\"token_vault_address\":\"GuXKCb9ibwSeRSdSYqaCL3dcxBZ7jJcj6Y7rDwzmUBu9\",\"token_decimals\":9},\"amm_info_address\":\"DSUvc5qf5LJHHV5e2tD184ixotSnCnwj7i4jJa4Xsrmt\",\"open_orders_address\":\"38p42yoKFWgxw2LCbB96wAKa2LwAxiBArY3fc3eA9yWv\"}"}'
+    dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.BOME/USD.provider_configs.[]' -v '{"name":"okx_ws","off_chain_ticker":"BOME-USDT","normalize_by_pair":{"Base":"USDT","Quote":"USD"},"invert":false,"metadata_JSON":""}'
     # Marketmap: DYDX-USD
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD' -v "{}"
     dasel put -t json -f "$GENESIS" '.app_state.marketmap.market_map.markets.DYDX/USD.ticker' -v "{}" 
@@ -1659,6 +1715,30 @@ function edit_genesis() {
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].exponent' -v '-9'
 	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[34].price' -v '2050000000'          # $2.05 = 1 DYDX.
 
+	# Market: EIGEN-USD
+	dasel put -t json -f "$GENESIS" '.app_state.prices.market_params.[]' -v "{}"
+	dasel put -t string -f "$GENESIS" '.app_state.prices.market_params.[35].pair' -v 'EIGEN-USD'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[35].id' -v '300'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[35].exponent' -v '-9'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[35].min_price_change_ppm' -v '800'  # 0.080%
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[35].min_exchanges' -v '1'
+	dasel put -t json -f "$GENESIS" '.app_state.prices.market_prices.[]' -v "{}"
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[35].id' -v '300'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[35].exponent' -v '-9'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[35].price' -v '4973000000'          # $4.973
+
+	# Market: BOME-USD
+	dasel put -t json -f "$GENESIS" '.app_state.prices.market_params.[]' -v "{}"
+	dasel put -t string -f "$GENESIS" '.app_state.prices.market_params.[36].pair' -v 'BOME-USD'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[36].id' -v '301'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[36].exponent' -v '-12'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[36].min_price_change_ppm' -v '800'  # 0.080%
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_params.[36].min_exchanges' -v '1'
+	dasel put -t json -f "$GENESIS" '.app_state.prices.market_prices.[]' -v "{}"
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[36].id' -v '301'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[36].exponent' -v '-12'
+	dasel put -t int -f "$GENESIS" '.app_state.prices.market_prices.[36].price' -v '8695478191'          # $0.008695
+
 	# Initialize bridge module account balance as total native token supply.
 	bridge_module_account_balance=$TOTAL_NATIVE_TOKEN_SUPPLY
 	total_accounts_quote_balance=0
@@ -2024,6 +2104,24 @@ function edit_genesis() {
 	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[32].step_base_quantums' -v '1000000'
 	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[32].subticks_per_tick' -v '1000000'
 	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[32].quantum_conversion_exponent' -v '-9'
+
+	# Clob: EIGEN-USD
+	dasel put -t json -f "$GENESIS" '.app_state.clob.clob_pairs.[]' -v "{}"
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[33].id' -v '300'
+	dasel put -t string -f "$GENESIS" '.app_state.clob.clob_pairs.[33].status' -v "$INITIAL_CLOB_PAIR_STATUS"
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[33].perpetual_clob_metadata.perpetual_id' -v '300'
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[33].step_base_quantums' -v '1000000'
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[33].subticks_per_tick' -v '1000000'
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[33].quantum_conversion_exponent' -v '-9'
+
+	# Clob: BOME-USD
+	dasel put -t json -f "$GENESIS" '.app_state.clob.clob_pairs.[]' -v "{}"
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[34].id' -v '301'
+	dasel put -t string -f "$GENESIS" '.app_state.clob.clob_pairs.[34].status' -v "$INITIAL_CLOB_PAIR_STATUS"
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[34].perpetual_clob_metadata.perpetual_id' -v '301'
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[34].step_base_quantums' -v '1000000'
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[34].subticks_per_tick' -v '1000000'
+	dasel put -t int -f "$GENESIS" '.app_state.clob.clob_pairs.[34].quantum_conversion_exponent' -v '-9'
 
 	# Liquidations
 	dasel put -t int -f "$GENESIS" '.app_state.clob.liquidations_config.max_liquidation_fee_ppm' -v '15000'  # 1.5%

--- a/protocol/x/clob/types/genesis.go
+++ b/protocol/x/clob/types/genesis.go
@@ -19,18 +19,12 @@ func DefaultGenesis() *GenesisState {
 func (gs GenesisState) Validate() error {
 	// Check for duplicated id in clobPair
 	clobPairIdMap := make(map[uint32]struct{})
-	expectedId := uint32(0)
 
 	for _, clobPair := range gs.ClobPairs {
 		if _, ok := clobPairIdMap[clobPair.Id]; ok {
 			return fmt.Errorf("duplicated id for clobPair")
 		}
 		clobPairIdMap[clobPair.Id] = struct{}{}
-
-		if clobPair.Id != expectedId {
-			return fmt.Errorf("found gap in clobPair id")
-		}
-		expectedId = expectedId + 1
 	}
 
 	if err := gs.BlockRateLimitConfig.Validate(); err != nil {

--- a/protocol/x/clob/types/genesis_test.go
+++ b/protocol/x/clob/types/genesis_test.go
@@ -101,19 +101,6 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 			expectedError: errors.New("duplicated id for clobPair"),
 		},
-		"gap in clobPair": {
-			genState: &types.GenesisState{
-				ClobPairs: []types.ClobPair{
-					{
-						Id: uint32(0),
-					},
-					{
-						Id: uint32(2),
-					},
-				},
-			},
-			expectedError: errors.New("found gap in clobPair id"),
-		},
 		"spread to maintenance margin ratio of 0 is invalid": {
 			genState: &types.GenesisState{
 				LiquidationsConfig: types.LiquidationsConfig{

--- a/protocol/x/perpetuals/types/genesis.go
+++ b/protocol/x/perpetuals/types/genesis.go
@@ -45,21 +45,14 @@ func (gs GenesisState) Validate() error {
 
 	// Validate perpetuals
 	// 1. keys are unique
-	// 2. IDs are sequential
-	// 3. `Ticker` is non-empty
+	// 2. `Ticker` is non-empty
 	perpKeyMap := make(map[uint32]struct{})
-	expectedPerpId := uint32(0)
 
 	for _, perp := range gs.Perpetuals {
 		if _, exists := perpKeyMap[perp.Params.Id]; exists {
 			return fmt.Errorf("duplicated perpetual id")
 		}
 		perpKeyMap[perp.Params.Id] = struct{}{}
-
-		if perp.Params.Id != expectedPerpId {
-			return fmt.Errorf("found a gap in perpetual id")
-		}
-		expectedPerpId = expectedPerpId + 1
 
 		if len(perp.Params.Ticker) == 0 {
 			return ErrTickerEmptyString

--- a/protocol/x/perpetuals/types/genesis_test.go
+++ b/protocol/x/perpetuals/types/genesis_test.go
@@ -84,43 +84,6 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 			expectedError: errors.New("duplicated perpetual id"),
 		},
-		"invalid: found a gap in perpetual id": {
-			genState: &types.GenesisState{
-				Perpetuals: []types.Perpetual{
-					{
-						Params: types.PerpetualParams{
-							Id:            0,
-							Ticker:        "EXAM-USD",
-							LiquidityTier: 0,
-						},
-						FundingIndex: dtypes.ZeroInt(),
-					},
-					{
-						Params: types.PerpetualParams{
-							Id:            2, // duplicate
-							Ticker:        "PERP-USD",
-							LiquidityTier: 0,
-						},
-						FundingIndex: dtypes.ZeroInt(),
-					},
-				},
-				LiquidityTiers: []types.LiquidityTier{
-					{
-						Id:                     0,
-						Name:                   "Large-Cap",
-						InitialMarginPpm:       500_000,
-						MaintenanceFractionPpm: 750_000,
-						ImpactNotional:         1_000_000_000,
-					},
-				},
-				Params: types.Params{
-					FundingRateClampFactorPpm: 6_000_000,
-					PremiumVoteClampFactorPpm: 60_000_000,
-					MinNumVotesPerSample:      15,
-				},
-			},
-			expectedError: errors.New("found a gap in perpetual id"),
-		},
 		"invalid: empty ticker": {
 			genState: &types.GenesisState{
 				Perpetuals: []types.Perpetual{


### PR DESCRIPTION
### Changelist
Copied over EIGEN,BOME params from prod

### Test Plan
Tested on localnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new perpetual markets: "EIGEN-USD" and "BOME-USD" with updated configurations.
	- Enhanced logging in the pregenesis script for better user feedback during execution.

- **Bug Fixes**
	- Removed strict sequential ID checks for `ClobPair` and `Perpetual` entries, simplifying validation processes.

- **Documentation**
	- Updated app version from "7.0.0-dev0-129-g2b9a6b6dd" to "7.0.0-dev0-149-g12cfb908b".

- **Tests**
	- Removed test cases related to gaps in `ClobPair` and `Perpetual` IDs, focusing on other validation aspects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->