### PR TITLE
[CT-1355] Handle Suborders in End Blocker

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/clob/order.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/clob/order.ts
@@ -731,9 +731,9 @@ export interface TwapParameters {
 
   interval: number;
   /**
-   * Price tolerance for each suborder. This will be applied to
+   * Price tolerance in ppm for each suborder. This will be applied to
    * the oracle price each time a suborder is triggered. Must be
-   * be in the range [0, 10000).
+   * be in the range [0, 1_000_000).
    */
 
   priceTolerance: number;
@@ -754,9 +754,9 @@ export interface TwapParametersSDKType {
 
   interval: number;
   /**
-   * Price tolerance for each suborder. This will be applied to
+   * Price tolerance in ppm for each suborder. This will be applied to
    * the oracle price each time a suborder is triggered. Must be
-   * be in the range [0, 10000).
+   * be in the range [0, 1_000_000).
    */
 
   price_tolerance: number;

--- a/proto/dydxprotocol/clob/order.proto
+++ b/proto/dydxprotocol/clob/order.proto
@@ -243,9 +243,9 @@ message TwapParameters {
   // [30 (30 seconds), 3600 (1 hour)].
   uint32 interval = 2;
 
-  // Price tolerance for each suborder. This will be applied to
+  // Price tolerance in ppm for each suborder. This will be applied to
   // the oracle price each time a suborder is triggered. Must be
-  // be in the range [0, 10000).
+  // be in the range [0, 1_000_000).
   uint32 price_tolerance = 3;
 }
 

--- a/protocol/lib/big_math.go
+++ b/protocol/lib/big_math.go
@@ -174,6 +174,20 @@ func BigDivCeil(a *big.Int, b *big.Int) *big.Int {
 	return result
 }
 
+// BigDivFloor returns the floor of `a / b`.
+func BigDivFloor(a *big.Int, b *big.Int) *big.Int {
+	result, remainder := new(big.Int).QuoRem(a, b, new(big.Int))
+
+	// If the value was rounded (i.e. there is a remainder), and the exact result would be negative,
+	// then subtract 1 from the result.
+	if remainder.Sign() != 0 && (a.Sign() != b.Sign()) {
+		result.Sub(result, big.NewInt(1))
+	}
+
+	return result
+}
+
+
 // BigRatRound takes an input and a direction to round (true for up, false for down).
 // It returns the result rounded to a `*big.Int` in the specified direction.
 func BigRatRound(n *big.Rat, roundUp bool) *big.Int {

--- a/protocol/lib/big_math.go
+++ b/protocol/lib/big_math.go
@@ -187,7 +187,6 @@ func BigDivFloor(a *big.Int, b *big.Int) *big.Int {
 	return result
 }
 
-
 // BigRatRound takes an input and a direction to round (true for up, false for down).
 // It returns the result rounded to a `*big.Int` in the specified direction.
 func BigRatRound(n *big.Rat, roundUp bool) *big.Int {

--- a/protocol/lib/quantums.go
+++ b/protocol/lib/quantums.go
@@ -88,3 +88,25 @@ func QuoteToBaseQuantums(
 
 	return result
 }
+
+// BigRatRoundToMultiple rounds a big.Rat to the nearest multiple of the given number.
+// If roundUp is true, it rounds up to the nearest multiple, otherwise it rounds down.
+func BigRatRoundToMultiple(
+	value *big.Rat,
+	multiple *big.Int,
+	roundUp bool,
+) *big.Int {
+	// Convert the value to a big.Int
+	valueInt := new(big.Int).Div(value.Num(), value.Denom())
+
+	// Calculate the remainder
+	remainder := new(big.Int).Mod(valueInt, multiple)
+
+	if roundUp && remainder.Sign() != 0 {
+		valueInt.Add(valueInt, new(big.Int).Sub(multiple, remainder))
+	} else {
+		valueInt.Sub(valueInt, remainder)
+	}
+
+	return valueInt
+}

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -78,6 +78,9 @@ func EndBlocker(
 	// Prune any fill amounts from state which are now past their `pruneableBlockHeight`.
 	keeper.PruneStateFillAmountsForShortTermOrders(ctx)
 
+	// Place any TWAP suborders that are due
+	keeper.GenerateAndPlaceTriggeredTwapSuborders(ctx)
+
 	// Prune expired stateful orders completely from state.
 	expiredStatefulOrderIds := keeper.RemoveExpiredStatefulOrders(ctx, ctx.BlockTime())
 	for _, orderId := range expiredStatefulOrderIds {

--- a/protocol/x/clob/client/cli/tx_place_order.go
+++ b/protocol/x/clob/client/cli/tx_place_order.go
@@ -70,6 +70,7 @@ func CmdPlaceOrder() *cobra.Command {
 							Number: argSubaccountNumber,
 						},
 						ClobPairId: argClobPairId,
+						OrderFlags: types.OrderIdFlags_ShortTerm,
 					},
 					Side:         types.Order_Side(argSide),
 					Quantums:     argQuantums,

--- a/protocol/x/clob/e2e/twap_orders_test.go
+++ b/protocol/x/clob/e2e/twap_orders_test.go
@@ -1,0 +1,297 @@
+package clob_test
+
+import (
+	"testing"
+	"time"
+
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	clobtestutils "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	testtx "github.com/dydxprotocol/v4-chain/protocol/testutil/tx"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTwapOrderPlacementAndCatchup(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+
+	// Create a TWAP order with:
+	// - 300 second duration (5 minutes, minimum allowed)
+	// - 60 second interval
+	// This will create 5 suborders total
+	twapOrder := *clobtypes.NewMsgPlaceOrder(
+		clobtypes.Order{
+			OrderId: clobtypes.OrderId{
+				SubaccountId: constants.Alice_Num0,
+				ClientId:     0,
+				OrderFlags:   clobtypes.OrderIdFlags_Twap,
+				ClobPairId:   0,
+			},
+			Side:     clobtypes.Order_SIDE_BUY,
+			Quantums: 100_000_000_000, // 10 BTC
+			Subticks: 0,               // market TWAP order
+			GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+				GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 300), // 5 minutes from now
+			},
+			TwapParameters: &clobtypes.TwapParameters{
+				Duration:       300, // 5 minutes
+				Interval:       60,  // 1 minute
+				PriceTolerance: 0,   // 0% slippage off oracle price
+			},
+		},
+	)
+
+	// Place the TWAP order
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, twapOrder) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+
+	// Advance block
+	ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+
+	// Verify the parent TWAP order state
+	twapOrderPlacement, found := tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.Order.OrderId,
+	)
+	require.True(t, found, "TWAP order placement should exist in state")
+	require.Equal(t, twapOrder.Order, twapOrderPlacement.Order)
+	require.Equal(t, uint32(4), twapOrderPlacement.RemainingLegs) // 5 original legs - 1 triggered
+	require.Equal(t, uint64(100_000_000_000), twapOrderPlacement.RemainingQuantums)
+
+	// Verify the first suborder was placed in the memclob
+	suborderId := clobtypes.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   clobtypes.OrderIdFlags_TwapSuborder,
+		ClobPairId:   0,
+	}
+
+	suborder, found := tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.True(t, found, "First suborder should exist in memclob")
+	require.Equal(t, uint64(20_000_000_000), suborder.Quantums) // 100B/5 = 20B per leg
+	require.Equal(t, uint64(200_000_000), suborder.Subticks)    // $20,000 oracle price
+	require.Equal(
+		t,
+		uint32(ctx.BlockTime().Unix()+3), // 3 seconds from now
+		suborder.GoodTilOneof.(*clobtypes.Order_GoodTilBlockTime).GoodTilBlockTime,
+	)
+	require.Equal(t, clobtypes.Order_SIDE_BUY, suborder.Side) // Same side as parent order
+
+	// Verify initial suborder in trigger store
+	nextSuborder, triggerTime, found := tApp.App.ClobKeeper.GetTwapTriggerPlacement(
+		ctx,
+		suborderId,
+	)
+	require.True(t, found, "TWAP trigger placement should exist")
+	require.Equal(t, suborderId, nextSuborder)
+	require.Equal(
+		t,
+		ctx.BlockTime().Unix()+int64(twapOrder.Order.TwapParameters.Interval),
+		triggerTime,
+	)
+
+	// Advance block time by 30 seconds
+	// Next suborder should not be triggered
+	ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 30),
+	})
+
+	// Verify TWAP order state
+	twapOrderPlacement, found = tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.Order.OrderId,
+	)
+	require.True(t, found, "TWAP order placement should still exist")
+	require.Equal(t, uint32(4), twapOrderPlacement.RemainingLegs)                   // One leg executed
+	require.Equal(t, uint64(100_000_000_000), twapOrderPlacement.RemainingQuantums) // 100B remaining - no quantums filled
+
+	suborder, found = tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.False(t, found, "Suborder should have been removed from memclob due to expiry")
+
+	// Advance block time by 30 seconds to trigger next suborder
+	ctx = tApp.AdvanceToBlock(4, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 30),
+	})
+
+	suborder1, found1 := tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.True(t, found1, "Second suborder should exist in memclob")
+	require.Equal(t, uint64(25_000_000_000), suborder1.Quantums) // 100B/4 = 25B per leg (catching up)
+	require.Equal(t, uint64(200_000_000), suborder1.Subticks)    // $20,000 per oracle price (not moved)
+	require.Equal(t, clobtypes.Order_SIDE_BUY, suborder1.Side)   // Same side as parent order
+
+	// Verify new suborder in trigger store
+	newSuborder, triggerTime, found := tApp.App.ClobKeeper.GetTwapTriggerPlacement(
+		ctx,
+		suborderId,
+	)
+	require.True(t, found, "TWAP trigger placement should exist")
+	require.Equal(t, suborderId, newSuborder)
+	require.Equal(
+		t,
+		ctx.BlockTime().Unix()+int64(twapOrder.Order.TwapParameters.Interval),
+		triggerTime,
+	)
+}
+
+func TestTWAPOrderWithMatchingOrders(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+
+	// Place a TWAP order to buy 100B quantums over 4 legs
+	twapOrder := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_Twap,
+			ClobPairId:   0,
+		},
+		Side:     clobtypes.Order_SIDE_BUY,
+		Quantums: 100_000_000_000, // 100B quantums
+		Subticks: 200_000_000,     // $20,000 per oracle price
+		TwapParameters: &clobtypes.TwapParameters{
+			Duration:       320,
+			Interval:       80,
+			PriceTolerance: 10_000,
+		},
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+			GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 100),
+		},
+	}
+
+	// Place a matching sell order at the same price
+	matchingOrder := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Bob_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:     clobtypes.Order_SIDE_SELL,
+		Quantums: 50_000_000_000, // 50B quantums
+		Subticks: 200_000_000,    // $20,000 per oracle price
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+			GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 3600),
+		},
+	}
+
+	// Place market order first and then TWAP order
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(
+		ctx,
+		tApp.App,
+		*clobtypes.NewMsgPlaceOrder(matchingOrder),
+	) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(
+		ctx,
+		tApp.App,
+		*clobtypes.NewMsgPlaceOrder(twapOrder),
+	) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+
+	suborderId := clobtypes.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   clobtypes.OrderIdFlags_TwapSuborder,
+		ClobPairId:   0,
+	}
+
+	ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+
+	ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 40),
+		RequestPrepareProposalTxsOverride: [][]byte{
+			testtx.MustGetTxBytes(&clobtypes.MsgProposedOperations{
+				OperationsQueue: []clobtypes.OperationRaw{
+					clobtestutils.NewMatchOperationRaw(
+						&clobtypes.Order{
+							OrderId:  suborderId,
+							Side:     clobtypes.Order_SIDE_BUY,
+							Quantums: 25_000_000_000,
+							Subticks: 200_000_000,
+						},
+						[]clobtypes.MakerFill{
+							{
+								FillAmount:   25_000_000_000,
+								MakerOrderId: matchingOrder.OrderId,
+							},
+						},
+					),
+				},
+			}),
+		},
+	})
+
+	// Verify TWAP order state is updated
+	twapOrderPlacement, found := tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.OrderId,
+	)
+	require.True(t, found, "TWAP order placement should exist")
+	require.Equal(t, uint32(3), twapOrderPlacement.RemainingLegs)
+	require.Equal(t, uint64(75_000_000_000), twapOrderPlacement.RemainingQuantums) // 100B - 25B filled
+
+	_, triggerTime, found1 := tApp.App.ClobKeeper.GetTwapTriggerPlacement(
+		ctx,
+		suborderId,
+	)
+	require.True(t, found1, "Second suborder should exist in trigger store")
+
+	require.Equal(t, int64(80), triggerTime)
+
+	_, placed_suborder1_found := tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.False(t, placed_suborder1_found, "Second suborder should not have been placed yet")
+
+	ctx = tApp.AdvanceToBlock(4, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 40),
+	})
+
+	filled_amount := tApp.App.ClobKeeper.MemClob.GetOrderFilledAmount(ctx, suborderId)
+	require.Equal(t, uint64(25_000_000_000), filled_amount.ToUint64())
+
+	ctx = tApp.AdvanceToBlock(5, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 0),
+		RequestPrepareProposalTxsOverride: [][]byte{
+			testtx.MustGetTxBytes(&clobtypes.MsgProposedOperations{
+				OperationsQueue: []clobtypes.OperationRaw{
+					clobtestutils.NewMatchOperationRaw(
+						&clobtypes.Order{
+							OrderId:  suborderId,
+							Side:     clobtypes.Order_SIDE_BUY,
+							Quantums: 25_000_000_000,
+							Subticks: 200_000_000,
+						},
+						[]clobtypes.MakerFill{
+							{
+								FillAmount:   25_000_000_000,
+								MakerOrderId: matchingOrder.OrderId,
+							},
+						},
+					),
+				},
+			}),
+		},
+	})
+
+	// Verify TWAP order state is updated again
+	twapOrderPlacement, found = tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.OrderId,
+	)
+	require.True(t, found, "TWAP order placement should still exist")
+	require.Equal(t, uint32(2), twapOrderPlacement.RemainingLegs)
+	require.Equal(t, uint64(50_000_000_000), twapOrderPlacement.RemainingQuantums) // 75B - 25B filled
+
+	_, triggerTime, found2 := tApp.App.ClobKeeper.GetTwapTriggerPlacement(
+		ctx,
+		suborderId,
+	)
+	require.True(t, found2, "Third suborder should exist in trigger store")
+	require.Equal(t, ctx.BlockTime().Unix()+int64(twapOrder.TwapParameters.Interval), triggerTime)
+}

--- a/protocol/x/clob/keeper/msg_server_place_order_test.go
+++ b/protocol/x/clob/keeper/msg_server_place_order_test.go
@@ -425,7 +425,7 @@ func TestPlaceOrder_Success(t *testing.T) {
 				twap_suborder, timestamp, found_suborder := ks.ClobKeeper.GetTwapTriggerPlacement(ctx, suborder.OrderId)
 				require.Equal(t, suborder.OrderId, twap_suborder)
 				require.True(t, found_suborder)
-				require.Equal(t, timestamp, uint64(ctx.BlockTime().Unix()))
+				require.Equal(t, timestamp, ctx.BlockTime().Unix())
 			} else {
 				_, found := ks.ClobKeeper.GetLongTermOrderPlacement(ctx, tc.StatefulOrderPlacement.GetOrderId())
 				require.True(t, found)

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -971,15 +971,11 @@ func (k Keeper) PerformStatefulOrderValidation(
 	}
 
 	if order.IsTwapOrder() {
-		totalLegs := order.GetTotalLegsTWAPOrder()
-		minOrderSize := uint64(totalLegs) * clobPair.StepBaseQuantums
-		if order.Quantums < minOrderSize {
+		num_suborders := uint64(order.TwapParameters.Duration / order.TwapParameters.Interval)
+		if order.Quantums/num_suborders < clobPair.StepBaseQuantums {
 			return errorsmod.Wrapf(
 				types.ErrInvalidPlaceOrder,
-				"Generated TWAP suborder sizes (%v/%v) must be greater than min size for clob pair %v",
-				order.Quantums,
-				totalLegs,
-				clobPair.StepBaseQuantums,
+				"TWAP suborder sizes must be greater than the minimum order size for the market",
 			)
 		}
 	}
@@ -1238,6 +1234,33 @@ func (k Keeper) InitStatefulOrders(
 			telemetry.IncrCounter(1, types.ModuleName, metrics.PlaceOrder, metrics.Hydrate, metrics.Matched)
 		}
 	}
+}
+
+// GetOraclePriceAdjustedByPercentageSubticks returns the oracle price in subticks
+// adjusted by a given directional price tolerance in ppm, rounded to the nearest multiple
+// of SubticksPerTick. A positive price tolerance increases the price, while a negative price
+// tolerance decreases it.
+//
+// For example:
+//   - price tolerance = 500_000 means 50% higher than oracle price
+//   - price tolerance = -500_000 means 50% lower than oracle price
+func (k Keeper) GetOraclePriceAdjustedByPercentageSubticks(
+	ctx sdk.Context,
+	clobPair types.ClobPair,
+	directionalPriceTolerancePpm int32,
+) uint64 {
+	oraclePriceSubticksRat := k.GetOraclePriceSubticksRat(ctx, clobPair)
+	adjustment := int32(1_000_000) + directionalPriceTolerancePpm
+
+	adjustedPrice := lib.BigRatMulPpm(oraclePriceSubticksRat, uint32(adjustment))
+	// Round to the nearest multiple of SubticksPerTick
+	roundedSubticks := lib.BigRatRoundToMultiple(
+		adjustedPrice,
+		new(big.Int).SetUint64(uint64(clobPair.SubticksPerTick)),
+		directionalPriceTolerancePpm >= 0, // round up for positive adjustments, down for negative
+	)
+
+	return roundedSubticks.Uint64()
 }
 
 // sendOffchainMessagesWithTxHash sends all the `Message` in the offchainUpdates passed in along with

--- a/protocol/x/clob/keeper/process_operations_stateful_validation.go
+++ b/protocol/x/clob/keeper/process_operations_stateful_validation.go
@@ -35,7 +35,7 @@ func (k Keeper) FetchOrderFromOrderId(
 	}
 
 	// For stateful orders, fetch from state. Do not fetch from untriggered conditional orders.
-	if orderId.IsLongTermOrder() {
+	if orderId.IsLongTermOrder() || orderId.IsTwapSuborder() {
 		statefulOrderPlacement, found := k.GetLongTermOrderPlacement(ctx, orderId)
 		if !found {
 			return order, errorsmod.Wrapf(

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -294,14 +294,14 @@ func (k Keeper) ProcessSingleMatch(
 	)
 
 	if !matchWithOrders.TakerOrder.IsLiquidation() {
-		taker_order := matchWithOrders.TakerOrder.MustGetOrder()
-		if taker_order.OrderId.IsTwapSuborder() {
+		takerOrder := matchWithOrders.TakerOrder.MustGetOrder()
+		if takerOrder.OrderId.IsTwapSuborder() {
 			// Get the parent order ID by removing the TWAP suborder flag
 			parentOrderId := types.OrderId{
-				SubaccountId: taker_order.OrderId.SubaccountId,
-				ClientId:     taker_order.OrderId.ClientId,
+				SubaccountId: takerOrder.OrderId.SubaccountId,
+				ClientId:     takerOrder.OrderId.ClientId,
 				OrderFlags:   types.OrderIdFlags_Twap, // Set directly to TWAP
-				ClobPairId:   taker_order.OrderId.ClobPairId,
+				ClobPairId:   takerOrder.OrderId.ClobPairId,
 			}
 
 			// Update the parent TWAP order state

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -296,7 +296,6 @@ func (k Keeper) ProcessSingleMatch(
 	if !matchWithOrders.TakerOrder.IsLiquidation() {
 		taker_order := matchWithOrders.TakerOrder.MustGetOrder()
 		if taker_order.OrderId.IsTwapSuborder() {
-			log.ErrorLog(ctx, "handling twap order", fmt.Sprintf("%+v", taker_order))
 			// Get the parent order ID by removing the TWAP suborder flag
 			parentOrderId := types.OrderId{
 				SubaccountId: taker_order.OrderId.SubaccountId,

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -1,10 +1,20 @@
 package keeper
 
 import (
-	"encoding/binary"
+	"math/big"
 
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+)
+
+const (
+	TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET = 3
+)
+
+var (
+	TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE = big.NewInt(3)
 )
 
 func (k Keeper) SetTWAPOrderPlacement(ctx sdk.Context,
@@ -52,7 +62,7 @@ func (k Keeper) GetTwapOrderPlacement(
 func (k Keeper) GetTwapTriggerPlacement(
 	ctx sdk.Context,
 	orderId types.OrderId,
-) (o types.OrderId, t uint64, found bool) {
+) (o types.OrderId, t int64, found bool) {
 	store := k.GetTWAPTriggerOrderPlacementStore(ctx)
 
 	iterator := store.Iterator(nil, nil)
@@ -62,7 +72,7 @@ func (k Keeper) GetTwapTriggerPlacement(
 		var suborderId types.OrderId
 		k.cdc.MustUnmarshal(iterator.Key()[8:], &suborderId)
 
-		timestamp := binary.BigEndian.Uint64(iterator.Key()[0:8])
+		timestamp := types.TimeFromTriggerKey(iterator.Key())
 		if suborderId == orderId {
 			return suborderId, timestamp, true
 		}
@@ -93,4 +103,211 @@ func (k Keeper) AddSuborderToTriggerStore(
 
 	// The value in the map is not used, so we can set it to an empty byte slice.
 	triggerStore.Set(triggerKey, []byte{})
+}
+
+// GenerateAndPlaceTriggeredTwapSuborders will iterate over the twap trigger
+// store and generate the suborders that need to be placed on the orderbook
+// based on the timestamps their triggers were set for.
+// It also has the responsibility of checking if the parent twap was
+// cancelled, in which case no subsequent suborders should be placed, and
+// also the case that the parent twap order was completed (no remaining legs),
+// in which case the parent twap order should be removed from the store.
+func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
+	triggerStore := k.GetTWAPTriggerOrderPlacementStore(ctx)
+	blockTime := ctx.BlockTime().Unix()
+	iterator := triggerStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	var operationsToProcess []struct {
+		keyToDelete        []byte
+		suborderToPlace    types.Order
+		twapOrderPlacement types.TwapOrderPlacement
+	}
+
+	for ; iterator.Valid(); iterator.Next() {
+		var orderId types.OrderId
+		k.cdc.MustUnmarshal(iterator.Key()[8:], &orderId)
+
+		triggerTime := types.TimeFromTriggerKey(iterator.Key())
+
+		if triggerTime > blockTime {
+			break // all remaining suborders are in the future
+		}
+
+		parentOrderId := types.OrderId{
+			SubaccountId: orderId.SubaccountId,
+			ClientId:     orderId.ClientId,
+			OrderFlags:   types.OrderIdFlags_Twap, // Set directly to TWAP
+			ClobPairId:   orderId.ClobPairId,
+		}
+
+		twapOrderPlacement, found := k.GetTwapOrderPlacement(ctx, parentOrderId)
+		if !found {
+			// TODO: (anmol) handle order cancellation
+			return
+		}
+
+		order := k.GenerateSuborder(ctx, orderId, twapOrderPlacement, blockTime)
+
+		operationsToProcess = append(operationsToProcess, struct {
+			keyToDelete        []byte
+			suborderToPlace    types.Order
+			twapOrderPlacement types.TwapOrderPlacement
+		}{
+			keyToDelete:        append([]byte{}, iterator.Key()...),
+			suborderToPlace:    order,
+			twapOrderPlacement: twapOrderPlacement,
+		})
+	}
+	iterator.Close()
+
+	for _, op := range operationsToProcess {
+		// Delete from trigger store
+		triggerStore.Delete(op.keyToDelete)
+
+		// decrement remaining legs
+		k.DecrementTwapOrderRemainingLegs(ctx, &op.twapOrderPlacement)
+
+		if op.twapOrderPlacement.RemainingLegs == 0 {
+			// remove the parent twap order from the store
+			store := k.GetTWAPOrderPlacementStore(ctx)
+			orderKey := op.twapOrderPlacement.Order.OrderId.ToStateKey()
+			store.Delete(orderKey)
+			// TODO: (anmol) handle missing parent order case
+			// TODO: (anmol) emit event?
+		} else {
+			// add the next suborder to the trigger store
+			k.AddSuborderToTriggerStore(
+				ctx,
+				op.suborderToPlace.OrderId,
+				int64(op.twapOrderPlacement.Order.TwapParameters.Interval),
+			)
+		}
+
+		// place triggered suborder
+		err := k.HandleMsgPlaceOrder(ctx, &types.MsgPlaceOrder{Order: op.suborderToPlace}, true)
+		if err != nil {
+			continue // TODO: (anmol) handle suborder placement failure
+		}
+	}
+}
+
+func (k Keeper) DecrementTwapOrderRemainingLegs(
+	ctx sdk.Context,
+	twapOrderPlacement *types.TwapOrderPlacement,
+) {
+	if twapOrderPlacement.RemainingLegs == 0 {
+		return // TODO: (anmol) handle end of twap order case
+	}
+
+	twapOrderPlacement.RemainingLegs--
+
+	// Store updated state
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
+	twapOrderPlacementBytes := k.cdc.MustMarshal(twapOrderPlacement)
+	store.Set(orderKey, twapOrderPlacementBytes)
+}
+
+// UpdateTWAPOrderRemainingQuantityOnFill updates the remaining quantity of the
+// parent twap order after a suborder has been filled.
+func (k Keeper) UpdateTWAPOrderRemainingQuantityOnFill(
+	ctx sdk.Context,
+	parentOrderId types.OrderId,
+	filledQuantums uint64,
+) error {
+	// Get the TWAP order placement
+	twapOrderPlacement, found := k.GetTwapOrderPlacement(ctx, parentOrderId)
+	if !found {
+		return errorsmod.Wrapf(
+			types.ErrInvalidTwapOrderPlacement,
+			"TWAP order %+v does not exist",
+			parentOrderId,
+		)
+	}
+
+	// Update remaining quantums
+	twapOrderPlacement.RemainingQuantums -= filledQuantums
+
+	// Store updated state
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := parentOrderId.ToStateKey()
+	twapOrderPlacementBytes := k.cdc.MustMarshal(&twapOrderPlacement)
+	store.Set(orderKey, twapOrderPlacementBytes)
+
+	return nil
+}
+
+func (k Keeper) calculateSuborderQuantums(
+	twapOrderPlacement types.TwapOrderPlacement,
+	clobPair types.ClobPair,
+) uint64 {
+	totalLegs := twapOrderPlacement.Order.GetTotalLegsTWAPOrder()
+	originalQuantums := twapOrderPlacement.Order.Quantums
+	originalQuantumsPerLeg := lib.BigDivCeil(lib.BigU(originalQuantums), lib.BigU(totalLegs))
+
+	// Calculate the quantums for the suborder capping at 3x the original quantums per leg
+	remainingQuantums := twapOrderPlacement.RemainingQuantums
+	remainingLegs := twapOrderPlacement.RemainingLegs
+	remainingQuantumsPerLeg := lib.BigDivCeil(lib.BigU(remainingQuantums), lib.BigU(remainingLegs))
+
+	maxSuborderSize := new(big.Int).Mul(originalQuantumsPerLeg, TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE)
+
+	suborderQuantums := lib.BigMin(
+		remainingQuantumsPerLeg,
+		maxSuborderSize,
+	)
+
+	// Round down to nearest multiple of StepBaseQuantums
+	quantumsByStepBaseQuantums := lib.BigDivFloor(suborderQuantums, lib.BigU(clobPair.StepBaseQuantums))
+	if quantumsByStepBaseQuantums.Uint64() == 0 {
+		// TODO: (anmol) cancel parent twap on order gen failure
+		return 0
+	}
+
+	suborderQuantumsRounded := quantumsByStepBaseQuantums.Mul(
+		quantumsByStepBaseQuantums,
+		lib.BigU(clobPair.StepBaseQuantums),
+	)
+	return suborderQuantumsRounded.Uint64()
+}
+
+// GenerateSuborder generates a suborder when it has been triggered via the
+// trigger store. The suborderId is given  by the store, and this method
+// generates the remaining required fields. Configured price tolerance is
+// applied to the oracle price to get the suborder price. Quantity is determined
+// as a function of the remaining quantums and legs. Good til block time is set
+// to the current block time plus the protocol defined offset.
+func (k Keeper) GenerateSuborder(
+	ctx sdk.Context,
+	suborderId types.OrderId,
+	twapOrderPlacement types.TwapOrderPlacement,
+	blockTime int64,
+) types.Order {
+	parentOrder := twapOrderPlacement.Order
+	order := types.Order{
+		OrderId:    suborderId,
+		Side:       twapOrderPlacement.Order.Side,
+		ReduceOnly: twapOrderPlacement.Order.ReduceOnly,
+	}
+
+	priceTolerancePpm := int32(parentOrder.TwapParameters.PriceTolerance)
+	if parentOrder.Side == types.Order_SIDE_SELL {
+		// for sell orders, we want to adjust the price down
+		priceTolerancePpm = -priceTolerancePpm
+	}
+
+	// calculate the suborder price with slippage adjustment
+	clobPair := k.mustGetClobPair(ctx, parentOrder.GetClobPairId())
+	order.Subticks = k.GetOraclePriceAdjustedByPercentageSubticks(ctx, clobPair, priceTolerancePpm)
+
+	// calculate the suborder quantums based on remaining quantums and legs
+	order.Quantums = k.calculateSuborderQuantums(twapOrderPlacement, clobPair)
+
+	// set good til block time from current block time
+	order.GoodTilOneof = &types.Order_GoodTilBlockTime{
+		GoodTilBlockTime: uint32(blockTime + TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET),
+	}
+
+	return order
 }

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -9,13 +9,13 @@ import (
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 )
 
-const (
-	TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET = 3
-)
+// TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET is the offset in seconds added to the
+// current block time to set the good til block time for a suborder.
+const TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET = 3
 
-var (
-	TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE = big.NewInt(3)
-)
+// TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE is the maximum multiple of the original
+// quantums per leg that a suborder can be.
+var TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE = big.NewInt(3)
 
 func (k Keeper) SetTWAPOrderPlacement(ctx sdk.Context,
 	order types.Order,
@@ -144,7 +144,7 @@ func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
 		twapOrderPlacement, found := k.GetTwapOrderPlacement(ctx, parentOrderId)
 		if !found {
 			// TODO: (anmol) handle order cancellation
-			return
+			continue
 		}
 
 		order := k.GenerateSuborder(ctx, orderId, twapOrderPlacement, blockTime)

--- a/protocol/x/clob/keeper/twap_order_state_test.go
+++ b/protocol/x/clob/keeper/twap_order_state_test.go
@@ -2,21 +2,27 @@ package keeper_test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"testing"
+	"time"
 
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
+	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
+	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
+	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTWAPOrderTriggerStoreOrderingBasedOffTimestamp(t *testing.T) {
 	ks := setupTestTWAPOrderState(t)
-
 	// Create test orders with same order ID but different timestamps
 	suborderId := types.OrderId{
 		SubaccountId: constants.Alice_Num0,
@@ -44,8 +50,8 @@ func TestTWAPOrderTriggerStoreOrderingBasedOffTimestamp(t *testing.T) {
 
 	// validate timestamps are in order
 	for ; iterator.Valid(); iterator.Next() {
-		timestamp := binary.BigEndian.Uint64(iterator.Key()[0:8])
-		require.Equal(t, ks.Ctx.BlockTime().Unix()+expectedOrder[index], int64(timestamp))
+		timestamp := types.TimeFromTriggerKey(iterator.Key())
+		require.Equal(t, ks.Ctx.BlockTime().Unix()+expectedOrder[index], timestamp)
 		index++
 	}
 	require.Equal(t, len(expectedOrder), index)
@@ -181,4 +187,434 @@ func setupTestTWAPOrderState(t *testing.T) (ks keepertest.ClobKeepersTestContext
 		&mocks.IndexerEventManager{},
 	)
 	return ks
+}
+
+func TestSetTWAPOrderPlacement(t *testing.T) {
+	tests := map[string]struct {
+		order             types.Order
+		blockHeight       uint32
+		expectedTotalLegs uint32
+		expectedQuantums  uint64
+	}{
+		"successfully sets TWAP order with 5 minute duration and 1 minute intervals": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: constants.Alice_Num0,
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_Twap,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 1000,
+				TwapParameters: &types.TwapParameters{
+					Duration: 300, // 5 minutes
+					Interval: 60,  // 1 minute
+				},
+			},
+			blockHeight:       100,
+			expectedTotalLegs: 5,
+			expectedQuantums:  1000,
+		},
+		"successfully sets TWAP order with 1 hour duration and 5 minute intervals": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: constants.Alice_Num0,
+					ClientId:     2,
+					OrderFlags:   types.OrderIdFlags_Twap,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_SELL,
+				Quantums: 2000,
+				TwapParameters: &types.TwapParameters{
+					Duration: 3600, // 1 hour
+					Interval: 300,  // 5 minutes
+				},
+			},
+			blockHeight:       200,
+			expectedTotalLegs: 12,
+			expectedQuantums:  2000,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Setup keeper state and test parameters
+			memClob := &mocks.MemClob{}
+			memClob.On("SetClobKeeper", mock.Anything).Return()
+			ks := keepertest.NewClobKeepersTestContextWithUninitializedMemStore(
+				t,
+				memClob,
+				&mocks.BankKeeper{},
+				&mocks.IndexerEventManager{},
+			)
+
+			// Set block time for consistent testing
+			ctx := ks.Ctx.WithBlockTime(time.Unix(1000, 0))
+
+			// Set the TWAP order placement
+			ks.ClobKeeper.SetTWAPOrderPlacement(ctx, tc.order, tc.blockHeight)
+
+			// Verify the order was stored correctly
+			storedOrder, found := ks.ClobKeeper.GetTwapOrderPlacement(ctx, tc.order.OrderId)
+			require.True(t, found, "TWAP order should be found in store")
+			require.Equal(t, tc.order, storedOrder.Order, "stored order should match input order")
+			require.Equal(t,
+				tc.expectedTotalLegs,
+				storedOrder.RemainingLegs,
+				"remaining legs should equal total legs initially",
+			)
+			require.Equal(t,
+				tc.expectedQuantums,
+				storedOrder.RemainingQuantums,
+				"remaining quantums should equal initial quantums",
+			)
+
+			// Verify the first suborder was created in trigger store
+			suborderId := types.OrderId{
+				SubaccountId: tc.order.OrderId.SubaccountId,
+				ClientId:     tc.order.OrderId.ClientId,
+				OrderFlags:   types.OrderIdFlags_TwapSuborder,
+				ClobPairId:   tc.order.OrderId.ClobPairId,
+			}
+			triggerPlacement, triggerTime, found := ks.ClobKeeper.GetTwapTriggerPlacement(ctx, suborderId)
+
+			require.True(t, found, "trigger placement should be found")
+			require.Equal(t, suborderId, triggerPlacement, "trigger placement should match suborderId")
+			require.Equal(t, int64(1000), triggerTime, "trigger time should match block time")
+		})
+	}
+}
+
+func TestGenerateSuborder(t *testing.T) {
+	tests := map[string]struct {
+		twapOrderPlacement types.TwapOrderPlacement
+		blockTime          int64
+		clobPair           types.ClobPair
+		expectedOrder      types.Order
+	}{
+		"buy order with positive price tolerance": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side:     types.Order_SIDE_BUY,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration:       360,
+						Interval:       60,
+						PriceTolerance: 500_000, // 50% tolerance
+					},
+				},
+				RemainingLegs:     5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 200,
+				Subticks: 1500,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003, // blockTime + TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET
+				},
+			},
+		},
+		"sell order with negative price tolerance": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side:     types.Order_SIDE_SELL,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration:       360,
+						Interval:       60,
+						PriceTolerance: 500_000, // 50% tolerance
+					},
+				},
+				RemainingLegs:     5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_SELL,
+				Quantums: 200,
+				Subticks: 500,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003, // blockTime + TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET
+				},
+			},
+		},
+		"buy order with 2.5% price tolerance and rounded up subticks": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side:     types.Order_SIDE_BUY,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration:       360,
+						Interval:       60,
+						PriceTolerance: 25_000, // 2.5% tolerance
+					},
+				},
+				RemainingLegs:     5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 200,
+				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+		"sell order with 2.5% price tolerance and rounded down subticks": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side:     types.Order_SIDE_SELL,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration:       360,
+						Interval:       60,
+						PriceTolerance: 25_000, // 2.5% tolerance
+					},
+				},
+				RemainingLegs:     5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_SELL,
+				Quantums: 200,
+				Subticks: 970, // 1000 * (1 - 0.025) rounded down to nearest 10
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+		"buy order with 2.5% price tolerance with rounded up subticks and quantums": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side:     types.Order_SIDE_BUY,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration:       360,
+						Interval:       60,
+						PriceTolerance: 25_000, // 2.5% tolerance
+					},
+				},
+				RemainingLegs:     6,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 165,  // 1000 / 6 = 166.67 rounded down to nearest 5 (step base quantums)
+				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+		"buy order with 2.5% price tolerance with rounded up subticks and max catchup quantums": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side:     types.Order_SIDE_BUY,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration:       360,
+						Interval:       60,
+						PriceTolerance: 25_000, // 2.5% tolerance
+					},
+				},
+				RemainingLegs:     1,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 500,  // (1000 / 6) * 3
+				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Setup keeper state and test parameters
+			memClob := &mocks.MemClob{}
+			indexerEventManager := &mocks.IndexerEventManager{}
+			clobKeeper := &mocks.MemClobKeeper{}
+
+			memClob.On("GetClobKeeper").Return(&clobKeeper)
+			memClob.On("SetClobKeeper", mock.Anything).Return()
+			memClob.On("CreateOrderbook", mock.Anything, mock.Anything).Return()
+			ks := keepertest.NewClobKeepersTestContextWithUninitializedMemStore(
+				t,
+				memClob,
+				&mocks.BankKeeper{},
+				indexerEventManager,
+			)
+
+			indexerEventManager.On(
+				"AddTxnEvent",
+				ks.Ctx,
+				indexerevents.SubtypePerpetualMarket,
+				indexerevents.PerpetualMarketEventVersion,
+				mock.Anything,
+			).Return()
+
+			// Set block time for consistent testing
+			ctx := ks.Ctx.WithBlockTime(time.Unix(tc.blockTime, 0))
+
+			keepertest.CreateTestPricesAndPerpetualMarkets(
+				t,
+				ks.Ctx,
+				ks.PerpetualsKeeper,
+				ks.PricesKeeper,
+				[]perptypes.Perpetual{
+					*perptest.GeneratePerpetual(
+						perptest.WithId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+						perptest.WithMarketId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+					),
+				},
+				[]pricestypes.MarketParamPrice{
+					*pricestest.GenerateMarketParamPrice(
+						pricestest.WithId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+						pricestest.WithPriceValue(100_000), // subticks = 1_000
+					),
+				},
+			)
+
+			clobPair := *clobtest.GenerateClobPair(
+				clobtest.WithId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+				clobtest.WithPerpetualId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+			)
+
+			keepertest.CreateTestClobPairs(t, ks.Ctx, ks.ClobKeeper, []types.ClobPair{clobPair})
+
+			// Generate the suborder
+			suborderId := types.OrderId{
+				SubaccountId: tc.twapOrderPlacement.Order.OrderId.SubaccountId,
+				ClientId:     tc.twapOrderPlacement.Order.OrderId.ClientId,
+				OrderFlags:   types.OrderIdFlags_TwapSuborder,
+				ClobPairId:   tc.twapOrderPlacement.Order.OrderId.ClobPairId,
+			}
+			generatedOrder := ks.ClobKeeper.GenerateSuborder(ctx, suborderId, tc.twapOrderPlacement, tc.blockTime)
+
+			// Verify the generated order matches expectations
+			require.Equal(t, tc.expectedOrder.OrderId, generatedOrder.OrderId)
+			require.Equal(t, tc.expectedOrder.Side, generatedOrder.Side)
+			require.Equal(t, tc.expectedOrder.GoodTilOneof, generatedOrder.GoodTilOneof)
+			require.Equal(t, tc.expectedOrder.Subticks, generatedOrder.Subticks)
+			require.Equal(t, tc.expectedOrder.Quantums, generatedOrder.Quantums)
+		})
+	}
 }

--- a/protocol/x/clob/types/errors.go
+++ b/protocol/x/clob/types/errors.go
@@ -225,6 +225,11 @@ var (
 		48,
 		"This field has been deprecated",
 	)
+	ErrInvalidTwapOrderPlacement = errorsmod.Register(
+		ModuleName,
+		49,
+		"Invalid TWAP order placement",
+	)
 
 	// Liquidations errors.
 	ErrInvalidLiquidationsConfig = errorsmod.Register(

--- a/protocol/x/clob/types/message_place_order.go
+++ b/protocol/x/clob/types/message_place_order.go
@@ -14,16 +14,16 @@ const (
 	MinTwapOrderInterval uint32 = 30
 
 	// the maximum interval in seconds for TWAP orders.
-	MaxTwapOrderInterval uint32 = 3600
+	MaxTwapOrderInterval uint32 = 3_600
 
 	// the minimum duration in seconds for TWAP orders.
 	MinTwapOrderDuration uint32 = 300 // 5 minutes
 
 	// the maximum duration in seconds for TWAP orders.
-	MaxTwapOrderDuration uint32 = 86400 // 24 hours
+	MaxTwapOrderDuration uint32 = 86_400 // 24 hours
 
-	// the maximum price tolerance for suborders in basis points.
-	MaxTwapOrderPriceTolerance uint32 = 10000
+	// the maximum price tolerance for suborders in ppm.
+	MaxTwapOrderPriceTolerance uint32 = 1_000_000
 )
 
 var _ sdk.Msg = &MsgPlaceOrder{}

--- a/protocol/x/clob/types/order.go
+++ b/protocol/x/clob/types/order.go
@@ -270,12 +270,21 @@ func (o *Order) GetTotalLegsTWAPOrder() uint32 {
 // GetTWAPTriggerKey returns the key for a TWAP trigger order.
 func GetTWAPTriggerKey(triggerTime int64, orderId OrderId) []byte {
 	// Write trigger time as big-endian uint64
-	timeBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(timeBytes, uint64(triggerTime))
+	timeBytes := TriggerTimeToBytes(triggerTime)
 
 	// Get marshaled orderId
 	orderIdBytes := orderId.ToStateKey()
 
 	// Combine time and orderId bytes
 	return append(timeBytes, orderIdBytes...)
+}
+
+func TriggerTimeToBytes(triggerTime int64) []byte {
+	timeBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(timeBytes, uint64(triggerTime))
+	return timeBytes
+}
+
+func TimeFromTriggerKey(triggerKey []byte) int64 {
+	return int64(binary.BigEndian.Uint64(triggerKey[0:8]))
 }

--- a/protocol/x/clob/types/order.pb.go
+++ b/protocol/x/clob/types/order.pb.go
@@ -833,9 +833,9 @@ type TwapParameters struct {
 	// whole number, a factor of the duration, and in the range
 	// [30 (30 seconds), 3600 (1 hour)].
 	Interval uint32 `protobuf:"varint,2,opt,name=interval,proto3" json:"interval,omitempty"`
-	// Price tolerance for each suborder. This will be applied to
+	// Price tolerance in ppm for each suborder. This will be applied to
 	// the oracle price each time a suborder is triggered. Must be
-	// be in the range [0, 10000).
+	// be in the range [0, 1_000_000).
 	PriceTolerance uint32 `protobuf:"varint,3,opt,name=price_tolerance,json=priceTolerance,proto3" json:"price_tolerance,omitempty"`
 }
 


### PR DESCRIPTION
### Changelist
This PR is dependent on #2778 and #2779.

Now that we have twap orders being stored upon placement, let's add logic to the end blocker to manage them. Using the TWAPTriggerStore, we can loop over the upcoming suborders (in order of timestamp) to determine if they should be placed. For each such suborder, we generate a new order based off the state stored for the parent twap, market price, and current block time.

Currently, this does not handle TWAP order cancellations and expects the parent twap order to be present in the state when looking for it (otherwise it panics). This will be handled in the next change.

### Test Plan
Unit testing and new end-to-end integration tests to test the end blocker functionality.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive support for Time-Weighted Average Price (TWAP) orders, including automated suborder generation, placement, and lifecycle management.
  - Added new error messages for invalid TWAP order placements.
  - Enhanced order placement commands to explicitly flag short-term orders.
  - Added functionality to adjust oracle prices by configurable price tolerance expressed in parts per million (ppm).
  - Added new rounding functions to improve numerical precision in order calculations.

- **Bug Fixes**
  - Improved validation and state management for TWAP orders and suborders, ensuring correct triggering, placement, and matching behavior.

- **Documentation**
  - Clarified documentation for price tolerance fields, specifying units as parts per million (ppm) and updating valid ranges for increased precision.
  - Updated constant values and comments for better clarity and accuracy.

- **Tests**
  - Added extensive end-to-end and unit tests for TWAP order placement, suborder generation, and matching scenarios to ensure robust functionality.

- **Refactor**
  - Modularized order trigger key encoding/decoding and improved code readability with helper functions and digit separators in constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->