### PR TITLE
Full Node Streaming: filter all pairs when none are specified

### DIFF
--- a/protocol/streaming/full_node_streaming_manager.go
+++ b/protocol/streaming/full_node_streaming_manager.go
@@ -212,6 +212,17 @@ func doFilterStreamUpdateBySubaccount(
 	return false, nil
 }
 
+func doFilterTakerOrderBySubaccount(
+	takerOrder *clobtypes.StreamUpdate_TakerOrder,
+	subaccountIds []satypes.SubaccountId,
+) bool {
+	order := takerOrder.TakerOrder.GetOrder()
+	if slices.Contains(subaccountIds, order.OrderId.SubaccountId) {
+		return true
+	}
+	return false
+}
+
 // If UpdateMessage is not a StreamUpdate_OrderUpdate, filter it
 // If a StreamUpdate_OrderUpdate contains updates for subscribed subaccounts, filter it
 // If a StreamUpdate_OrderUpdate contains no updates for subscribed subaccounts, drop it
@@ -237,7 +248,9 @@ func FilterStreamUpdateBySubaccount(
 				continue
 			}
 		case *clobtypes.StreamUpdate_TakerOrder:
-
+			if !doFilterTakerOrderBySubaccount(updateMessage, subaccountIds) {
+				continue
+			}
 		}
 		filteredUpdates = append(filteredUpdates, update)
 	}

--- a/protocol/streaming/full_node_streaming_manager_test.go
+++ b/protocol/streaming/full_node_streaming_manager_test.go
@@ -288,8 +288,8 @@ func TestFilterStreamUpdates(t *testing.T) {
 	)
 
 	orderBookFillUpdate := NewStreamOrderbookFill(0, 0)
-	clobOrder := NewOrder(NewOrderId("foo", 23))
-	takerOrderUpdate := NewStreamTakerOrder(0, 0, clobOrder, 0, 0)
+	takerOrderUpdate := NewStreamTakerOrder(0, 0, NewOrder(NewOrderId(subaccountId.Owner, subaccountId.Number)), 0, 0)
+	neverInScopeTakerOrderUpdate := NewStreamTakerOrder(0, 0, NewOrder(NewOrderId("foo", 23)), 0, 0)
 	subaccountUpdate := NewSubaccountUpdate(
 		0,
 		0,
@@ -393,15 +393,20 @@ func TestFilterStreamUpdates(t *testing.T) {
 			subaccountIds:   []satypes.SubaccountId{subaccountId},
 			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate, *orderBookFillUpdate},
 		},
-		"takerOrderUpdates": {
-			updates:         []clobtypes.StreamUpdate{*takerOrderUpdate},
+		"takerOrderUpdatesNoIds": {
+			updates:         []clobtypes.StreamUpdate{*neverInScopeTakerOrderUpdate, *takerOrderUpdate},
 			subaccountIds:   []satypes.SubaccountId{},
+			filteredUpdates: []clobtypes.StreamUpdate{},
+		},
+		"takerOrderUpdates": {
+			updates:         []clobtypes.StreamUpdate{*neverInScopeTakerOrderUpdate, *takerOrderUpdate},
+			subaccountIds:   []satypes.SubaccountId{subaccountId},
 			filteredUpdates: []clobtypes.StreamUpdate{*takerOrderUpdate},
 		},
 		"takerOrderUpdatesDropUpdate": {
-			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate, otherStreamUpdate},
+			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *neverInScopeTakerOrderUpdate, otherStreamUpdate},
 			subaccountIds:   []satypes.SubaccountId{},
-			filteredUpdates: []clobtypes.StreamUpdate{*takerOrderUpdate},
+			filteredUpdates: []clobtypes.StreamUpdate{},
 		},
 		"takerOrderUpdatesFilterUpdate": {
 			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate},
@@ -409,7 +414,12 @@ func TestFilterStreamUpdates(t *testing.T) {
 			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate},
 		},
 		"takerOrderUpdatesFilterAndDropUpdate": {
-			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate, otherStreamUpdate},
+			updates: []clobtypes.StreamUpdate{
+				baseStreamUpdate,
+				*neverInScopeTakerOrderUpdate,
+				otherStreamUpdate,
+				*takerOrderUpdate,
+			},
 			subaccountIds:   []satypes.SubaccountId{subaccountId},
 			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate},
 		},

--- a/protocol/streaming/types/errors.go
+++ b/protocol/streaming/types/errors.go
@@ -13,4 +13,9 @@ var (
 		2,
 		"Invalid full node streaming request",
 	)
+	ErrInvalidSubaccountFilteringRequest = errorsmod.Register(
+		ModuleName,
+		3,
+		"Invalid subaccount ID filtering request",
+	)
 )


### PR DESCRIPTION
### Changelist

Currently:
- CLOB pair id's must be specified to filter orders when subaccount id filtering is specified
- other updates specific to subaccounts are not filtered
  - taker orders
  - fills
    - taker
    - liquidation
    - deleveraging

Change subaccount filtering semantics to:
- if pair id's are specified, only filter orders for those pairs
- if pair id's are not specified, filter all orders for specified subaccounts
- filter taker orders and fills by subaccount id like order updates

### Test Plan
Unit Tests
Local validation

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the streaming update service with refined filtering options for subaccount subscriptions, enabling more efficient handling of diverse order updates.
  - Improved error messaging now provides clearer feedback on invalid filtering requests.

- **Tests**
  - Expanded test coverage to verify robust filtering behavior, including scenarios with duplicate subaccount identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->