### PR TITLE
Check for blocked address before withdrawing to it

### DIFF
--- a/protocol/testutil/keeper/bank.go
+++ b/protocol/testutil/keeper/bank.go
@@ -7,8 +7,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 )
 
@@ -25,7 +27,9 @@ func createBankKeeper(
 		cdc,
 		runtime.NewKVStoreService(storeKey),
 		accountKeeper,
-		map[string]bool{},
+		map[string]bool{
+			authtypes.NewModuleAddress(distrtypes.ModuleName).String(): true,
+		},
 		lib.GovModuleAddress.String(),
 		log.NewNopLogger(),
 	)

--- a/protocol/x/subaccounts/keeper/transfer.go
+++ b/protocol/x/subaccounts/keeper/transfer.go
@@ -7,6 +7,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
@@ -194,6 +195,10 @@ func (k Keeper) WithdrawFundsFromSubaccountToAccount(
 	collateralPoolAddr, err := k.GetCollateralPoolForSubaccount(ctx, fromSubaccountId)
 	if err != nil {
 		return err
+	}
+
+	if k.bankKeeper.BlockedAddr(toAccount) {
+		return errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", toAccount)
 	}
 
 	// Send coins from `fromModule` to the `subaccounts` module account.

--- a/protocol/x/subaccounts/types/expected_keepers.go
+++ b/protocol/x/subaccounts/types/expected_keepers.go
@@ -100,6 +100,7 @@ type BankKeeper interface {
 	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
 	SendCoins(ctx context.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
 	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	BlockedAddr(addr sdk.AccAddress) bool
 }
 
 type BlocktimeKeeper interface {


### PR DESCRIPTION
### Changelist
- Checked if account is blocked prior to withdrawing to it.

### Test Plan
- Added test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced fund transfer validation by adding blocked address checks
	- Improved error handling for unauthorized transfers

- **Bug Fixes**
	- Prevented transfers to blocked addresses in subaccount transactions

- **Tests**
	- Added test case for blocked address transfer scenarios
	- Updated test infrastructure to support more flexible recipient address testing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->