### PR TITLE
perf(postgres): Improve sparklines query

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250306153101_add_candles_resolution_started_at_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250306153101_add_candles_resolution_started_at_index.ts
@@ -1,0 +1,21 @@
+import * as Knex from 'knex';
+
+// Disable transactions because CREATE INDEX CONCURRENTLY cannot run inside a transaction block
+export const config = {
+  transaction: false,
+};
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS candles_resolution_started_at_1_4_hour_feb2025_idx
+    ON candles (resolution, "startedAt")
+    WHERE resolution IN ('1HOUR', '4HOURS')
+      AND "startedAt" > '2025-02-01 00:00:00+00'::timestamp with time zone;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS candles_resolution_started_at_1_4_hour_feb2025_idx;
+  `);
+}

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250306153101_add_candles_sparklines_feb2025_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250306153101_add_candles_sparklines_feb2025_idx.ts
@@ -5,9 +5,10 @@ export const config = {
   transaction: false,
 };
 
+// Index for efficiently retrieving recent 1 and 4 hour candles (used by sparklines endpoint).
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS candles_resolution_started_at_1_4_hour_feb2025_idx
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS add_candles_sparklines_feb2025_idx
     ON candles (resolution, "startedAt")
     WHERE resolution IN ('1HOUR', '4HOURS')
       AND "startedAt" > '2025-02-01 00:00:00+00'::timestamp with time zone;
@@ -16,6 +17,6 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
-    DROP INDEX IF EXISTS candles_resolution_started_at_1_4_hour_feb2025_idx;
+    DROP INDEX IF EXISTS add_candles_sparklines_feb2025_idx;
   `);
 }

--- a/indexer/services/comlink/src/lib/constants.ts
+++ b/indexer/services/comlink/src/lib/constants.ts
@@ -16,16 +16,19 @@ export const ZERO_USDC_POSITION: AssetPositionResponseObject = {
   subaccountNumber: 0,
 };
 
-export const SPARKLINE_TIME_PERIOD_TO_LIMIT_MAP:
-Record<SparklineTimePeriod, number> = {
-  [SparklineTimePeriod.ONE_DAY]: 24, // 24 hours in a day
-  [SparklineTimePeriod.SEVEN_DAYS]: 7 * 6, // 7 days times (6 * 4 hr candles per day)
-};
-
 export const SPARKLINE_TIME_PERIOD_TO_RESOLUTION_MAP:
 Record<SparklineTimePeriod, CandleResolution> = {
   [SparklineTimePeriod.ONE_DAY]: CandleResolution.ONE_HOUR,
   [SparklineTimePeriod.SEVEN_DAYS]: CandleResolution.FOUR_HOURS,
+};
+
+export const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+export const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
+
+export const SPARKLINE_TIME_PERIOD_TO_LOOKBACK_MAP
+: Record<SparklineTimePeriod, number> = {
+  [SparklineTimePeriod.ONE_DAY]: ONE_DAY_MS,
+  [SparklineTimePeriod.SEVEN_DAYS]: SEVEN_DAYS_MS,
 };
 
 export const DYDX_ADDRESS_PREFIX: string = 'dydx';

--- a/indexer/services/comlink/src/request-helpers/request-transformer.ts
+++ b/indexer/services/comlink/src/request-helpers/request-transformer.ts
@@ -540,7 +540,6 @@ export function candleToResponseObject(
 export function candlesToSparklineResponseObject(
   tickers: string[],
   unsortedTickerCandles: CandleFromDatabase[],
-  limit: number,
 ): SparklineResponseObject {
   const response: SparklineResponseObject = _.fromPairs(
     _.map(tickers, (ticker: string) => [ticker, []]),
@@ -548,9 +547,8 @@ export function candlesToSparklineResponseObject(
   return _.reduce(
     unsortedTickerCandles,
     (accumulator: { [ticker: string]: string[] }, candle: CandleFromDatabase) => {
-      if (accumulator[candle.ticker].length < limit) {
-        accumulator[candle.ticker].push(candle[CandleColumns.close]);
-      }
+      accumulator[candle.ticker].push(candle[CandleColumns.close]);
+
       // Do not add to accumulator if accumulator length is already at limit.
       // Since candles are sorted by startedAt in descending order, the first 'limit' candles
       // will be the most recent candles.


### PR DESCRIPTION
### Changelist
Currently `sparklines` endpoint get all `tickers` and explicitly pass them into `candleTable.findAll` query, which is in efficient. 
- Added an index for `resolution - started` so the query can just retrieve all recent candles
- Update `sparklines` endpoint accordingly.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced candle retrieval for sparkline displays by leveraging dynamic lookback periods for more accurate, timely data.
  
- **Tests**
  - Expanded test coverage to ensure that candle data is correctly filtered by specified timeframes.

- **Refactor / Chores**
  - Updated sparkline response handling for improved data consistency.
  - Introduced a database index to optimize query performance for recent candle data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->