### PR TITLE
Support non critical opt extions in clob and sending cli

### DIFF
--- a/protocol/app/flags/permissioned_keys_flags.go
+++ b/protocol/app/flags/permissioned_keys_flags.go
@@ -1,0 +1,29 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	FlagAuthenticators = "authenticators"
+)
+
+// AddTxPermissionedKeyFlagsToCmd adds common flags to a module tx command.
+func AddTxPermissionedKeyFlagsToCmd(cmd *cobra.Command) {
+	f := cmd.Flags()
+	f.UintSlice(FlagAuthenticators, nil, "Authenticators to use for authenticating this transaction.")
+}
+
+// GetPermisionedKeyAuthenticatorsForExtOptions returns the authenticators from the provided command flags.
+func GetPermisionedKeyAuthenticatorsForExtOptions(cmd *cobra.Command) ([]uint64, error) {
+	flags := cmd.Flags()
+	values, err := flags.GetUintSlice(FlagAuthenticators)
+	if err == nil {
+		authenticators := make([]uint64, len(values))
+		for i, v := range values {
+			authenticators[i] = uint64(v)
+		}
+		return authenticators, nil
+	}
+	return nil, err
+}

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -472,7 +472,7 @@ replace (
 	// Use dYdX fork of CometBFT
 	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20241126215519-69cdde955fd0
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241127172510-4ee58434cdea
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241219194626-713334f028e7
 	github.com/cosmos/iavl => github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85
 )
 

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -960,8 +960,8 @@ github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dydxprotocol/cometbft v0.38.6-0.20241126215519-69cdde955fd0 h1:KBMuBNAE91SVeULnq2XBnmSDGeimI6aM1+YxlLb0yOI=
 github.com/dydxprotocol/cometbft v0.38.6-0.20241126215519-69cdde955fd0/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241127172510-4ee58434cdea h1:5jsj2e6zqnx7Q7SiNTYC7UGEW0ymgKFTbLxzp27/2Fg=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241127172510-4ee58434cdea/go.mod h1:z/5+LD4MJzLqbe+fBCWI2pZLnQbOlzSM82snAw2zceg=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241219194626-713334f028e7 h1:uYf2XRrDik5Aq93hIWOPG5qW+k5I4RMEuSQPT+fZOCs=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20241219194626-713334f028e7/go.mod h1:z/5+LD4MJzLqbe+fBCWI2pZLnQbOlzSM82snAw2zceg=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d h1:HgLu1FD2oDFzlKW6/+SFXlH5Os8cwNTbplQIrQOWx8w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85 h1:5B/yGZyTBX/OZASQQMnk6Ms/TZja56MYd8OBaVc0Mho=

--- a/protocol/x/clob/client/cli/tx_batch_cancel.go
+++ b/protocol/x/clob/client/cli/tx_batch_cancel.go
@@ -7,6 +7,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	customflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	aptypes "github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/spf13/cast"
@@ -70,11 +73,30 @@ func CmdBatchCancel() *cobra.Command {
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+
+			txf, err := tx.NewFactoryCLI(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			authenticatorIds, err := customflags.GetPermisionedKeyAuthenticatorsForExtOptions(cmd)
+			if err == nil && len(authenticatorIds) > 0 {
+				value, err := codectypes.NewAnyWithValue(
+					&aptypes.TxExtension{
+						SelectedAuthenticators: authenticatorIds,
+					},
+				)
+				if err != nil {
+					return err
+				}
+				txf = txf.WithNonCriticalExtensionOptions(value)
+			}
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
+	customflags.AddTxPermissionedKeyFlagsToCmd(cmd)
 
 	return cmd
 }

--- a/protocol/x/clob/client/cli/tx_cancel_order.go
+++ b/protocol/x/clob/client/cli/tx_cancel_order.go
@@ -4,6 +4,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	customflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	aptypes "github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/spf13/cast"
@@ -58,11 +61,30 @@ func CmdCancelOrder() *cobra.Command {
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+
+			txf, err := tx.NewFactoryCLI(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			authenticatorIds, err := customflags.GetPermisionedKeyAuthenticatorsForExtOptions(cmd)
+			if err == nil && len(authenticatorIds) > 0 {
+				value, err := codectypes.NewAnyWithValue(
+					&aptypes.TxExtension{
+						SelectedAuthenticators: authenticatorIds,
+					},
+				)
+				if err != nil {
+					return err
+				}
+				txf = txf.WithNonCriticalExtensionOptions(value)
+			}
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
+	customflags.AddTxPermissionedKeyFlagsToCmd(cmd)
 
 	return cmd
 }

--- a/protocol/x/clob/client/cli/tx_place_order.go
+++ b/protocol/x/clob/client/cli/tx_place_order.go
@@ -4,6 +4,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	customflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	aptypes "github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/spf13/cast"
@@ -77,11 +80,30 @@ func CmdPlaceOrder() *cobra.Command {
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+
+			txf, err := tx.NewFactoryCLI(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			authenticatorIds, err := customflags.GetPermisionedKeyAuthenticatorsForExtOptions(cmd)
+			if err == nil && len(authenticatorIds) > 0 {
+				value, err := codectypes.NewAnyWithValue(
+					&aptypes.TxExtension{
+						SelectedAuthenticators: authenticatorIds,
+					},
+				)
+				if err != nil {
+					return err
+				}
+				txf = txf.WithNonCriticalExtensionOptions(value)
+			}
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
+	customflags.AddTxPermissionedKeyFlagsToCmd(cmd)
 
 	return cmd
 }

--- a/protocol/x/sending/client/cli/tx_deposit_to_subaccount.go
+++ b/protocol/x/sending/client/cli/tx_deposit_to_subaccount.go
@@ -4,6 +4,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	customflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	aptypes "github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
 	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -60,11 +63,30 @@ Note, the '--from' flag is ignored as it is implied from [sender_key_or_address]
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+
+			txf, err := tx.NewFactoryCLI(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			authenticatorIds, err := customflags.GetPermisionedKeyAuthenticatorsForExtOptions(cmd)
+			if err == nil && len(authenticatorIds) > 0 {
+				value, err := codectypes.NewAnyWithValue(
+					&aptypes.TxExtension{
+						SelectedAuthenticators: authenticatorIds,
+					},
+				)
+				if err != nil {
+					return err
+				}
+				txf = txf.WithNonCriticalExtensionOptions(value)
+			}
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
+	customflags.AddTxPermissionedKeyFlagsToCmd(cmd)
 
 	return cmd
 }

--- a/protocol/x/sending/client/cli/tx_withdraw_from_subaccount.go
+++ b/protocol/x/sending/client/cli/tx_withdraw_from_subaccount.go
@@ -4,6 +4,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	customflags "github.com/dydxprotocol/v4-chain/protocol/app/flags"
+	aptypes "github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
 	assettypes "github.com/dydxprotocol/v4-chain/protocol/x/assets/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
@@ -60,11 +63,30 @@ Note, the '--from' flag is ignored as it is implied from [sender_key_or_address]
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+
+			txf, err := tx.NewFactoryCLI(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			authenticatorIds, err := customflags.GetPermisionedKeyAuthenticatorsForExtOptions(cmd)
+			if err == nil && len(authenticatorIds) > 0 {
+				value, err := codectypes.NewAnyWithValue(
+					&aptypes.TxExtension{
+						SelectedAuthenticators: authenticatorIds,
+					},
+				)
+				if err != nil {
+					return err
+				}
+				txf = txf.WithNonCriticalExtensionOptions(value)
+			}
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
+	customflags.AddTxPermissionedKeyFlagsToCmd(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality for managing transaction flags related to authenticators in the command-line interface.
	- Added new command flags for permissioned key usage across various transaction commands.
- **Bug Fixes**
	- Enhanced error handling for retrieving permissioned key authenticators.
- **Documentation**
	- Updated command implementations to reflect new transaction handling mechanisms and flag management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->