### PR TITLE
perf(postgres,comlink): Improve `order/parentSubaccount` query

### DIFF
--- a/indexer/packages/postgres/src/stores/order-table.ts
+++ b/indexer/packages/postgres/src/stores/order-table.ts
@@ -2,7 +2,13 @@ import { IndexerOrderId } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
 import { QueryBuilder } from 'objection';
 
-import { BUFFER_ENCODING_UTF_8, DEFAULT_POSTGRES_OPTIONS } from '../constants';
+import {
+  BUFFER_ENCODING_UTF_8,
+  DEFAULT_POSTGRES_OPTIONS,
+  MAX_PARENT_SUBACCOUNTS,
+  CHILD_SUBACCOUNT_MULTIPLIER,
+} from '../constants';
+import { knexReadReplica } from '../helpers/knex';
 import { setupBaseQuery, verifyAllRequiredFields } from '../helpers/stores-helpers';
 import Transaction from '../helpers/transaction';
 import { getUuid } from '../helpers/uuid';
@@ -69,12 +75,17 @@ export async function findAll(
     goodTilBlockTimeBeforeOrAt,
     goodTilBlockTimeAfter,
     clientMetadata,
+    parentSubaccount,
     triggerPrice,
     page,
   }: OrderQueryConfig,
   requiredFields: QueryableField[],
   options: Options = DEFAULT_POSTGRES_OPTIONS,
 ): Promise<PaginationFromDatabase<OrderFromDatabase>> {
+  if (subaccountId !== undefined && parentSubaccount !== undefined) {
+    throw new Error('Cannot specify both subaccountId and parentSubaccount in order query');
+  }
+
   verifyAllRequiredFields(
     {
       limit,
@@ -93,6 +104,7 @@ export async function findAll(
       goodTilBlockBeforeOrAt,
       goodTilBlockTimeBeforeOrAt,
       clientMetadata,
+      parentSubaccount,
     } as QueryConfig,
     requiredFields,
   );
@@ -108,6 +120,26 @@ export async function findAll(
 
   if (subaccountId !== undefined) {
     baseQuery = baseQuery.whereIn(OrderColumns.subaccountId, subaccountId);
+  } else if (parentSubaccount !== undefined) {
+    const subaccountQuery = knexReadReplica.getConnection()
+      .select('id as subaccountId')
+      .from('subaccounts')
+      .where('address', parentSubaccount.address)
+      .whereRaw(
+        `"subaccountNumber" IN (
+          SELECT generate_series(
+            ?, 
+            ? + ${MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER}, 
+            ${MAX_PARENT_SUBACCOUNTS}
+          )
+        )`,
+        [parentSubaccount.subaccountNumber, parentSubaccount.subaccountNumber],
+      );
+
+    baseQuery = baseQuery.whereIn(
+      OrderColumns.subaccountId,
+      subaccountQuery,
+    );
   }
 
   if (clientId !== undefined) {

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -5,6 +5,7 @@ import { Liquidity } from './fill-types';
 import { OrderSide, OrderStatus, OrderType } from './order-types';
 import { PerpetualPositionStatus } from './perpetual-position-types';
 import { PositionSide } from './position-types';
+import { ParentSubaccount } from './subaccount-types';
 import { TradingRewardAggregationPeriod } from './trading-reward-aggregation-types';
 import { IsoString } from './utility-types';
 
@@ -95,6 +96,7 @@ export enum QueryableField {
   KEY = 'key',
   TOKEN = 'token',
   ADDRESS_IN_WALLETS_TABLE = 'addressInWalletsTable',
+  PARENT_SUBACCOUNT = 'parentSubaccount'
 }
 
 export interface QueryConfig {
@@ -149,6 +151,7 @@ export interface OrderQueryConfig extends QueryConfig {
   [QueryableField.ORDER_FLAGS]?: string,
   [QueryableField.CLIENT_METADATA]?: string,
   [QueryableField.TRIGGER_PRICE]?: string,
+  [QueryableField.PARENT_SUBACCOUNT]?: ParentSubaccount,
 }
 
 export interface PerpetualMarketQueryConfig extends QueryConfig {

--- a/indexer/packages/postgres/src/types/subaccount-types.ts
+++ b/indexer/packages/postgres/src/types/subaccount-types.ts
@@ -22,3 +22,8 @@ export enum SubaccountColumns {
   updatedAt = 'updatedAt',
   updatedAtHeight = 'updatedAtHeight',
 }
+
+export interface ParentSubaccount {
+  address: string,
+  subaccountNumber: number,
+}


### PR DESCRIPTION
### Changelist

Instead of passing in all possible childSubaccountid into findAll, add a subquery that retrieves existing subaccounts.

### Test Plan
• Current unit tests passed
• Tested hotfix on internal mainnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced parent subaccount support for order queries, allowing searches based on a parent account’s address and subaccount number.
  - Improved query validations to ensure that only one identifier (either an individual subaccount or a parent subaccount) is provided per request.
  - Expanded order query configuration options for more flexible filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->