### PR TITLE
Fix sidecar version checker

### DIFF
--- a/protocol/daemons/slinky/client/sidecar_version_checker.go
+++ b/protocol/daemons/slinky/client/sidecar_version_checker.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"cosmossdk.io/log"
 	"github.com/hashicorp/go-version"
@@ -50,7 +51,13 @@ func (s *SidecarVersionCheckerImpl) CheckSidecarVersion(ctx context.Context) err
 	if err != nil {
 		return err
 	}
-	current, err := version.NewVersion(slinkyResponse.Version)
+
+	versionStr := slinkyResponse.Version
+	if idx := strings.LastIndex(versionStr, "/"); idx != -1 {
+		versionStr = versionStr[idx+1:]
+	}
+
+	current, err := version.NewVersion(versionStr)
 	if err != nil {
 		return fmt.Errorf("failed to parse current version: %w", err)
 	}

--- a/protocol/daemons/slinky/client/sidecar_version_checker_test.go
+++ b/protocol/daemons/slinky/client/sidecar_version_checker_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"cosmossdk.io/log"
@@ -43,6 +44,36 @@ func TestSidecarVersionChecker(t *testing.T) {
 		require.NoError(t, fetcher.Start(context.Background()))
 		require.ErrorContains(t, fetcher.CheckSidecarVersion(context.Background()),
 			"Sidecar version 0.0.0 is less than minimum required version")
+		fetcher.Stop()
+	})
+
+	t.Run("Checks sidecar version passes with prefix before version", func(t *testing.T) {
+		slinky := mocks.NewOracleClient(t)
+		slinky.On("Stop").Return(nil)
+		slinky.On("Start", mock.Anything).Return(nil).Once()
+		require.True(t, strings.HasPrefix(client.MinSidecarVersion, "v"), "MinSidecarVersion must start with 'v'")
+
+		slinky.On("Version", mock.Anything, mock.Anything).
+			Return(&types.QueryVersionResponse{
+				Version: client.MinSidecarVersion[1:], // Remove the "v" prefix
+			}, nil)
+		fetcher = client.NewSidecarVersionChecker(slinky, logger)
+		require.NoError(t, fetcher.Start(context.Background()))
+		require.NoError(t, fetcher.CheckSidecarVersion(context.Background()))
+		fetcher.Stop()
+	})
+
+	t.Run("Checks sidecar version passes without v prefix", func(t *testing.T) {
+		slinky := mocks.NewOracleClient(t)
+		slinky.On("Stop").Return(nil)
+		slinky.On("Start", mock.Anything).Return(nil).Once()
+		slinky.On("Version", mock.Anything, mock.Anything).
+			Return(&types.QueryVersionResponse{
+				Version: "tests/integration/v1.2.0",
+			}, nil)
+		fetcher = client.NewSidecarVersionChecker(slinky, logger)
+		require.NoError(t, fetcher.Start(context.Background()))
+		require.NoError(t, fetcher.CheckSidecarVersion(context.Background()))
 		fetcher.Stop()
 	})
 

--- a/protocol/docker-compose.yml
+++ b/protocol/docker-compose.yml
@@ -116,7 +116,7 @@ services:
     volumes:
       - ./localnet/dydxprotocol3:/dydxprotocol/chain/.dave/data
   slinky0:
-    image: ghcr.io/skip-mev/slinky-sidecar:v1.0.13
+    image: ghcr.io/skip-mev/slinky-sidecar:v1.1.0
     entrypoint: >
       sh -c "slinky --marketmap-provider dydx_migration_api --oracle-config /etc/slinky/oracle.json --log-std-out-level error"
     environment:


### PR DESCRIPTION
### Changelist
Sidecar version can return `tests/integration/v1.2.0`, which caused an error when trying to parse that into a semantic version. Handle this case.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced version checking logic for the sidecar service to correctly handle version strings with or without prefixes.
	- Updated the Slinky sidecar service to version `v1.1.0`, potentially introducing new features and improvements.

- **Bug Fixes**
	- Improved handling of version strings in the version checking process.

- **Tests**
	- Added new test cases to ensure the version checking logic works correctly with various version string formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->