### PR TITLE
perf(ender): Use empty JSONB for skipped event

### DIFF
--- a/.github/workflows/indexer-build-and-push-dev-staging.yml
+++ b/.github/workflows/indexer-build-and-push-dev-staging.yml
@@ -6,7 +6,6 @@ on: # yamllint disable-line rule:truthy
       - main
       - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/indexer/v0.1.x
       - 'release/indexer/v[0-9]+.x'  # e.g. release/indexer/v1.x
-      - 'td/empty-event-for-skipped'
     # TODO(DEC-837): Customize github build and push to ECR by service with paths
 
 jobs:

--- a/.github/workflows/indexer-build-and-push-dev-staging.yml
+++ b/.github/workflows/indexer-build-and-push-dev-staging.yml
@@ -6,6 +6,7 @@ on: # yamllint disable-line rule:truthy
       - main
       - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/indexer/v0.1.x
       - 'release/indexer/v[0-9]+.x'  # e.g. release/indexer/v1.x
+      - 'td/empty-event-for-skipped'
     # TODO(DEC-837): Customize github build and push to ECR by service with paths
 
 jobs:

--- a/indexer/services/ender/src/lib/block-processor.ts
+++ b/indexer/services/ender/src/lib/block-processor.ts
@@ -276,12 +276,12 @@ export class BlockProcessor {
     await Promise.all(this.sqlEventPromises).then((values) => {
       for (let i: number = 0; i < this.block.events.length; i++) {
         const event: IndexerTendermintEvent = this.block.events[i];
+
         this.sqlBlock.events[i] = {
           ...event,
-          // Specifically use the decoded version of the event instead of the bytes
-          // since the SQL block processor doesn't know how to decode protobuf
-          // natively.
-          dataBytes: values[i],
+          // For skipped events, use an empty object since the SQL processor will ignore it
+          // For other events, use the decoded version of the event
+          dataBytes: event.subtype === SKIPPED_EVENT_SUBTYPE ? {} : values[i],
         };
       }
     });

--- a/indexer/services/ender/src/lib/block-processor.ts
+++ b/indexer/services/ender/src/lib/block-processor.ts
@@ -279,8 +279,9 @@ export class BlockProcessor {
 
         this.sqlBlock.events[i] = {
           ...event,
-          // For skipped events, use an empty object since the SQL processor will ignore it
-          // For other events, use the decoded version of the event
+          // For skipped events, use an empty object since SQL block processor ignores them.
+          // Otherwise, use the decoded event since SQL block processor doesn't know how to decode
+          // protobuf.
           dataBytes: event.subtype === SKIPPED_EVENT_SUBTYPE ? {} : values[i],
         };
       }


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Refined event data processing to correctly ignore events that are not meant to be processed. This update prevents unintended data assignments and improves the overall reliability and accuracy of event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->