### PR TITLE
[CT-1356] Handle TWAP Cancels and Expiry

### DIFF
--- a/protocol/testutil/constants/subaccounts.go
+++ b/protocol/testutil/constants/subaccounts.go
@@ -10,13 +10,6 @@ import (
 
 var (
 	// Subaccounts.
-	Alice_Num0_0USD = satypes.Subaccount{
-		Id: &Alice_Num0,
-		AssetPositions: []*satypes.AssetPosition{
-			&Usdc_Asset_0,
-		},
-		PerpetualPositions: []*satypes.PerpetualPosition{},
-	}
 	Alice_Num0_1USD = satypes.Subaccount{
 		Id: &Alice_Num0,
 		AssetPositions: []*satypes.AssetPosition{

--- a/protocol/testutil/constants/subaccounts.go
+++ b/protocol/testutil/constants/subaccounts.go
@@ -10,6 +10,13 @@ import (
 
 var (
 	// Subaccounts.
+	Alice_Num0_0USD = satypes.Subaccount{
+		Id: &Alice_Num0,
+		AssetPositions: []*satypes.AssetPosition{
+			&Usdc_Asset_0,
+		},
+		PerpetualPositions: []*satypes.PerpetualPosition{},
+	}
 	Alice_Num0_1USD = satypes.Subaccount{
 		Id: &Alice_Num0,
 		AssetPositions: []*satypes.AssetPosition{

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -78,9 +78,6 @@ func EndBlocker(
 	// Prune any fill amounts from state which are now past their `pruneableBlockHeight`.
 	keeper.PruneStateFillAmountsForShortTermOrders(ctx)
 
-	// Place any TWAP suborders that are due
-	keeper.GenerateAndPlaceTriggeredTwapSuborders(ctx)
-
 	// Prune expired stateful orders completely from state.
 	expiredStatefulOrderIds := keeper.RemoveExpiredStatefulOrders(ctx, ctx.BlockTime())
 	for _, orderId := range expiredStatefulOrderIds {
@@ -113,6 +110,9 @@ func EndBlocker(
 	// Update the memstore with expired order ids.
 	// These expired stateful order ids will be purged from the memclob in `Commit`.
 	processProposerMatchesEvents.ExpiredStatefulOrderIds = expiredStatefulOrderIds
+
+	// Place any TWAP suborders that are due
+	keeper.GenerateAndPlaceTriggeredTwapSuborders(ctx)
 
 	// Poll out all triggered conditional orders from `UntriggeredConditionalOrders` and update state.
 	triggeredConditionalOrderIds := keeper.MaybeTriggerConditionalOrders(ctx)

--- a/protocol/x/clob/e2e/twap_orders_test.go
+++ b/protocol/x/clob/e2e/twap_orders_test.go
@@ -297,33 +297,6 @@ func TestTWAPOrderWithMatchingOrders(t *testing.T) {
 	require.Equal(t, ctx.BlockTime().Unix()+int64(twapOrder.TwapParameters.Interval), triggerTime)
 }
 
-func TestNormalOrderWithNoCollateral(t *testing.T) {
-	tApp := testapp.NewTestAppBuilder(t).Build()
-	ctx := tApp.InitChain()
-
-	tApp.App.SubaccountsKeeper.SetSubaccount(ctx, constants.Alice_Num0_0USD)
-
-	order := clobtypes.Order{
-		OrderId: clobtypes.OrderId{
-			SubaccountId: constants.Alice_Num0,
-			ClientId:     0,
-			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
-			ClobPairId:   0,
-		},
-		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
-			GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 50),
-		},
-		Side:     clobtypes.Order_SIDE_BUY,
-		Quantums: 100_000_000_000_000_000, // 10 BTC
-		Subticks: 100_000_000_000,
-	}
-
-	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(order)) {
-		resp := tApp.CheckTx(checkTx)
-		require.False(t, resp.IsOK(), "Expected CheckTx to fail with insufficient collateral. Response: %+v", resp)
-	}
-}
-
 func TestTwapOrderStopsPlacingSubordersWhenCollateralIsDepleted(t *testing.T) {
 	tApp := testapp.NewTestAppBuilder(t).Build()
 	ctx := tApp.InitChain()

--- a/protocol/x/clob/e2e/twap_orders_test.go
+++ b/protocol/x/clob/e2e/twap_orders_test.go
@@ -560,6 +560,3 @@ func TestTwapOrderStatefulOrderCount(t *testing.T) {
 	statefulOrderCount = tApp.App.ClobKeeper.GetStatefulOrderCount(ctx, constants.Alice_Num0)
 	require.Equal(t, uint32(0), statefulOrderCount, "Stateful order count should be 0 after completion")
 }
-
-
-

--- a/protocol/x/clob/e2e/twap_orders_test.go
+++ b/protocol/x/clob/e2e/twap_orders_test.go
@@ -449,7 +449,6 @@ func TestTwapOrderStopsPlacingSubordersWhenCollateralIsDepleted(t *testing.T) {
 		},
 	})
 
-	// tApp.App.SubaccountsKeeper.SetSubaccount(ctx, constants.Alice_Num0_0USD) // doesnt work
 	withdrawal := &sendingtypes.MsgWithdrawFromSubaccount{
 		Sender:    constants.Alice_Num0,
 		Recipient: constants.BobAccAddress.String(), // send to bob

--- a/protocol/x/clob/e2e/twap_orders_test.go
+++ b/protocol/x/clob/e2e/twap_orders_test.go
@@ -295,3 +295,93 @@ func TestTWAPOrderWithMatchingOrders(t *testing.T) {
 	require.True(t, found2, "Third suborder should exist in trigger store")
 	require.Equal(t, ctx.BlockTime().Unix()+int64(twapOrder.TwapParameters.Interval), triggerTime)
 }
+
+func TestTwapOrderCancellation(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+
+	// Create a TWAP order with:
+	// - 300 second duration (5 minutes)
+	// - 60 second interval
+	// This will create 5 suborders total
+	twapOrder := *clobtypes.NewMsgPlaceOrder(
+		clobtypes.Order{
+			OrderId: clobtypes.OrderId{
+				SubaccountId: constants.Alice_Num0,
+				ClientId:     0,
+				OrderFlags:   clobtypes.OrderIdFlags_Twap,
+				ClobPairId:   0,
+			},
+			Side:     clobtypes.Order_SIDE_BUY,
+			Quantums: 100_000_000_000, // 10 BTC
+			Subticks: 0,               // market TWAP order
+			GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+				GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 300), // 5 minutes from now
+			},
+			TwapParameters: &clobtypes.TwapParameters{
+				Duration:       300, // 5 minutes
+				Interval:       60,  // 1 minute
+				PriceTolerance: 0,   // 0% slippage off oracle price
+			},
+		},
+	)
+
+	// Place the TWAP order
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, twapOrder) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+
+	// Advance block time to trigger first suborder
+	ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 60),
+	})
+
+	// Verify first suborder was created
+	suborderId := clobtypes.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   clobtypes.OrderIdFlags_TwapSuborder,
+		ClobPairId:   0,
+	}
+	suborder, found := tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.True(t, found, "First suborder should exist in memclob")
+	require.Equal(t, uint64(20_000_000_000), suborder.Quantums) // 100B/5 = 20B per leg
+
+	// Cancel the TWAP order
+	cancelMsg := clobtypes.MsgCancelOrder{
+		OrderId: twapOrder.Order.OrderId,
+		GoodTilOneof: &clobtypes.MsgCancelOrder_GoodTilBlockTime{
+			// 5 minutes and 30 seconds from now
+			GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 330),
+		},
+	}
+
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, cancelMsg) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+
+	// Advance block to deliver cancellation message
+	ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{})
+
+	// Verify TWAP order was removed from state
+	_, found = tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.Order.OrderId,
+	)
+	require.False(t, found, "TWAP order placement should be removed")
+
+	// Verify suborder was removed from memclob
+	_, found = tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.False(t, found, "Suborder should be removed from memclob")
+
+	// Verify no more suborders will be triggered
+	tApp.AdvanceToBlock(4, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 60),
+	})
+
+	// Verify no new suborder was created
+	_, found = tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.False(t, found, "No new suborder should be created after cancellation")
+}

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -300,12 +300,7 @@ func (k Keeper) InitMemStore(ctx sdk.Context) {
 	// Ensure that the stateful order count is accurately represented in the memstore on restart.
 	statefulOrders := k.GetAllStatefulOrders(ctx)
 	for _, order := range statefulOrders {
-		subaccountId := order.GetSubaccountId()
-		k.SetStatefulOrderCount(
-			ctx,
-			subaccountId,
-			k.GetStatefulOrderCount(ctx, subaccountId)+1,
-		)
+		k.CheckAndIncrementStatefulOrderCount(ctx, order.GetOrderId())
 	}
 }
 

--- a/protocol/x/clob/keeper/keeper_test.go
+++ b/protocol/x/clob/keeper/keeper_test.go
@@ -69,7 +69,11 @@ func TestInitMemStore_StatefulOrderCount(t *testing.T) {
 	)
 
 	// Reset the stateful order count to zero.
-	ks.ClobKeeper.SetStatefulOrderCount(ks.Ctx, constants.Alice_Num0, 0)
+	ks.ClobKeeper.SetStatefulOrderCount(
+		ks.Ctx,
+		constants.Alice_Num0,
+		0,
+	)
 
 	// InitMemStore should repopulate the count.
 	ks.ClobKeeper.InitMemStore(ks.Ctx)

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -727,11 +727,11 @@ func (k Keeper) PerformOrderCancellationStatefulValidation(
 		}
 
 		// Fetch the highest priority order we are trying to cancel from state.
-		statefulOrderPlacement, orderToCancelExists := k.GetLongTermOrderPlacement(ctx, orderIdToCancel)
+		existingStatefulOrder, orderToCancelExists := k.getOrderFromStore(ctx, orderIdToCancel)
 
 		// The order we are cancelling must exist in uncommitted or committed state.
 		if !orderToCancelExists {
-			statefulOrderPlacement, orderToCancelExists = k.GetUncommittedStatefulOrderPlacement(ctx, orderIdToCancel)
+			statefulOrderPlacement, orderToCancelExists := k.GetUncommittedStatefulOrderPlacement(ctx, orderIdToCancel)
 
 			if !orderToCancelExists {
 				return errorsmod.Wrapf(
@@ -740,10 +740,10 @@ func (k Keeper) PerformOrderCancellationStatefulValidation(
 					orderIdToCancel,
 				)
 			}
+
+			existingStatefulOrder = statefulOrderPlacement.Order
 		}
 
-		// Highest priority stateful matching order to cancel.
-		existingStatefulOrder := statefulOrderPlacement.Order
 		// Return an error if cancellation's GTBT is less than stateful order's GTBT.
 		if cancelGoodTilBlockTime < existingStatefulOrder.GetGoodTilBlockTime() {
 			return errorsmod.Wrapf(
@@ -751,7 +751,7 @@ func (k Keeper) PerformOrderCancellationStatefulValidation(
 				"cancellation goodTilBlockTime less than stateful order goodTilBlockTime."+
 					" cancellation %+v, order %+v",
 				msgCancelOrder,
-				statefulOrderPlacement,
+				existingStatefulOrder,
 			)
 		}
 	} else {
@@ -760,6 +760,15 @@ func (k Keeper) PerformOrderCancellationStatefulValidation(
 		}
 	}
 	return nil
+}
+
+func (k Keeper) getOrderFromStore(ctx sdk.Context, orderId types.OrderId) (types.Order, bool) {
+	if orderId.IsTwapOrder() {
+		twapOrderPlacement, found := k.GetTwapOrderPlacement(ctx, orderId)
+		return twapOrderPlacement.Order, found
+	}
+	longTermOrderPlacement, found := k.GetLongTermOrderPlacement(ctx, orderId)
+	return longTermOrderPlacement.Order, found
 }
 
 // validateGoodTilBlock validates that the good til block (GTB) is within valid bounds, specifically

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -325,6 +325,9 @@ func (k Keeper) MustRemoveStatefulOrder(
 
 	k.DeleteLongTermOrderPlacement(ctx, orderId)
 
+	// Cancelling a TWAP parent order will attempt to cancel the in-flight suborder.
+	// Since a TWAP suborder is maintained as a normal stateful order, cancelling a
+	// suborder follows the same flow as other stateful orders.
 	if order.OrderId.IsTwapOrder() {
 		suborderId := k.twapToSuborderId(order.OrderId)
 		// GoodTilBlockTime is set to the current block time + 10 seconds.

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -469,6 +469,10 @@ func (k Keeper) SetStatefulOrderCount(
 	}
 }
 
+// Increment the stateful order count only once for TWAP orders.
+// Suborders that are generated from a TWAP order are not counted
+// towards the stateful order count because technically they are
+// part of one parent order.
 func (k Keeper) CheckAndIncrementStatefulOrderCount(
 	ctx sdk.Context,
 	orderId types.OrderId,

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -63,11 +64,7 @@ func (k Keeper) SetLongTermOrderPlacement(
 
 	if !found {
 		// Increment the stateful order count.
-		k.SetStatefulOrderCount(
-			ctx,
-			order.OrderId.SubaccountId,
-			k.GetStatefulOrderCount(ctx, order.OrderId.SubaccountId)+1,
-		)
+		k.CheckAndIncrementStatefulOrderCount(ctx, order.OrderId)
 
 		telemetry.IncrCounterWithLabels(
 			[]string{types.ModuleName, metrics.StatefulOrder, metrics.Count},
@@ -146,24 +143,16 @@ func (k Keeper) DeleteLongTermOrderPlacement(
 	orderId.MustBeStatefulOrder()
 
 	store := k.fetchStateStoresForOrder(ctx, orderId)
-
-	count := k.GetStatefulOrderCount(ctx, orderId.SubaccountId)
 	orderKey := orderId.ToStateKey()
-	if store.Has(orderKey) {
-		if count == 0 {
-			log.ErrorLog(ctx, "Stateful order count is zero but order is in the store. Underflow",
-				"orderId", cometbftlog.NewLazySprintf("%+v", orderId),
-			)
-		} else {
-			count--
-		}
-	}
+	orderExists := store.Has(orderKey)
 
 	// Delete the `StatefulOrderPlacement` from state.
 	store.Delete(orderKey)
 
 	// Set the count.
-	k.SetStatefulOrderCount(ctx, orderId.SubaccountId, count)
+	if orderExists {
+		k.CheckAndDecrementStatefulOrderCount(ctx, orderId)
+	}
 
 	telemetry.IncrCounterWithLabels(
 		[]string{types.ModuleName, metrics.StatefulOrderRemoved, metrics.Count},
@@ -319,19 +308,40 @@ func (k Keeper) MustRemoveStatefulOrder(
 	// If this is a Short-Term order, panic.
 	orderId.MustBeStatefulOrder()
 
-	longTermOrderPlacement, exists := k.GetLongTermOrderPlacement(ctx, orderId)
+	order, exists := k.getOrderFromStore(ctx, orderId)
 	if !exists {
 		panic(fmt.Sprintf("MustRemoveStatefulOrder: order %v does not exist", orderId))
 	}
 
-	goodTilBlockTime := longTermOrderPlacement.Order.MustGetUnixGoodTilBlockTime()
-	k.RemoveStatefulOrderIdExpiration(ctx, goodTilBlockTime, orderId)
+	// TWAP orders are not maintained by these states because expiry and
+	// fills are updated by the generated suborders.
+	if !order.OrderId.IsTwapOrder() {
+		goodTilBlockTime := order.MustGetUnixGoodTilBlockTime()
+		k.RemoveStatefulOrderIdExpiration(ctx, goodTilBlockTime, orderId)
+		// Remove the order fill amount from state.
+		k.RemoveOrderFillAmount(ctx, orderId)
+		// Delete the Stateful order placement from state.
+	}
 
-	// Remove the order fill amount from state.
-	k.RemoveOrderFillAmount(ctx, orderId)
-
-	// Delete the Stateful order placement from state.
 	k.DeleteLongTermOrderPlacement(ctx, orderId)
+
+	if order.OrderId.IsTwapOrder() {
+		suborderId := k.twapToSuborderId(order.OrderId)
+		// GoodTilBlockTime is set to the current block time + 10 seconds.
+		// This is because an in-flight suborder will have a good-til-block time of
+		// the current block time + 3 seconds, so 10 seconds is a reasonable buffer.
+		err := k.HandleMsgCancelOrder(ctx, &types.MsgCancelOrder{
+			OrderId: suborderId,
+			GoodTilOneof: &types.MsgCancelOrder_GoodTilBlockTime{
+				GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 10),
+			},
+		})
+		// We can expect a suborder to not exist during the window while it is waiting
+		// to be triggered.
+		if err != nil && !errors.Is(err, types.ErrStatefulOrderDoesNotExist) {
+			panic(fmt.Sprintf("MustRemoveStatefulOrder: error cancelling twap order and suborder: %v", err))
+		}
+	}
 }
 
 // IsConditionalOrderTriggered checks if a given order ID is triggered or untriggered in state.
@@ -453,5 +463,36 @@ func (k Keeper) SetStatefulOrderCount(
 			subaccountId.ToStateKey(),
 			k.cdc.MustMarshal(&result),
 		)
+	}
+}
+
+func (k Keeper) CheckAndIncrementStatefulOrderCount(
+	ctx sdk.Context,
+	orderId types.OrderId,
+) {
+	if orderId.IsTwapSuborder() {
+		return
+	}
+	subaccountId := orderId.SubaccountId
+	count := k.GetStatefulOrderCount(ctx, subaccountId)
+	k.SetStatefulOrderCount(ctx, subaccountId, count+1)
+}
+
+func (k Keeper) CheckAndDecrementStatefulOrderCount(
+	ctx sdk.Context,
+	orderId types.OrderId,
+) {
+	if orderId.IsTwapSuborder() {
+		return
+	}
+
+	subaccountId := orderId.SubaccountId
+	count := k.GetStatefulOrderCount(ctx, subaccountId)
+	if count == 0 {
+		log.ErrorLog(ctx, "Stateful order count is zero but order is in the store. Underflow",
+			"orderId", cometbftlog.NewLazySprintf("%+v", orderId),
+		)
+	} else {
+		k.SetStatefulOrderCount(ctx, subaccountId, count-1)
 	}
 }

--- a/protocol/x/clob/keeper/stateful_order_state_test.go
+++ b/protocol/x/clob/keeper/stateful_order_state_test.go
@@ -328,8 +328,6 @@ func TestGetSetDeleteLongTermOrderState(t *testing.T) {
 			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-			types.StatefulOrderCountPrefix +
-				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +
@@ -339,8 +337,6 @@ func TestGetSetDeleteLongTermOrderState(t *testing.T) {
 			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-			types.StatefulOrderCountPrefix +
-				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +
@@ -350,8 +346,6 @@ func TestGetSetDeleteLongTermOrderState(t *testing.T) {
 			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
-			types.StatefulOrderCountPrefix +
-				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
 			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -17,6 +17,21 @@ const TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET = 3
 // quantums per leg that a suborder can be.
 var TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE = big.NewInt(3)
 
+type twapOperationType int
+
+const (
+	parentTwapCompleted twapOperationType = iota
+	parentTwapCancelled
+	createSuborder
+)
+
+type twapOrderOperation struct {
+	operationType      twapOperationType
+	keyToDelete        []byte
+	suborderToPlace    *types.Order
+	twapOrderPlacement *types.TwapOrderPlacement
+}
+
 func (k Keeper) SetTWAPOrderPlacement(ctx sdk.Context,
 	order types.Order,
 	blockHeight uint32,
@@ -95,7 +110,7 @@ func (k Keeper) AddSuborderToTriggerStore(
 	ctx sdk.Context,
 	suborderId types.OrderId,
 	triggerOffset int64,
-) {
+) []byte {
 	triggerStore := k.GetTWAPTriggerOrderPlacementStore(ctx)
 	triggerTime := ctx.BlockTime().Unix() + triggerOffset
 
@@ -103,6 +118,15 @@ func (k Keeper) AddSuborderToTriggerStore(
 
 	// The value in the map is not used, so we can set it to an empty byte slice.
 	triggerStore.Set(triggerKey, []byte{})
+	return triggerKey
+}
+
+func (k Keeper) DeleteSuborderFromTriggerStore(
+	ctx sdk.Context,
+	triggerKey []byte,
+) {
+	triggerStore := k.GetTWAPTriggerOrderPlacementStore(ctx)
+	triggerStore.Delete(triggerKey)
 }
 
 // GenerateAndPlaceTriggeredTwapSuborders will iterate over the twap trigger
@@ -115,15 +139,9 @@ func (k Keeper) AddSuborderToTriggerStore(
 func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
 	triggerStore := k.GetTWAPTriggerOrderPlacementStore(ctx)
 	blockTime := ctx.BlockTime().Unix()
+	var operationsToProcess []twapOrderOperation
+
 	iterator := triggerStore.Iterator(nil, nil)
-	defer iterator.Close()
-
-	var operationsToProcess []struct {
-		keyToDelete        []byte
-		suborderToPlace    types.Order
-		twapOrderPlacement types.TwapOrderPlacement
-	}
-
 	for ; iterator.Valid(); iterator.Next() {
 		var orderId types.OrderId
 		k.cdc.MustUnmarshal(iterator.Key()[8:], &orderId)
@@ -143,20 +161,24 @@ func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
 
 		twapOrderPlacement, found := k.GetTwapOrderPlacement(ctx, parentOrderId)
 		if !found {
-			// TODO: (anmol) handle order cancellation
+			// If parent TWAP was cancelled/found, do not place any pending suborders.
+			operationsToProcess = append(operationsToProcess, twapOrderOperation{
+				operationType: parentTwapCancelled,
+				keyToDelete:   append([]byte{}, iterator.Key()...),
+			})
 			continue
 		}
 
-		order := k.GenerateSuborder(ctx, orderId, twapOrderPlacement, blockTime)
-
-		operationsToProcess = append(operationsToProcess, struct {
-			keyToDelete        []byte
-			suborderToPlace    types.Order
-			twapOrderPlacement types.TwapOrderPlacement
-		}{
+		operationType := createSuborder
+		order, isGenerated := k.GenerateSuborder(ctx, orderId, twapOrderPlacement, blockTime)
+		if !isGenerated {
+			operationType = parentTwapCompleted
+		}
+		operationsToProcess = append(operationsToProcess, twapOrderOperation{
+			operationType:      operationType,
 			keyToDelete:        append([]byte{}, iterator.Key()...),
 			suborderToPlace:    order,
-			twapOrderPlacement: twapOrderPlacement,
+			twapOrderPlacement: &twapOrderPlacement,
 		})
 	}
 	iterator.Close()
@@ -165,53 +187,59 @@ func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
 		// Delete from trigger store
 		triggerStore.Delete(op.keyToDelete)
 
-		// decrement remaining legs
-		k.DecrementTwapOrderRemainingLegs(ctx, &op.twapOrderPlacement)
-
-		if op.twapOrderPlacement.RemainingLegs == 0 {
-			// remove the parent twap order from the store
-			store := k.GetTWAPOrderPlacementStore(ctx)
-			orderKey := op.twapOrderPlacement.Order.OrderId.ToStateKey()
-			store.Delete(orderKey)
-			// TODO: (anmol) handle missing parent order case
-			// TODO: (anmol) emit event?
-		}
-
-		// place triggered suborder
-		err := k.HandleMsgPlaceOrder(ctx, &types.MsgPlaceOrder{Order: op.suborderToPlace}, true)
-		if err != nil {
-			k.Logger(ctx).Error(
-				"Failed to place TWAP suborder",
-				"error", err.Error(),
-				"suborderId", op.suborderToPlace.OrderId,
-			)
-			continue // TODO: (anmol) handle suborder placement failure
-		}
-
-		if op.twapOrderPlacement.RemainingLegs > 0 {
-			k.AddSuborderToTriggerStore(
+		switch op.operationType {
+		case parentTwapCancelled:
+			// no-op after trigger key has been deleted
+		case parentTwapCompleted:
+			// TODO: (anmol) emit indexer event (TWAP completion)?
+			k.DeleteTWAPOrderPlacement(ctx, *op.twapOrderPlacement)
+		case createSuborder:
+			// decrement remaining legs
+			k.DecrementTwapOrderRemainingLegs(ctx, *op.twapOrderPlacement)
+			// add the next suborder to the trigger store
+			triggerKey := k.AddSuborderToTriggerStore(
 				ctx,
 				op.suborderToPlace.OrderId,
 				int64(op.twapOrderPlacement.Order.TwapParameters.Interval),
+			)
+
+			// place triggered suborder
+			err := k.HandleMsgPlaceOrder(ctx, &types.MsgPlaceOrder{Order: *op.suborderToPlace}, true)
+			if err != nil {
+				// TODO: (anmol) emit indexer event (TWAP error)
+				k.DeleteTWAPOrderPlacement(ctx, *op.twapOrderPlacement)
+				k.DeleteSuborderFromTriggerStore(ctx, triggerKey)
+			}
+		default:
+			k.Logger(ctx).Error(
+				"unsupported twap operation type can not be processed",
+				"operationType", op.operationType,
 			)
 		}
 	}
 }
 
+func (k Keeper) DeleteTWAPOrderPlacement(
+	ctx sdk.Context,
+	twapOrderPlacement types.TwapOrderPlacement,
+) {
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
+	store.Delete(orderKey)
+}
+
 func (k Keeper) DecrementTwapOrderRemainingLegs(
 	ctx sdk.Context,
-	twapOrderPlacement *types.TwapOrderPlacement,
+	twapOrderPlacement types.TwapOrderPlacement,
 ) {
-	if twapOrderPlacement.RemainingLegs == 0 {
-		return // TODO: (anmol) handle end of twap order case
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
+	if twapOrderPlacement.IsCompleted() {
+		panic("twap order has already been completed")
 	}
 
 	twapOrderPlacement.RemainingLegs--
-
-	// Store updated state
-	store := k.GetTWAPOrderPlacementStore(ctx)
-	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
-	twapOrderPlacementBytes := k.cdc.MustMarshal(twapOrderPlacement)
+	twapOrderPlacementBytes := k.cdc.MustMarshal(&twapOrderPlacement)
 	store.Set(orderKey, twapOrderPlacementBytes)
 }
 
@@ -257,7 +285,10 @@ func (k Keeper) calculateSuborderQuantums(
 	remainingLegs := twapOrderPlacement.RemainingLegs
 	remainingQuantumsPerLeg := lib.BigDivCeil(lib.BigU(remainingQuantums), lib.BigU(remainingLegs))
 
-	maxSuborderSize := new(big.Int).Mul(originalQuantumsPerLeg, TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE)
+	maxSuborderSize := new(big.Int).Mul(
+		originalQuantumsPerLeg,
+		TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE,
+	)
 
 	suborderQuantums := lib.BigMin(
 		remainingQuantumsPerLeg,
@@ -289,12 +320,16 @@ func (k Keeper) GenerateSuborder(
 	suborderId types.OrderId,
 	twapOrderPlacement types.TwapOrderPlacement,
 	blockTime int64,
-) types.Order {
+) (*types.Order, bool) {
+	if twapOrderPlacement.IsCompleted() {
+		return nil, false
+	}
+
 	parentOrder := twapOrderPlacement.Order
 	order := types.Order{
 		OrderId:    suborderId,
 		Side:       twapOrderPlacement.Order.Side,
-		ReduceOnly: twapOrderPlacement.Order.ReduceOnly,
+		ReduceOnly: twapOrderPlacement.Order.ReduceOnly, // TODO: (anmol) client metadata?
 	}
 
 	priceTolerancePpm := int32(parentOrder.TwapParameters.PriceTolerance)
@@ -315,5 +350,5 @@ func (k Keeper) GenerateSuborder(
 		GoodTilBlockTime: uint32(blockTime + TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET),
 	}
 
-	return order
+	return &order, true
 }

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -47,9 +47,6 @@ func (k Keeper) SetTWAPOrderPlacement(ctx sdk.Context,
 		RemainingQuantums: order.Quantums,
 	}
 
-	// Increment the stateful order count only once for TWAP orders.
-	// Suborders that are generated from a TWAP order are not counted
-	// towards the stateful order count.
 	k.CheckAndIncrementStatefulOrderCount(ctx, order.OrderId)
 
 	twapOrderPlacementBytes := k.cdc.MustMarshal(&twapOrderPlacement)

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -336,9 +336,10 @@ func (k Keeper) GenerateSuborder(
 
 	parentOrder := twapOrderPlacement.Order
 	order := types.Order{
-		OrderId:    suborderId,
-		Side:       twapOrderPlacement.Order.Side,
-		ReduceOnly: twapOrderPlacement.Order.ReduceOnly, // TODO: (anmol) client metadata?
+		OrderId:        suborderId,
+		Side:           twapOrderPlacement.Order.Side,
+		ReduceOnly:     twapOrderPlacement.Order.ReduceOnly,
+		ClientMetadata: twapOrderPlacement.Order.ClientMetadata,
 	}
 
 	priceTolerancePpm := int32(parentOrder.TwapParameters.PriceTolerance)

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -228,6 +228,9 @@ func (k Keeper) DeleteTWAPOrderPlacement(
 	ctx sdk.Context,
 	twapOrderPlacement types.TwapOrderPlacement,
 ) {
+	// Decrement the stateful order count for the TWAP order.
+	k.CheckAndDecrementStatefulOrderCount(ctx, twapOrderPlacement.Order.OrderId)
+
 	store := k.GetTWAPOrderPlacementStore(ctx)
 	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
 	store.Delete(orderKey)

--- a/protocol/x/clob/keeper/twap_order_state_test.go
+++ b/protocol/x/clob/keeper/twap_order_state_test.go
@@ -607,9 +607,15 @@ func TestGenerateSuborder(t *testing.T) {
 				OrderFlags:   types.OrderIdFlags_TwapSuborder,
 				ClobPairId:   tc.twapOrderPlacement.Order.OrderId.ClobPairId,
 			}
-			generatedOrder := ks.ClobKeeper.GenerateSuborder(ctx, suborderId, tc.twapOrderPlacement, tc.blockTime)
+			generatedOrder, isGenerated := ks.ClobKeeper.GenerateSuborder(
+				ctx,
+				suborderId,
+				tc.twapOrderPlacement,
+				tc.blockTime,
+			)
 
 			// Verify the generated order matches expectations
+			require.True(t, isGenerated)
 			require.Equal(t, tc.expectedOrder.OrderId, generatedOrder.OrderId)
 			require.Equal(t, tc.expectedOrder.Side, generatedOrder.Side)
 			require.Equal(t, tc.expectedOrder.GoodTilOneof, generatedOrder.GoodTilOneof)

--- a/protocol/x/clob/types/order.go
+++ b/protocol/x/clob/types/order.go
@@ -288,3 +288,8 @@ func TriggerTimeToBytes(triggerTime int64) []byte {
 func TimeFromTriggerKey(triggerKey []byte) int64 {
 	return int64(binary.BigEndian.Uint64(triggerKey[0:8]))
 }
+
+// IsCompleted returns true if the TWAP order has no remaining legs to execute.
+func (t *TwapOrderPlacement) IsCompleted() bool {
+	return t.RemainingLegs == 0
+}


### PR DESCRIPTION
### Changelist
This PR is dependent on #2780 and #2779.

Now that we can fire off suborders from the end blocker, we need to handle the cases on which we will stop processing suborders for a twap order. The cases are:
- Parent TWAP is cancelled
- Parent TWAP is complete
- Suborder fails to be placed

The state for all these cases is already stored in the TWAP Placement Store - so when processing the suborders in the end blocker we can simply check it and act accordingly. When one of these cases is true, we need to remove both the parent twap from the placement store as well as delete the key in the trigger store. Since there is only one key in the trigger store per parent twap at any time, we should just be able to delete the existing key and not need to iterate over the whole store to find others.

### Test Plan
Add e2e test to ensure that twap order placement prevents any further suborders from being placed.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling and tracking of TWAP (Time-Weighted Average Price) order lifecycle, including better management of suborders, cancellations, and stateful order counts.
  * Enhanced error handling and state management for TWAP orders, ensuring accurate updates when collateral is depleted or orders are cancelled.

* **Bug Fixes**
  * Resolved issues with suborder triggering and removal, preventing creation of new suborders when collateral is insufficient or after cancellation.

* **Tests**
  * Added comprehensive end-to-end tests for TWAP order lifecycle, covering collateral depletion, cancellation, multi-suborder scenarios, and stateful order count accuracy.

* **Other Improvements**
  * Improved internal logic for order state management, resulting in more robust and reliable order processing for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->