### PR TITLE
feat(fills): Improve `fills/parentSubaccount` query

### DIFF
--- a/indexer/packages/postgres/src/stores/fill-table.ts
+++ b/indexer/packages/postgres/src/stores/fill-table.ts
@@ -578,3 +578,50 @@ export async function getFeesPaid(
 
   return Big(result.rows[0].feesPaid);
 }
+
+/**
+ * Returns fills across all subaccounts belonging to a parent subaccount.
+ * A parent subaccount is defined by an address and parent subaccount number,
+ * where child subaccounts have subaccount numbers in increments of 128 from the parent.
+ *
+ * @param address The wallet address
+ * @param parentSubaccountNumber The parent subaccount number
+ * @param limit Maximum number of fills to return
+ * @param options Query options
+ */
+export async function getFillsForParentSubaccount(
+  address: string,
+  parentSubaccountNumber: number,
+  limit: number = 200,
+): Promise<FillFromDatabase[]> {
+  const query = `
+-- Step 1: Get all child subaccount IDs under the parent subaccount
+WITH target_subaccounts AS (
+  SELECT id as "subaccountId"
+  FROM subaccounts 
+  WHERE address = ?
+  AND "subaccountNumber" IN (
+    SELECT generate_series(?, 12800, 128)
+  )
+)
+
+-- Step 2: Get all child subaccounts that exist in subaccounts table, 
+-- and get all fills for these subaccounts.
+SELECT f.* 
+FROM target_subaccounts s
+JOIN LATERAL (
+  SELECT *
+  FROM fills f
+  WHERE f."subaccountId" = s."subaccountId"
+  ORDER BY f."createdAtHeight" DESC
+) f ON true
+ORDER BY f."createdAtHeight" DESC
+LIMIT ?;
+`;
+
+  const result = await knexReadReplica
+    .getConnection()
+    .raw(query, [address, parentSubaccountNumber, limit]);
+
+  return result.rows;
+}

--- a/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
@@ -437,59 +437,6 @@ describe('fills-controller#V4', () => {
       );
     });
 
-    it('Get /fills/parentSubaccountNumber gets fills for isolated market', async () => {
-      await OrderTable.create(testConstants.defaultOrder);
-      await FillTable.create(testConstants.defaultFill);
-      await OrderTable.create(testConstants.isolatedMarketOrder);
-      await FillTable.create(testConstants.isolatedMarketFill);
-      await FillTable.create(testConstants.isolatedMarketFill2);
-
-      const parentSubaccountNumber: number = 0;
-      const response: request.Response = await sendRequest({
-        type: RequestMethod.GET,
-        path: `/v4/fills/parentSubaccountNumber?address=${testConstants.defaultAddress}` +
-            `&parentSubaccountNumber=${parentSubaccountNumber}` +
-            `&market=${testConstants.isolatedPerpetualMarket.ticker}&marketType=${MarketType.PERPETUAL}`,
-      });
-
-      // Use fillResponseObjectFromFillCreateObject to create expectedFills
-      const expectedFills: Partial<FillResponseObject>[] = [
-        fillResponseObjectFromFillCreateObject(testConstants.isolatedMarketFill,
-          testConstants.isolatedSubaccount.subaccountNumber),
-        fillResponseObjectFromFillCreateObject(testConstants.isolatedMarketFill2,
-          testConstants.isolatedSubaccount2.subaccountNumber),
-      ];
-
-      expect(response.body.fills).toHaveLength(2);
-      expect(response.body.fills).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            ...expectedFills[0],
-          }),
-          expect.objectContaining({
-            ...expectedFills[1],
-          }),
-        ]),
-      );
-    });
-
-    it('Get /fills/parentSubaccountNumber with market with no fills', async () => {
-      await OrderTable.create(testConstants.defaultOrder);
-      await FillTable.create(testConstants.defaultFill);
-      await OrderTable.create(testConstants.isolatedMarketOrder);
-      await FillTable.create(testConstants.isolatedMarketFill);
-
-      const parentSubaccountNumber: number = 0;
-      const response: request.Response = await sendRequest({
-        type: RequestMethod.GET,
-        path: `/v4/fills/parentSubaccountNumber?address=${testConstants.defaultAddress}` +
-            `&parentSubaccountNumber=${parentSubaccountNumber}` +
-            `&market=${testConstants.isolatedPerpetualMarket2.ticker}&marketType=${MarketType.PERPETUAL}`,
-      });
-
-      expect(response.body.fills).toEqual([]);
-    });
-
     it.each([
       [
         'market passed in without marketType',
@@ -550,25 +497,5 @@ describe('fills-controller#V4', () => {
         ]),
       }));
     });
-
-    it('Returns 404 with unknown market and type on parentSubaccount endpt', async () => {
-      const parentSubaccountNumber: number = 0;
-      const response: request.Response = await sendRequest({
-        type: RequestMethod.GET,
-        path: `/v4/fills/parentSubaccountNumber?address=${testConstants.defaultAddress}` +
-            `&parentSubaccountNumber=${parentSubaccountNumber}` +
-            `&market=${invalidMarket}&marketType=${MarketType.PERPETUAL}`,
-        expectedStatus: 404,
-      });
-
-      expect(response.body).toEqual({
-        errors: [
-          {
-            msg: `${invalidMarket} not found in markets of type ${MarketType.PERPETUAL}`,
-          },
-        ],
-      });
-    });
-
   });
 });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1273,6 +1273,7 @@ fetch(`${baseURL}/fills/parentSubaccount?address=string&parentSubaccountNumber=0
 |address|query|string|true|none|
 |parentSubaccountNumber|query|number(double)|true|none|
 |limit|query|number(double)|false|none|
+|page|query|number(double)|false|none|
 
 > Example responses
 

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -1272,19 +1272,7 @@ fetch(`${baseURL}/fills/parentSubaccount?address=string&parentSubaccountNumber=0
 |---|---|---|---|---|
 |address|query|string|true|none|
 |parentSubaccountNumber|query|number(double)|true|none|
-|market|query|string|false|none|
-|marketType|query|[MarketType](#schemamarkettype)|false|none|
 |limit|query|number(double)|false|none|
-|createdBeforeOrAtHeight|query|number(double)|false|none|
-|createdBeforeOrAt|query|[IsoString](#schemaisostring)|false|none|
-|page|query|number(double)|false|none|
-
-#### Enumerated Values
-
-|Parameter|Value|
-|---|---|
-|marketType|PERPETUAL|
-|marketType|SPOT|
 
 > Example responses
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -2230,6 +2230,15 @@
               "format": "double",
               "type": "number"
             }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
           }
         ]
       }

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -2224,49 +2224,7 @@
           },
           {
             "in": "query",
-            "name": "market",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "marketType",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/MarketType"
-            }
-          },
-          {
-            "in": "query",
             "name": "limit",
-            "required": false,
-            "schema": {
-              "format": "double",
-              "type": "number"
-            }
-          },
-          {
-            "in": "query",
-            "name": "createdBeforeOrAtHeight",
-            "required": false,
-            "schema": {
-              "format": "double",
-              "type": "number"
-            }
-          },
-          {
-            "in": "query",
-            "name": "createdBeforeOrAt",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/IsoString"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page",
             "required": false,
             "schema": {
               "format": "double",

--- a/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
@@ -120,27 +120,13 @@ class FillsController extends Controller {
   }
 
   @Get('/parentSubaccount')
+  // Note: This is expected to be used for FE only, where `parentSubaccount -> childSubaccount`
+  // mapping is relevant. API traders should use `orders` instead.
   async getFillsForParentSubaccount(
     @Query() address: string,
       @Query() parentSubaccountNumber: number,
-      @Query() market?: string,
-      @Query() marketType?: MarketType,
       @Query() limit?: number,
-      @Query() createdBeforeOrAtHeight?: number,
-      @Query() createdBeforeOrAt?: IsoString,
-      @Query() page?: number,
   ): Promise<FillResponse> {
-    // TODO(DEC-656): Change to using a cache of markets in Redis similar to Librarian instead of
-    // querying the DB.
-    let clobPairId: string | undefined;
-    if (isDefined(market) && isDefined(marketType)) {
-      clobPairId = await getClobPairId(market!, marketType!);
-
-      if (clobPairId === undefined) {
-        throw new NotFoundError(`${market} not found in markets of type ${marketType}`);
-      }
-    }
-
     // Get subaccountIds for all child subaccounts of the parent subaccount
     // Create a record of subaccountId to subaccount number
     const childIdtoSubaccountNumber: Record<string, number> = {};
@@ -149,26 +135,13 @@ class FillsController extends Controller {
         childIdtoSubaccountNumber[SubaccountTable.uuid(address, subaccountNum)] = subaccountNum;
       },
     );
-    const subaccountIds: string[] = Object.keys(childIdtoSubaccountNumber);
 
-    const {
-      results: fills,
-      limit: pageSize,
-      offset,
-      total,
-    } = await FillTable.findAll(
-      {
-        subaccountId: subaccountIds,
-        clobPairId,
-        limit,
-        createdBeforeOrAtHeight: createdBeforeOrAtHeight
-          ? createdBeforeOrAtHeight.toString()
-          : undefined,
-        createdBeforeOrAt,
-        page,
-      },
-      [QueryableField.LIMIT],
-      page !== undefined ? { orderBy: [[FillColumns.eventId, Ordering.ASC]] } : undefined,
+    // Don't change other parts in this function.
+    // Get fills for all child subaccounts using the new optimized query
+    const fills: FillFromDatabase[] = await FillTable.getFillsForParentSubaccount(
+      address,
+      parentSubaccountNumber,
+      limit,
     );
 
     const clobPairIdToPerpetualMarket: Record<
@@ -189,9 +162,6 @@ class FillsController extends Controller {
         return fillToResponseObject(fill, clobPairIdToMarket,
           childIdtoSubaccountNumber[fill.subaccountId]);
       }),
-      pageSize,
-      totalResults: total,
-      offset,
     };
   }
 }
@@ -314,12 +284,7 @@ router.get(
     const {
       address,
       parentSubaccountNumber,
-      market,
-      marketType,
       limit,
-      createdBeforeOrAtHeight,
-      createdBeforeOrAt,
-      page,
     }: ParentSubaccountFillRequest = matchedData(req) as ParentSubaccountFillRequest;
 
     // The schema checks allow subaccountNumber to be a string, but we know it's a number here.
@@ -332,12 +297,7 @@ router.get(
       const response: FillResponse = await controller.getFillsForParentSubaccount(
         address,
         parentSubaccountNum,
-        market,
-        marketType,
         limit,
-        createdBeforeOrAtHeight,
-        createdBeforeOrAt,
-        page,
       );
 
       return res.send(response);


### PR DESCRIPTION
### Changelist
[Context](https://dydx-team.slack.com/archives/C068Z7HA8AX/p1740666999034729?thread_ts=1740588878.524589&cid=C068Z7HA8AX)

### Test Plan
Unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced mechanism to retrieve order fills across parent and child subaccounts with improved result ordering.
- **Bug Fixes**
  - Removed outdated test cases that were no longer relevant to the current functionality.
- **Documentation**
  - Updated public API guidelines and specifications to reflect a streamlined fill retrieval process, including the removal of several query parameters.
- **Refactor**
  - Simplified the fill retrieval endpoint by removing several optional query filters and pagination fields, resulting in a cleaner and more efficient response structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->