### PR TITLE
Fix ASA-2025-001 and ASA-2025-002

### DIFF
--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -470,7 +470,7 @@ replace (
 	// Use dYdX fork of Cosmos SDK/store
 	cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d
 	// Use dYdX fork of CometBFT
-	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20241126215519-69cdde955fd0
+	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250203202601-3ab07f44e83a
 	// Fixes the issue that `tx_search` resolves to a single entry, due to an cometbft-db interface
 	// change in v0.13.0+.
 	// TODO(CT-1343): Remove and fix properly by backporting upstream fix to cometbft fork.

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -958,8 +958,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20241126215519-69cdde955fd0 h1:KBMuBNAE91SVeULnq2XBnmSDGeimI6aM1+YxlLb0yOI=
-github.com/dydxprotocol/cometbft v0.38.6-0.20241126215519-69cdde955fd0/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250203202601-3ab07f44e83a h1:5YMBn6k8mj9NvbJ+HVFfclkdOkaZW3zK8l3QV4rFZ1A=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250203202601-3ab07f44e83a/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
 github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250113155252-f00c500eaff3 h1:F9zv2Yvn7wurRAbC1mrZ/c/7GyWp1ux7uLxk3ZPHLH0=
 github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250113155252-f00c500eaff3/go.mod h1:z/5+LD4MJzLqbe+fBCWI2pZLnQbOlzSM82snAw2zceg=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d h1:HgLu1FD2oDFzlKW6/+SFXlH5Os8cwNTbplQIrQOWx8w=


### PR DESCRIPTION
### Changelist
- Update comet with fixes for these issues

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated a backend dependency to integrate the latest improvements, which may enhance stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->