### PR TITLE
Improve vault start pnl query.

### DIFF
--- a/indexer/packages/postgres/src/stores/vault-pnl-ticks-view.ts
+++ b/indexer/packages/postgres/src/stores/vault-pnl-ticks-view.ts
@@ -62,3 +62,27 @@ export async function getVaultsPnl(
 
   return result.rows;
 }
+
+export async function getLatestVaultPnl(): Promise<PnlTicksFromDatabase[]> {
+  const result: {
+    rows: PnlTicksFromDatabase[],
+  } = await knexReadReplica.getConnection().raw(
+    `
+    SELECT DISTINCT ON ("subaccountId")
+      "id",
+      "subaccountId",
+      "equity",
+      "totalPnl",
+      "netTransfers",
+      "createdAt",
+      "blockHeight",
+      "blockTime"
+    FROM ${VAULT_HOURLY_PNL_VIEW}
+    ORDER BY "subaccountId", "blockTime" DESC;
+    `,
+  ) as unknown as {
+    rows: PnlTicksFromDatabase[],
+  };
+
+  return result.rows;
+}

--- a/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
@@ -24,7 +24,7 @@ import { getFixedRepresentation, sendRequest } from '../../../helpers/helpers';
 import { DateTime, Settings } from 'luxon';
 import Big from 'big.js';
 import config from '../../../../src/config';
-import { clearVaultStartPnl, startVaultStartPnlCache } from '../../../../src/caches/vault-start-pnl'
+import { clearVaultStartPnl, startVaultStartPnlCache } from '../../../../src/caches/vault-start-pnl';
 
 describe('vault-controller#V4', () => {
   const latestBlockHeight: string = '25';

--- a/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/vault-controller.test.ts
@@ -24,6 +24,7 @@ import { getFixedRepresentation, sendRequest } from '../../../helpers/helpers';
 import { DateTime, Settings } from 'luxon';
 import Big from 'big.js';
 import config from '../../../../src/config';
+import { clearVaultStartPnl, startVaultStartPnlCache } from '../../../../src/caches/vault-start-pnl'
 
 describe('vault-controller#V4', () => {
   const latestBlockHeight: string = '25';
@@ -131,6 +132,7 @@ describe('vault-controller#V4', () => {
       await dbHelpers.clearData();
       await VaultPnlTicksView.refreshDailyView();
       await VaultPnlTicksView.refreshHourlyView();
+      clearVaultStartPnl();
       config.VAULT_PNL_HISTORY_HOURS = vaultPnlHistoryHoursPrev;
       config.VAULT_LATEST_PNL_TICK_WINDOW_HOURS = vaultPnlLastPnlWindowPrev;
       config.VAULT_PNL_START_DATE = vaultPnlStartDatePrev;
@@ -653,6 +655,7 @@ describe('vault-controller#V4', () => {
     }
     await VaultPnlTicksView.refreshDailyView();
     await VaultPnlTicksView.refreshHourlyView();
+    await startVaultStartPnlCache();
 
     return createdTicks;
   }

--- a/indexer/services/comlink/src/caches/vault-start-pnl.ts
+++ b/indexer/services/comlink/src/caches/vault-start-pnl.ts
@@ -1,0 +1,32 @@
+import {
+  PnlTicksFromDatabase,
+  PnlTicksTable,
+} from '@dydxprotocol-indexer/postgres';
+import _ from 'lodash';
+import { getVaultMapping, getVaultPnlStartDate } from '../lib/helpers';
+import { VaultMapping } from '../types';
+import { NodeEnv } from '@dydxprotocol-indexer/base';
+
+let vaultStartPnl: PnlTicksFromDatabase[] = [];
+
+export async function startVaultStartPnlCache(): Promise<void> {
+  const vaultMapping: VaultMapping = await getVaultMapping();
+  vaultStartPnl = await PnlTicksTable.getLatestPnlTick(
+    _.keys(vaultMapping),
+    // Add a buffer of 10 minutes to get the first PnL tick for PnL data as PnL ticks aren't
+    // created exactly on the hour.
+    getVaultPnlStartDate().plus({ minutes: 10 }),
+  );
+}
+
+export function getVaultStartPnl(): PnlTicksFromDatabase[] {
+  return vaultStartPnl;
+}
+
+export function clearVaultStartPnl(): void {
+  if (process.env.NODE_ENV !== NodeEnv.TEST) {
+    throw Error('cannot clear vault start pnl cache outside of test environment');
+  }
+
+  vaultStartPnl = [];
+}

--- a/indexer/services/comlink/src/caches/vault-start-pnl.ts
+++ b/indexer/services/comlink/src/caches/vault-start-pnl.ts
@@ -1,11 +1,12 @@
+import { NodeEnv } from '@dydxprotocol-indexer/base';
 import {
   PnlTicksFromDatabase,
   PnlTicksTable,
 } from '@dydxprotocol-indexer/postgres';
 import _ from 'lodash';
+
 import { getVaultMapping, getVaultPnlStartDate } from '../lib/helpers';
 import { VaultMapping } from '../types';
-import { NodeEnv } from '@dydxprotocol-indexer/base';
 
 let vaultStartPnl: PnlTicksFromDatabase[] = [];
 

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -1,7 +1,6 @@
-import { logger, stats } from '@dydxprotocol-indexer/base';
+import { stats } from '@dydxprotocol-indexer/base';
 import {
   PnlTicksFromDatabase,
-  PnlTicksTable,
   perpetualMarketRefresher,
   PerpetualMarketFromDatabase,
   USDC_ASSET_ID,
@@ -41,6 +40,7 @@ import {
 } from 'tsoa';
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { getVaultStartPnl } from '../../../caches/vault-start-pnl';
 import config from '../../../config';
 import {
   aggregateHourlyPnlTicks,
@@ -65,7 +65,6 @@ import {
   VaultsHistoricalPnlRequest,
   AggregatedPnlTick,
 } from '../../../types';
-import { getVaultStartPnl } from '../../../caches/vault-start-pnl';
 
 const router: express.Router = express.Router();
 const controllerName: string = 'vault-controller';
@@ -547,13 +546,8 @@ function getPnlTicksWithCurrentTick(
   return pnlTicks.concat([currentTick]);
 }
 
-export async function getLatestPnlTicks(
-  vaultSubaccountIds: string[],
-): Promise<PnlTicksFromDatabase[]> {
-  const latestPnlTicks: PnlTicksFromDatabase[] = await PnlTicksTable.getLatestPnlTick(
-    vaultSubaccountIds,
-    DateTime.now().toUTC(),
-  );
+export async function getLatestPnlTicks(): Promise<PnlTicksFromDatabase[]> {
+  const latestPnlTicks: PnlTicksFromDatabase[] = await VaultPnlTicksView.getLatestVaultPnl();
   const adjustedPnlTicks: PnlTicksFromDatabase[] = adjustVaultPnlTicks(
     latestPnlTicks,
     getVaultStartPnl(),

--- a/indexer/services/comlink/src/index.ts
+++ b/indexer/services/comlink/src/index.ts
@@ -9,6 +9,7 @@ import config from './config';
 import IndexV4 from './controllers/api/index-v4';
 import { connect as connectToRedis } from './helpers/redis/redis-controller';
 import Server from './request-helpers/server';
+import { startVaultStartPnlCache } from './caches/vault-start-pnl';
 
 process.on('SIGTERM', () => {
   logger.info({
@@ -42,6 +43,8 @@ async function start() {
   ]);
   wrapBackgroundTask(perpetualMarketRefresher.start(), true, 'startUpdatePerpetualMarkets');
   wrapBackgroundTask(liquidityTierRefresher.start(), true, 'startUpdateLiquidityTiers');
+  // Initialize cache for vault start PnL
+  await startVaultStartPnlCache();
 
   await connectToRedis();
   logger.info({

--- a/indexer/services/comlink/src/index.ts
+++ b/indexer/services/comlink/src/index.ts
@@ -5,11 +5,11 @@ import {
 } from '@dydxprotocol-indexer/base';
 import { perpetualMarketRefresher, liquidityTierRefresher } from '@dydxprotocol-indexer/postgres';
 
+import { startVaultStartPnlCache } from './caches/vault-start-pnl';
 import config from './config';
 import IndexV4 from './controllers/api/index-v4';
 import { connect as connectToRedis } from './helpers/redis/redis-controller';
 import Server from './request-helpers/server';
-import { startVaultStartPnlCache } from './caches/vault-start-pnl';
 
 process.on('SIGTERM', () => {
   logger.info({

--- a/indexer/services/comlink/src/lib/helpers.ts
+++ b/indexer/services/comlink/src/lib/helpers.ts
@@ -24,6 +24,7 @@ import {
   AssetFromDatabase,
   AssetColumns,
   MarketColumns,
+  VaultFromDatabase, VaultTable, perpetualMarketRefresher,
 } from '@dydxprotocol-indexer/postgres';
 import Big from 'big.js';
 import express from 'express';
@@ -51,9 +52,6 @@ import {
 } from '../types';
 import { ZERO, ZERO_USDC_POSITION } from './constants';
 import { InvalidParamError, NotFoundError } from './errors';
-import { VaultFromDatabase } from '@dydxprotocol-indexer/postgres';
-import { VaultTable } from '@dydxprotocol-indexer/postgres';
-import { perpetualMarketRefresher } from '@dydxprotocol-indexer/postgres';
 
 /* ------- GENERIC HELPERS ------- */
 

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -24,6 +24,7 @@ import {
   TradeType,
   TradingRewardAggregationPeriod,
   TransferType,
+  VaultFromDatabase,
 } from '@dydxprotocol-indexer/postgres';
 import { RedisOrder } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
@@ -690,6 +691,10 @@ export interface MegavaultHistoricalPnlRequest {
 }
 
 export interface VaultsHistoricalPnlRequest extends MegavaultHistoricalPnlRequest {}
+
+export interface VaultMapping {
+  [subaccountId: string]: VaultFromDatabase,
+}
 
 /* ------- Affiliates Types ------- */
 export interface AffiliateMetadataRequest{


### PR DESCRIPTION
### Changelist
Only fetch the starting vault pnl rows once when starting the service as this never changes. Use the hourly view to get the latest PnL ticks rather than the table as it contains less data.

### Test Plan
Unit tests and deployed to a testing env.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
