### PR TITLE
perf(postgres,comlink): Improve `historical-pnl/parentSubaccount` query 

### DIFF
--- a/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
+++ b/indexer/packages/postgres/src/stores/pnl-ticks-table.ts
@@ -41,58 +41,6 @@ export function uuid(
 }
 
 /**
- * Handles pagination and limit logic for fill queries
- * @param baseQuery The base query to apply pagination to
- * @param limit Maximum number of fills to return
- * @param page Page number
- * @returns Promise<PaginationFromDatabase<FillFromDatabase>>
- */
-// NEXT: generalize as common utility.
-async function handleLimitAndPagination(
-  baseQuery: QueryBuilder<PnlTicksModel>,
-  limit?: number,
-  page?: number,
-): Promise<PaginationFromDatabase<PnlTicksFromDatabase>> {
-  let query = baseQuery;
-
-  /**
-   * If a query is made using a page number, then the limit property is used as 'page limit'
-   */
-  if (page !== undefined && limit !== undefined) {
-    /**
-     * We make sure that the page number is always >= 1
-     */
-    const currentPage: number = Math.max(1, page);
-    const offset: number = (currentPage - 1) * limit;
-
-    /**
-     * Ensure sorting is applied to maintain consistent pagination results.
-     * Also a casting of the ts type is required since the infer of the type
-     * obtained from the count is not performed.
-     */
-    const count: { count?: string } = await query.clone().clearOrder().count({ count: '*' }).first() as unknown as { count?: string };
-
-    query = query.offset(offset).limit(limit);
-
-    return {
-      results: await query.returning('*'),
-      limit,
-      offset,
-      total: parseInt(count.count ?? '0', 10),
-    };
-  }
-
-  // If no pagination, just apply the limit
-  if (limit !== undefined) {
-    query = query.limit(limit);
-  }
-
-  return {
-    results: await query.returning('*'),
-  };
-}
-
-/**
  * Returns fills across all subaccounts belonging to a parent subaccount.
  * A parent subaccount is defined by an address and parent subaccount number,
  * where child subaccounts have subaccount numbers in increments of 128 from the parent.
@@ -105,10 +53,9 @@ async function handleLimitAndPagination(
 export async function getPnlTicksForParentSubaccount(
   address: string,
   parentSubaccountNumber: number,
-  limit: number,
+  limit?: number,
   createdBeforeOrAt?: string,
   createdOnOrAfter?: string,
-  page?: number,
 ): Promise<PaginationFromDatabase<PnlTicksFromDatabase>> {
   // Create base query to get subaccount IDs
   const subaccountQuery = knexReadReplica.getConnection()
@@ -142,7 +89,14 @@ export async function getPnlTicksForParentSubaccount(
     baseQuery = baseQuery.where(PnlTicksColumns.createdAt, '>=', createdOnOrAfter);
   }
 
-  return handleLimitAndPagination(baseQuery, limit, page);
+  // If no pagination, just apply the limit
+  if (limit !== undefined) {
+    baseQuery = baseQuery.limit(limit);
+  }
+
+  return {
+    results: await baseQuery.returning('*'),
+  };
 }
 
 export async function findAll(

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -96,7 +96,7 @@ export enum QueryableField {
   KEY = 'key',
   TOKEN = 'token',
   ADDRESS_IN_WALLETS_TABLE = 'addressInWalletsTable',
-  PARENT_SUBACCOUNT = 'parentSubaccount'
+  PARENT_SUBACCOUNT = 'parentSubaccount',
 }
 
 export interface QueryConfig {
@@ -278,6 +278,7 @@ export interface PnlTicksQueryConfig extends QueryConfig {
   [QueryableField.CREATED_BEFORE_OR_AT_BLOCK_HEIGHT]?: string,
   [QueryableField.CREATED_ON_OR_AFTER]?: string,
   [QueryableField.CREATED_ON_OR_AFTER_BLOCK_HEIGHT]?: string,
+  [QueryableField.PARENT_SUBACCOUNT]?: ParentSubaccount,
 }
 
 export interface FundingIndexUpdatesQueryConfig extends QueryConfig {

--- a/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
@@ -107,8 +107,10 @@ class HistoricalPnlController extends Controller {
     @Query() address: string,
       @Query() parentSubaccountNumber: number,
       @Query() limit?: number,
+      // NEXT: remove
       @Query() createdBeforeOrAtHeight?: number,
       @Query() createdBeforeOrAt?: IsoString,
+      // NEXT: remove this
       @Query() createdOnOrAfterHeight?: number,
       @Query() createdOnOrAfter?: IsoString,
   ): Promise<HistoricalPnlResponse> {

--- a/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
@@ -131,25 +131,32 @@ class HistoricalPnlController extends Controller {
         },
         [QueryableField.ID],
       ),
-      PnlTicksTable.findAll(
-        {
-          subaccountId: childSubaccountIds,
-          limit,
-          createdBeforeOrAtBlockHeight: createdBeforeOrAtHeight
-            ? createdBeforeOrAtHeight.toString()
-            : undefined,
-          createdBeforeOrAt,
-          createdOnOrAfterBlockHeight: createdOnOrAfterHeight
-            ? createdOnOrAfterHeight.toString()
-            : undefined,
-          createdOnOrAfter,
-        },
-        [QueryableField.LIMIT],
-        {
-          ...DEFAULT_POSTGRES_OPTIONS,
-          orderBy: [[QueryableField.BLOCK_HEIGHT, Ordering.DESC]],
-        },
+      PnlTicksTable.getPnlTicksForParentSubaccount(
+        address,
+        parentSubaccountNumber,
+        limit,
+        createdBeforeOrAt,
+        createdOnOrAfter,
       ),
+      // PnlTicksTable.findAll(
+      //   {
+      //     subaccountId: childSubaccountIds,
+      //     limit,
+      //     createdBeforeOrAtBlockHeight: createdBeforeOrAtHeight
+      //       ? createdBeforeOrAtHeight.toString()
+      //       : undefined,
+      //     createdBeforeOrAt,
+      //     createdOnOrAfterBlockHeight: createdOnOrAfterHeight
+      //       ? createdOnOrAfterHeight.toString()
+      //       : undefined,
+      //     createdOnOrAfter,
+      //   },
+      //   [QueryableField.LIMIT],
+      //   {
+      //     ...DEFAULT_POSTGRES_OPTIONS,
+      //     orderBy: [[QueryableField.BLOCK_HEIGHT, Ordering.DESC]],
+      //   },
+      // ),
     ]);
 
     if (subaccounts.length === 0) {

--- a/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
@@ -107,10 +107,8 @@ class HistoricalPnlController extends Controller {
     @Query() address: string,
       @Query() parentSubaccountNumber: number,
       @Query() limit?: number,
-      // NEXT: remove
       @Query() createdBeforeOrAtHeight?: number,
       @Query() createdBeforeOrAt?: IsoString,
-      // NEXT: remove this
       @Query() createdOnOrAfterHeight?: number,
       @Query() createdOnOrAfter?: IsoString,
   ): Promise<HistoricalPnlResponse> {
@@ -131,32 +129,28 @@ class HistoricalPnlController extends Controller {
         },
         [QueryableField.ID],
       ),
-      PnlTicksTable.getPnlTicksForParentSubaccount(
-        address,
-        parentSubaccountNumber,
-        limit,
-        createdBeforeOrAt,
-        createdOnOrAfter,
+      PnlTicksTable.findAll(
+        {
+          parentSubaccount: {
+            address,
+            subaccountNumber: parentSubaccountNumber,
+          },
+          limit,
+          createdBeforeOrAtBlockHeight: createdBeforeOrAtHeight
+            ? createdBeforeOrAtHeight.toString()
+            : undefined,
+          createdBeforeOrAt,
+          createdOnOrAfterBlockHeight: createdOnOrAfterHeight
+            ? createdOnOrAfterHeight.toString()
+            : undefined,
+          createdOnOrAfter,
+        },
+        [QueryableField.LIMIT],
+        {
+          ...DEFAULT_POSTGRES_OPTIONS,
+          orderBy: [[QueryableField.BLOCK_HEIGHT, Ordering.DESC]],
+        },
       ),
-      // PnlTicksTable.findAll(
-      //   {
-      //     subaccountId: childSubaccountIds,
-      //     limit,
-      //     createdBeforeOrAtBlockHeight: createdBeforeOrAtHeight
-      //       ? createdBeforeOrAtHeight.toString()
-      //       : undefined,
-      //     createdBeforeOrAt,
-      //     createdOnOrAfterBlockHeight: createdOnOrAfterHeight
-      //       ? createdOnOrAfterHeight.toString()
-      //       : undefined,
-      //     createdOnOrAfter,
-      //   },
-      //   [QueryableField.LIMIT],
-      //   {
-      //     ...DEFAULT_POSTGRES_OPTIONS,
-      //     orderBy: [[QueryableField.BLOCK_HEIGHT, Ordering.DESC]],
-      //   },
-      // ),
     ]);
 
     if (subaccounts.length === 0) {


### PR DESCRIPTION
### Changelist
Instead of passing in all possible `childSubaccountid` into `findAll`, add a subquery that retrieves existing subaccounts. 

### Test Plan
- Current unit tests passed
- Tested hotfix on internal mainnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering historical PnL data using a parent subaccount identifier (including address and subaccount number).
  - Implemented validation to ensure that child and parent subaccount filters are not used simultaneously.
  - Enhanced query configuration for more accurate parent-child account data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->