### PR TITLE
[ENG-29] Use New Instant Liquidity Tier for IML

### DIFF
--- a/protocol/x/listing/keeper/listing.go
+++ b/protocol/x/listing/keeper/listing.go
@@ -142,7 +142,7 @@ func (k Keeper) CreatePerpetual(
 		marketId,
 		atomicResolution,
 		types.DefaultFundingPpm,
-		types.LiquidityTier_Isolated,
+		types.LiquidityTier_Instant_5x,
 		perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED,
 	)
 	if err != nil {

--- a/protocol/x/listing/keeper/listing.go
+++ b/protocol/x/listing/keeper/listing.go
@@ -142,7 +142,7 @@ func (k Keeper) CreatePerpetual(
 		marketId,
 		atomicResolution,
 		types.DefaultFundingPpm,
-		types.LiquidityTier_Instant_5x,
+		types.LiquidityTier_IML_5x,
 		perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED,
 	)
 	if err != nil {

--- a/protocol/x/listing/keeper/listing_test.go
+++ b/protocol/x/listing/keeper/listing_test.go
@@ -181,7 +181,7 @@ func TestCreatePerpetual(t *testing.T) {
 					// Expected resolution = -6 - (Floor(log10(1000000000))-10) = -5
 					require.Equal(t, int32(-5), perpetual.Params.AtomicResolution)
 					require.Equal(t, int32(types.DefaultFundingPpm), perpetual.Params.DefaultFundingPpm)
-					require.Equal(t, uint32(types.LiquidityTier_Isolated), perpetual.Params.LiquidityTier)
+					require.Equal(t, uint32(types.LiquidityTier_Instant_5x), perpetual.Params.LiquidityTier)
 					require.Equal(
 						t, perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED,
 						perpetual.Params.MarketType,

--- a/protocol/x/listing/keeper/listing_test.go
+++ b/protocol/x/listing/keeper/listing_test.go
@@ -181,7 +181,7 @@ func TestCreatePerpetual(t *testing.T) {
 					// Expected resolution = -6 - (Floor(log10(1000000000))-10) = -5
 					require.Equal(t, int32(-5), perpetual.Params.AtomicResolution)
 					require.Equal(t, int32(types.DefaultFundingPpm), perpetual.Params.DefaultFundingPpm)
-					require.Equal(t, uint32(types.LiquidityTier_Instant_5x), perpetual.Params.LiquidityTier)
+					require.Equal(t, uint32(types.LiquidityTier_IML_5x), perpetual.Params.LiquidityTier)
 					require.Equal(
 						t, perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED,
 						perpetual.Params.MarketType,

--- a/protocol/x/listing/keeper/msg_create_market_permissionless_test.go
+++ b/protocol/x/listing/keeper/msg_create_market_permissionless_test.go
@@ -9,6 +9,7 @@ import (
 	testutil "github.com/dydxprotocol/v4-chain/protocol/testutil/util"
 	"github.com/dydxprotocol/v4-chain/protocol/x/listing/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/listing/types"
+	perpetualstypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	vaulttypes "github.com/dydxprotocol/v4-chain/protocol/x/vault/types"
@@ -87,6 +88,21 @@ func TestMsgCreateMarketPermissionless(t *testing.T) {
 										},
 									},
 								}
+							},
+						)
+
+						testapp.UpdateGenesisDocWithAppStateForModule(
+							&genesis,
+							func(genesisState *perpetualstypes.GenesisState) {
+								genesisState.LiquidityTiers = append(genesisState.LiquidityTiers, perpetualstypes.LiquidityTier{
+									Id:                     7,
+									Name:                   "Instant",
+									InitialMarginPpm:       200000,
+									MaintenanceFractionPpm: 500000,
+									ImpactNotional:         1000000000,
+									OpenInterestLowerCap:   500000000000,
+									OpenInterestUpperCap:   1000000000000,
+								})
 							},
 						)
 						return genesis

--- a/protocol/x/listing/keeper/msg_create_market_permissionless_test.go
+++ b/protocol/x/listing/keeper/msg_create_market_permissionless_test.go
@@ -96,7 +96,7 @@ func TestMsgCreateMarketPermissionless(t *testing.T) {
 							func(genesisState *perpetualstypes.GenesisState) {
 								genesisState.LiquidityTiers = append(genesisState.LiquidityTiers, perpetualstypes.LiquidityTier{
 									Id:                     7,
-									Name:                   "Instant",
+									Name:                   "IML 5x",
 									InitialMarginPpm:       200000,
 									MaintenanceFractionPpm: 500000,
 									ImpactNotional:         1000000000,

--- a/protocol/x/listing/types/constants.go
+++ b/protocol/x/listing/types/constants.go
@@ -5,7 +5,7 @@ const (
 
 	DefaultFundingPpm = 100 // 1bps per 8 hour or 0.125bps per hour
 
-	LiquidityTier_Isolated uint32 = 4
+	LiquidityTier_Instant_5x uint32 = 7
 
 	DefaultStepBaseQuantums uint64 = 1_000_000
 

--- a/protocol/x/listing/types/constants.go
+++ b/protocol/x/listing/types/constants.go
@@ -5,7 +5,7 @@ const (
 
 	DefaultFundingPpm = 100 // 1bps per 8 hour or 0.125bps per hour
 
-	LiquidityTier_Instant_5x uint32 = 7
+	LiquidityTier_IML_5x uint32 = 7
 
 	DefaultStepBaseQuantums uint64 = 1_000_000
 


### PR DESCRIPTION
### Changelist
A proposal was requested by foundation to create a new liquidity tier. Here is the json that was submitted as the new liquidity tier. While the proposal is being pushed out - we also need to update the protocol to use the new liquidity tier (7).

### Test Plan
Update unit tests to reflect usage of new liquidity tier.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Markets now operate with an updated liquidity tier—"IML 5x"—which replaces the previous configuration. This change brings refined defaults for risk and margin parameters during market setups.
	- Added functionality to configure the new liquidity tier during the genesis state setup for tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->