### PR TITLE
Add subaccount usernames table to list of tables to export.

### DIFF
--- a/indexer/services/roundtable/src/lib/athena-ddl-tables/subaccount_usernames.ts
+++ b/indexer/services/roundtable/src/lib/athena-ddl-tables/subaccount_usernames.ts
@@ -1,0 +1,31 @@
+import {
+  getAthenaTableCreationStatement,
+  getExternalAthenaTableCreationStatement,
+} from '../../helpers/sql';
+
+const TABLE_NAME: string = 'subaccount_usernames';
+const RAW_TABLE_COLUMNS: string = `
+  \`username\` string,
+  \`subaccountId\` string
+`;
+const TABLE_COLUMNS: string = `
+  "username",
+  "subaccountId"
+`;
+
+export function generateRawTable(tablePrefix: string, rdsExportIdentifier: string): string {
+  return getExternalAthenaTableCreationStatement(
+    tablePrefix,
+    rdsExportIdentifier,
+    TABLE_NAME,
+    RAW_TABLE_COLUMNS,
+  );
+}
+
+export function generateTable(tablePrefix: string): string {
+  return getAthenaTableCreationStatement(
+    tablePrefix,
+    TABLE_NAME,
+    TABLE_COLUMNS,
+  );
+}

--- a/indexer/services/roundtable/src/tasks/update-research-environment.ts
+++ b/indexer/services/roundtable/src/tasks/update-research-environment.ts
@@ -40,6 +40,7 @@ import * as athenaTradingRewards from '../lib/athena-ddl-tables/trading_rewards'
 import * as athenaTransfers from '../lib/athena-ddl-tables/transfers';
 import * as athenaVaults from '../lib/athena-ddl-tables/vaults';
 import * as athenaWallets from '../lib/athena-ddl-tables/wallets';
+import * as athenaSubaccountUsernames  from '../lib/athena-ddl-tables/subaccount_usernames';
 
 export const tablesToAddToAthena: { [table: string]: AthenaTableDDLQueries } = {
   asset_positions: athenaAssetPositions,
@@ -64,6 +65,7 @@ export const tablesToAddToAthena: { [table: string]: AthenaTableDDLQueries } = {
   affiliate_info: athenaAffiliateInfo,
   affiliate_referred_users: athenaAffiliateReferredUsers,
   vaults: athenaVaults,
+  subaccount_usernames: athenaSubaccountUsernames,
 };
 
 const statStart: string = `${config.SERVICE_NAME}.update_research_environment`;

--- a/indexer/services/roundtable/src/tasks/update-research-environment.ts
+++ b/indexer/services/roundtable/src/tasks/update-research-environment.ts
@@ -33,6 +33,7 @@ import * as athenaOrders from '../lib/athena-ddl-tables/orders';
 import * as athenaPerpetualMarkets from '../lib/athena-ddl-tables/perpetual_markets';
 import * as athenaPerpetualPositions from '../lib/athena-ddl-tables/perpetual_positions';
 import * as athenaPnlTicks from '../lib/athena-ddl-tables/pnl_ticks';
+import * as athenaSubaccountUsernames from '../lib/athena-ddl-tables/subaccount_usernames';
 import * as athenaSubaccounts from '../lib/athena-ddl-tables/subaccounts';
 import * as athenaTendermintEvents from '../lib/athena-ddl-tables/tendermint_events';
 import * as athenaTradingRewardAggregations from '../lib/athena-ddl-tables/trading_reward_aggregations';
@@ -40,7 +41,6 @@ import * as athenaTradingRewards from '../lib/athena-ddl-tables/trading_rewards'
 import * as athenaTransfers from '../lib/athena-ddl-tables/transfers';
 import * as athenaVaults from '../lib/athena-ddl-tables/vaults';
 import * as athenaWallets from '../lib/athena-ddl-tables/wallets';
-import * as athenaSubaccountUsernames  from '../lib/athena-ddl-tables/subaccount_usernames';
 
 export const tablesToAddToAthena: { [table: string]: AthenaTableDDLQueries } = {
   asset_positions: athenaAssetPositions,


### PR DESCRIPTION
### Changelist
Add DDL for subaccount usernames table to research env export task.

### Test Plan
N/A

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for generating Athena table creation statements for subaccount usernames.
	- Expanded table creation capabilities in the research environment update process.

- **Chores**
	- Integrated new module for handling subaccount username table definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->