### PR TITLE
initialize candles cache based on latest indexed block time

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/candle-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/candle-table.test.ts
@@ -1,10 +1,17 @@
-import { CandleFromDatabase, CandleUpdateObject } from '../../src/types';
+import { DateTime } from 'luxon';
+
+import {
+  CandleFromDatabase, CandleResolution, CandlesMap, CandleUpdateObject,
+} from '../../src/types';
+import * as BlockTable from '../../src/stores/block-table';
 import * as CandleTable from '../../src/stores/candle-table';
 import {
   clearData,
   teardown,
 } from '../../src/helpers/db-helpers';
-import { defaultCandle, defaultCandleId, defaultPerpetualMarket2 } from '../helpers/constants';
+import {
+  defaultCandle, defaultCandleId, defaultPerpetualMarket2,
+} from '../helpers/constants';
 
 describe('CandleTable', () => {
   afterEach(async () => {
@@ -76,5 +83,61 @@ describe('CandleTable', () => {
     );
 
     expect(candle).toEqual(expect.objectContaining(updatedCandle));
+  });
+
+  it('Successfully finds candles map based on latest block', async () => {
+    const latestBlockTime: DateTime = DateTime.utc(2022, 6, 1);
+    const candleMinuteResThreeHoursAgo = {
+      ...defaultCandle,
+      resolution: CandleResolution.ONE_MINUTE,
+      startedAt: latestBlockTime.minus({ hours: 3 }).toISO(),
+    };
+    const candleFiveMinuteResTwoHoursAgo = {
+      ...defaultCandle,
+      resolution: CandleResolution.FIVE_MINUTES,
+      startedAt: latestBlockTime.minus({ hours: 2 }).toISO(),
+    };
+    const candleHourResThreeDaysAgo = {
+      ...defaultCandle,
+      resolution: CandleResolution.FOUR_HOURS,
+      startedAt: latestBlockTime.minus({ days: 3 }).toISO(),
+    };
+    const candleDayResOneDayAgo = {
+      ...defaultCandle,
+      resolution: CandleResolution.ONE_DAY,
+      startedAt: latestBlockTime.minus({ days: 1 }).toISO(),
+    };
+    await Promise.all([
+      // Create two blocks with block time 1 second apart.
+      BlockTable.create({
+        blockHeight: '1',
+        time: latestBlockTime.minus({ seconds: 1 }).toISO(),
+      }),
+      BlockTable.create({
+        blockHeight: '2',
+        time: latestBlockTime.toISO(),
+      }),
+      // Create candles.
+      CandleTable.create(candleMinuteResThreeHoursAgo), // should not be part of candles map
+      CandleTable.create(candleFiveMinuteResTwoHoursAgo), // should be part of candles map
+      CandleTable.create(candleHourResThreeDaysAgo), // should not be part of candles map
+      CandleTable.create(candleDayResOneDayAgo), // should be part of candles map
+    ]);
+
+    const candlesMap: CandlesMap = await CandleTable.findCandlesMap(
+      [defaultCandle.ticker],
+      latestBlockTime.toISO(),
+    );
+
+    expect(Object.keys(candlesMap)).toEqual([defaultCandle.ticker]);
+    expect(
+      Object.keys(candlesMap[defaultCandle.ticker]),
+    ).toEqual([CandleResolution.FIVE_MINUTES, CandleResolution.ONE_DAY]);
+    expect(
+      candlesMap[defaultCandle.ticker][CandleResolution.FIVE_MINUTES],
+    ).toEqual(expect.objectContaining(candleFiveMinuteResTwoHoursAgo));
+    expect(
+      candlesMap[defaultCandle.ticker][CandleResolution.ONE_DAY],
+    ).toEqual(expect.objectContaining(candleDayResOneDayAgo));
   });
 });

--- a/indexer/services/ender/src/caches/candle-cache.ts
+++ b/indexer/services/ender/src/caches/candle-cache.ts
@@ -1,9 +1,11 @@
 import { NodeEnv } from '@dydxprotocol-indexer/base';
 import {
+  BlockTable,
   CandleFromDatabase,
   CandleResolution,
   CandlesMap,
   CandleTable,
+  IsoString,
   PerpetualMarketColumns,
   PerpetualMarketFromDatabase,
   PerpetualMarketTable,
@@ -13,6 +15,10 @@ import _ from 'lodash';
 let candlesMap: CandlesMap = {};
 
 export async function startCandleCache(txId?: number): Promise<void> {
+  const latestBlockTime: IsoString = await BlockTable.getLatest({ txId })
+    .then((latestBlock) => latestBlock.time)
+    .catch(() => new Date().toISOString());
+
   const perpetualMarkets: PerpetualMarketFromDatabase[] = await PerpetualMarketTable.findAll(
     {}, [], { txId },
   );
@@ -23,6 +29,7 @@ export async function startCandleCache(txId?: number): Promise<void> {
 
   candlesMap = await CandleTable.findCandlesMap(
     tickers,
+    latestBlockTime,
   );
 }
 


### PR DESCRIPTION
### Changelist
candles cache should initialize based on latest block time (instead of current timestamp) when there's at least one indexed block

### Test Plan
unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Revised candle data retrieval now leverages the latest available block timestamp for more accurate time-based filtering.
  - Enhanced error handling in the candle cache functionality to ensure reliability.

- **Tests**
  - Expanded test coverage with scenarios ensuring candle mapping works correctly using varied resolutions and timestamps relative to the most recent block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->