### PR TITLE
perf(postgres): Add index on blocks."time" and optimize roundtable query

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -459,11 +459,11 @@ export const defaultConditionalOrderId: string = OrderTable.uuid(
 
 export const defaultBlock: BlockCreateObject = {
   blockHeight: '1',
-  time: DateTime.utc(2025, 3, 5).toISO(),
+  time: DateTime.utc(2022, 6, 1).toISO(),
 };
 export const defaultBlock2: BlockCreateObject = {
   blockHeight: '2',
-  time: DateTime.utc(2025, 3, 6).toISO(),
+  time: DateTime.utc(2022, 6, 2).toISO(),
 };
 
 // ============== TendermintEvents ==============

--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -459,11 +459,11 @@ export const defaultConditionalOrderId: string = OrderTable.uuid(
 
 export const defaultBlock: BlockCreateObject = {
   blockHeight: '1',
-  time: DateTime.utc(2022, 6, 1).toISO(),
+  time: DateTime.utc(2025, 3, 5).toISO(),
 };
 export const defaultBlock2: BlockCreateObject = {
   blockHeight: '2',
-  time: DateTime.utc(2022, 6, 2).toISO(),
+  time: DateTime.utc(2025, 3, 6).toISO(),
 };
 
 // ============== TendermintEvents ==============

--- a/indexer/packages/postgres/__tests__/stores/block-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/block-table.test.ts
@@ -5,8 +5,17 @@ import {
   migrate,
   teardown,
 } from '../../src/helpers/db-helpers';
-import { defaultBlock, defaultBlock2 } from '../helpers/constants';
 import { DateTime } from 'luxon';
+
+const testBlock1 = {
+  blockHeight: '1',
+  time: DateTime.utc(2025, 3, 5).toISO(),
+};
+
+const testBlock2 = {
+  blockHeight: '2',
+  time: DateTime.utc(2025, 3, 6).toISO(),
+};
 
 describe('Block store', () => {
   beforeAll(async () => {
@@ -22,13 +31,13 @@ describe('Block store', () => {
   });
 
   it('Successfully creates a Block', async () => {
-    await BlockTable.create(defaultBlock);
+    await BlockTable.create(testBlock1);
   });
 
   it('Successfully finds all Blocks', async () => {
     await Promise.all([
-      BlockTable.create(defaultBlock),
-      BlockTable.create(defaultBlock2),
+      BlockTable.create(testBlock1),
+      BlockTable.create(testBlock2),
     ]);
 
     const blocks: BlockFromDatabase[] = await BlockTable.findAll(
@@ -38,14 +47,14 @@ describe('Block store', () => {
     );
 
     expect(blocks.length).toEqual(2);
-    expect(blocks[0]).toEqual(expect.objectContaining(defaultBlock));
-    expect(blocks[1]).toEqual(expect.objectContaining(defaultBlock2));
+    expect(blocks[0]).toEqual(expect.objectContaining(testBlock1));
+    expect(blocks[1]).toEqual(expect.objectContaining(testBlock2));
   });
 
   it('Successfully finds Block with block height', async () => {
     await Promise.all([
-      BlockTable.create(defaultBlock),
-      BlockTable.create(defaultBlock2),
+      BlockTable.create(testBlock1),
+      BlockTable.create(testBlock2),
     ]);
 
     const blocks: BlockFromDatabase[] = await BlockTable.findAll(
@@ -57,36 +66,36 @@ describe('Block store', () => {
     );
 
     expect(blocks.length).toEqual(1);
-    expect(blocks[0]).toEqual(expect.objectContaining(defaultBlock));
+    expect(blocks[0]).toEqual(expect.objectContaining(testBlock1));
   });
 
   it('Successfully finds a Block', async () => {
-    await BlockTable.create(defaultBlock);
+    await BlockTable.create(testBlock1);
 
     const block: BlockFromDatabase | undefined = await
     BlockTable.findByBlockHeight(
-      defaultBlock.blockHeight,
+      testBlock1.blockHeight,
     );
 
-    expect(block).toEqual(expect.objectContaining(defaultBlock));
+    expect(block).toEqual(expect.objectContaining(testBlock1));
   });
 
   it('Unable finds a Block', async () => {
     const block: BlockFromDatabase | undefined = await
     BlockTable.findByBlockHeight(
-      defaultBlock.blockHeight,
+      testBlock1.blockHeight,
     );
     expect(block).toEqual(undefined);
   });
 
   it('Successfully gets latest Block', async () => {
     await Promise.all([
-      BlockTable.create(defaultBlock),
-      BlockTable.create(defaultBlock2),
+      BlockTable.create(testBlock1),
+      BlockTable.create(testBlock2),
     ]);
 
     const block: BlockFromDatabase = await BlockTable.getLatest();
-    expect(block).toEqual(expect.objectContaining(defaultBlock2));
+    expect(block).toEqual(expect.objectContaining(testBlock2));
   });
 
   it('Unable to find latest Block', async () => {
@@ -95,8 +104,8 @@ describe('Block store', () => {
 
   it('Successfully finds first block created on or after timestamp', async () => {
     await Promise.all([
-      BlockTable.create(defaultBlock),
-      BlockTable.create(defaultBlock2),
+      BlockTable.create(testBlock1),
+      BlockTable.create(testBlock2),
     ]);
 
     const block: BlockFromDatabase | undefined = await BlockTable.findBlockByCreatedOnOrAfter(
@@ -104,13 +113,13 @@ describe('Block store', () => {
     );
 
     expect(block).toBeDefined();
-    expect(block).toEqual(expect.objectContaining(defaultBlock));
+    expect(block).toEqual(expect.objectContaining(testBlock1));
   });
 
   it('Successfully finds first block when querying with later timestamp', async () => {
     await Promise.all([
-      BlockTable.create(defaultBlock),
-      BlockTable.create(defaultBlock2),
+      BlockTable.create(testBlock1),
+      BlockTable.create(testBlock2),
     ]);
 
     const block: BlockFromDatabase | undefined = await BlockTable.findBlockByCreatedOnOrAfter(
@@ -118,13 +127,13 @@ describe('Block store', () => {
     );
 
     expect(block).toBeDefined();
-    expect(block).toEqual(expect.objectContaining(defaultBlock2));
+    expect(block).toEqual(expect.objectContaining(testBlock2));
   });
 
   it('Returns undefined when no blocks found after timestamp', async () => {
     await Promise.all([
-      BlockTable.create(defaultBlock),
-      BlockTable.create(defaultBlock2),
+      BlockTable.create(testBlock1),
+      BlockTable.create(testBlock2),
     ]);
 
     const block: BlockFromDatabase | undefined = await BlockTable.findBlockByCreatedOnOrAfter(

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250226144411_create_blocks_time_since_march2025_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250226144411_create_blocks_time_since_march2025_idx.ts
@@ -1,0 +1,20 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "blocks_time_since_march2025_idx"
+    ON "blocks" ("time")
+    WHERE "time" >= '2025-03-01 00:00:00+00';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS 
+    "blocks_time_since_march2025_idx";
+  `);
+}
+
+export const config = {
+  transaction: false,
+};

--- a/indexer/packages/postgres/src/stores/block-table.ts
+++ b/indexer/packages/postgres/src/stores/block-table.ts
@@ -17,24 +17,6 @@ import {
 } from '../types';
 
 /**
- * Find blocks by their block heights.
- */
-export async function findByBlockHeights(
-  blockHeights: string[],
-  options: Options = DEFAULT_POSTGRES_OPTIONS,
-): Promise<BlockFromDatabase[]> {
-  const baseQuery: QueryBuilder<BlockModel> = setupBaseQuery<BlockModel>(
-    BlockModel,
-    options,
-  );
-
-  return baseQuery
-    .whereIn(BlockColumns.blockHeight, blockHeights)
-    .orderBy(BlockColumns.blockHeight, Ordering.ASC)
-    .returning('*');
-}
-
-/**
  * Find the first block created on or after the given timestamp.
  * Uses the blocks_time_since_march2025_idx index for efficient querying.
  */

--- a/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
+++ b/indexer/services/roundtable/src/tasks/aggregate-trading-rewards.ts
@@ -381,12 +381,12 @@ export class AggregateTradingReward {
   }
 
   private async getNextBlock(time: IsoString): Promise<string> {
-    const blocks: BlockFromDatabase[] = await BlockTable.findAll({
-      createdOnOrAfter: time,
-      limit: 1,
-    }, [], { readReplica: true });
+    const block: BlockFromDatabase | undefined = await BlockTable.findBlockByCreatedOnOrAfter(
+      time,
+      { readReplica: true },
+    );
 
-    if (blocks.length === 0) {
+    if (block === undefined) {
       logger.error({
         at: 'aggregate-trading-rewards#getStartedAtHeight',
         message: 'No blocks found after time, this should never happen',
@@ -395,7 +395,7 @@ export class AggregateTradingReward {
       });
       throw new Error(`No blocks found after ${time}`);
     }
-    return blocks[0].blockHeight;
+    return block.blockHeight;
   }
 
   private isEndofPeriod(endTime: DateTime): boolean {


### PR DESCRIPTION
### Changelist
[Context](https://www.notion.so/dydx/Postgres-Slow-Query-Analysis-19e21fec1be780f5ac70fc227b03c180?pvs=4#19e21fec1be780229a63f9d1008e339a)
- Replaced BlockTable.findAll() with new optimized BlockTable.findBlockByCreatedOnOrAfter() function
- Updated the getNextBlock in `AggregateTradingReward class`

### Test Plan
Unit test

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved block data retrieval based on creation timestamps to enhance reward calculations.
- **Refactor**
  - Streamlined the reward processing workflow by simplifying block lookup logic.
- **Chores**
  - Added an optimized database indexing strategy for recent block records to boost overall performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->