### PR TITLE
remove single clob msg restriction for stateful orders

### DIFF
--- a/.github/workflows/protocol-sim.yml
+++ b/.github/workflows/protocol-sim.yml
@@ -44,7 +44,7 @@ jobs:
         run: go version
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4.2.2
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/protocol-sim.yml
+++ b/.github/workflows/protocol-sim.yml
@@ -62,7 +62,7 @@ jobs:
           go-version: 1.22
       - name: Display go version
         run: go version
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4.2.2
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -112,7 +112,7 @@ jobs:
           go-version: 1.22
       - name: Display go version
         run: go version
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4.2.2
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -162,7 +162,7 @@ jobs:
           go-version: 1.22
       - name: Display go version
         run: go version
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4.2.2
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -212,7 +212,7 @@ jobs:
           go-version: 1.22
       - name: Display go version
         run: go version
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4.2.2
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/protocol/app/ante.go
+++ b/protocol/app/ante.go
@@ -191,10 +191,13 @@ func (h *lockingAnteHandler) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate boo
 		log.BlockHeight, ctx.BlockHeight()+1,
 	)
 
-	isClob, err := clobante.IsSingleClobMsgTx(tx)
-	if err != nil {
-		return ctx, err
-	} else if isClob {
+	//isClob, err := clobante.IsSingleClobMsgTx(tx)
+	//if err != nil {
+	//	return ctx, err
+	//} else if isClob {
+	//	return h.clobAnteHandle(ctx, tx, simulate)
+	//}
+	if clobante.HasClobMsg(tx) {
 		return h.clobAnteHandle(ctx, tx, simulate)
 	}
 	if libante.IsSingleAppInjectedMsg(tx.GetMsgs()) {

--- a/protocol/app/ante.go
+++ b/protocol/app/ante.go
@@ -191,12 +191,6 @@ func (h *lockingAnteHandler) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate boo
 		log.BlockHeight, ctx.BlockHeight()+1,
 	)
 
-	//isClob, err := clobante.IsSingleClobMsgTx(tx)
-	//if err != nil {
-	//	return ctx, err
-	//} else if isClob {
-	//	return h.clobAnteHandle(ctx, tx, simulate)
-	//}
 	if clobante.HasClobMsg(tx) {
 		return h.clobAnteHandle(ctx, tx, simulate)
 	}

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -347,7 +347,6 @@ func IsValidClobMsgTx(tx sdk.Tx) (bool, error) {
 	}
 
 	return true, nil
-
 }
 
 // GetTimeoutHeight returns the timeout height of a transaction. If the transaction does not have

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -53,17 +53,6 @@ func (cd ClobDecorator) AnteHandle(
 		return next(ctx, tx, simulate)
 	}
 
-	// Ensure that if this is a clob message then that there is only one.
-	// If it isn't a clob message then pass to the next AnteHandler.
-	//isSingleClobMsgTx, err := IsSingleClobMsgTx(tx)
-	//if err != nil {
-	//	return ctx, err
-	//}
-	//
-	//if !isSingleClobMsgTx {
-	//	return next(ctx, tx, simulate)
-	//}
-
 	// Return an error if there is more than one msg with a short term order in the transaction.
 	// Move on if there are no short term orders in the transaction
 	isShortTermClobMsgTx, err := IsShortTermClobMsgTx(ctx, tx)
@@ -80,11 +69,9 @@ func (cd ClobDecorator) AnteHandle(
 	}
 
 	msgs := tx.GetMsgs()
-	//var msg = msgs[0]
 
 	err = nil
 	for _, msg := range msgs {
-
 		switch msg := msg.(type) {
 		case *types.MsgCancelOrder:
 			if msg.OrderId.IsStatefulOrder() {

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -293,6 +293,8 @@ func IsValidClobMsgTx(tx sdk.Tx) error {
 
 	var hasShortTermOrder = false
 	var numTransferMsgs = 0
+	// Non CLOB msgs are not allowed in CLOB msg transactions because there is no fee charged
+	// for CLOB transactions
 	var hasNonClobMsg = false
 
 	for _, msg := range msgs {
@@ -322,6 +324,8 @@ func IsValidClobMsgTx(tx sdk.Tx) error {
 		)
 	}
 
+	// We only expect a single transfer msg to be batched with a PlaceOrder msg. This is primarily used
+	// to transfer collateral to an isolated subaccount for an isolated position order
 	if numTransferMsgs > 1 {
 		return errorsmod.Wrap(
 			sdkerrors.ErrInvalidRequest,

--- a/protocol/x/clob/ante/clob.go
+++ b/protocol/x/clob/ante/clob.go
@@ -179,7 +179,6 @@ func (cd ClobDecorator) AnteHandle(
 		if err != nil {
 			return ctx, err
 		}
-
 	}
 
 	return next(ctx, tx, simulate)

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -252,6 +252,20 @@ func TestClobDecorator_MsgPlaceOrder(t *testing.T) {
 			useWithIsCheckTxContext: true,
 			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},
+		"Fails if there are multiple transfer messages": {
+			msgs: []sdk.Msg{
+				constants.Msg_Transfer, constants.Msg_Transfer, constants.Msg_PlaceOrder_LongTerm,
+			},
+			useWithIsCheckTxContext: true,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
+		},
+		"Fails if there are non CLOB, non transfer messages": {
+			msgs: []sdk.Msg{
+				constants.Msg_Transfer, constants.Msg_Send,
+			},
+			useWithIsCheckTxContext: true,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
+		},
 		// Test for hotfix.
 		"PlaceShortTermOrder is not called on keeper CheckTx if transaction timeout height < goodTilBlock": {
 			msgs:                      []sdk.Msg{constants.Msg_PlaceOrder},
@@ -596,6 +610,20 @@ func TestClobDecorator_MsgCancelOrder(t *testing.T) {
 		},
 		"Fails if there are a mix of off-chain and on-chain messages": {
 			msgs:                    []sdk.Msg{constants.Msg_CancelOrder, constants.Msg_Send},
+			useWithIsCheckTxContext: true,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
+		},
+		"Fails if there are multiple transfer messages": {
+			msgs: []sdk.Msg{
+				constants.Msg_Transfer, constants.Msg_Transfer, constants.Msg_CancelOrder_LongTerm,
+			},
+			useWithIsCheckTxContext: true,
+			expectedErr:             sdkerrors.ErrInvalidRequest,
+		},
+		"Fails if there are non CLOB, non transfer messages": {
+			msgs: []sdk.Msg{
+				constants.Msg_Transfer, constants.Msg_Send,
+			},
 			useWithIsCheckTxContext: true,
 			expectedErr:             sdkerrors.ErrInvalidRequest,
 		},

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -407,24 +407,24 @@ func TestIsShortTermClobTransaction(t *testing.T) {
 			expectedResult: false,
 			expectedErr:    nil,
 		},
-		"Returns true and error for multiple `PlaceOrder` message": {
+		"Returns false and error for multiple `PlaceOrder` message": {
 			msgs:           []sdk.Msg{constants.Msg_PlaceOrder_LongTerm, constants.Msg_PlaceOrder},
-			expectedResult: true,
+			expectedResult: false,
 			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
-		"Returns true and error for multiple `CancelOrder` messages": {
+		"Returns false and error for multiple `CancelOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_CancelOrder_LongTerm, constants.Msg_CancelOrder},
-			expectedResult: true,
+			expectedResult: false,
 			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
-		"Returns true and error for mix of `PlaceOrder` and `CancelOrder` messages": {
+		"Returns false and error for mix of `PlaceOrder` and `CancelOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_CancelOrder},
-			expectedResult: true,
+			expectedResult: false,
 			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns false and error for mix of `MsgSend` and `PlaceOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_Send, constants.Msg_PlaceOrder},
-			expectedResult: true,
+			expectedResult: false,
 			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns true for a Short-Term `CancelOrder` message": {
@@ -558,7 +558,7 @@ func TestIsValidClobTransaction(t *testing.T) {
 				tx := builder.GetTx()
 
 				// Invoke the function under test.
-				err = ante.IsValidClobMsgTx(tx)
+				err = ante.ValidateMsgsInClobTx(tx)
 
 				// Assert the results.
 				require.ErrorIs(t, tc.expectedErr, err)

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -116,6 +116,36 @@ func TestClobDecorator_MsgPlaceOrder(t *testing.T) {
 			useWithIsCheckTxContext: true,
 			expectedErr:             nil,
 		},
+		"Successfully places multiple stateful orders within the same transaction": {
+			msgs: []sdk.Msg{constants.Msg_PlaceOrder_LongTerm, constants.Msg_PlaceOrder_LongTerm},
+			setupMocks: func(ctx sdk.Context, mck *mocks.ClobKeeper) {
+				mck.On(
+					"PlaceStatefulOrder",
+					ctx,
+					constants.Msg_PlaceOrder_LongTerm,
+					false,
+				).Return(
+					nil,
+				)
+			},
+			useWithIsCheckTxContext: true,
+			expectedErr:             nil,
+		},
+		"Successfully places transfer and stateful order within the same transaction": {
+			msgs: []sdk.Msg{constants.Msg_Transfer, constants.Msg_PlaceOrder_LongTerm},
+			setupMocks: func(ctx sdk.Context, mck *mocks.ClobKeeper) {
+				mck.On(
+					"PlaceStatefulOrder",
+					ctx,
+					constants.Msg_PlaceOrder_LongTerm,
+					false,
+				).Return(
+					nil,
+				)
+			},
+			useWithIsCheckTxContext: true,
+			expectedErr:             nil,
+		},
 		"Successfully places a conditional order using a single message": {
 			msgs: []sdk.Msg{constants.Msg_PlaceOrder_Conditional},
 			setupMocks: func(ctx sdk.Context, mck *mocks.ClobKeeper) {

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -511,11 +511,6 @@ func TestClobDecorator_MsgCancelOrder(t *testing.T) {
 			useWithIsCheckTxContext: true,
 			expectedErr:             nil,
 		},
-		"Works with any number of off-chain messages": {
-			msgs:                    []sdk.Msg{constants.Msg_Send, constants.Msg_Send},
-			useWithIsCheckTxContext: true,
-			expectedErr:             nil,
-		},
 		"CancelShortTermOrder is not called on keeper during deliver": {
 			msgs:                    []sdk.Msg{constants.Msg_CancelOrder},
 			useWithIsCheckTxContext: false,

--- a/protocol/x/clob/ante/clob_test.go
+++ b/protocol/x/clob/ante/clob_test.go
@@ -363,24 +363,24 @@ func TestIsShortTermClobTransaction(t *testing.T) {
 			expectedResult: false,
 			expectedErr:    nil,
 		},
-		"Returns false and error for multiple `PlaceOrder` message": {
+		"Returns true and error for multiple `PlaceOrder` message": {
 			msgs:           []sdk.Msg{constants.Msg_PlaceOrder_LongTerm, constants.Msg_PlaceOrder},
-			expectedResult: false,
+			expectedResult: true,
 			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
-		"Returns false and error for multiple `CancelOrder` messages": {
+		"Returns true and error for multiple `CancelOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_CancelOrder_LongTerm, constants.Msg_CancelOrder},
-			expectedResult: false,
+			expectedResult: true,
 			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
-		"Returns false and error for mix of `PlaceOrder` and `CancelOrder` messages": {
+		"Returns true and error for mix of `PlaceOrder` and `CancelOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_PlaceOrder, constants.Msg_CancelOrder},
-			expectedResult: false,
+			expectedResult: true,
 			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns false and error for mix of `MsgSend` and `PlaceOrder` messages": {
 			msgs:           []sdk.Msg{constants.Msg_Send, constants.Msg_PlaceOrder},
-			expectedResult: false,
+			expectedResult: true,
 			expectedErr:    sdkerrors.ErrInvalidRequest,
 		},
 		"Returns true for a Short-Term `CancelOrder` message": {


### PR DESCRIPTION
### Changelist
Today, we restrict multiple msgs in any clob msg tx. Remove this restriction in order to package multiple msgs that need to be executed in the same block
Ex. Transfer+Place order for isolated markets, Place multiple orders for SCALE orders

### Test Plan
Added unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the processing of order-related transactions by refining the validation logic. The system now supports multiple valid order types with more consistent error feedback for invalid combinations.
  
- **Tests**
  - Expanded test coverage with new and adjusted scenarios for order placement and cancellation, ensuring a robust and reliable user transaction experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->