### PR TITLE
fix(feetiers): Reject malformed address in query

### DIFF
--- a/protocol/x/feetiers/client/cli/query_test.go
+++ b/protocol/x/feetiers/client/cli/query_test.go
@@ -56,7 +56,11 @@ func TestQueryPerpetualFeeParams(t *testing.T) {
 func TestQueryUserFeeTier(t *testing.T) {
 	net, ctx := setupNetwork(t)
 
-	out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdQueryUserFeeTier(), []string{"dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4"})
+	out, err := clitestutil.ExecTestCLICmd(
+		ctx,
+		cli.CmdQueryUserFeeTier(),
+		[]string{"dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4"},
+	)
 
 	require.NoError(t, err)
 	var resp types.QueryUserFeeTierResponse

--- a/protocol/x/feetiers/client/cli/query_test.go
+++ b/protocol/x/feetiers/client/cli/query_test.go
@@ -56,7 +56,7 @@ func TestQueryPerpetualFeeParams(t *testing.T) {
 func TestQueryUserFeeTier(t *testing.T) {
 	net, ctx := setupNetwork(t)
 
-	out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdQueryUserFeeTier(), []string{"alice"})
+	out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdQueryUserFeeTier(), []string{"dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4"})
 
 	require.NoError(t, err)
 	var resp types.QueryUserFeeTierResponse

--- a/protocol/x/feetiers/keeper/grpc_query.go
+++ b/protocol/x/feetiers/keeper/grpc_query.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"context"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/feetiers/types"
 	"google.golang.org/grpc/codes"
@@ -42,6 +44,10 @@ func (k Keeper) UserFeeTier(
 	}
 
 	ctx := lib.UnwrapSDKContext(c, types.ModuleName)
+
+	if _, err := sdk.AccAddressFromBech32(req.User); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "user address is valid bech32 address")
+	}
 	index, tier := k.getUserFeeTier(ctx, req.User)
 	return &types.QueryUserFeeTierResponse{
 		Index: index,

--- a/protocol/x/feetiers/keeper/grpc_query.go
+++ b/protocol/x/feetiers/keeper/grpc_query.go
@@ -46,7 +46,7 @@ func (k Keeper) UserFeeTier(
 	ctx := lib.UnwrapSDKContext(c, types.ModuleName)
 
 	if _, err := sdk.AccAddressFromBech32(req.User); err != nil {
-		return nil, status.Error(codes.InvalidArgument, "user address is valid bech32 address")
+		return nil, status.Error(codes.InvalidArgument, "invalid bech32 address")
 	}
 	index, tier := k.getUserFeeTier(ctx, req.User)
 	return &types.QueryUserFeeTierResponse{

--- a/protocol/x/feetiers/keeper/grpc_query_test.go
+++ b/protocol/x/feetiers/keeper/grpc_query_test.go
@@ -83,7 +83,7 @@ func TestUserFeeTier(t *testing.T) {
 				User: "alice",
 			},
 			res: nil,
-			err: status.Error(codes.InvalidArgument, "user address is valid bech32 address"),
+			err: status.Error(codes.InvalidArgument, "invalid bech32 address"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/protocol/x/feetiers/keeper/grpc_query_test.go
+++ b/protocol/x/feetiers/keeper/grpc_query_test.go
@@ -58,7 +58,7 @@ func TestUserFeeTier(t *testing.T) {
 	}{
 		"Success": {
 			req: &types.QueryUserFeeTierRequest{
-				User: "alice",
+				User: "dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4",
 			},
 			res: &types.QueryUserFeeTierResponse{
 				Index: 0,
@@ -77,6 +77,13 @@ func TestUserFeeTier(t *testing.T) {
 			req: nil,
 			res: nil,
 			err: status.Error(codes.InvalidArgument, "invalid request"),
+		},
+		"Malformed address": {
+			req: &types.QueryUserFeeTierRequest{
+				User: "alice",
+			},
+			res: nil,
+			err: status.Error(codes.InvalidArgument, "user address is valid bech32 address"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### Changelist
https://dydx-team.slack.com/archives/C03FVKBHD5H/p1732319479334399

### Test Plan
Unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user address validation in the fee tier request process.

- **Bug Fixes**
	- Improved error handling for invalid user addresses.

- **Tests**
	- Updated test cases to include validation for valid and malformed user addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->