### PR TITLE
intrument sizes of bids and asks in orderbook cache

### DIFF
--- a/indexer/services/roundtable/__tests__/tasks/orderbook-instrumentation.test.ts
+++ b/indexer/services/roundtable/__tests__/tasks/orderbook-instrumentation.test.ts
@@ -95,6 +95,13 @@ describe('orderbook-instrumentation', () => {
             sizeDeltaInQuantums: '3500',
             client: redisClient,
           }),
+          OrderbookLevelsCache.updatePriceLevel({
+            ticker: perpetualMarket.ticker,
+            side: OrderSide.SELL,
+            humanPrice: '46800',
+            sizeDeltaInQuantums: '1500',
+            client: redisClient,
+          }),
         ]);
       },
       ));
@@ -102,7 +109,7 @@ describe('orderbook-instrumentation', () => {
     await orderbookInstrumentationTask();
 
     perpetualMarkets.forEach((perpetualMarket: PerpetualMarketFromDatabase) => {
-      const tags: Object = { clob_pair_id: perpetualMarket.clobPairId };
+      const tags: Object = { ticker: perpetualMarket.ticker };
 
       // Check for human prices being gauged
       expect(stats.gauge).toHaveBeenCalledWith(
@@ -116,6 +123,11 @@ describe('orderbook-instrumentation', () => {
         tags,
       );
       expect(stats.gauge).toHaveBeenCalledWith(
+        'roundtable.crossed_orderbook.num_bid_levels',
+        3,
+        tags,
+      );
+      expect(stats.gauge).toHaveBeenCalledWith(
         'roundtable.uncrossed_orderbook.best_ask_human',
         45300,
         tags,
@@ -123,6 +135,11 @@ describe('orderbook-instrumentation', () => {
       expect(stats.gauge).toHaveBeenCalledWith(
         'roundtable.crossed_orderbook.best_ask_human',
         45000,
+        tags,
+      );
+      expect(stats.gauge).toHaveBeenCalledWith(
+        'roundtable.crossed_orderbook.num_ask_levels',
+        4,
         tags,
       );
 

--- a/indexer/services/roundtable/src/tasks/orderbook-instrumentation.ts
+++ b/indexer/services/roundtable/src/tasks/orderbook-instrumentation.ts
@@ -59,17 +59,17 @@ function statOrderbook(
     stats.gauge(
       `${config.SERVICE_NAME}.${stat}.best_bid_human`,
       Big(orderbookLevels.bids[0].humanPrice).toNumber(),
-      { ticker: ticker },
+      { ticker },
     );
     stats.gauge(
       `${config.SERVICE_NAME}.${stat}.best_bid_subticks`,
       priceToSubticks(orderbookLevels.bids[0].humanPrice, perpetualMarket),
-      { ticker: ticker },
+      { ticker },
     );
     stats.gauge(
-      `${config.SERVICE_NAME}.${stat}.num_bids`,
+      `${config.SERVICE_NAME}.${stat}.num_bid_levels`,
       orderbookLevels.bids.length,
-      { ticker: ticker },
+      { ticker },
     );
   }
   // Don't stat best ask if there are no asks in the orderbook
@@ -77,17 +77,17 @@ function statOrderbook(
     stats.gauge(
       `${config.SERVICE_NAME}.${stat}.best_ask_human`,
       Big(orderbookLevels.asks[0].humanPrice).toNumber(),
-      { ticker: ticker },
+      { ticker },
     );
     stats.gauge(
       `${config.SERVICE_NAME}.${stat}.best_ask_subticks`,
       priceToSubticks(orderbookLevels.asks[0].humanPrice, perpetualMarket),
-      { ticker: ticker },
+      { ticker },
     );
     stats.gauge(
-      `${config.SERVICE_NAME}.${stat}.num_asks`,
+      `${config.SERVICE_NAME}.${stat}.num_ask_levels`,
       orderbookLevels.asks.length,
-      { ticker: ticker },
+      { ticker },
     );
   }
   logger.info({


### PR DESCRIPTION
### Changelist
emit metric on how many total bids and asks are in orderbook cache for each market

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new metrics to report the count of bids and asks in the orderbook.
- **Refactor**
  - Updated orderbook statistics and logs to use ticker identifiers instead of clob pair IDs.
  - Log messages now display only the first 10 bids and asks for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->