### PR TITLE
feat(default-funding): Add default funding to `nextFunding` calculation

### DIFF
--- a/indexer/packages/postgres/src/types/perpetual-market-types.ts
+++ b/indexer/packages/postgres/src/types/perpetual-market-types.ts
@@ -37,6 +37,7 @@ export interface PerpetualMarketUpdateObject {
   subticksPerTick?: number,
   stepBaseQuantums?: number,
   liquidityTierId?: number,
+  defaultFundingRate1H?: string,
 }
 
 export enum PerpetualMarketColumns {

--- a/indexer/packages/redis/__tests__/caches/next-funding-cache.test.ts
+++ b/indexer/packages/redis/__tests__/caches/next-funding-cache.test.ts
@@ -17,8 +17,14 @@ describe('nextFundingCache', () => {
       await addFundingSample('BTC', new Big('0.0001'), client);
       await addFundingSample('BTC', new Big('0.0002'), client);  // avg = 0.00015
       await addFundingSample('ETH', new Big('0.0005'), client);  // avg = 0.0005
-      expect(await getNextFunding(client, ['BTC', 'ETH'])).toEqual(
-        { BTC: new Big('0.00015'), ETH: new Big('0.0005') },
+      expect(await getNextFunding(client, [
+        ['BTC', '0.0001'],
+        ['ETH', '0'],
+      ])).toEqual(
+        {
+          BTC: new Big('0.00025'), // 0.00015 + 0.0001
+          ETH: new Big('0.0005'), // 0.0005 + 0
+        },
       );
     });
 
@@ -27,13 +33,23 @@ describe('nextFundingCache', () => {
       await addFundingSample('BTC', new Big('0.0002'), client);  // avg = 0.00015
       await clearFundingSamples('BTC', client);
       await addFundingSample('ETH', new Big('0.0005'), client);  // avg = 0.0005
-      expect(await getNextFunding(client, ['BTC', 'ETH'])).toEqual(
-        { BTC: undefined, ETH: new Big('0.0005') },
+      expect(await getNextFunding(client, [
+        ['BTC', '0.0001'],
+        ['ETH', '0.00015'],
+      ])).toEqual(
+        {
+          BTC: undefined, // no samples
+          ETH: new Big('0.00065'), // 0.0005 + 0.00015
+        },
       );
     });
 
     it('get next funding with no values', async () => {
-      expect(await getNextFunding(client, ['BTC'])).toEqual(
+      expect(await getNextFunding(client, [
+        ['BTC', '0.001'],
+      ])).toEqual(
+        // Even though default funding rate is 0.001,
+        // return undefined since there are no samples
         { BTC: undefined },
       );
     });

--- a/indexer/packages/redis/src/caches/next-funding-cache.ts
+++ b/indexer/packages/redis/src/caches/next-funding-cache.ts
@@ -20,11 +20,12 @@ function getKey(ticker: string): string {
  */
 export async function getNextFunding(
   client: RedisClient,
-  tickers: string[],
+  tickerDefaultFundingRate1HPairs: [string, string][],
 ): Promise<{ [ticker: string]: Big | undefined }> {
   const fundingRates: { [ticker: string]: Big | undefined } = {};
+
   await Promise.all(
-    tickers.map(async (ticker: string) => {
+    tickerDefaultFundingRate1HPairs.map(async ([ticker, defaultFundingRate1H]) => {
       const rates: string[] = await lRangeAsync(
         getKey(ticker),
         client,
@@ -36,7 +37,7 @@ export async function getNextFunding(
           new Big(0),
         );
         const avg: Big = sum.div(rates.length);
-        fundingRates[ticker] = avg;
+        fundingRates[ticker] = avg.plus(new Big(defaultFundingRate1H));
       } else {
         fundingRates[ticker] = undefined;
       }

--- a/indexer/services/ender/__tests__/helpers/redis-helpers.ts
+++ b/indexer/services/ender/__tests__/helpers/redis-helpers.ts
@@ -9,14 +9,15 @@ import Big from 'big.js';
 import { redisClient } from '../../src/helpers/redis/redis-controller';
 
 export async function expectNextFundingRate(
+  expectedRate: Big | undefined,
   ticker: string,
-  rate: Big | undefined,
+  defaultFundingRate1H: string = '0',
 ): Promise<void> {
   const rates: { [ticker: string]: Big | undefined } = await NextFundingCache.getNextFunding(
     redisClient,
-    [ticker],
+    [[ticker, defaultFundingRate1H]],
   );
-  expect(rates[ticker]).toEqual(rate);
+  expect(rates[ticker]).toEqual(expectedRate);
 }
 
 export async function expectStateFilledQuantums(

--- a/indexer/services/roundtable/src/tasks/market-updater.ts
+++ b/indexer/services/roundtable/src/tasks/market-updater.ts
@@ -69,7 +69,14 @@ export default async function runTask(): Promise<void> {
   // Derive data from perpetual markets
   const perpetualMarketIds: string[] = _.map(perpetualMarkets, PerpetualMarketColumns.id);
   const clobPairIds: string[] = _.map(perpetualMarkets, PerpetualMarketColumns.clobPairId);
-  const tickers: string[] = _.map(perpetualMarkets, PerpetualMarketColumns.ticker);
+  const tickerDefaultFundingRate1HPairs: [string, string][] = _.map(
+    perpetualMarkets,
+    (market) => [
+      market[PerpetualMarketColumns.ticker],
+      // Use 0 as default for null default funding rate
+      market[PerpetualMarketColumns.defaultFundingRate1H] ?? '0',
+    ],
+  );
 
   stats.timing(
     `${config.SERVICE_NAME}.market_updater_initial_queries`,
@@ -89,8 +96,7 @@ export default async function runTask(): Promise<void> {
       // TODO(DEC-1149 Add support for pulling information from candles
       FillTable.get24HourInformation(clobPairIds),
       PerpetualPositionTable.getOpenInterestLong(perpetualMarketIds),
-      // TODO(CT-1340): Need to add default funding rate to this value.
-      NextFundingCache.getNextFunding(redisClient, tickers),
+      NextFundingCache.getNextFunding(redisClient, tickerDefaultFundingRate1HPairs),
     ]);
 
     stats.timing(


### PR DESCRIPTION
### Changelist
Follow-up to https://github.com/dydxprotocol/v4-chain/pull/2674. Now that default funding is stored, add it to `nextFunding` calculation. 

### Test Plan
Unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
