### PR TITLE
fix: return nil instead of error directly

### DIFF
--- a/protocol/testing/containertest/testnet.go
+++ b/protocol/testing/containertest/testnet.go
@@ -77,7 +77,7 @@ func NewTestnetWithPreupgradeGenesis() (testnet *Testnet, err error) {
 		return nil, err
 	}
 	testnet.isPreupgradeGenesis = true
-	return testnet, err
+	return testnet, nil
 }
 
 func (t *Testnet) Start() (err error) {

--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -701,7 +701,7 @@ func (m *MemClobPriceTimePriority) PlacePerpetualLiquidation(
 	return liquidationOrderStatus.OrderOptimisticallyFilledQuantums,
 		liquidationOrderStatus.OrderStatus,
 		offchainUpdates,
-		err
+		nil
 }
 
 // DeleverageSubaccount will deleverage a subaccount by finding perpetual positions that can be used to offset


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

The logic of err not being nil has been processed and returned before, so err must be nil here.


### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
