### PR TITLE
allow x/vault MsgUpdateDefaultQuotingParams to be an external msg

### DIFF
--- a/protocol/app/msgs/internal_msgs.go
+++ b/protocol/app/msgs/internal_msgs.go
@@ -206,12 +206,10 @@ var (
 		"/dydxprotocol.stats.MsgUpdateParamsResponse": nil,
 
 		// vault
-		"/dydxprotocol.vault.MsgUnlockShares":                       &vault.MsgUnlockShares{},
-		"/dydxprotocol.vault.MsgUnlockSharesResponse":               nil,
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams":         &vault.MsgUpdateDefaultQuotingParams{},
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse": nil,
-		"/dydxprotocol.vault.MsgUpdateOperatorParams":               &vault.MsgUpdateOperatorParams{},
-		"/dydxprotocol.vault.MsgUpdateOperatorParamsResponse":       nil,
+		"/dydxprotocol.vault.MsgUnlockShares":                 &vault.MsgUnlockShares{},
+		"/dydxprotocol.vault.MsgUnlockSharesResponse":         nil,
+		"/dydxprotocol.vault.MsgUpdateOperatorParams":         &vault.MsgUpdateOperatorParams{},
+		"/dydxprotocol.vault.MsgUpdateOperatorParamsResponse": nil,
 
 		// vest
 		"/dydxprotocol.vest.MsgSetVestEntry":            &vest.MsgSetVestEntry{},

--- a/protocol/app/msgs/internal_msgs_test.go
+++ b/protocol/app/msgs/internal_msgs_test.go
@@ -164,8 +164,6 @@ func TestInternalMsgSamples_Gov_Key(t *testing.T) {
 		// vault
 		"/dydxprotocol.vault.MsgUnlockShares",
 		"/dydxprotocol.vault.MsgUnlockSharesResponse",
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParams",
-		"/dydxprotocol.vault.MsgUpdateDefaultQuotingParamsResponse",
 		"/dydxprotocol.vault.MsgUpdateOperatorParams",
 		"/dydxprotocol.vault.MsgUpdateOperatorParamsResponse",
 

--- a/protocol/lib/ante/internal_msg.go
+++ b/protocol/lib/ante/internal_msg.go
@@ -135,7 +135,6 @@ func IsInternalMsg(msg sdk.Msg) bool {
 
 		// vault
 		*vault.MsgUnlockShares,
-		*vault.MsgUpdateDefaultQuotingParams,
 		*vault.MsgUpdateOperatorParams,
 
 		// vest


### PR DESCRIPTION
### Changelist
allow `MsgUpdateDefaultQuotingParams` in `x/vault` to be an external msg so that an operator can submit this msg without going through governance

### Test Plan
tested on localnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
