### PR TITLE
fix(pnl): Fix PNL ticks leaderboard test flakiness

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/pnl-ticks-table.test.ts
@@ -513,105 +513,93 @@ describe('PnlTicks store', () => {
 });
 
 async function setupRankedPnlTicksData() {
-  await Promise.all([
-    BlockTable.create({
-      blockHeight: '3',
-      time: defaultBlock.time,
-    }),
-    BlockTable.create({
-      blockHeight: '5',
-      time: defaultBlock.time,
-    }),
-    BlockTable.create({
-      blockHeight: '7',
-      time: defaultBlock.time,
-    }),
-    BlockTable.create({
-      blockHeight: '9',
-      time: defaultBlock.time,
-    }),
-  ]);
+  const now = DateTime.utc().startOf('day');
+  const thirtyDaysAgo = now.minus({ days: 30 });
+  const sevenDaysAgo = now.minus({ days: 7 });
+  const oneDayAgo = now.minus({ days: 1 });
+  const oneYearAgo = now.minus({ years: 1 });
+
   await PnlTicksTable.createMany([
     {
       subaccountId: defaultSubaccountId,
       equity: '1100',
-      createdAt: DateTime.utc().toISO(),
       totalPnl: '1200',
       netTransfers: '50',
+      createdAt: now.toISO(),
       blockHeight: '9',
-      blockTime: defaultBlock.time,
+      blockTime: now.toISO(),
     },
     {
       subaccountId: defaultSubaccountId,
       equity: '1090',
-      createdAt: DateTime.utc().minus({ day: 1 }).toISO(),
       totalPnl: '1190',
       netTransfers: '50',
+      createdAt: oneDayAgo.toISO(),
       blockHeight: '7',
-      blockTime: defaultBlock.time,
+      blockTime: oneDayAgo.toISO(),
     },
     {
       subaccountId: defaultSubaccountId,
       equity: '1080',
-      createdAt: DateTime.utc().minus({ day: 7 }).toISO(),
       totalPnl: '1180',
       netTransfers: '50',
+      createdAt: sevenDaysAgo.toISO(),
       blockHeight: '5',
-      blockTime: defaultBlock.time,
+      blockTime: sevenDaysAgo.toISO(),
     },
     {
       subaccountId: defaultSubaccountId,
       equity: '1070',
-      createdAt: DateTime.utc().minus({ day: 30 }).toISO(),
       totalPnl: '1170',
       netTransfers: '50',
+      createdAt: thirtyDaysAgo.toISO(),
       blockHeight: '3',
-      blockTime: defaultBlock.time,
+      blockTime: thirtyDaysAgo.toISO(),
     },
     {
       subaccountId: defaultSubaccountId,
       equity: '1060',
-      createdAt: DateTime.utc().minus({ day: 365 }).toISO(),
       totalPnl: '1160',
       netTransfers: '50',
+      createdAt: oneYearAgo.toISO(),
       blockHeight: '1',
-      blockTime: defaultBlock.time,
+      blockTime: oneYearAgo.toISO(),
     },
     {
       subaccountId: defaultSubaccountIdWithAlternateAddress,
       equity: '200',
-      createdAt: DateTime.utc().toISO(),
+      createdAt: now.toISO(),
       totalPnl: '300',
       netTransfers: '50',
       blockHeight: '9',
-      blockTime: defaultBlock.time,
+      blockTime: now.toISO(),
     },
     {
       subaccountId: defaultSubaccountIdWithAlternateAddress,
       equity: '210',
-      createdAt: DateTime.utc().minus({ day: 1 }).toISO(),
+      createdAt: oneDayAgo.toISO(),
       totalPnl: '310',
       netTransfers: '50',
       blockHeight: '7',
-      blockTime: defaultBlock.time,
+      blockTime: oneDayAgo.toISO(),
     },
     {
       subaccountId: defaultSubaccountIdWithAlternateAddress,
       equity: '220',
-      createdAt: DateTime.utc().minus({ week: 1 }).toISO(),
       totalPnl: '320',
       netTransfers: '50',
+      createdAt: sevenDaysAgo.toISO(),
       blockHeight: '5',
-      blockTime: defaultBlock.time,
+      blockTime: sevenDaysAgo.toISO(),
     },
     {
       subaccountId: defaultSubaccountIdWithAlternateAddress,
       equity: '230',
-      createdAt: DateTime.utc().minus({ month: 1 }).toISO(),
       totalPnl: '330',
       netTransfers: '50',
+      createdAt: thirtyDaysAgo.toISO(),
       blockHeight: '3',
-      blockTime: defaultBlock.time,
+      blockTime: thirtyDaysAgo.toISO(),
     },
   ]);
 }


### PR DESCRIPTION

### Problem
The PNL ticks leaderboard test was failing intermittently due to inconsistent date handling in the test data setup, where timestamps were being dynamically generated using JavaScript's DateTime, making the test results dependent on when the test was run.

### Solution
Fixed the test data setup in `pnl-ticks-table.test.ts` to ensure consistent timestamp handling by:
1. Using `DateTime.utc().startOf('day')` to ensure all test data timestamps are aligned to UTC midnight
2. Ensuring both `createdAt` and `blockTime` fields use consistent timestamps in the test data
3. Properly aligning test data timestamps with PostgreSQL's date handling expectations

### Test Plan
- Verified that "Get thirty days ranked pnl ticks" test now passes consistently
- Confirmed that other PNL ticks store tests continue to pass
- Ensured that the changes maintain the original business logic while fixing the timing issues

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved the simulation accuracy in our testing environment by replacing static timestamp values with dynamically calculated dates. This update provides more realistic test data, ensuring enhanced reliability during quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->