### PR TITLE
perf(db): Improve `market-updater` task and `getLatestPrice` query

### DIFF
--- a/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
+++ b/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
@@ -164,7 +164,7 @@ export async function getPnlTicksCreateObjects(
       blockHeight,
       txId,
     ),
-    OraclePriceTable.findLatestPrices(blockHeight),
+    OraclePriceTable.findLatestPricesBeforeOrAtHeight(blockHeight),
     FundingIndexUpdatesTable.findFundingIndexMap(blockHeight),
   ]);
   stats.timing(

--- a/indexer/services/roundtable/src/tasks/market-updater.ts
+++ b/indexer/services/roundtable/src/tasks/market-updater.ts
@@ -48,15 +48,28 @@ export function getPriceChange(
 export default async function runTask(): Promise<void> {
   const start: number = Date.now();
 
-  const liquidityTiers:
-  LiquidityTiersFromDatabase[] = await LiquidityTiersTable.findAll({}, []);
-  const perpetualMarkets:
-  PerpetualMarketFromDatabase[] = await PerpetualMarketTable.findAll({}, []);
+  // Run all initial database queries in parallel
+  const [
+    liquidityTiers,
+    perpetualMarkets,
+    latestPrices,
+    prices24hAgo,
+  ] : [
+    LiquidityTiersFromDatabase[],
+    PerpetualMarketFromDatabase[],
+    PriceMap,
+    PriceMap,
+  ] = await Promise.all([
+    LiquidityTiersTable.findAll({}, []),
+    PerpetualMarketTable.findAll({}, []),
+    OraclePriceTable.getLatestPrices(),
+    OraclePriceTable.getPricesFrom24hAgo(),
+  ]);
+
+  // Derive data from perpetual markets
   const perpetualMarketIds: string[] = _.map(perpetualMarkets, PerpetualMarketColumns.id);
   const clobPairIds: string[] = _.map(perpetualMarkets, PerpetualMarketColumns.clobPairId);
   const tickers: string[] = _.map(perpetualMarkets, PerpetualMarketColumns.ticker);
-  const latestPrices: PriceMap = await OraclePriceTable.getLatestPrices();
-  const prices24hAgo: PriceMap = await OraclePriceTable.getPricesFrom24hAgo();
 
   stats.timing(
     `${config.SERVICE_NAME}.market_updater_initial_queries`,


### PR DESCRIPTION
### Changelist
- Improve `GetLatestBlockByDatetime` SQL query that makes use of index. 
- Add unit test for `GetLatestBlockByDatetime`
- Improve `market-updater` task

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added enhanced functionality for retrieving pricing data based on date-time criteria.
- **Refactor**
	- Upgraded price retrieval logic to better handle effective timing for data accuracy.
	- Improved market update processes by fetching data concurrently for faster performance.
- **Tests**
	- Expanded testing to ensure pricing information returns accurately under the new criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->