### PR TITLE
perf(postgres): Add short-term open order index for `cancel-stale-orders` task. 

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250310121018_add_orders_shortterm_open_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250310121018_add_orders_shortterm_open_idx.ts
@@ -3,7 +3,7 @@ import * as Knex from 'knex';
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
     CREATE INDEX CONCURRENTLY IF NOT EXISTS "orders_open_shortterm_idx" 
-    ON "orders" 
+    ON "orders" ("goodTilBlock")
     WHERE status = 'OPEN' AND "orderFlags" = 0;
   `);
 }

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250310121018_add_orders_shortterm_open_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250310121018_add_orders_shortterm_open_idx.ts
@@ -4,7 +4,7 @@ export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
     CREATE INDEX CONCURRENTLY IF NOT EXISTS "orders_open_shortterm_idx" 
     ON "orders" ("goodTilBlock")
-    WHERE status = 'OPEN' AND "orderFlags" = 0;
+    WHERE status = 'OPEN' AND "orderFlags" = 0 AND "goodTilBlock" IS NOT NULL;
   `);
 }
 

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250310121018_add_orders_shortterm_open_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250310121018_add_orders_shortterm_open_idx.ts
@@ -1,0 +1,19 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "orders_open_shortterm_idx" 
+    ON "orders" 
+    WHERE status = 'OPEN' AND "orderFlags" = 0;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "orders_open_shortterm_idx";
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
[context](https://www.notion.so/dydx/Postgres-Slow-Query-Analysis-19e21fec1be780f5ac70fc227b03c180?pvs=4#1a321fec1be780e29cd2f28f247bb695)

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced backend performance by optimizing the retrieval of active orders through improved database efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->