### PR TITLE
update actions/cache to v4 (v2.1.3 is deprecated)

### DIFF
--- a/.github/workflows/protocol-sim.yml
+++ b/.github/workflows/protocol-sim.yml
@@ -44,7 +44,7 @@ jobs:
         run: go version
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -62,7 +62,7 @@ jobs:
           go-version: 1.22
       - name: Display go version
         run: go version
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -112,7 +112,7 @@ jobs:
           go-version: 1.22
       - name: Display go version
         run: go version
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -162,7 +162,7 @@ jobs:
           go-version: 1.22
       - name: Display go version
         run: go version
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -212,7 +212,7 @@ jobs:
           go-version: 1.22
       - name: Display go version
         run: go version
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/protocol/.github/workflows/release-sims.yml
+++ b/protocol/.github/workflows/release-sims.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install runsim
         run: |
           export GO111MODULE="on" && go get github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -42,7 +42,7 @@ jobs:
         with:
           submodules: recursive
           token: ${{ secrets.GH_REPO_READ_TOKEN }}
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary


### PR DESCRIPTION
### Changelist
v2.1.3 is deprecated. see [workflow failure](https://github.com/dydxprotocol/v4-chain/actions/runs/13819299981)

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the caching mechanism in our continuous integration processes to enhance efficiency and reliability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->