### PR TITLE
Fix bug with socks subaccount subscription with best effort canceled logic.

### DIFF
--- a/.github/workflows/indexer-build-and-push-dev-staging.yml
+++ b/.github/workflows/indexer-build-and-push-dev-staging.yml
@@ -6,6 +6,7 @@ on: # yamllint disable-line rule:truthy
       - main
       - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/indexer/v0.1.x
       - 'release/indexer/v[0-9]+.x'  # e.g. release/indexer/v1.x
+      - 'vincentc/*'
     # TODO(DEC-837): Customize github build and push to ECR by service with paths
 
 jobs:

--- a/.github/workflows/indexer-build-and-push-dev-staging.yml
+++ b/.github/workflows/indexer-build-and-push-dev-staging.yml
@@ -6,7 +6,6 @@ on: # yamllint disable-line rule:truthy
       - main
       - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/indexer/v0.1.x
       - 'release/indexer/v[0-9]+.x'  # e.g. release/indexer/v1.x
-      - 'vincentc/*'
     # TODO(DEC-837): Customize github build and push to ECR by service with paths
 
 jobs:

--- a/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
@@ -492,7 +492,19 @@ router.get(
         options: { gt: 0 },
       },
     },
+    goodTilBlockAfter: {
+      in: 'query',
+      optional: true,
+      isInt: {
+        options: { gt: 0 },
+      },
+    },
     goodTilBlockTimeBeforeOrAt: {
+      in: 'query',
+      optional: true,
+      isISO8601: true,
+    },
+    goodTilBlockTimeAfter: {
       in: 'query',
       optional: true,
       isISO8601: true,

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -59,7 +59,7 @@ describe('Subscriptions', () => {
     [Channel.V4_ACCOUNTS]: [
       '/v4/addresses/.+/subaccountNumber/.+',
       '/v4/orders?.+subaccountNumber.+OPEN,UNTRIGGERED,BEST_EFFORT_OPENED',
-      '/v4/orders?.+subaccountNumber.+BEST_EFFORT_CANCELED.+goodTilBlockAfter.+',
+      '/v4/orders?.+subaccountNumber.+BEST_EFFORT_CANCELED.+goodTilBlockAfter=[0-9]+',
     ],
     [Channel.V4_CANDLES]: ['/v4/candles/perpetualMarkets/.+?resolution=.+'],
     [Channel.V4_MARKETS]: ['/v4/perpetualMarkets'],
@@ -68,7 +68,7 @@ describe('Subscriptions', () => {
     [Channel.V4_PARENT_ACCOUNTS]: [
       '/v4/addresses/.+/parentSubaccountNumber/.+',
       '/v4/orders/parentSubaccountNumber?.+parentSubaccountNumber.+OPEN,UNTRIGGERED,BEST_EFFORT_OPENED',
-      '/v4/orders/parentSubaccountNumber?.+parentSubaccountNumber.+BEST_EFFORT_CANCELED.+goodTilBlockAfter.+',
+      '/v4/orders/parentSubaccountNumber?.+parentSubaccountNumber.+BEST_EFFORT_CANCELED.+goodTilBlockAfter=[0-9]+',
     ],
     [Channel.V4_BLOCK_HEIGHT]: ['v4/height'],
   };

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -545,7 +545,7 @@ export class Subscriptions {
       throw new Error('Invalid undefined id');
     }
 
-    logger.info({
+    logger.error({
       at: "getInitialResponseForSubaccountSubscription",
       message: `Getting initial subaccount data for ${id}`,
     });
@@ -562,7 +562,7 @@ export class Subscriptions {
       const blockHeight: string = await blockHeightRefresher.getLatestBlockHeight();
       const numBlockHeight: number = parseInt(blockHeight, 10);
 
-      logger.info({
+      logger.error({
         at: "getInitialResponseForSubaccountSubscription",
         message: `Got initial block height ${numBlockHeight}`,
         id,
@@ -598,7 +598,7 @@ export class Subscriptions {
         }),
         axiosRequest({
           method: RequestMethod.GET,
-          url: `${COMLINK_URL}/v4/orders?address=${address}&subaccountNumber=${subaccountNumber}&status=BEST_EFFORT_CANCELED&goodTilBlockAfter=$${Math.max(numBlockHeight - 20, 1)}`,
+          url: `${COMLINK_URL}/v4/orders?address=${address}&subaccountNumber=${subaccountNumber}&status=BEST_EFFORT_CANCELED&goodTilBlockAfter=${Math.max(numBlockHeight - 20, 1)}`,
           timeout: config.INITIAL_GET_TIMEOUT_MS,
           headers: {
             'cf-ipcountry': country,
@@ -607,7 +607,7 @@ export class Subscriptions {
         }),
       ]);
 
-      logger.info({
+      logger.error({
         at: "getInitialResponseForSubaccountSubscription",
         message: `Got order responses`,
         id,
@@ -622,7 +622,7 @@ export class Subscriptions {
       );
       const allOrders: OrderFromDatabase[] = orders.concat(currentBestEffortCanceledOrders);
 
-      logger.info({
+      logger.error({
         at: "getInitialResponseForSubaccountScription",
         message: `Concatenated orders`,
         allOrders,
@@ -663,6 +663,11 @@ export class Subscriptions {
       throw new Error('Invalid undefined id');
     }
 
+    logger.error({
+      at: "getInitialResponseForParentSubaccountSubscription",
+      message: `Getting initial parent subaccount data for ${id}`,
+    });
+
     try {
       const {
         address,
@@ -674,6 +679,12 @@ export class Subscriptions {
 
       const blockHeight: string = await blockHeightRefresher.getLatestBlockHeight();
       const numBlockHeight: number = parseInt(blockHeight, 10);
+
+      logger.error({
+        at: "getInitialResponseForParentSubaccountSubscription",
+        message: `Got initial block height ${numBlockHeight}`,
+        id,
+      });
 
       const [
         subaccountsResponse,
@@ -714,11 +725,27 @@ export class Subscriptions {
         }),
       ]);
 
+      logger.error({
+        at: "getInitialResponseForParentSubaccountSubscription",
+        message: `Got order responses`,
+        id,
+        subaccountsResponse,
+        ordersResponse,
+        currentBestEffortCanceledOrdersResponse,
+      });
+
       const orders: OrderFromDatabase[] = JSON.parse(ordersResponse);
       const currentBestEffortCanceledOrders: OrderFromDatabase[] = JSON.parse(
         currentBestEffortCanceledOrdersResponse,
       );
       const allOrders: OrderFromDatabase[] = orders.concat(currentBestEffortCanceledOrders);
+
+      logger.error({
+        at: "getInitialResponseForSubaccountScription",
+        message: `Concatenated orders`,
+        allOrders,
+        id,
+      });
 
       return JSON.stringify({
         ...JSON.parse(subaccountsResponse),

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -545,11 +545,6 @@ export class Subscriptions {
       throw new Error('Invalid undefined id');
     }
 
-    logger.error({
-      at: "getInitialResponseForSubaccountSubscription",
-      message: `Getting initial subaccount data for ${id}`,
-    });
-
     try {
       const {
         address,
@@ -561,12 +556,6 @@ export class Subscriptions {
 
       const blockHeight: string = await blockHeightRefresher.getLatestBlockHeight();
       const numBlockHeight: number = parseInt(blockHeight, 10);
-
-      logger.error({
-        at: "getInitialResponseForSubaccountSubscription",
-        message: `Got initial block height ${numBlockHeight}`,
-        id,
-      });
 
       const [
         subaccountsResponse,
@@ -607,27 +596,11 @@ export class Subscriptions {
         }),
       ]);
 
-      logger.error({
-        at: "getInitialResponseForSubaccountSubscription",
-        message: `Got order responses`,
-        id,
-        subaccountsResponse,
-        ordersResponse,
-        currentBestEffortCanceledOrdersResponse,
-      });
-
       const orders: OrderFromDatabase[] = JSON.parse(ordersResponse);
       const currentBestEffortCanceledOrders: OrderFromDatabase[] = JSON.parse(
         currentBestEffortCanceledOrdersResponse,
       );
       const allOrders: OrderFromDatabase[] = orders.concat(currentBestEffortCanceledOrders);
-
-      logger.error({
-        at: "getInitialResponseForSubaccountScription",
-        message: `Concatenated orders`,
-        allOrders,
-        id,
-      });
 
       return JSON.stringify({
         ...JSON.parse(subaccountsResponse),
@@ -635,11 +608,6 @@ export class Subscriptions {
         blockHeight,
       });
     } catch (error) {
-      logger.error({
-        at: 'getInitialResponseForSubaccountSubscription',
-        message: `Received error when subscribing ${id}`,
-        error,
-      });
       // The subaccounts API endpoint returns a 404 for subaccounts that are not indexed, however
       // such subaccounts can be subscribed to and events can be sent when the subaccounts are
       // indexed to an existing subscription.
@@ -663,11 +631,6 @@ export class Subscriptions {
       throw new Error('Invalid undefined id');
     }
 
-    logger.error({
-      at: "getInitialResponseForParentSubaccountSubscription",
-      message: `Getting initial parent subaccount data for ${id}`,
-    });
-
     try {
       const {
         address,
@@ -679,12 +642,6 @@ export class Subscriptions {
 
       const blockHeight: string = await blockHeightRefresher.getLatestBlockHeight();
       const numBlockHeight: number = parseInt(blockHeight, 10);
-
-      logger.error({
-        at: "getInitialResponseForParentSubaccountSubscription",
-        message: `Got initial block height ${numBlockHeight}`,
-        id,
-      });
 
       const [
         subaccountsResponse,
@@ -725,27 +682,11 @@ export class Subscriptions {
         }),
       ]);
 
-      logger.error({
-        at: "getInitialResponseForParentSubaccountSubscription",
-        message: `Got order responses`,
-        id,
-        subaccountsResponse,
-        ordersResponse,
-        currentBestEffortCanceledOrdersResponse,
-      });
-
       const orders: OrderFromDatabase[] = JSON.parse(ordersResponse);
       const currentBestEffortCanceledOrders: OrderFromDatabase[] = JSON.parse(
         currentBestEffortCanceledOrdersResponse,
       );
       const allOrders: OrderFromDatabase[] = orders.concat(currentBestEffortCanceledOrders);
-
-      logger.error({
-        at: "getInitialResponseForSubaccountScription",
-        message: `Concatenated orders`,
-        allOrders,
-        id,
-      });
 
       return JSON.stringify({
         ...JSON.parse(subaccountsResponse),

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -608,6 +608,12 @@ export class Subscriptions {
         blockHeight,
       });
     } catch (error) {
+      logger.error({
+        at: 'getInitialResponseForSubaccountSubscription',
+        message: 'Error on getting initial response for subaccount subscription',
+        id,
+        error,
+      });
       // The subaccounts API endpoint returns a 404 for subaccounts that are not indexed, however
       // such subaccounts can be subscribed to and events can be sent when the subaccounts are
       // indexed to an existing subscription.
@@ -694,6 +700,12 @@ export class Subscriptions {
         blockHeight,
       });
     } catch (error) {
+      logger.error({
+        at: 'getInitialResponseForParentSubaccountSubscription',
+        message: 'Error on getting initial response for subaccount subscription',
+        id,
+        error,
+      });
       // The subaccounts API endpoint returns a 404 for subaccounts that are not indexed, however
       // such subaccounts can be subscribed to and events can be sent when the subaccounts are
       // indexed to an existing subscription.

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -545,6 +545,11 @@ export class Subscriptions {
       throw new Error('Invalid undefined id');
     }
 
+    logger.info({
+      at: "getInitialResponseForSubaccountSubscription",
+      message: `Getting initial subaccount data for ${id}`,
+    });
+
     try {
       const {
         address,
@@ -556,6 +561,12 @@ export class Subscriptions {
 
       const blockHeight: string = await blockHeightRefresher.getLatestBlockHeight();
       const numBlockHeight: number = parseInt(blockHeight, 10);
+
+      logger.info({
+        at: "getInitialResponseForSubaccountSubscription",
+        message: `Got initial block height ${numBlockHeight}`,
+        id,
+      });
 
       const [
         subaccountsResponse,
@@ -596,11 +607,27 @@ export class Subscriptions {
         }),
       ]);
 
+      logger.info({
+        at: "getInitialResponseForSubaccountSubscription",
+        message: `Got order responses`,
+        id,
+        subaccountsResponse,
+        ordersResponse,
+        currentBestEffortCanceledOrdersResponse,
+      });
+
       const orders: OrderFromDatabase[] = JSON.parse(ordersResponse);
       const currentBestEffortCanceledOrders: OrderFromDatabase[] = JSON.parse(
         currentBestEffortCanceledOrdersResponse,
       );
       const allOrders: OrderFromDatabase[] = orders.concat(currentBestEffortCanceledOrders);
+
+      logger.info({
+        at: "getInitialResponseForSubaccountScription",
+        message: `Concatenated orders`,
+        allOrders,
+        id,
+      });
 
       return JSON.stringify({
         ...JSON.parse(subaccountsResponse),

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -608,6 +608,11 @@ export class Subscriptions {
         blockHeight,
       });
     } catch (error) {
+      logger.error({
+        at: 'getInitialResponseForSubaccountSubscription',
+        message: `Received error when subscribing ${id}`,
+        error,
+      });
       // The subaccounts API endpoint returns a 404 for subaccounts that are not indexed, however
       // such subaccounts can be subscribed to and events can be sent when the subaccounts are
       // indexed to an existing subscription.


### PR DESCRIPTION
### Changelist
Fix typo + add test to catch issues with subscribing to subaccount orders initial response.

### Test Plan
Unit tests, tested in staging.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Introduced two optional filtering parameters for order listings, allowing for more precise query results.
- Improvements
	- Enhanced parameter validation to ensure accurate filtering.
	- Strengthened subscription response reliability with refined URL handling and improved error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->