### PR TITLE
Add schema checks for addresses in url endpoints

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -78,7 +78,7 @@ export const blockedAddress: string = 'dydx1f9k5qldwmqrnwy8hcgp4fw6heuvszt35egvt
 export const vaultAddress: string = 'dydx1c0m5x87llaunl5sgv3q5vd7j5uha26d2q2r2q0';
 
 // ============== Subaccounts ==============
-export const defaultWalletAddress: string = 'defaultWalletAddress';
+export const defaultWalletAddress: string = 'dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4';
 
 export const defaultSubaccount: SubaccountCreateObject = {
   address: defaultAddress,

--- a/indexer/pnpm-lock.yaml
+++ b/indexer/pnpm-lock.yaml
@@ -470,6 +470,7 @@ importers:
       '@types/response-time': ^2.3.5
       '@types/supertest': ^2.0.12
       '@types/swagger-ui-express': ^4.1.3
+      bech32: 1.1.4
       big.js: ^6.2.1
       binary-searching: ^2.0.5
       body-parser: ^1.20.0
@@ -510,6 +511,7 @@ importers:
       '@dydxprotocol-indexer/v4-protos': link:../../packages/v4-protos
       '@keplr-wallet/cosmos': 0.12.122
       '@tsoa/runtime': 5.0.0
+      bech32: 1.1.4
       big.js: 6.2.1
       binary-searching: 2.0.5
       body-parser: 1.20.0

--- a/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
@@ -406,16 +406,13 @@ describe('addresses-controller#V4', () => {
       const response: request.Response = await sendRequest({
         type: RequestMethod.GET,
         path: `/v4/addresses/${invalidAddress}`,
-        expectedStatus: 400,
+        expectedStatus: 404,
       });
 
       expect(response.body).toEqual({
         errors: [
           {
-            msg: 'address must be a valid dydx address',
-            location: 'params',
-            param: 'address',
-            value: 'invalidAddress',
+            msg: 'No subaccounts found for address invalidAddress',
           },
         ],
       });
@@ -736,10 +733,7 @@ describe('addresses-controller#V4', () => {
       expect(response.body).toEqual({
         errors: [
           {
-            msg: 'address must be a valid dydx address',
-            location: 'params',
-            param: 'address',
-            value: 'invalidAddress',
+            msg: 'Address invalidAddress is not a valid dYdX V4 address',
           },
         ],
       });

--- a/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/addresses-controller.test.ts
@@ -22,6 +22,7 @@ import { Secp256k1 } from '@cosmjs/crypto';
 import { toBech32 } from '@cosmjs/encoding';
 import { DateTime } from 'luxon';
 import { verifyADR36Amino } from '@keplr-wallet/cosmos';
+import { defaultAddress3 } from '@dydxprotocol-indexer/postgres/build/__tests__/helpers/constants';
 
 jest.mock('@cosmjs/crypto', () => ({
   ...jest.requireActual('@cosmjs/crypto'),
@@ -211,7 +212,7 @@ describe('addresses-controller#V4', () => {
     it('Get / with non-existent address and subaccount number returns 404', async () => {
       const response: request.Response = await sendRequest({
         type: RequestMethod.GET,
-        path: `/v4/addresses/${invalidAddress}/subaccountNumber/` +
+        path: `/v4/addresses/${defaultAddress3}/subaccountNumber/` +
         `${testConstants.defaultSubaccount.subaccountNumber}`,
         expectedStatus: 404,
       });
@@ -219,7 +220,7 @@ describe('addresses-controller#V4', () => {
       expect(response.body).toEqual({
         errors: [
           {
-            msg: `No subaccount found with address ${invalidAddress} and ` +
+            msg: `No subaccount found with address ${defaultAddress3} and ` +
             `subaccountNumber ${testConstants.defaultSubaccount.subaccountNumber}`,
           },
         ],
@@ -405,21 +406,19 @@ describe('addresses-controller#V4', () => {
       const response: request.Response = await sendRequest({
         type: RequestMethod.GET,
         path: `/v4/addresses/${invalidAddress}`,
-        expectedStatus: 404,
+        expectedStatus: 400,
       });
 
       expect(response.body).toEqual({
         errors: [
           {
-            msg: `No subaccounts found for address ${invalidAddress}`,
+            msg: 'address must be a valid dydx address',
+            location: 'params',
+            param: 'address',
+            value: 'invalidAddress',
           },
         ],
       });
-      expect(stats.increment).toHaveBeenCalledWith('comlink.addresses-controller.response_status_code.404', 1,
-        {
-          path: '/:address',
-          method: 'GET',
-        });
     });
   });
 
@@ -561,7 +560,7 @@ describe('addresses-controller#V4', () => {
   it('Get /:address/parentSubaccountNumber/ with non-existent address returns 404', async () => {
     const response: request.Response = await sendRequest({
       type: RequestMethod.GET,
-      path: `/v4/addresses/${invalidAddress}/parentSubaccountNumber/` +
+      path: `/v4/addresses/${defaultAddress3}/parentSubaccountNumber/` +
           `${testConstants.defaultSubaccount.subaccountNumber}`,
       expectedStatus: 404,
     });
@@ -569,7 +568,7 @@ describe('addresses-controller#V4', () => {
     expect(response.body).toEqual({
       errors: [
         {
-          msg: `No subaccounts found for address ${invalidAddress} and ` +
+          msg: `No subaccounts found for address ${defaultAddress3} and ` +
               `parentSubaccountNumber ${testConstants.defaultSubaccount.subaccountNumber}`,
         },
       ],
@@ -737,13 +736,12 @@ describe('addresses-controller#V4', () => {
       expect(response.body).toEqual({
         errors: [
           {
-            msg: 'Address invalidAddress is not a valid dYdX V4 address',
+            msg: 'address must be a valid dydx address',
+            location: 'params',
+            param: 'address',
+            value: 'invalidAddress',
           },
         ],
-      });
-      expect(statsSpy).toHaveBeenCalledWith('comlink.addresses-controller.response_status_code.400', 1, {
-        path: '/:address/registerToken',
-        method: 'POST',
       });
     });
 

--- a/indexer/services/comlink/__tests__/controllers/api/v4/historical-pnl-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/historical-pnl-controller.test.ts
@@ -264,14 +264,14 @@ describe('pnlTicks-controller#V4', () => {
     it('Get /historical-pnl with non-existent address and subaccount number returns 404', async () => {
       const response: request.Response = await sendRequest({
         type: RequestMethod.GET,
-        path: '/v4/historical-pnl?address=invalid_address&subaccountNumber=100',
+        path: '/v4/historical-pnl?address=invalidaddress&subaccountNumber=100',
         expectedStatus: 404,
       });
 
       expect(response.body).toEqual({
         errors: [
           {
-            msg: 'No subaccount found with address invalid_address and subaccountNumber 100',
+            msg: 'No subaccount found with address invalidaddress and subaccountNumber 100',
           },
         ],
       });

--- a/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
@@ -433,14 +433,14 @@ describe('transfers-controller#V4', () => {
     it('Get /transfers with non-existent address and subaccount number returns 404', async () => {
       const response: request.Response = await sendRequest({
         type: RequestMethod.GET,
-        path: '/v4/transfers?address=invalid_address&subaccountNumber=100',
+        path: '/v4/transfers?address=invalidaddress&subaccountNumber=100',
         expectedStatus: 404,
       });
 
       expect(response.body).toEqual({
         errors: [
           {
-            msg: 'No subaccount found with address invalid_address and subaccountNumber 100',
+            msg: 'No subaccount found with address invalidaddress and subaccountNumber 100',
           },
         ],
       });
@@ -981,14 +981,14 @@ describe('transfers-controller#V4', () => {
     it('Get /transfers/parentSubaccountNumber with non-existent address and subaccount number returns 404', async () => {
       const response: request.Response = await sendRequest({
         type: RequestMethod.GET,
-        path: '/v4/transfers/parentSubaccountNumber?address=invalid_address&parentSubaccountNumber=100',
+        path: '/v4/transfers/parentSubaccountNumber?address=invalidaddress&parentSubaccountNumber=100',
         expectedStatus: 404,
       });
 
       expect(response.body).toEqual({
         errors: [
           {
-            msg: 'No subaccount found with address invalid_address and parentSubaccountNumber 100',
+            msg: 'No subaccount found with address invalidaddress and parentSubaccountNumber 100',
           },
         ],
       });

--- a/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
+++ b/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
@@ -17,7 +17,12 @@ describe('schemas', () => {
   const defaultAddress: string = testConstants.defaultSubaccount.address;
   describe('CheckSubaccountSchema', () => {
     it.each([
-      ['missing address', { subaccountNumber: defaultSubaccountNumber }, 'address', 'Invalid value'],
+      [
+        'missingaddress',
+        { subaccountNumber: defaultSubaccountNumber },
+        'address',
+        'address must be a valid dydx address',
+      ],
       [
         'missing subaccountNumber',
         { address: defaultAddress },

--- a/indexer/services/comlink/package.json
+++ b/indexer/services/comlink/package.json
@@ -35,6 +35,7 @@
     "@dydxprotocol-indexer/v4-protos": "workspace:^0.0.1",
     "@keplr-wallet/cosmos": "^0.12.122",
     "@tsoa/runtime": "^5.0.0",
+    "bech32": "1.1.4",
     "big.js": "^6.2.1",
     "binary-searching": "^2.0.5",
     "body-parser": "^1.20.0",

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -23,6 +23,7 @@ import { complianceProvider } from '../../../helpers/compliance/compliance-clien
 import { create4xxResponse, handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
 import { getIpAddr } from '../../../lib/utils';
+import { CheckAddressSchema } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { ComplianceRequest, ComplianceResponse } from '../../../types';

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -23,7 +23,6 @@ import { complianceProvider } from '../../../helpers/compliance/compliance-clien
 import { create4xxResponse, handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
 import { getIpAddr } from '../../../lib/utils';
-import { CheckAddressSchema } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import { ComplianceRequest, ComplianceResponse } from '../../../types';

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -1,5 +1,3 @@
-import * as console from 'node:console';
-
 import { isValidLanguageCode } from '@dydxprotocol-indexer/notifications';
 import {
   perpetualMarketRefresher,

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -52,7 +52,7 @@ export const checkAddressSchemaRecord: Record<string, ParamSchema> = {
     custom: {
       options: isValidAddress,
     },
-    errorMessage: 'address must be a valid dydx address',
+    errorMessage: 'address must be a valid address',
   },
 };
 

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -288,9 +288,12 @@ function verifyIsBech32(address: string): Error | undefined {
   return undefined;
 }
 
-export function isValidAddress(address: string): boolean {
+export function isValidDydxAddress(address: string): boolean {
   // An address is valid if it starts with `dydx1` and is Bech32 format.
-  const ret: boolean = address.startsWith('dydx1') && (verifyIsBech32(address) === undefined);
-  console.log('is valid address: ', ret);
-  return ret;
+  return address.startsWith('dydx1') && (verifyIsBech32(address) === undefined);
+}
+
+export function isValidAddress(address: string): boolean {
+  // Address is valid if its under 90 characters and alphanumeric
+  return address.length <= 90 && /^[a-zA-Z0-9]*$/.test(address);
 }


### PR DESCRIPTION
### Changelist
Add additional schema checks to ensure the addresses in url endpoints are actual dydx addresses

### Test Plan
Existing modified tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced address validation logic with Bech32 support
  - Introduced new constants for address handling in tests

- **Dependencies**
  - Added `bech32` library for address encoding and decoding

- **Bug Fixes**
  - Improved error handling for invalid address scenarios
  - Updated error messages for consistency in address formats

- **Chores**
  - Updated test constants and address references
<!-- end of auto-generated comment: release notes by coderabbit.ai -->