### PR TITLE
Full Node Streaming: filter all pairs when none are specified

### DIFF
--- a/protocol/streaming/full_node_streaming_manager.go
+++ b/protocol/streaming/full_node_streaming_manager.go
@@ -43,16 +43,12 @@ type FullNodeStreamingManagerImpl struct {
 	// TODO: Consolidate the streamUpdateCache and streamUpdateSubscriptionCache into a single
 	// struct to avoid the need to maintain two separate slices for the same data.
 
-	// list of stream updates.
-	streamUpdateCache []clobtypes.StreamUpdate
-	// list of subscription ids for each stream update.
-	streamUpdateSubscriptionCache [][]uint32
-	// map from clob pair id to subscription ids.
-	clobPairIdToSubscriptionIdMapping map[uint32][]uint32
-	// map from subaccount id to subscription ids.
+	streamUpdateCache                   []clobtypes.StreamUpdate
+	streamUpdateSubscriptionCache       [][]uint32
+	clobPairIdToSubscriptionIdMapping   map[uint32][]uint32
 	subaccountIdToSubscriptionIdMapping map[satypes.SubaccountId][]uint32
-	// map from market id to subscription ids.
-	marketIdToSubscriptionIdMapping map[uint32][]uint32
+	marketIdToSubscriptionIdMapping     map[uint32][]uint32
+	allClobPairSubscriptionIdMapping    map[uint32]struct{}
 
 	maxUpdatesInCache          uint32
 	maxSubscriptionChannelSize uint32
@@ -71,27 +67,25 @@ type FullNodeStreamingManagerImpl struct {
 type OrderbookSubscription struct {
 	subscriptionId uint32
 
-	// Whether the subscription is initialized with snapshot.
-	initialized *atomic.Bool
+	initializedWithSnapshot *atomic.Bool
+	clobPairIds             []uint32
+	subaccountIds           []satypes.SubaccountId
+	marketIds               []uint32
 
-	// Clob pair ids to subscribe to.
-	clobPairIds []uint32
-
-	// Subaccount ids to subscribe to.
-	subaccountIds []satypes.SubaccountId
-
-	// market ids to subscribe to.
-	marketIds []uint32
-
-	// Stream
-	messageSender types.OutgoingMessageSender
-
-	// Channel to buffer writes before the stream
-	updatesChannel chan []clobtypes.StreamUpdate
+	messageSender        types.OutgoingMessageSender
+	streamUpdatesChannel chan []clobtypes.StreamUpdate
 
 	// If interval snapshots are turned on, the next block height at which
 	// a snapshot should be sent out.
 	nextSnapshotBlock uint32
+}
+
+func (sm *FullNodeStreamingManagerImpl) AllClobPairSubscriptionIds() []uint32 {
+	allClobPairSubscriptionIds := []uint32{}
+	for subscriptionId := range sm.allClobPairSubscriptionIdMapping {
+		allClobPairSubscriptionIds = append(allClobPairSubscriptionIds, subscriptionId)
+	}
+	return allClobPairSubscriptionIds
 }
 
 func (sm *FullNodeStreamingManagerImpl) NewOrderbookSubscription(
@@ -101,18 +95,18 @@ func (sm *FullNodeStreamingManagerImpl) NewOrderbookSubscription(
 	messageSender types.OutgoingMessageSender,
 ) *OrderbookSubscription {
 	return &OrderbookSubscription{
-		subscriptionId: sm.getNextAvailableSubscriptionId(),
-		initialized:    &atomic.Bool{}, // False by default.
-		clobPairIds:    clobPairIds,
-		subaccountIds:  subaccountIds,
-		marketIds:      marketIds,
-		messageSender:  messageSender,
-		updatesChannel: make(chan []clobtypes.StreamUpdate, sm.maxSubscriptionChannelSize),
+		subscriptionId:          sm.getNextAvailableSubscriptionId(),
+		initializedWithSnapshot: &atomic.Bool{}, // False by default.
+		clobPairIds:             clobPairIds,
+		subaccountIds:           subaccountIds,
+		marketIds:               marketIds,
+		messageSender:           messageSender,
+		streamUpdatesChannel:    make(chan []clobtypes.StreamUpdate, sm.maxSubscriptionChannelSize),
 	}
 }
 
 func (sub *OrderbookSubscription) IsInitialized() bool {
-	return sub.initialized.Load()
+	return sub.initializedWithSnapshot.Load()
 }
 
 func NewFullNodeStreamingManager(
@@ -136,6 +130,7 @@ func NewFullNodeStreamingManager(
 		clobPairIdToSubscriptionIdMapping:   make(map[uint32][]uint32),
 		subaccountIdToSubscriptionIdMapping: make(map[satypes.SubaccountId][]uint32),
 		marketIdToSubscriptionIdMapping:     make(map[uint32][]uint32),
+		allClobPairSubscriptionIdMapping:    make(map[uint32]struct{}),
 
 		maxUpdatesInCache:          maxUpdatesInCache,
 		maxSubscriptionChannelSize: maxSubscriptionChannelSize,
@@ -186,7 +181,7 @@ func (sm *FullNodeStreamingManagerImpl) EmitMetrics() {
 	for _, subscription := range sm.orderbookSubscriptions {
 		metrics.AddSampleWithLabels(
 			metrics.GrpcSubscriptionChannelLength,
-			float32(len(subscription.updatesChannel)),
+			float32(len(subscription.streamUpdatesChannel)),
 			metrics.GetLabelForIntValue(metrics.SubscriptionId, int(subscription.subscriptionId)),
 		)
 	}
@@ -202,19 +197,87 @@ func (sm *FullNodeStreamingManagerImpl) getNextAvailableSubscriptionId() uint32 
 	return id
 }
 
-func doFilterStreamUpdateBySubaccount(
+func doFilterOrderbookUpdateBySubaccount(
 	orderBookUpdate *clobtypes.StreamUpdate_OrderbookUpdate,
 	subaccountIds []satypes.SubaccountId,
 ) (bool, error) {
+	if orderBookUpdate.OrderbookUpdate.Snapshot {
+		return true, nil
+	}
 	for _, orderBookUpdate := range orderBookUpdate.OrderbookUpdate.Updates {
 		orderBookUpdateSubaccountId, err := streaming_util.GetOffChainUpdateV1SubaccountId(orderBookUpdate)
 		if err != nil {
 			return false, err
-		} else if slices.Contains(subaccountIds, orderBookUpdateSubaccountId) {
+		}
+		if slices.Contains(subaccountIds, orderBookUpdateSubaccountId) {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+func doFilterTakerOrderBySubaccount(
+	takerOrder *clobtypes.StreamUpdate_TakerOrder,
+	subaccountIds []satypes.SubaccountId,
+) bool {
+	return slices.Contains(subaccountIds, takerOrder.TakerOrder.GetOrder().OrderId.SubaccountId)
+}
+
+func doFilterOrderFillBySubaccount(
+	orderFill *clobtypes.StreamUpdate_OrderFill,
+	subaccountIds []satypes.SubaccountId,
+) bool {
+	switch match := orderFill.OrderFill.GetClobMatch().GetMatch().(type) {
+	case *clobtypes.ClobMatch_MatchOrders:
+		if slices.Contains(subaccountIds, match.MatchOrders.TakerOrderId.SubaccountId) {
+			return true
+		}
+		for _, fill := range match.MatchOrders.Fills {
+			if slices.Contains(subaccountIds, fill.MakerOrderId.SubaccountId) {
+				return true
+			}
+		}
+		return false
+	case *clobtypes.ClobMatch_MatchPerpetualLiquidation:
+		if slices.Contains(subaccountIds, match.MatchPerpetualLiquidation.Liquidated) {
+			return true
+		}
+		for _, fill := range match.MatchPerpetualLiquidation.Fills {
+			if slices.Contains(subaccountIds, fill.MakerOrderId.SubaccountId) {
+				return true
+			}
+		}
+		return false
+	case *clobtypes.ClobMatch_MatchPerpetualDeleveraging:
+		if slices.Contains(subaccountIds, match.MatchPerpetualDeleveraging.Liquidated) {
+			return true
+		}
+		for _, fill := range match.MatchPerpetualDeleveraging.Fills {
+			if slices.Contains(subaccountIds, fill.OffsettingSubaccountId) {
+				return true
+			}
+		}
+		return false
+	case nil:
+		return false
+	}
+	return true
+}
+
+func doFilterStreamUpdateBySubaccount(
+	update *clobtypes.StreamUpdate,
+	subaccountIds []satypes.SubaccountId,
+) (bool, error) {
+	// If reflection becomes too expensive, split updatesChannel by message type
+	switch updateMessage := update.UpdateMessage.(type) {
+	case *clobtypes.StreamUpdate_OrderbookUpdate:
+		return doFilterOrderbookUpdateBySubaccount(updateMessage, subaccountIds)
+	case *clobtypes.StreamUpdate_TakerOrder:
+		return doFilterTakerOrderBySubaccount(updateMessage, subaccountIds), nil
+	case *clobtypes.StreamUpdate_OrderFill:
+		return doFilterOrderFillBySubaccount(updateMessage, subaccountIds), nil
+	}
+	return true, nil
 }
 
 // If UpdateMessage is not a StreamUpdate_OrderUpdate, filter it
@@ -226,28 +289,19 @@ func FilterStreamUpdateBySubaccount(
 	subaccountIds []satypes.SubaccountId,
 	logger log.Logger,
 ) []clobtypes.StreamUpdate {
-	// If reflection becomes too expensive, split updatesChannel by message type
 	filteredUpdates := []clobtypes.StreamUpdate{}
 	for _, update := range updates {
-		switch updateMessage := update.UpdateMessage.(type) {
-		case *clobtypes.StreamUpdate_OrderbookUpdate:
-			if updateMessage.OrderbookUpdate.Snapshot {
-				break
-			}
-			doFilter, err := doFilterStreamUpdateBySubaccount(updateMessage, subaccountIds)
-			if err != nil {
-				logger.Error(err.Error())
-			}
-			if !doFilter {
-				continue
-			}
+		doFilter, err := doFilterStreamUpdateBySubaccount(&update, subaccountIds)
+		if err != nil {
+			logger.Error(err.Error())
 		}
-		filteredUpdates = append(filteredUpdates, update)
+		if doFilter {
+			filteredUpdates = append(filteredUpdates, update)
+		}
 	}
 	return filteredUpdates
 }
 
-// Subscribe subscribes to the orderbook updates stream.
 func (sm *FullNodeStreamingManagerImpl) Subscribe(
 	clobPairIds []uint32,
 	subaccountIds []*satypes.SubaccountId,
@@ -263,7 +317,7 @@ func (sm *FullNodeStreamingManagerImpl) Subscribe(
 	}
 	if filterOrdersBySubAccountId && (len(subaccountIds) == 0) {
 		sm.logger.Error("filterOrdersBySubaccountId with no subaccountIds")
-		return types.ErrInvalidStreamingRequest
+		return types.ErrInvalidSubaccountFilteringRequest
 	}
 
 	sm.Lock()
@@ -273,7 +327,9 @@ func (sm *FullNodeStreamingManagerImpl) Subscribe(
 	}
 
 	subscription := sm.NewOrderbookSubscription(clobPairIds, sIds, marketIds, messageSender)
-
+	if len(clobPairIds) == 0 {
+		sm.allClobPairSubscriptionIdMapping[subscription.subscriptionId] = struct{}{}
+	}
 	for _, clobPairId := range clobPairIds {
 		// if clobPairId exists in the map, append the subscription id to the slice
 		// otherwise, create a new slice with the subscription id
@@ -308,11 +364,17 @@ func (sm *FullNodeStreamingManagerImpl) Subscribe(
 		)
 	}
 
+	var clobPairIdString string
+	if _, ok := sm.allClobPairSubscriptionIdMapping[subscription.subscriptionId]; ok {
+		clobPairIdString = "*"
+	} else {
+		clobPairIdString = fmt.Sprintf("%+v", clobPairIds)
+	}
 	sm.logger.Info(
 		fmt.Sprintf(
-			"New subscription id %+v for clob pair ids: %+v and subaccount ids: %+v. filter orders by subaccount ids: %+v",
+			"New subscription id %+v for clob pair ids: %v and subaccount ids: %+v. filter orders by subaccount ids: %+v",
 			subscription.subscriptionId,
-			clobPairIds,
+			clobPairIdString,
 			subaccountIds,
 			filterOrdersBySubAccountId,
 		),
@@ -324,7 +386,7 @@ func (sm *FullNodeStreamingManagerImpl) Subscribe(
 
 	// Use current goroutine to consistently poll subscription channel for updates
 	// to send through stream.
-	for updates := range subscription.updatesChannel {
+	for updates := range subscription.streamUpdatesChannel {
 		if filterOrdersBySubAccountId {
 			updates = FilterStreamUpdateBySubaccount(updates, sIds, sm.logger)
 		}
@@ -374,9 +436,10 @@ func (sm *FullNodeStreamingManagerImpl) removeSubscription(
 	if subscription == nil {
 		return
 	}
-	close(subscription.updatesChannel)
+	close(subscription.streamUpdatesChannel)
 	delete(sm.orderbookSubscriptions, subscriptionIdToRemove)
 	delete(sm.activeSubscriptionIds, subscriptionIdToRemove)
+	delete(sm.allClobPairSubscriptionIdMapping, subscriptionIdToRemove)
 
 	// Iterate over the clobPairIdToSubscriptionIdMapping to remove the subscriptionIdToRemove
 	for pairId, subscriptionIds := range sm.clobPairIdToSubscriptionIdMapping {
@@ -511,7 +574,7 @@ func (sm *FullNodeStreamingManagerImpl) sendStreamUpdates(
 	)
 
 	select {
-	case subscription.updatesChannel <- streamUpdates:
+	case subscription.streamUpdatesChannel <- streamUpdates:
 	default:
 		// Buffer is full. Emit metric and drop subscription.
 		sm.EmitMetrics()
@@ -992,7 +1055,7 @@ func (sm *FullNodeStreamingManagerImpl) FlushStreamUpdatesWithLock() {
 				metrics.GetLabelForIntValue(metrics.SubscriptionId, int(id)),
 			)
 			select {
-			case subscription.updatesChannel <- updates:
+			case subscription.streamUpdatesChannel <- updates:
 			default:
 				// Buffer is full. Emit metric and drop subscription.
 				sm.EmitMetrics()
@@ -1026,7 +1089,7 @@ func (sm *FullNodeStreamingManagerImpl) GetSubaccountSnapshotsForInitStreams(
 	ret := make(map[satypes.SubaccountId]*satypes.StreamSubaccountUpdate)
 	for _, subscription := range sm.orderbookSubscriptions {
 		// If the subscription has been initialized, no need to grab the subaccount snapshot.
-		if alreadyInitialized := subscription.initialized.Load(); alreadyInitialized {
+		if alreadyInitialized := subscription.initializedWithSnapshot.Load(); alreadyInitialized {
 			continue
 		}
 
@@ -1050,7 +1113,7 @@ func (sm *FullNodeStreamingManagerImpl) GetPriceSnapshotsForInitStreams(
 	ret := make(map[uint32]*pricestypes.StreamPriceUpdate)
 	for _, subscription := range sm.orderbookSubscriptions {
 		// If the subscription has been initialized, no need to grab the price snapshot.
-		if alreadyInitialized := subscription.initialized.Load(); alreadyInitialized {
+		if alreadyInitialized := subscription.initializedWithSnapshot.Load(); alreadyInitialized {
 			continue
 		}
 
@@ -1074,10 +1137,12 @@ func (sm *FullNodeStreamingManagerImpl) cacheStreamUpdatesByClobPairWithLock(
 	clobPairIds []uint32,
 ) {
 	sm.streamUpdateCache = append(sm.streamUpdateCache, streamUpdates...)
+	allClobPairSubscriptionIds := sm.AllClobPairSubscriptionIds()
 	for _, clobPairId := range clobPairIds {
+		subscriptionIds := append(sm.clobPairIdToSubscriptionIdMapping[clobPairId], allClobPairSubscriptionIds...)
 		sm.streamUpdateSubscriptionCache = append(
 			sm.streamUpdateSubscriptionCache,
-			sm.clobPairIdToSubscriptionIdMapping[clobPairId],
+			subscriptionIds,
 		)
 	}
 }
@@ -1252,7 +1317,7 @@ func (sm *FullNodeStreamingManagerImpl) InitializeNewStreams(
 	updatesByClobPairId := make(map[uint32]*clobtypes.OffchainUpdates)
 
 	for subscriptionId, subscription := range sm.orderbookSubscriptions {
-		if alreadyInitialized := subscription.initialized.Swap(true); !alreadyInitialized {
+		if alreadyInitialized := subscription.initializedWithSnapshot.Swap(true); !alreadyInitialized {
 			allUpdates := clobtypes.NewOffchainUpdates()
 			for _, clobPairId := range subscription.clobPairIds {
 				if _, ok := updatesByClobPairId[clobPairId]; !ok {
@@ -1306,7 +1371,7 @@ func (sm *FullNodeStreamingManagerImpl) InitializeNewStreams(
 		// reset the `atomic.Bool` so snapshots are sent for the next block.
 		if sm.snapshotBlockInterval > 0 &&
 			blockHeight+1 == subscription.nextSnapshotBlock {
-			subscription.initialized = &atomic.Bool{} // False by default.
+			subscription.initializedWithSnapshot = &atomic.Bool{} // False by default.
 		}
 	}
 }

--- a/protocol/streaming/full_node_streaming_manager_test.go
+++ b/protocol/streaming/full_node_streaming_manager_test.go
@@ -89,7 +89,7 @@ func toStreamUpdate(snapshot bool, offChainUpdates ...ocutypes.OffChainUpdateV1)
 	}
 }
 
-func NewStreamOrderbookFill(
+func NewStreamUpdateNilOrderbookFill(
 	blockHeight uint32,
 	execMode uint32,
 ) *clobtypes.StreamUpdate {
@@ -98,6 +98,47 @@ func NewStreamOrderbookFill(
 		ExecMode:    execMode,
 		UpdateMessage: &clobtypes.StreamUpdate_OrderFill{
 			OrderFill: nil,
+		},
+	}
+}
+
+func NewStreamUpdateOrderbookFill(
+	blockHeight uint32,
+	execMode uint32,
+	takerSubaccountId satypes.SubaccountId,
+	makerSubaccountIds []satypes.SubaccountId,
+) *clobtypes.StreamUpdate {
+	makerFills := []clobtypes.MakerFill{}
+	for _, makerSubaccountId := range makerSubaccountIds {
+		makerFill := clobtypes.MakerFill{
+			FillAmount: 1,
+			MakerOrderId: clobtypes.OrderId{
+				SubaccountId: makerSubaccountId,
+				ClientId:     uint32(0),
+				OrderFlags:   uint32(0),
+				ClobPairId:   uint32(0),
+			},
+		}
+		makerFills = append(makerFills, makerFill)
+	}
+	return &clobtypes.StreamUpdate{
+		BlockHeight: blockHeight,
+		ExecMode:    execMode,
+		UpdateMessage: &clobtypes.StreamUpdate_OrderFill{
+			OrderFill: &clobtypes.StreamOrderbookFill{
+				ClobMatch: &clobtypes.ClobMatch{
+					Match: &clobtypes.ClobMatch_MatchOrders{
+						MatchOrders: &clobtypes.MatchOrders{
+							TakerOrderId: clobtypes.OrderId{
+								SubaccountId: takerSubaccountId,
+							},
+							Fills: makerFills,
+						},
+					},
+				},
+				Orders:      nil,
+				FillAmounts: nil,
+			},
 		},
 	}
 }
@@ -287,17 +328,62 @@ func TestFilterStreamUpdates(t *testing.T) {
 		otherUpdateOrder,
 	)
 
-	orderBookFillUpdate := NewStreamOrderbookFill(0, 0)
-	clobOrder := NewOrder(NewOrderId("foo", 23))
-	takerOrderUpdate := NewStreamTakerOrder(0, 0, clobOrder, 0, 0)
+	nilOrderBookFillUpdate := NewStreamUpdateNilOrderbookFill(0, 0)
+	baseTakerOtherMakerOrderBookFillUpdate := NewStreamUpdateOrderbookFill(
+		0,
+		0,
+		subaccountId,
+		[]satypes.SubaccountId{otherSubaccountId},
+	)
+	otherTakerBaseMakerOrderBookFillUpdate := NewStreamUpdateOrderbookFill(
+		0,
+		0,
+		otherSubaccountId,
+		[]satypes.SubaccountId{subaccountId},
+	)
+
+	takerOrderUpdate := NewStreamTakerOrder(0, 0, NewOrder(NewOrderId(subaccountId.Owner, subaccountId.Number)), 0, 0)
+
+	neverInScopeTakerOrderUpdate := NewStreamTakerOrder(0, 0, NewOrder(NewOrderId("foo", 23)), 0, 0)
+
 	subaccountUpdate := NewSubaccountUpdate(
 		0,
 		0,
 		(*satypes.SubaccountId)(&orderId.SubaccountId),
 	)
+
 	priceUpdate := NewPriceUpdate(0, 0)
 
 	tests := map[string]TestCase{
+		"baseMakerInScopeOrderbookFill": {
+			updates:         []clobtypes.StreamUpdate{*otherTakerBaseMakerOrderBookFillUpdate},
+			subaccountIds:   []satypes.SubaccountId{subaccountId},
+			filteredUpdates: []clobtypes.StreamUpdate{*otherTakerBaseMakerOrderBookFillUpdate},
+		},
+		"otherTakerInScopeOrderbookFill": {
+			updates:         []clobtypes.StreamUpdate{*otherTakerBaseMakerOrderBookFillUpdate},
+			subaccountIds:   []satypes.SubaccountId{otherSubaccountId},
+			filteredUpdates: []clobtypes.StreamUpdate{*otherTakerBaseMakerOrderBookFillUpdate},
+		},
+		"bothInScopeOrderbookFill": {
+			updates: []clobtypes.StreamUpdate{
+				*baseTakerOtherMakerOrderBookFillUpdate,
+				*otherTakerBaseMakerOrderBookFillUpdate,
+			},
+			subaccountIds: []satypes.SubaccountId{otherSubaccountId},
+			filteredUpdates: []clobtypes.StreamUpdate{
+				*baseTakerOtherMakerOrderBookFillUpdate,
+				*otherTakerBaseMakerOrderBookFillUpdate,
+			},
+		},
+		"neitherInScopeOrderbookFill": {
+			updates: []clobtypes.StreamUpdate{
+				*baseTakerOtherMakerOrderBookFillUpdate,
+				*otherTakerBaseMakerOrderBookFillUpdate,
+			},
+			subaccountIds:   []satypes.SubaccountId{},
+			filteredUpdates: []clobtypes.StreamUpdate{},
+		},
 		"snapshotNotInScope": {
 			updates:         []clobtypes.StreamUpdate{snapshotBaseStreamUpdate},
 			subaccountIds:   []satypes.SubaccountId{neverInScopeSubaccountId},
@@ -373,35 +459,40 @@ func TestFilterStreamUpdates(t *testing.T) {
 			subaccountIds:   []satypes.SubaccountId{},
 			filteredUpdates: []clobtypes.StreamUpdate{},
 		},
-		"orderBookFillUpdates": {
-			updates:         []clobtypes.StreamUpdate{*orderBookFillUpdate},
+		"nilOrderBookFillUpdates": {
+			updates:         []clobtypes.StreamUpdate{*nilOrderBookFillUpdate},
 			subaccountIds:   []satypes.SubaccountId{},
-			filteredUpdates: []clobtypes.StreamUpdate{*orderBookFillUpdate},
+			filteredUpdates: []clobtypes.StreamUpdate{},
 		},
-		"orderBookFillUpdatesDropUpdate": {
-			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *orderBookFillUpdate, otherStreamUpdate},
+		"noUpdatesInScopeDropNilOrderBookFillUpdate": {
+			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *nilOrderBookFillUpdate, otherStreamUpdate},
 			subaccountIds:   []satypes.SubaccountId{},
-			filteredUpdates: []clobtypes.StreamUpdate{*orderBookFillUpdate},
+			filteredUpdates: []clobtypes.StreamUpdate{},
 		},
-		"orderBookFillUpdatesFilterUpdate": {
-			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *orderBookFillUpdate},
+		"filterUpdateDropNilOrderBookFillUpdate": {
+			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *nilOrderBookFillUpdate},
 			subaccountIds:   []satypes.SubaccountId{subaccountId},
-			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate, *orderBookFillUpdate},
+			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate},
 		},
-		"orderBookFillUpdatesFilterAndDropUpdate": {
-			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *orderBookFillUpdate, otherStreamUpdate},
+		"filterUpdateDropNilOrderBookFillUpdateDropOtherUpdate": {
+			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *nilOrderBookFillUpdate, otherStreamUpdate},
 			subaccountIds:   []satypes.SubaccountId{subaccountId},
-			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate, *orderBookFillUpdate},
+			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate},
+		},
+		"takerOrderUpdatesNoIds": {
+			updates:         []clobtypes.StreamUpdate{*neverInScopeTakerOrderUpdate, *takerOrderUpdate},
+			subaccountIds:   []satypes.SubaccountId{},
+			filteredUpdates: []clobtypes.StreamUpdate{},
 		},
 		"takerOrderUpdates": {
-			updates:         []clobtypes.StreamUpdate{*takerOrderUpdate},
-			subaccountIds:   []satypes.SubaccountId{},
+			updates:         []clobtypes.StreamUpdate{*neverInScopeTakerOrderUpdate, *takerOrderUpdate},
+			subaccountIds:   []satypes.SubaccountId{subaccountId},
 			filteredUpdates: []clobtypes.StreamUpdate{*takerOrderUpdate},
 		},
 		"takerOrderUpdatesDropUpdate": {
-			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate, otherStreamUpdate},
+			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *neverInScopeTakerOrderUpdate, otherStreamUpdate},
 			subaccountIds:   []satypes.SubaccountId{},
-			filteredUpdates: []clobtypes.StreamUpdate{*takerOrderUpdate},
+			filteredUpdates: []clobtypes.StreamUpdate{},
 		},
 		"takerOrderUpdatesFilterUpdate": {
 			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate},
@@ -409,7 +500,12 @@ func TestFilterStreamUpdates(t *testing.T) {
 			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate},
 		},
 		"takerOrderUpdatesFilterAndDropUpdate": {
-			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate, otherStreamUpdate},
+			updates: []clobtypes.StreamUpdate{
+				baseStreamUpdate,
+				*neverInScopeTakerOrderUpdate,
+				otherStreamUpdate,
+				*takerOrderUpdate,
+			},
 			subaccountIds:   []satypes.SubaccountId{subaccountId},
 			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate, *takerOrderUpdate},
 		},
@@ -452,6 +548,53 @@ func TestFilterStreamUpdates(t *testing.T) {
 			updates:         []clobtypes.StreamUpdate{baseStreamUpdate, *priceUpdate, otherStreamUpdate},
 			subaccountIds:   []satypes.SubaccountId{subaccountId},
 			filteredUpdates: []clobtypes.StreamUpdate{baseStreamUpdate, *priceUpdate},
+		},
+	}
+
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			filteredUpdates := streaming.FilterStreamUpdateBySubaccount(testCase.updates, testCase.subaccountIds, logger)
+			require.Equal(t, testCase.filteredUpdates, filteredUpdates)
+		})
+	}
+}
+
+func TestFilterStreamUpdatesWithDuplicateSubaccountIds(t *testing.T) {
+	logger := NewLogger()
+
+	subaccountId := satypes.SubaccountId{Owner: "me", Number: 1337}
+	orderId := NewIndexerOrderId(subaccountId.Owner, subaccountId.Number)
+	order := NewIndexerOrder(orderId)
+
+	otherSubaccountId := satypes.SubaccountId{Owner: "we", Number: 2600}
+
+	orderPlaceTime := time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC)
+	openOrder := OpenOrder(&order, &orderPlaceTime)
+	cancelOrder := CancelOrder(&orderId, &orderPlaceTime)
+	replaceOrder := ReplaceOrder(&orderId, &order, &orderPlaceTime)
+	updateOrder := UpdateOrder(&orderId, uint64(1988))
+	streamUpdate := toStreamUpdate(false, openOrder, cancelOrder, replaceOrder, updateOrder)
+	priceUpdate := NewPriceUpdate(0, 0)
+
+	tests := map[string]TestCase{
+		"duplicateSubaccountIdsBase": {
+			updates:       []clobtypes.StreamUpdate{streamUpdate},
+			subaccountIds: []satypes.SubaccountId{subaccountId, subaccountId},
+			filteredUpdates: []clobtypes.StreamUpdate{
+				streamUpdate,
+			},
+		},
+		"duplicateSubaccountIdsOther": {
+			updates:         []clobtypes.StreamUpdate{streamUpdate},
+			subaccountIds:   []satypes.SubaccountId{otherSubaccountId, otherSubaccountId},
+			filteredUpdates: []clobtypes.StreamUpdate{},
+		},
+		"priceUpdateWithDuplicateSubaccountIds": {
+			updates:       []clobtypes.StreamUpdate{*priceUpdate},
+			subaccountIds: []satypes.SubaccountId{subaccountId, subaccountId},
+			filteredUpdates: []clobtypes.StreamUpdate{
+				*priceUpdate,
+			},
 		},
 	}
 

--- a/protocol/streaming/types/errors.go
+++ b/protocol/streaming/types/errors.go
@@ -13,4 +13,9 @@ var (
 		2,
 		"Invalid full node streaming request",
 	)
+	ErrInvalidSubaccountFilteringRequest = errorsmod.Register(
+		ModuleName,
+		3,
+		"Invalid subaccount ID filtering request",
+	)
 )


### PR DESCRIPTION
### Changelist

Currently:
- CLOB pair id's must be specified to filter orders when subaccount id filtering is specified
- other updates specific to subaccounts are not filtered
  - taker orders
  - fills
    - taker
    - liquidation
    - deleveraging

Change subaccount filtering semantics to:
- if pair id's are specified, only filter orders for those pairs
- if pair id's are not specified, filter all orders for specified subaccounts
- filter taker orders and fills by subaccount id like order updates

### Test Plan
Unit Tests
Local validation

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
