### PR TITLE
Cast oracle price to bigint and then numeric to get proper values

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -746,7 +746,7 @@ export const isolatedMarket: MarketCreateObject = {
 export const isolatedMarket2: MarketCreateObject = {
   id: 4,
   pair: 'ISO2-USD',
-  exponent: -12,
+  exponent: -20,
   minPriceChangePpm: 50,
   oraclePrice: '0.000000085',
 };

--- a/indexer/services/ender/__tests__/handlers/markets/market-price-update-handler.test.ts
+++ b/indexer/services/ender/__tests__/handlers/markets/market-price-update-handler.test.ts
@@ -15,6 +15,7 @@ import { DydxIndexerSubtypes, MarketPriceUpdateEventMessage } from '../../../src
 import {
   defaultHeight,
   defaultMarketPriceUpdate,
+  defaultMarketPriceUpdate3,
   defaultPreviousHeight,
   defaultTime,
   defaultTxHash,
@@ -138,6 +139,39 @@ describe('marketPriceUpdateHandler', () => {
 
     expectOraclePriceMatchesEvent(
       defaultMarketPriceUpdate as MarketPriceUpdateEventMessage,
+      oraclePrice,
+      market,
+      defaultHeight,
+    );
+
+    const contents: MarketMessageContents = generateOraclePriceContents(
+      oraclePrice,
+      market.pair,
+    );
+
+    expectMarketKafkaMessage({
+      producerSendMock,
+      contents: JSON.stringify(contents),
+    });
+  });
+
+  it('successfully inserts new oracle price for market with very low exponent', async () => {
+    const transactionIndex: number = 0;
+
+    const kafkaMessage: KafkaMessage = createKafkaMessageFromMarketEvent({
+      marketEvents: [defaultMarketPriceUpdate3],
+      transactionIndex,
+      height: defaultHeight,
+      time: defaultTime,
+      txHash: defaultTxHash,
+    });
+
+    await onMessage(kafkaMessage);
+
+    const { market, oraclePrice } = await getDbState(defaultMarketPriceUpdate3);
+
+    expectOraclePriceMatchesEvent(
+      defaultMarketPriceUpdate3 as MarketPriceUpdateEventMessage,
       oraclePrice,
       market,
       defaultHeight,

--- a/indexer/services/ender/__tests__/helpers/constants.ts
+++ b/indexer/services/ender/__tests__/helpers/constants.ts
@@ -67,6 +67,13 @@ export const defaultMarketPriceUpdate2: MarketEventV1 = {
   },
 };
 
+export const defaultMarketPriceUpdate3: MarketEventV1 = {
+  marketId: 4,
+  priceUpdate: {
+    priceWithExponent: Long.fromValue(100000000, true),
+  },
+};
+
 export const defaultFundingUpdateSampleEvent: FundingEventMessage = {
   type: FundingEventV1_Type.TYPE_PREMIUM_SAMPLE,
   updates: [

--- a/indexer/services/ender/src/scripts/handlers/dydx_market_price_update_handler.sql
+++ b/indexer/services/ender/src/scripts/handlers/dydx_market_price_update_handler.sql
@@ -11,6 +11,8 @@ CREATE OR REPLACE FUNCTION dydx_market_price_update_handler(block_height int, bl
 
   (Note that no text should exist before the function declaration to ensure that exception line numbers are correct.)
 */
+
+
 DECLARE
     market_record_id integer;
     market_record markets%ROWTYPE;
@@ -25,8 +27,8 @@ BEGIN
     END IF;
 
     oracle_price = dydx_trim_scale(
-        dydx_from_jsonlib_long(event_data->'priceUpdate'->'priceWithExponent') *
-        power(10, market_record.exponent::numeric));
+        (dydx_from_jsonlib_long(event_data->'priceUpdate'->'priceWithExponent') *
+        power(10, market_record.exponent::bigint))::numeric);
 
     market_record."oraclePrice" = oracle_price;
 


### PR DESCRIPTION
### Changelist
Currently, the conversion of the calculated oracle price to a numeric type leads to truncation for some reason which leads to an oracle price of 0
The solution here is to first cast the calculated value to a bigint and follow that with a numeric

### Test Plan
Added test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced market price update handling for markets with very low exponent values

- **Bug Fixes**
  - Improved oracle price calculation precision for market price updates

- **Tests**
  - Added new test case to validate market price updates with low exponent values

The changes improve the system's ability to handle market price updates with extremely precise pricing models, ensuring accurate data processing and representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->