### PR TITLE
[CT-1338] Add channel and id properties to error message on subscription failure.

### DIFF
--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -244,6 +244,8 @@ describe('Subscriptions', () => {
           message: expect.stringContaining(
             `Internal error, could not fetch data for subscription: ${Channel.V4_ACCOUNTS}`,
           ),
+          channel: Channel.V4_ACCOUNTS,
+          id: mockSubaccountId,
         }));
       expect(subscriptions.subscriptions[Channel.V4_ACCOUNTS]).toBeUndefined();
       expect(subscriptions.subscriptionLists[connectionId]).toBeUndefined();
@@ -278,6 +280,8 @@ describe('Subscriptions', () => {
           connection_id: connectionId,
           type: 'error',
           message: expectedError.message,
+          channel: Channel.V4_ACCOUNTS,
+          id: mockSubaccountId,
         }));
       expect(subscriptions.subscriptions[Channel.V4_ACCOUNTS]).toBeUndefined();
       expect(subscriptions.subscriptionLists[connectionId]).toBeUndefined();

--- a/indexer/services/socks/src/helpers/message.ts
+++ b/indexer/services/socks/src/helpers/message.ts
@@ -13,12 +13,16 @@ export function createErrorMessage(
   message: string,
   connectionId: string,
   messageId: number,
+  channel?: string,
+  id?: string,
 ): ErrorMessage {
   return {
     type: OutgoingMessageType.ERROR,
     message,
     connection_id: connectionId,
     message_id: messageId,
+    channel,
+    id,
   };
 }
 

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -172,6 +172,8 @@ export class Subscriptions {
           errorMsg,
           connectionId,
           messageId,
+          channel,
+          id,
         ),
       );
 

--- a/indexer/services/socks/src/types.ts
+++ b/indexer/services/socks/src/types.ts
@@ -67,6 +67,8 @@ export interface OutgoingMessage {
 
 export interface ErrorMessage extends OutgoingMessage {
   message: string,
+  channel?: string,
+  id?: string,
 }
 
 export interface SubscribedMessage extends OutgoingMessage {


### PR DESCRIPTION
### Changelist
Add channel and id to error messages returned when subscribing to a channel fails so clients can correctly retry the subscription.

### Test Plan
Unit tests.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messaging for WebSocket subscriptions with optional channel and ID details
	- Improved error reporting to provide more context during subscription failures

- **Bug Fixes**
	- Added additional parameters to error message generation to support more detailed error tracking

- **Refactor**
	- Updated message creation functions to conditionally include channel and ID information
	- Modified error message interfaces to support more flexible error reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->