### PR TITLE
[CT-1358] Support Limit Price for TWAP

### DIFF
--- a/indexer/packages/v4-protos/src/codegen/dydxprotocol/clob/order.ts
+++ b/indexer/packages/v4-protos/src/codegen/dydxprotocol/clob/order.ts
@@ -731,9 +731,9 @@ export interface TwapParameters {
 
   interval: number;
   /**
-   * Price tolerance for each suborder. This will be applied to
+   * Price tolerance in ppm for each suborder. This will be applied to
    * the oracle price each time a suborder is triggered. Must be
-   * be in the range [0, 10000).
+   * be in the range [0, 1_000_000).
    */
 
   priceTolerance: number;
@@ -754,9 +754,9 @@ export interface TwapParametersSDKType {
 
   interval: number;
   /**
-   * Price tolerance for each suborder. This will be applied to
+   * Price tolerance in ppm for each suborder. This will be applied to
    * the oracle price each time a suborder is triggered. Must be
-   * be in the range [0, 10000).
+   * be in the range [0, 1_000_000).
    */
 
   price_tolerance: number;

--- a/proto/dydxprotocol/clob/order.proto
+++ b/proto/dydxprotocol/clob/order.proto
@@ -243,9 +243,9 @@ message TwapParameters {
   // [30 (30 seconds), 3600 (1 hour)].
   uint32 interval = 2;
 
-  // Price tolerance for each suborder. This will be applied to
+  // Price tolerance in ppm for each suborder. This will be applied to
   // the oracle price each time a suborder is triggered. Must be
-  // be in the range [0, 10000).
+  // be in the range [0, 1_000_000).
   uint32 price_tolerance = 3;
 }
 

--- a/protocol/lib/quantums.go
+++ b/protocol/lib/quantums.go
@@ -88,3 +88,25 @@ func QuoteToBaseQuantums(
 
 	return result
 }
+
+// BigRatRoundToMultiple rounds a big.Rat to the nearest multiple of the given number.
+// If roundUp is true, it rounds up to the nearest multiple, otherwise it rounds down.
+func BigRatRoundToMultiple(
+	value *big.Rat,
+	multiple *big.Int,
+	roundUp bool,
+) *big.Int {
+	// Convert the value to a big.Int
+	valueInt := new(big.Int).Div(value.Num(), value.Denom())
+
+	// Calculate the remainder
+	remainder := new(big.Int).Mod(valueInt, multiple)
+
+	if roundUp && remainder.Sign() != 0 {
+		valueInt.Add(valueInt, new(big.Int).Sub(multiple, remainder))
+	} else {
+		valueInt.Sub(valueInt, remainder)
+	}
+
+	return valueInt
+}

--- a/protocol/testutil/constants/stateful_orders.go
+++ b/protocol/testutil/constants/stateful_orders.go
@@ -1416,4 +1416,43 @@ var (
 		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
 		TimeInForce:  clobtypes.Order_TIME_IN_FORCE_IOC,
 	}
+
+	// TWAP orders.
+	TwapOrder_Bob_Num0_Id1_Clob0_Buy10_Price35_GTB20_RO = clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: Bob_Num0,
+			ClientId:     1,
+			OrderFlags:   clobtypes.OrderIdFlags_Twap,
+			ClobPairId:   0,
+		},
+		TwapParameters: &clobtypes.TwapParameters{
+			Duration:       300,
+			Interval:       30,
+			PriceTolerance: 0,
+		},
+		Side:         clobtypes.Order_SIDE_BUY,
+		Quantums:     10,
+		Subticks:     35,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+		ReduceOnly:   true,
+	}
+
+	TwapOrder_Bob_Num0_Id1_Clob0_Buy1000_Price35_GTB20_RO = clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: Bob_Num0,
+			ClientId:     1,
+			OrderFlags:   clobtypes.OrderIdFlags_Twap,
+			ClobPairId:   0,
+		},
+		TwapParameters: &clobtypes.TwapParameters{
+			Duration:       300,
+			Interval:       30,
+			PriceTolerance: 0,
+		},
+		Side:         clobtypes.Order_SIDE_BUY,
+		Quantums:     1000,
+		Subticks:     35,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+		ReduceOnly:   true,
+	}
 )

--- a/protocol/x/clob/abci.go
+++ b/protocol/x/clob/abci.go
@@ -78,6 +78,9 @@ func EndBlocker(
 	// Prune any fill amounts from state which are now past their `pruneableBlockHeight`.
 	keeper.PruneStateFillAmountsForShortTermOrders(ctx)
 
+	// Place any TWAP suborders that are due
+	keeper.GenerateAndPlaceTriggeredTwapSuborders(ctx)
+
 	// Prune expired stateful orders completely from state.
 	expiredStatefulOrderIds := keeper.RemoveExpiredStatefulOrders(ctx, ctx.BlockTime())
 	for _, orderId := range expiredStatefulOrderIds {

--- a/protocol/x/clob/client/cli/tx_place_order.go
+++ b/protocol/x/clob/client/cli/tx_place_order.go
@@ -70,6 +70,7 @@ func CmdPlaceOrder() *cobra.Command {
 							Number: argSubaccountNumber,
 						},
 						ClobPairId: argClobPairId,
+						OrderFlags: types.OrderIdFlags_ShortTerm,
 					},
 					Side:         types.Order_Side(argSide),
 					Quantums:     argQuantums,

--- a/protocol/x/clob/e2e/twap_orders_test.go
+++ b/protocol/x/clob/e2e/twap_orders_test.go
@@ -295,3 +295,93 @@ func TestTWAPOrderWithMatchingOrders(t *testing.T) {
 	require.True(t, found2, "Third suborder should exist in trigger store")
 	require.Equal(t, ctx.BlockTime().Unix()+int64(twapOrder.TwapParameters.Interval), triggerTime)
 }
+
+func TestTwapOrderCancellation(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+
+	// Create a TWAP order with:
+	// - 300 second duration (5 minutes)
+	// - 60 second interval
+	// This will create 5 suborders total
+	twapOrder := *clobtypes.NewMsgPlaceOrder(
+		clobtypes.Order{
+			OrderId: clobtypes.OrderId{
+				SubaccountId: constants.Alice_Num0,
+				ClientId:     0,
+				OrderFlags:   clobtypes.OrderIdFlags_Twap,
+				ClobPairId:   0,
+			},
+			Side:     clobtypes.Order_SIDE_BUY,
+			Quantums: 100_000_000_000, // 10 BTC
+			Subticks: 0,               // market TWAP order
+			GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+				GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 300), // 5 minutes from now
+			},
+			TwapParameters: &clobtypes.TwapParameters{
+				Duration:       300, // 5 minutes
+				Interval:       60,  // 1 minute
+				PriceTolerance: 0,   // 0% slippage off oracle price
+			},
+		},
+	)
+
+	// Place the TWAP order
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, twapOrder) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+
+	// Advance block time to trigger first suborder
+	ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 60),
+	})
+
+	// Verify first suborder was created
+	suborderId := clobtypes.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   clobtypes.OrderIdFlags_TwapSuborder,
+		ClobPairId:   0,
+	}
+	suborder, found := tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.True(t, found, "First suborder should exist in memclob")
+	require.Equal(t, uint64(20_000_000_000), suborder.Quantums) // 100B/5 = 20B per leg
+
+	// Cancel the TWAP order
+	cancelMsg := clobtypes.MsgCancelOrder{
+		OrderId: twapOrder.Order.OrderId,
+		GoodTilOneof: &clobtypes.MsgCancelOrder_GoodTilBlockTime{
+			// 5 minutes and 30 seconds from now
+			GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 330),
+		},
+	}
+
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, cancelMsg) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+
+	// Advance block to deliver cancellation message
+	ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{})
+
+	// Verify TWAP order was removed from state
+	_, found = tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.Order.OrderId,
+	)
+	require.False(t, found, "TWAP order placement should be removed")
+
+	// Verify suborder was removed from memclob
+	_, found = tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.False(t, found, "Suborder should be removed from memclob")
+
+	// Verify no more suborders will be triggered
+	tApp.AdvanceToBlock(4, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 60),
+	})
+
+	// Verify no new suborder was created
+	_, found = tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.False(t, found, "No new suborder should be created after cancellation")
+}

--- a/protocol/x/clob/e2e/twap_orders_test.go
+++ b/protocol/x/clob/e2e/twap_orders_test.go
@@ -1,0 +1,297 @@
+package clob_test
+
+import (
+	"testing"
+	"time"
+
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	clobtestutils "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	testtx "github.com/dydxprotocol/v4-chain/protocol/testutil/tx"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTwapOrderPlacementAndCatchup(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+
+	// Create a TWAP order with:
+	// - 300 second duration (5 minutes, minimum allowed)
+	// - 60 second interval
+	// This will create 5 suborders total
+	twapOrder := *clobtypes.NewMsgPlaceOrder(
+		clobtypes.Order{
+			OrderId: clobtypes.OrderId{
+				SubaccountId: constants.Alice_Num0,
+				ClientId:     0,
+				OrderFlags:   clobtypes.OrderIdFlags_Twap,
+				ClobPairId:   0,
+			},
+			Side:     clobtypes.Order_SIDE_BUY,
+			Quantums: 100_000_000_000, // 10 BTC
+			Subticks: 0,               // market TWAP order
+			GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+				GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 300), // 5 minutes from now
+			},
+			TwapParameters: &clobtypes.TwapParameters{
+				Duration:       300, // 5 minutes
+				Interval:       60,  // 1 minute
+				PriceTolerance: 0,   // 0% slippage off oracle price
+			},
+		},
+	)
+
+	// Place the TWAP order
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(ctx, tApp.App, twapOrder) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+
+	// Advance block
+	ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+
+	// Verify the parent TWAP order state
+	twapOrderPlacement, found := tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.Order.OrderId,
+	)
+	require.True(t, found, "TWAP order placement should exist in state")
+	require.Equal(t, twapOrder.Order, twapOrderPlacement.Order)
+	require.Equal(t, uint32(4), twapOrderPlacement.RemainingLegs) // 5 original legs - 1 triggered
+	require.Equal(t, uint64(100_000_000_000), twapOrderPlacement.RemainingQuantums)
+
+	// Verify the first suborder was placed in the memclob
+	suborderId := clobtypes.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   clobtypes.OrderIdFlags_TwapSuborder,
+		ClobPairId:   0,
+	}
+
+	suborder, found := tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.True(t, found, "First suborder should exist in memclob")
+	require.Equal(t, uint64(20_000_000_000), suborder.Quantums) // 100B/5 = 20B per leg
+	require.Equal(t, uint64(200_000_000), suborder.Subticks)    // $20,000 oracle price
+	require.Equal(
+		t,
+		uint32(ctx.BlockTime().Unix()+3), // 3 seconds from now
+		suborder.GoodTilOneof.(*clobtypes.Order_GoodTilBlockTime).GoodTilBlockTime,
+	)
+	require.Equal(t, clobtypes.Order_SIDE_BUY, suborder.Side) // Same side as parent order
+
+	// Verify initial suborder in trigger store
+	nextSuborder, triggerTime, found := tApp.App.ClobKeeper.GetTwapTriggerPlacement(
+		ctx,
+		suborderId,
+	)
+	require.True(t, found, "TWAP trigger placement should exist")
+	require.Equal(t, suborderId, nextSuborder)
+	require.Equal(
+		t,
+		ctx.BlockTime().Unix()+int64(twapOrder.Order.TwapParameters.Interval),
+		triggerTime,
+	)
+
+	// Advance block time by 30 seconds
+	// Next suborder should not be triggered
+	ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 30),
+	})
+
+	// Verify TWAP order state
+	twapOrderPlacement, found = tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.Order.OrderId,
+	)
+	require.True(t, found, "TWAP order placement should still exist")
+	require.Equal(t, uint32(4), twapOrderPlacement.RemainingLegs)                   // One leg executed
+	require.Equal(t, uint64(100_000_000_000), twapOrderPlacement.RemainingQuantums) // 100B remaining - no quantums filled
+
+	suborder, found = tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.False(t, found, "Suborder should have been removed from memclob due to expiry")
+
+	// Advance block time by 30 seconds to trigger next suborder
+	ctx = tApp.AdvanceToBlock(4, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 30),
+	})
+
+	suborder1, found1 := tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.True(t, found1, "Second suborder should exist in memclob")
+	require.Equal(t, uint64(25_000_000_000), suborder1.Quantums) // 100B/4 = 25B per leg (catching up)
+	require.Equal(t, uint64(200_000_000), suborder1.Subticks)    // $20,000 per oracle price (not moved)
+	require.Equal(t, clobtypes.Order_SIDE_BUY, suborder1.Side)   // Same side as parent order
+
+	// Verify new suborder in trigger store
+	newSuborder, triggerTime, found := tApp.App.ClobKeeper.GetTwapTriggerPlacement(
+		ctx,
+		suborderId,
+	)
+	require.True(t, found, "TWAP trigger placement should exist")
+	require.Equal(t, suborderId, newSuborder)
+	require.Equal(
+		t,
+		ctx.BlockTime().Unix()+int64(twapOrder.Order.TwapParameters.Interval),
+		triggerTime,
+	)
+}
+
+func TestTWAPOrderWithMatchingOrders(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+
+	// Place a TWAP order to buy 100B quantums over 4 legs
+	twapOrder := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_Twap,
+			ClobPairId:   0,
+		},
+		Side:     clobtypes.Order_SIDE_BUY,
+		Quantums: 100_000_000_000, // 100B quantums
+		Subticks: 200_000_000,     // $20,000 per oracle price
+		TwapParameters: &clobtypes.TwapParameters{
+			Duration:       320,
+			Interval:       80,
+			PriceTolerance: 10_000,
+		},
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+			GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 100),
+		},
+	}
+
+	// Place a matching sell order at the same price
+	matchingOrder := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Bob_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:     clobtypes.Order_SIDE_SELL,
+		Quantums: 50_000_000_000, // 50B quantums
+		Subticks: 200_000_000,    // $20,000 per oracle price
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{
+			GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 3600),
+		},
+	}
+
+	// Place market order first and then TWAP order
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(
+		ctx,
+		tApp.App,
+		*clobtypes.NewMsgPlaceOrder(matchingOrder),
+	) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+	for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(
+		ctx,
+		tApp.App,
+		*clobtypes.NewMsgPlaceOrder(twapOrder),
+	) {
+		resp := tApp.CheckTx(checkTx)
+		require.True(t, resp.IsOK(), "Expected CheckTx to succeed. Response: %+v", resp)
+	}
+
+	suborderId := clobtypes.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   clobtypes.OrderIdFlags_TwapSuborder,
+		ClobPairId:   0,
+	}
+
+	ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+
+	ctx = tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 40),
+		RequestPrepareProposalTxsOverride: [][]byte{
+			testtx.MustGetTxBytes(&clobtypes.MsgProposedOperations{
+				OperationsQueue: []clobtypes.OperationRaw{
+					clobtestutils.NewMatchOperationRaw(
+						&clobtypes.Order{
+							OrderId:  suborderId,
+							Side:     clobtypes.Order_SIDE_BUY,
+							Quantums: 25_000_000_000,
+							Subticks: 200_000_000,
+						},
+						[]clobtypes.MakerFill{
+							{
+								FillAmount:   25_000_000_000,
+								MakerOrderId: matchingOrder.OrderId,
+							},
+						},
+					),
+				},
+			}),
+		},
+	})
+
+	// Verify TWAP order state is updated
+	twapOrderPlacement, found := tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.OrderId,
+	)
+	require.True(t, found, "TWAP order placement should exist")
+	require.Equal(t, uint32(3), twapOrderPlacement.RemainingLegs)
+	require.Equal(t, uint64(75_000_000_000), twapOrderPlacement.RemainingQuantums) // 100B - 25B filled
+
+	_, triggerTime, found1 := tApp.App.ClobKeeper.GetTwapTriggerPlacement(
+		ctx,
+		suborderId,
+	)
+	require.True(t, found1, "Second suborder should exist in trigger store")
+
+	require.Equal(t, int64(80), triggerTime)
+
+	_, placed_suborder1_found := tApp.App.ClobKeeper.MemClob.GetOrder(suborderId)
+	require.False(t, placed_suborder1_found, "Second suborder should not have been placed yet")
+
+	ctx = tApp.AdvanceToBlock(4, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 40),
+	})
+
+	filled_amount := tApp.App.ClobKeeper.MemClob.GetOrderFilledAmount(ctx, suborderId)
+	require.Equal(t, uint64(25_000_000_000), filled_amount.ToUint64())
+
+	ctx = tApp.AdvanceToBlock(5, testapp.AdvanceToBlockOptions{
+		BlockTime: ctx.BlockTime().Add(time.Second * 0),
+		RequestPrepareProposalTxsOverride: [][]byte{
+			testtx.MustGetTxBytes(&clobtypes.MsgProposedOperations{
+				OperationsQueue: []clobtypes.OperationRaw{
+					clobtestutils.NewMatchOperationRaw(
+						&clobtypes.Order{
+							OrderId:  suborderId,
+							Side:     clobtypes.Order_SIDE_BUY,
+							Quantums: 25_000_000_000,
+							Subticks: 200_000_000,
+						},
+						[]clobtypes.MakerFill{
+							{
+								FillAmount:   25_000_000_000,
+								MakerOrderId: matchingOrder.OrderId,
+							},
+						},
+					),
+				},
+			}),
+		},
+	})
+
+	// Verify TWAP order state is updated again
+	twapOrderPlacement, found = tApp.App.ClobKeeper.GetTwapOrderPlacement(
+		ctx,
+		twapOrder.OrderId,
+	)
+	require.True(t, found, "TWAP order placement should still exist")
+	require.Equal(t, uint32(2), twapOrderPlacement.RemainingLegs)
+	require.Equal(t, uint64(50_000_000_000), twapOrderPlacement.RemainingQuantums) // 75B - 25B filled
+
+	_, triggerTime, found2 := tApp.App.ClobKeeper.GetTwapTriggerPlacement(
+		ctx,
+		suborderId,
+	)
+	require.True(t, found2, "Third suborder should exist in trigger store")
+	require.Equal(t, ctx.BlockTime().Unix()+int64(twapOrder.TwapParameters.Interval), triggerTime)
+}

--- a/protocol/x/clob/keeper/keeper.go
+++ b/protocol/x/clob/keeper/keeper.go
@@ -300,12 +300,7 @@ func (k Keeper) InitMemStore(ctx sdk.Context) {
 	// Ensure that the stateful order count is accurately represented in the memstore on restart.
 	statefulOrders := k.GetAllStatefulOrders(ctx)
 	for _, order := range statefulOrders {
-		subaccountId := order.GetSubaccountId()
-		k.SetStatefulOrderCount(
-			ctx,
-			subaccountId,
-			k.GetStatefulOrderCount(ctx, subaccountId)+1,
-		)
+		k.CheckAndIncrementStatefulOrderCount(ctx, order.GetOrderId())
 	}
 }
 

--- a/protocol/x/clob/keeper/keeper_test.go
+++ b/protocol/x/clob/keeper/keeper_test.go
@@ -69,7 +69,11 @@ func TestInitMemStore_StatefulOrderCount(t *testing.T) {
 	)
 
 	// Reset the stateful order count to zero.
-	ks.ClobKeeper.SetStatefulOrderCount(ks.Ctx, constants.Alice_Num0, 0)
+	ks.ClobKeeper.SetStatefulOrderCount(
+		ks.Ctx,
+		constants.Alice_Num0,
+		0,
+	)
 
 	// InitMemStore should repopulate the count.
 	ks.ClobKeeper.InitMemStore(ks.Ctx)

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -130,10 +130,10 @@ func (k Keeper) HandleMsgPlaceOrder(
 		)
 		// TODO: add indexer event here
 	} else if order.IsTwapOrder() {
-		// we should not be adding twap orders to the delivered 
-		// long term list to prevent needing to special case for 
+		// we should not be adding twap orders to the delivered
+		// long term list to prevent needing to special case for
 		// twap orders in `PlaceStatefulOrdersFromLastBlock`
-		
+
 		// TODO: (anmol) add indexer event here
 	} else {
 		k.GetIndexerEventManager().AddTxnEvent(

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -128,6 +128,13 @@ func (k Keeper) HandleMsgPlaceOrder(
 			ctx,
 			order.OrderId,
 		)
+		// TODO: add indexer event here
+	} else if order.IsTwapOrder() {
+		// we should not be adding twap orders to the delivered
+		// long term list to prevent needing to special case for
+		// twap orders in `PlaceStatefulOrdersFromLastBlock`
+
+		// TODO: (anmol) add indexer event here
 	} else {
 		k.GetIndexerEventManager().AddTxnEvent(
 			ctx,

--- a/protocol/x/clob/keeper/msg_server_place_order.go
+++ b/protocol/x/clob/keeper/msg_server_place_order.go
@@ -130,10 +130,10 @@ func (k Keeper) HandleMsgPlaceOrder(
 		)
 		// TODO: add indexer event here
 	} else if order.IsTwapOrder() {
-		// we should not be adding twap orders to the delivered
-		// long term list to prevent needing to special case for
+		// we should not be adding twap orders to the delivered 
+		// long term list to prevent needing to special case for 
 		// twap orders in `PlaceStatefulOrdersFromLastBlock`
-
+		
 		// TODO: (anmol) add indexer event here
 	} else {
 		k.GetIndexerEventManager().AddTxnEvent(

--- a/protocol/x/clob/keeper/msg_server_place_order_test.go
+++ b/protocol/x/clob/keeper/msg_server_place_order_test.go
@@ -425,7 +425,7 @@ func TestPlaceOrder_Success(t *testing.T) {
 				twap_suborder, timestamp, found_suborder := ks.ClobKeeper.GetTwapTriggerPlacement(ctx, suborder.OrderId)
 				require.Equal(t, suborder.OrderId, twap_suborder)
 				require.True(t, found_suborder)
-				require.Equal(t, timestamp, uint64(ctx.BlockTime().Unix()))
+				require.Equal(t, timestamp, ctx.BlockTime().Unix())
 			} else {
 				_, found := ks.ClobKeeper.GetLongTermOrderPlacement(ctx, tc.StatefulOrderPlacement.GetOrderId())
 				require.True(t, found)

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -365,32 +365,38 @@ func (k Keeper) PlaceStatefulOrder(
 		if err := k.ValidateSubaccountEquityTierLimitForStatefulOrder(ctx, order); err != nil {
 			return err
 		}
+	}
 
-		// 4. Perform a check on the subaccount updates for the full size of the order to mitigate spam.
-		if !order.IsConditionalOrder() {
-			updateResult := k.AddOrderToOrderbookSubaccountUpdatesCheck(
-				ctx,
-				order.OrderId.SubaccountId,
-				types.PendingOpenOrder{
-					RemainingQuantums: order.GetBaseQuantums(),
-					IsBuy:             order.IsBuy(),
-					Subticks:          order.GetOrderSubticks(),
-					ClobPairId:        order.GetClobPairId(),
-				},
-			)
+	// 4. Perform a check on the subaccount updates for the full size of the order to mitigate spam.
+	// These checks should happen for all non-internal orders and for generated TWAP suborders.
+	// For market TWAP orders where subticks are 0, use the oracle price for collateralization check.
+	if order.IsCollateralCheckRequired(isInternalOrder) {
+		order_subticks, err := k.GetSubticksForCollatCheck(ctx, order)
+		if err != nil {
+			return err
+		}
+		updateResult := k.AddOrderToOrderbookSubaccountUpdatesCheck(
+			ctx,
+			order.OrderId.SubaccountId,
+			types.PendingOpenOrder{
+				RemainingQuantums: order.GetBaseQuantums(),
+				IsBuy:             order.IsBuy(),
+				Subticks:          order_subticks,
+				ClobPairId:        order.GetClobPairId(),
+			},
+		)
 
-			if !updateResult.IsSuccess() {
-				err := types.ErrStatefulOrderCollateralizationCheckFailed
-				if updateResult.IsIsolatedSubaccountError() {
-					err = types.ErrWouldViolateIsolatedSubaccountConstraints
-				}
-				return errorsmod.Wrapf(
-					err,
-					"PlaceStatefulOrder: order (%+v), result (%s)",
-					order,
-					updateResult.String(),
-				)
+		if !updateResult.IsSuccess() {
+			err := types.ErrStatefulOrderCollateralizationCheckFailed
+			if updateResult.IsIsolatedSubaccountError() {
+				err = types.ErrWouldViolateIsolatedSubaccountConstraints
 			}
+			return errorsmod.Wrapf(
+				err,
+				"PlaceStatefulOrder: order (%+v), result (%s)",
+				order,
+				updateResult.String(),
+			)
 		}
 	}
 
@@ -398,12 +404,16 @@ func (k Keeper) PlaceStatefulOrder(
 	// state.
 	if lib.IsDeliverTxMode(ctx) {
 		// Write the stateful order to state and the memstore.
-		k.SetLongTermOrderPlacement(ctx, order, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
-		k.AddStatefulOrderIdExpiration(
-			ctx,
-			order.MustGetUnixGoodTilBlockTime(),
-			order.GetOrderId(),
-		)
+		if order.IsTwapOrder() {
+			k.SetTWAPOrderPlacement(ctx, order, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
+		} else {
+			k.SetLongTermOrderPlacement(ctx, order, lib.MustConvertIntegerToUint32(ctx.BlockHeight()))
+			k.AddStatefulOrderIdExpiration(
+				ctx,
+				order.MustGetUnixGoodTilBlockTime(),
+				order.GetOrderId(),
+			)
+		}
 	} else {
 		// Write the stateful order to a transient store. PerformStatefulOrderValidation will ensure that the order does
 		// not exist which will prevent MustAddUncommittedStatefulOrderPlacement from panicking.
@@ -960,6 +970,20 @@ func (k Keeper) PerformStatefulOrderValidation(
 		}
 	}
 
+	if order.IsTwapOrder() {
+		totalLegs := order.GetTotalLegsTWAPOrder()
+		minOrderSize := uint64(totalLegs) * clobPair.StepBaseQuantums
+		if order.Quantums < minOrderSize {
+			return errorsmod.Wrapf(
+				types.ErrInvalidPlaceOrder,
+				"Generated TWAP suborder sizes (%v/%v) must be greater than min size for clob pair %v",
+				order.Quantums,
+				totalLegs,
+				clobPair.StepBaseQuantums,
+			)
+		}
+	}
+
 	return nil
 }
 
@@ -1016,6 +1040,22 @@ func (k Keeper) MustValidateReduceOnlyOrder(
 		)
 	}
 	return nil
+}
+
+func (k Keeper) GetSubticksForCollatCheck(ctx sdk.Context, order types.Order) (types.Subticks, error) {
+	if order.IsTwapOrder() && order.Subticks == uint64(0) {
+		// if twap market order, use the current oracle price as subticks
+		clobPairId := order.GetClobPairId()
+		clobPair, found := k.GetClobPair(ctx, clobPairId)
+		if !found {
+			return 0, types.ErrInvalidClob
+		}
+		oraclePriceSubticksRat := k.GetOraclePriceSubticksRat(ctx, clobPair)
+		orderSubticks := lib.BigRatRound(oraclePriceSubticksRat, false).Uint64()
+
+		return types.Subticks(orderSubticks), nil
+	}
+	return order.GetOrderSubticks(), nil
 }
 
 // AddOrderToOrderbookSubaccountUpdatesCheck performs checks on the subaccount updates that will occur

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -1233,9 +1233,9 @@ func (k Keeper) InitStatefulOrders(
 	}
 }
 
-// GetOraclePriceAdjustedByPercentageSubticks returns the oracle price in subticks 
-// adjusted by a given directional price tolerance in ppm, rounded to the nearest multiple 
-// of SubticksPerTick. A positive price tolerance increases the price, while a negative price 
+// GetOraclePriceAdjustedByPercentageSubticks returns the oracle price in subticks
+// adjusted by a given directional price tolerance in ppm, rounded to the nearest multiple
+// of SubticksPerTick. A positive price tolerance increases the price, while a negative price
 // tolerance decreases it.
 //
 // For example:

--- a/protocol/x/clob/keeper/process_operations_stateful_validation.go
+++ b/protocol/x/clob/keeper/process_operations_stateful_validation.go
@@ -35,7 +35,7 @@ func (k Keeper) FetchOrderFromOrderId(
 	}
 
 	// For stateful orders, fetch from state. Do not fetch from untriggered conditional orders.
-	if orderId.IsLongTermOrder() {
+	if orderId.IsLongTermOrder() || orderId.IsTwapSuborder() {
 		statefulOrderPlacement, found := k.GetLongTermOrderPlacement(ctx, orderId)
 		if !found {
 			return order, errorsmod.Wrapf(

--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -293,6 +293,29 @@ func (k Keeper) ProcessSingleMatch(
 		curMakerPruneableBlockHeight,
 	)
 
+	if !matchWithOrders.TakerOrder.IsLiquidation() {
+		taker_order := matchWithOrders.TakerOrder.MustGetOrder()
+		if taker_order.OrderId.IsTwapSuborder() {
+			log.ErrorLog(ctx, "handling twap order", fmt.Sprintf("%+v", taker_order))
+			// Get the parent order ID by removing the TWAP suborder flag
+			parentOrderId := types.OrderId{
+				SubaccountId: taker_order.OrderId.SubaccountId,
+				ClientId:     taker_order.OrderId.ClientId,
+				OrderFlags:   types.OrderIdFlags_Twap, // Set directly to TWAP
+				ClobPairId:   taker_order.OrderId.ClobPairId,
+			}
+
+			// Update the parent TWAP order state
+			if err := k.UpdateTWAPOrderStateOnSuborderFill(
+				ctx,
+				parentOrderId,
+				fillAmount.ToUint64(),
+			); err != nil {
+				return false, takerUpdateResult, makerUpdateResult, affiliateRevSharesQuoteQuantums, err
+			}
+		}
+	}
+
 	return true, takerUpdateResult, makerUpdateResult, affiliateRevSharesQuoteQuantums, nil
 }
 

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -63,11 +64,7 @@ func (k Keeper) SetLongTermOrderPlacement(
 
 	if !found {
 		// Increment the stateful order count.
-		k.SetStatefulOrderCount(
-			ctx,
-			order.OrderId.SubaccountId,
-			k.GetStatefulOrderCount(ctx, order.OrderId.SubaccountId)+1,
-		)
+		k.CheckAndIncrementStatefulOrderCount(ctx, order.OrderId)
 
 		telemetry.IncrCounterWithLabels(
 			[]string{types.ModuleName, metrics.StatefulOrder, metrics.Count},
@@ -146,24 +143,15 @@ func (k Keeper) DeleteLongTermOrderPlacement(
 	orderId.MustBeStatefulOrder()
 
 	store := k.fetchStateStoresForOrder(ctx, orderId)
-
-	count := k.GetStatefulOrderCount(ctx, orderId.SubaccountId)
 	orderKey := orderId.ToStateKey()
-	if store.Has(orderKey) {
-		if count == 0 {
-			log.ErrorLog(ctx, "Stateful order count is zero but order is in the store. Underflow",
-				"orderId", cometbftlog.NewLazySprintf("%+v", orderId),
-			)
-		} else {
-			count--
-		}
-	}
 
 	// Delete the `StatefulOrderPlacement` from state.
 	store.Delete(orderKey)
 
 	// Set the count.
-	k.SetStatefulOrderCount(ctx, orderId.SubaccountId, count)
+	if store.Has(orderKey) {
+		k.CheckAndDecrementStatefulOrderCount(ctx, orderId)
+	}
 
 	telemetry.IncrCounterWithLabels(
 		[]string{types.ModuleName, metrics.StatefulOrderRemoved, metrics.Count},
@@ -319,19 +307,40 @@ func (k Keeper) MustRemoveStatefulOrder(
 	// If this is a Short-Term order, panic.
 	orderId.MustBeStatefulOrder()
 
-	longTermOrderPlacement, exists := k.GetLongTermOrderPlacement(ctx, orderId)
+	order, exists := k.getOrderFromStore(ctx, orderId)
 	if !exists {
 		panic(fmt.Sprintf("MustRemoveStatefulOrder: order %v does not exist", orderId))
 	}
 
-	goodTilBlockTime := longTermOrderPlacement.Order.MustGetUnixGoodTilBlockTime()
-	k.RemoveStatefulOrderIdExpiration(ctx, goodTilBlockTime, orderId)
+	// TWAP orders are not maintained by these states because expiry and
+	// fills are updated by the generated suborders.
+	if !order.OrderId.IsTwapOrder() {
+		goodTilBlockTime := order.MustGetUnixGoodTilBlockTime()
+		k.RemoveStatefulOrderIdExpiration(ctx, goodTilBlockTime, orderId)
+		// Remove the order fill amount from state.
+		k.RemoveOrderFillAmount(ctx, orderId)
+		// Delete the Stateful order placement from state.
+	}
 
-	// Remove the order fill amount from state.
-	k.RemoveOrderFillAmount(ctx, orderId)
-
-	// Delete the Stateful order placement from state.
 	k.DeleteLongTermOrderPlacement(ctx, orderId)
+
+	if order.OrderId.IsTwapOrder() {
+		suborderId := k.twapToSuborderId(order.OrderId)
+		// GoodTilBlockTime is set to the current block time + 10 seconds.
+		// This is because an in-flight suborder will have a good-til-block time of
+		// the current block time + 3 seconds, so 10 seconds is a reasonable buffer.
+		err := k.HandleMsgCancelOrder(ctx, &types.MsgCancelOrder{
+			OrderId: suborderId,
+			GoodTilOneof: &types.MsgCancelOrder_GoodTilBlockTime{
+				GoodTilBlockTime: uint32(ctx.BlockTime().Unix() + 10),
+			},
+		})
+		// We can expect a suborder to not exist during the window while it is waiting
+		// to be triggered.
+		if err != nil && !errors.Is(err, types.ErrStatefulOrderDoesNotExist) {
+			panic(fmt.Sprintf("MustRemoveStatefulOrder: error cancelling twap order and suborder: %v", err))
+		}
+	}
 }
 
 // IsConditionalOrderTriggered checks if a given order ID is triggered or untriggered in state.
@@ -453,5 +462,36 @@ func (k Keeper) SetStatefulOrderCount(
 			subaccountId.ToStateKey(),
 			k.cdc.MustMarshal(&result),
 		)
+	}
+}
+
+func (k Keeper) CheckAndIncrementStatefulOrderCount(
+	ctx sdk.Context,
+	orderId types.OrderId,
+) {
+	if orderId.IsTwapSuborder() {
+		return
+	}
+	subaccountId := orderId.SubaccountId
+	count := k.GetStatefulOrderCount(ctx, subaccountId)
+	k.SetStatefulOrderCount(ctx, subaccountId, count+1)
+}
+
+func (k Keeper) CheckAndDecrementStatefulOrderCount(
+	ctx sdk.Context,
+	orderId types.OrderId,
+) {
+	if orderId.IsTwapSuborder() {
+		return
+	}
+
+	subaccountId := orderId.SubaccountId
+	count := k.GetStatefulOrderCount(ctx, subaccountId)
+	if count == 0 {
+		log.ErrorLog(ctx, "Stateful order count is zero but order is in the store. Underflow",
+			"orderId", cometbftlog.NewLazySprintf("%+v", orderId),
+		)
+	} else {
+		k.SetStatefulOrderCount(ctx, subaccountId, count-1)
 	}
 }

--- a/protocol/x/clob/keeper/stateful_order_state.go
+++ b/protocol/x/clob/keeper/stateful_order_state.go
@@ -144,12 +144,13 @@ func (k Keeper) DeleteLongTermOrderPlacement(
 
 	store := k.fetchStateStoresForOrder(ctx, orderId)
 	orderKey := orderId.ToStateKey()
+	orderExists := store.Has(orderKey)
 
 	// Delete the `StatefulOrderPlacement` from state.
 	store.Delete(orderKey)
 
 	// Set the count.
-	if store.Has(orderKey) {
+	if orderExists {
 		k.CheckAndDecrementStatefulOrderCount(ctx, orderId)
 	}
 

--- a/protocol/x/clob/keeper/stateful_order_state_test.go
+++ b/protocol/x/clob/keeper/stateful_order_state_test.go
@@ -328,8 +328,6 @@ func TestGetSetDeleteLongTermOrderState(t *testing.T) {
 			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
-			types.StatefulOrderCountPrefix +
-				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id0_Clob0_Buy5_Price10_GTBT20),
 			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +
@@ -339,8 +337,6 @@ func TestGetSetDeleteLongTermOrderState(t *testing.T) {
 			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
-			types.StatefulOrderCountPrefix +
-				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num0_Id1_Clob1_Sell65_Price15_GTBT25),
 			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +
@@ -350,8 +346,6 @@ func TestGetSetDeleteLongTermOrderState(t *testing.T) {
 			// Delete the order from state and decrement the stateful order count.
 			types.LongTermOrderPlacementKeyPrefix +
 				orderToStringId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
-			types.StatefulOrderCountPrefix +
-				orderToStringSubaccountId(constants.LongTermOrder_Alice_Num1_Id0_Clob0_Sell15_Price5_GTBT10),
 			// Write the order to state and increment the stateful order count.
 			types.NextStatefulOrderBlockTransactionIndexKey,
 			types.LongTermOrderPlacementKeyPrefix +

--- a/protocol/x/clob/keeper/stores.go
+++ b/protocol/x/clob/keeper/stores.go
@@ -78,6 +78,20 @@ func (k Keeper) GetTriggeredConditionalOrderPlacementStore(ctx sdk.Context) pref
 	)
 }
 
+func (k Keeper) GetTWAPOrderPlacementStore(ctx sdk.Context) prefix.Store {
+	return prefix.NewStore(
+		ctx.KVStore(k.storeKey),
+		[]byte(types.TWAPOrderKeyPrefix),
+	)
+}
+
+func (k Keeper) GetTWAPTriggerOrderPlacementStore(ctx sdk.Context) prefix.Store {
+	return prefix.NewStore(
+		ctx.KVStore(k.storeKey),
+		[]byte(types.TWAPTriggerOrderKeyPrefix),
+	)
+}
+
 // getTransientStore fetches a transient store used for reading and
 // updating the transient store.
 func (k Keeper) getTransientStore(ctx sdk.Context) storetypes.KVStore {
@@ -102,8 +116,10 @@ func (k Keeper) fetchStateStoresForOrder(
 			return k.GetTriggeredConditionalOrderPlacementStore(ctx)
 		}
 		return k.GetUntriggeredConditionalOrderPlacementStore(ctx)
-	} else if orderId.IsLongTermOrder() {
+	} else if orderId.IsLongTermOrder() || orderId.IsTwapSuborder() {
 		return k.GetLongTermOrderPlacementStore(ctx)
+	} else if orderId.IsTwapOrder() {
+		return k.GetTWAPOrderPlacementStore(ctx)
 	}
 	panic(
 		fmt.Sprintf(

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -1,10 +1,18 @@
 package keeper
 
 import (
-	"encoding/binary"
+	"math"
 
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+)
+
+const (
+	TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET = 3
+
+	TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE = 3
 )
 
 func (k Keeper) SetTWAPOrderPlacement(ctx sdk.Context,
@@ -52,7 +60,7 @@ func (k Keeper) GetTwapOrderPlacement(
 func (k Keeper) GetTwapTriggerPlacement(
 	ctx sdk.Context,
 	orderId types.OrderId,
-) (o types.OrderId, t uint64, found bool) {
+) (o types.OrderId, t int64, found bool) {
 	store := k.GetTWAPTriggerOrderPlacementStore(ctx)
 
 	iterator := store.Iterator(nil, nil)
@@ -62,7 +70,7 @@ func (k Keeper) GetTwapTriggerPlacement(
 		var suborderId types.OrderId
 		k.cdc.MustUnmarshal(iterator.Key()[8:], &suborderId)
 
-		timestamp := binary.BigEndian.Uint64(iterator.Key()[0:8])
+		timestamp := types.TimeFromTriggerKey(iterator.Key())
 		if suborderId == orderId {
 			return suborderId, timestamp, true
 		}
@@ -93,4 +101,179 @@ func (k Keeper) AddSuborderToTriggerStore(
 
 	// The value in the map is not used, so we can set it to an empty byte slice.
 	triggerStore.Set(triggerKey, []byte{})
+}
+
+func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
+	triggerStore := k.GetTWAPTriggerOrderPlacementStore(ctx)
+	blockTime := ctx.BlockTime().Unix()
+	iterator := triggerStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	var operationsToProcess []struct {
+		keyToDelete        []byte
+		suborderToPlace    types.Order
+		twapOrderPlacement types.TwapOrderPlacement
+	}
+
+	for ; iterator.Valid(); iterator.Next() {
+		var orderId types.OrderId
+		k.cdc.MustUnmarshal(iterator.Key()[8:], &orderId)
+
+		triggerTime := types.TimeFromTriggerKey(iterator.Key())
+
+		if triggerTime > blockTime {
+			break // all remaining suborders are in the future
+		}
+
+		parentOrderId := types.OrderId{
+			SubaccountId: orderId.SubaccountId,
+			ClientId:     orderId.ClientId,
+			OrderFlags:   types.OrderIdFlags_Twap, // Set directly to TWAP
+			ClobPairId:   orderId.ClobPairId,
+		}
+
+		twapOrderPlacement, found := k.GetTwapOrderPlacement(ctx, parentOrderId)
+		if !found {
+			panic("parent twap order not found") // TODO: (anmol) handle order cancellation
+		}
+
+		order := k.GenerateSuborder(ctx, orderId, twapOrderPlacement, blockTime)
+
+		operationsToProcess = append(operationsToProcess, struct {
+			keyToDelete        []byte
+			suborderToPlace    types.Order
+			twapOrderPlacement types.TwapOrderPlacement
+		}{
+			keyToDelete:        append([]byte{}, iterator.Key()...),
+			suborderToPlace:    order,
+			twapOrderPlacement: twapOrderPlacement,
+		})
+	}
+	iterator.Close()
+
+	for _, op := range operationsToProcess {
+		// Delete from trigger store
+		triggerStore.Delete(op.keyToDelete)
+
+		// decrement remaining legs
+		k.DecrementTwapOrderRemainingLegs(ctx, &op.twapOrderPlacement)
+
+		if op.twapOrderPlacement.RemainingLegs == 0 {
+			// remove the parent twap order from the store
+			store := k.GetTWAPOrderPlacementStore(ctx)
+			orderKey := op.twapOrderPlacement.Order.OrderId.ToStateKey()
+			store.Delete(orderKey)
+			// TODO: (anmol) handle missing parent order case
+			// TODO: (anmol) emit event?
+			continue
+		}
+
+		// add the next suborder to the trigger store
+		k.AddSuborderToTriggerStore(
+			ctx,
+			op.suborderToPlace.OrderId,
+			int64(op.twapOrderPlacement.Order.TwapParameters.Interval),
+		)
+
+		// place triggered suborder
+		err := k.HandleMsgPlaceOrder(ctx, &types.MsgPlaceOrder{Order: op.suborderToPlace}, true)
+		if err != nil {
+			continue // TODO: (anmol) handle suborder placement failure
+		}
+	}
+}
+
+func (k Keeper) DecrementTwapOrderRemainingLegs(
+	ctx sdk.Context,
+	twapOrderPlacement *types.TwapOrderPlacement,
+) {
+	if twapOrderPlacement.RemainingLegs == 0 {
+		return // TODO: (anmol) handle end of twap order case
+	}
+
+	twapOrderPlacement.RemainingLegs--
+
+	// Store updated state
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
+	twapOrderPlacementBytes := k.cdc.MustMarshal(twapOrderPlacement)
+	store.Set(orderKey, twapOrderPlacementBytes)
+}
+
+func (k Keeper) UpdateTWAPOrderStateOnSuborderFill(
+	ctx sdk.Context,
+	parentOrderId types.OrderId,
+	filledQuantums uint64,
+) error {
+	// Get the TWAP order placement
+	twapOrderPlacement, found := k.GetTwapOrderPlacement(ctx, parentOrderId)
+	if !found {
+		return errorsmod.Wrapf(
+			types.ErrInvalidTwapOrderPlacement,
+			"TWAP order %+v does not exist",
+			parentOrderId,
+		)
+	}
+
+	// Update remaining quantums
+	twapOrderPlacement.RemainingQuantums -= filledQuantums
+
+	// Store updated state
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := parentOrderId.ToStateKey()
+	twapOrderPlacementBytes := k.cdc.MustMarshal(&twapOrderPlacement)
+	store.Set(orderKey, twapOrderPlacementBytes)
+
+	return nil
+}
+
+func (k Keeper) calculateSuborderQuantums(
+	twapOrderPlacement types.TwapOrderPlacement,
+	clobPair types.ClobPair,
+) uint64 {
+	originalQuantumsPerLeg := float64(twapOrderPlacement.Order.Quantums) / float64(twapOrderPlacement.Order.GetTotalLegsTWAPOrder())
+
+	// Calculate the quantums for the suborder capping at 3x the original quantums per leg
+	remainingPerLeg := float64(twapOrderPlacement.RemainingQuantums) / float64(twapOrderPlacement.RemainingLegs)
+	suborderQuantums := lib.Min(remainingPerLeg, TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE*originalQuantumsPerLeg)
+
+	// Round down to nearest multiple of StepBaseQuantums
+	quantumsByStepBaseQuantums := uint64(math.Floor(suborderQuantums / float64(clobPair.StepBaseQuantums)))
+	suborderQuantumsRounded := quantumsByStepBaseQuantums * clobPair.StepBaseQuantums
+
+	return suborderQuantumsRounded
+}
+
+func (k Keeper) GenerateSuborder(
+	ctx sdk.Context,
+	suborderId types.OrderId,
+	twapOrderPlacement types.TwapOrderPlacement,
+	blockTime int64,
+) types.Order {
+	parentOrder := twapOrderPlacement.Order
+	order := types.Order{
+		OrderId:    suborderId,
+		Side:       twapOrderPlacement.Order.Side,
+		ReduceOnly: twapOrderPlacement.Order.ReduceOnly,
+	}
+
+	priceTolerancePpm := int32(parentOrder.TwapParameters.PriceTolerance)
+	if parentOrder.Side == types.Order_SIDE_SELL {
+		// for sell orders, we want to adjust the price down
+		priceTolerancePpm = -priceTolerancePpm
+	}
+
+	// calculate the suborder price with slippage adjustment
+	clobPair := k.mustGetClobPair(ctx, parentOrder.GetClobPairId())
+	order.Subticks = k.GetOraclePriceAdjustedByPercentageSubticks(ctx, clobPair, priceTolerancePpm)
+
+	// calculate the suborder quantums based on remaining quantums and legs
+	order.Quantums = k.calculateSuborderQuantums(twapOrderPlacement, clobPair)
+
+	// set good til block time from current block time
+	order.GoodTilOneof = &types.Order_GoodTilBlockTime{
+		GoodTilBlockTime: uint32(blockTime + TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET),
+	}
+
+	return order
 }

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -1,0 +1,96 @@
+package keeper
+
+import (
+	"encoding/binary"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+)
+
+func (k Keeper) SetTWAPOrderPlacement(ctx sdk.Context,
+	order types.Order,
+	blockHeight uint32,
+) {
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := order.OrderId.ToStateKey()
+
+	total_legs := order.GetTotalLegsTWAPOrder()
+
+	twapOrderPlacement := types.TwapOrderPlacement{
+		Order:             order,
+		RemainingLegs:     total_legs,
+		RemainingQuantums: order.Quantums,
+	}
+
+	k.AddSuborderToTriggerStore(ctx, k.twapToSuborderId(order.OrderId), 0)
+
+	twapOrderPlacementBytes := k.cdc.MustMarshal(&twapOrderPlacement)
+	store.Set(orderKey, twapOrderPlacementBytes)
+}
+
+// GetTwapOrderPlacement gets a TWAP order placement from the store.
+// Returns false if no TWAP order exists in store with `orderId`.
+func (k Keeper) GetTwapOrderPlacement(
+	ctx sdk.Context,
+	orderId types.OrderId,
+) (val types.TwapOrderPlacement, found bool) {
+	store := k.GetTWAPOrderPlacementStore(ctx)
+
+	b := store.Get(orderId.ToStateKey())
+	if b == nil {
+		return val, false
+	}
+
+	k.cdc.MustUnmarshal(b, &val)
+	return val, true
+}
+
+// GetTwapTriggerPlacement gets a TWAP trigger placement for a given orderId.
+// Returns false if no trigger placement exists in store with `orderId`.
+// This iterates over the entire store because the keys in the store are
+// formatted as [timestamp, orderId].
+func (k Keeper) GetTwapTriggerPlacement(
+	ctx sdk.Context,
+	orderId types.OrderId,
+) (o types.OrderId, t uint64, found bool) {
+	store := k.GetTWAPTriggerOrderPlacementStore(ctx)
+
+	iterator := store.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var suborderId types.OrderId
+		k.cdc.MustUnmarshal(iterator.Key()[8:], &suborderId)
+
+		timestamp := binary.BigEndian.Uint64(iterator.Key()[0:8])
+		if suborderId == orderId {
+			return suborderId, timestamp, true
+		}
+	}
+	return types.OrderId{}, 0, false
+}
+
+func (k Keeper) twapToSuborderId(twapOrderId types.OrderId) types.OrderId {
+	return types.OrderId{
+		SubaccountId: twapOrderId.SubaccountId,
+		ClientId:     twapOrderId.ClientId,
+		OrderFlags:   types.OrderIdFlags_TwapSuborder,
+		ClobPairId:   twapOrderId.ClobPairId,
+	}
+}
+
+// AddSuborderToTriggerStore adds a suborder to the trigger store with the
+// binary encoded [timestamp][suborderId] key.
+func (k Keeper) AddSuborderToTriggerStore(
+	ctx sdk.Context,
+	suborderId types.OrderId,
+	triggerOffset int64,
+) {
+	triggerStore := k.GetTWAPTriggerOrderPlacementStore(ctx)
+	triggerTime := ctx.BlockTime().Unix() + triggerOffset
+
+	triggerKey := types.GetTWAPTriggerKey(triggerTime, suborderId)
+
+	// The value in the map is not used, so we can set it to an empty byte slice.
+	triggerStore.Set(triggerKey, []byte{})
+}

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -15,6 +15,21 @@ const (
 	TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE = 3
 )
 
+type twapOperationType int
+
+const (
+	parentTwapCancelled twapOperationType = iota
+	parentTwapCompleted
+	createSuborder
+)
+
+type twapOrderOperation struct {
+	operationType      twapOperationType
+	keyToDelete        []byte
+	suborderToPlace    *types.Order
+	twapOrderPlacement *types.TwapOrderPlacement
+}
+
 func (k Keeper) SetTWAPOrderPlacement(ctx sdk.Context,
 	order types.Order,
 	blockHeight uint32,
@@ -106,15 +121,9 @@ func (k Keeper) AddSuborderToTriggerStore(
 func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
 	triggerStore := k.GetTWAPTriggerOrderPlacementStore(ctx)
 	blockTime := ctx.BlockTime().Unix()
+	var operationsToProcess []twapOrderOperation
+
 	iterator := triggerStore.Iterator(nil, nil)
-	defer iterator.Close()
-
-	var operationsToProcess []struct {
-		keyToDelete        []byte
-		suborderToPlace    types.Order
-		twapOrderPlacement types.TwapOrderPlacement
-	}
-
 	for ; iterator.Valid(); iterator.Next() {
 		var orderId types.OrderId
 		k.cdc.MustUnmarshal(iterator.Key()[8:], &orderId)
@@ -134,19 +143,26 @@ func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
 
 		twapOrderPlacement, found := k.GetTwapOrderPlacement(ctx, parentOrderId)
 		if !found {
-			panic("parent twap order not found") // TODO: (anmol) handle order cancellation
+			// If parent TWAP was cancelled, do not place any pending suborders.
+			operationsToProcess = append(operationsToProcess, twapOrderOperation{
+				operationType:      parentTwapCancelled,
+				keyToDelete:        append([]byte{}, iterator.Key()...),
+				suborderToPlace:    nil,
+				twapOrderPlacement: nil,
+			})
+			continue
 		}
 
-		order := k.GenerateSuborder(ctx, orderId, twapOrderPlacement, blockTime)
-
-		operationsToProcess = append(operationsToProcess, struct {
-			keyToDelete        []byte
-			suborderToPlace    types.Order
-			twapOrderPlacement types.TwapOrderPlacement
-		}{
+		operationType := createSuborder
+		order, isGenerated := k.GenerateSuborder(ctx, orderId, twapOrderPlacement, blockTime)
+		if !isGenerated {
+			operationType = parentTwapCompleted
+		}
+		operationsToProcess = append(operationsToProcess, twapOrderOperation{
+			operationType:      operationType,
 			keyToDelete:        append([]byte{}, iterator.Key()...),
 			suborderToPlace:    order,
-			twapOrderPlacement: twapOrderPlacement,
+			twapOrderPlacement: &twapOrderPlacement,
 		})
 	}
 	iterator.Close()
@@ -155,48 +171,53 @@ func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
 		// Delete from trigger store
 		triggerStore.Delete(op.keyToDelete)
 
-		// decrement remaining legs
-		k.DecrementTwapOrderRemainingLegs(ctx, &op.twapOrderPlacement)
+		switch op.operationType {
+		case parentTwapCancelled:
+			// Suborder deleted and should not be placed
+		case parentTwapCompleted:
+			k.DeleteTWAPOrderPlacement(ctx, *op.twapOrderPlacement)
+		case createSuborder:
+			// decrement remaining legs
+			k.DecrementTwapOrderRemainingLegs(ctx, *op.twapOrderPlacement)
+			// add the next suborder to the trigger store
+			k.AddSuborderToTriggerStore(
+				ctx,
+				op.suborderToPlace.OrderId,
+				int64(op.twapOrderPlacement.Order.TwapParameters.Interval),
+			)
 
-		if op.twapOrderPlacement.RemainingLegs == 0 {
-			// remove the parent twap order from the store
-			store := k.GetTWAPOrderPlacementStore(ctx)
-			orderKey := op.twapOrderPlacement.Order.OrderId.ToStateKey()
-			store.Delete(orderKey)
-			// TODO: (anmol) handle missing parent order case
-			// TODO: (anmol) emit event?
-			continue
-		}
-
-		// add the next suborder to the trigger store
-		k.AddSuborderToTriggerStore(
-			ctx,
-			op.suborderToPlace.OrderId,
-			int64(op.twapOrderPlacement.Order.TwapParameters.Interval),
-		)
-
-		// place triggered suborder
-		err := k.HandleMsgPlaceOrder(ctx, &types.MsgPlaceOrder{Order: op.suborderToPlace}, true)
-		if err != nil {
-			continue // TODO: (anmol) handle suborder placement failure
+			// place triggered suborder
+			err := k.HandleMsgPlaceOrder(ctx, &types.MsgPlaceOrder{Order: *op.suborderToPlace}, true)
+			if err != nil {
+				k.DeleteTWAPOrderPlacement(ctx, *op.twapOrderPlacement)
+			}
+		default:
+			panic("unsupported twap operation type can not be processed")
 		}
 	}
 }
 
+func (k Keeper) DeleteTWAPOrderPlacement(
+	ctx sdk.Context,
+	twapOrderPlacement types.TwapOrderPlacement,
+) {
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
+	store.Delete(orderKey)
+}
+
 func (k Keeper) DecrementTwapOrderRemainingLegs(
 	ctx sdk.Context,
-	twapOrderPlacement *types.TwapOrderPlacement,
+	twapOrderPlacement types.TwapOrderPlacement,
 ) {
-	if twapOrderPlacement.RemainingLegs == 0 {
-		return // TODO: (anmol) handle end of twap order case
+	store := k.GetTWAPOrderPlacementStore(ctx)
+	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
+	if twapOrderPlacement.IsCompleted() {
+		panic("twap order has already been completed")
 	}
 
 	twapOrderPlacement.RemainingLegs--
-
-	// Store updated state
-	store := k.GetTWAPOrderPlacementStore(ctx)
-	orderKey := twapOrderPlacement.Order.OrderId.ToStateKey()
-	twapOrderPlacementBytes := k.cdc.MustMarshal(twapOrderPlacement)
+	twapOrderPlacementBytes := k.cdc.MustMarshal(&twapOrderPlacement)
 	store.Set(orderKey, twapOrderPlacementBytes)
 }
 
@@ -257,12 +278,16 @@ func (k Keeper) GenerateSuborder(
 	suborderId types.OrderId,
 	twapOrderPlacement types.TwapOrderPlacement,
 	blockTime int64,
-) types.Order {
+) (*types.Order, bool) {
+	if twapOrderPlacement.IsCompleted() {
+		return nil, false
+	}
+
 	parentOrder := twapOrderPlacement.Order
 	order := types.Order{
 		OrderId:    suborderId,
 		Side:       twapOrderPlacement.Order.Side,
-		ReduceOnly: twapOrderPlacement.Order.ReduceOnly,
+		ReduceOnly: twapOrderPlacement.Order.ReduceOnly, // TODO: (anmol) client metadata?
 	}
 
 	priceTolerancePpm := int32(parentOrder.TwapParameters.PriceTolerance)
@@ -283,5 +308,5 @@ func (k Keeper) GenerateSuborder(
 		GoodTilBlockTime: uint32(blockTime + TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET),
 	}
 
-	return order
+	return &order, true
 }

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -231,11 +231,19 @@ func (k Keeper) calculateSuborderQuantums(
 	twapOrderPlacement types.TwapOrderPlacement,
 	clobPair types.ClobPair,
 ) uint64 {
-	originalQuantumsPerLeg := float64(twapOrderPlacement.Order.Quantums) / float64(twapOrderPlacement.Order.GetTotalLegsTWAPOrder())
+	totalLegs := twapOrderPlacement.Order.GetTotalLegsTWAPOrder()
+	originalQuantums := twapOrderPlacement.Order.Quantums
+	originalQuantumsPerLeg := float64(originalQuantums) / float64(totalLegs)
 
 	// Calculate the quantums for the suborder capping at 3x the original quantums per leg
-	remainingPerLeg := float64(twapOrderPlacement.RemainingQuantums) / float64(twapOrderPlacement.RemainingLegs)
-	suborderQuantums := lib.Min(remainingPerLeg, TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE*originalQuantumsPerLeg)
+	remainingQuantums := twapOrderPlacement.RemainingQuantums
+	remainingLegs := twapOrderPlacement.RemainingLegs
+	remainingQuantumsPerLeg := float64(remainingQuantums) / float64(remainingLegs)
+
+	suborderQuantums := lib.Min(
+		remainingQuantumsPerLeg,
+		TWAP_MAX_SUBORDER_CATCHUP_MULTIPLE*originalQuantumsPerLeg,
+	)
 
 	// Round down to nearest multiple of StepBaseQuantums
 	quantumsByStepBaseQuantums := uint64(math.Floor(suborderQuantums / float64(clobPair.StepBaseQuantums)))

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -273,6 +273,20 @@ func (k Keeper) calculateSuborderQuantums(
 	return suborderQuantumsRounded
 }
 
+func calculateSuborderPrice(
+	parentOrder types.Order,
+	adjustedSubticks uint64,
+) uint64 {
+	if parentOrder.Subticks != 0 {
+		if parentOrder.Side == types.Order_SIDE_BUY {
+			return lib.Min(adjustedSubticks, parentOrder.Subticks)
+		} else {
+			return lib.Max(adjustedSubticks, parentOrder.Subticks)
+		}
+	}
+	return adjustedSubticks
+}
+
 func (k Keeper) GenerateSuborder(
 	ctx sdk.Context,
 	suborderId types.OrderId,
@@ -298,8 +312,11 @@ func (k Keeper) GenerateSuborder(
 
 	// calculate the suborder price with slippage adjustment
 	clobPair := k.mustGetClobPair(ctx, parentOrder.GetClobPairId())
-	order.Subticks = k.GetOraclePriceAdjustedByPercentageSubticks(ctx, clobPair, priceTolerancePpm)
+	suborderAdjustedPrice := k.GetOraclePriceAdjustedByPercentageSubticks(ctx, clobPair, priceTolerancePpm)
 
+	// set the subticks based on the adjusted price and the limit price (if configured)
+	// by the parent twap order
+	order.Subticks = calculateSuborderPrice(parentOrder, suborderAdjustedPrice)
 	// calculate the suborder quantums based on remaining quantums and legs
 	order.Quantums = k.calculateSuborderQuantums(twapOrderPlacement, clobPair)
 

--- a/protocol/x/clob/keeper/twap_order_state_test.go
+++ b/protocol/x/clob/keeper/twap_order_state_test.go
@@ -1,0 +1,176 @@
+package keeper_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/dydxprotocol/v4-chain/protocol/mocks"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
+	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTWAPOrderTriggerStoreOrderingSameOrderId(t *testing.T) {
+	ks := setupTestTWAPOrderState(t)
+
+	// Create test orders with same order ID but different timestamps
+	suborderId := types.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   types.OrderIdFlags_TwapSuborder,
+		ClobPairId:   0,
+	}
+
+	// Set different trigger offsets to test timestamp ordering
+	triggerOffsets := []int64{10, 5, 15, 0}
+
+	// Add orders to trigger store with different timestamps
+	for _, offset := range triggerOffsets {
+		ks.ClobKeeper.AddSuborderToTriggerStore(ks.Ctx, suborderId, offset)
+	}
+
+	// Get all orders from trigger store and verify ordering
+	store := ks.ClobKeeper.GetTWAPTriggerOrderPlacementStore(ks.Ctx)
+	iterator := store.Iterator(nil, nil)
+	defer iterator.Close()
+
+	// Expected order based on timestamp (ascending)
+	expectedOrder := []int64{0, 5, 10, 15}
+	index := 0
+
+	// validate timestamps are in order
+	for ; iterator.Valid(); iterator.Next() {
+		timestamp := binary.BigEndian.Uint64(iterator.Key()[0:8])
+		require.Equal(t, ks.Ctx.BlockTime().Unix()+expectedOrder[index], int64(timestamp))
+		index++
+	}
+	require.Equal(t, len(expectedOrder), index)
+}
+
+func TestTWAPOrderTriggerStoreOrdering(t *testing.T) {
+	ks := setupTestTWAPOrderState(t)
+
+	// Create test orders with different timestamps and order IDs
+	suborderIds := []types.OrderId{
+		{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     0,
+			OrderFlags:   types.OrderIdFlags_TwapSuborder,
+			ClobPairId:   0,
+		},
+		{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     0,
+			OrderFlags:   types.OrderIdFlags_TwapSuborder,
+			ClobPairId:   0,
+		},
+		{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     0,
+			OrderFlags:   types.OrderIdFlags_TwapSuborder,
+			ClobPairId:   1,
+		},
+		{
+			SubaccountId: constants.Bob_Num0,
+			ClientId:     0,
+			OrderFlags:   types.OrderIdFlags_TwapSuborder,
+			ClobPairId:   0,
+		},
+	}
+
+	// Set different trigger offsets to test timestamp ordering
+	triggerOffsets := []int64{0, 5, 5, 5}
+
+	// Add orders to trigger store with different timestamps
+	for i, suborderId := range suborderIds {
+		ks.ClobKeeper.AddSuborderToTriggerStore(ks.Ctx, suborderId, triggerOffsets[i])
+	}
+
+	//ks.ClobKeeper.GetTwapTriggerPlacement(ks.Ctx, suborderIds[0])
+
+	// Get all orders from trigger store and verify ordering
+	store := ks.ClobKeeper.GetTWAPTriggerOrderPlacementStore(ks.Ctx)
+	iterator := store.Iterator(nil, nil)
+	defer iterator.Close()
+
+	// Expected order based on timestamp (ascending) and then orderId
+	expectedOrder := []types.OrderId{
+		suborderIds[0], // offset 0
+		suborderIds[3], // offset 5 - bob subaccountId < alice subaccountId
+		suborderIds[1], // offset 5 - alice clobPairId 0 < 1
+		suborderIds[2], // offset 5
+	}
+
+	// Verify the order of retrieved orders matches expected order
+	index := 0
+	for ; iterator.Valid(); iterator.Next() {
+		var orderId types.OrderId
+		// The key is [timestamp (8 bytes)][orderId state key]
+		// We unmarshal just the orderId portion
+		key := iterator.Key()
+		orderIdBytes := key[8:]
+		ks.Cdc.MustUnmarshal(orderIdBytes, &orderId)
+		require.Equal(t, expectedOrder[index], orderId)
+		index++
+	}
+	require.Equal(t, len(expectedOrder), index)
+}
+
+func TestTWAPOrderKeyBytes(t *testing.T) {
+	orderId1 := types.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   types.OrderIdFlags_TwapSuborder,
+		ClobPairId:   0,
+	}
+	orderId2 := types.OrderId{
+		SubaccountId: constants.Alice_Num0,
+		ClientId:     0,
+		OrderFlags:   types.OrderIdFlags_TwapSuborder,
+		ClobPairId:   1,
+	}
+
+	key1 := types.GetTWAPTriggerKey(5, orderId1)
+	key2 := types.GetTWAPTriggerKey(5, orderId2)
+
+	// Print the actual bytes to see the ordering
+	fmt.Printf("Key1: %v\n", key1)
+	fmt.Printf("Key2: %v\n", key2)
+
+	// Compare the keys
+	result := bytes.Compare(key1, key2)
+	require.True(t, result < 0) // key1 should come before key2
+
+	ks := setupTestTWAPOrderState(t)
+
+	store := ks.ClobKeeper.GetTWAPTriggerOrderPlacementStore(ks.Ctx)
+	iterator := store.Iterator(nil, nil)
+	defer iterator.Close()
+	expectedOrderId := []types.OrderId{
+		orderId1,
+		orderId2,
+	}
+	index := 0
+	for ; iterator.Valid(); iterator.Next() {
+		var orderId types.OrderId
+		ks.Cdc.MustUnmarshal(iterator.Key()[8:], &orderId)
+		require.Equal(t, expectedOrderId[index], orderId)
+		index++
+	}
+}
+
+func setupTestTWAPOrderState(t *testing.T) (ks keepertest.ClobKeepersTestContext) {
+	memClob := &mocks.MemClob{}
+	memClob.On("SetClobKeeper", mock.Anything).Return()
+	ks = keepertest.NewClobKeepersTestContextWithUninitializedMemStore(
+		t,
+		memClob,
+		&mocks.BankKeeper{},
+		&mocks.IndexerEventManager{},
+	)
+	return ks
+}

--- a/protocol/x/clob/keeper/twap_order_state_test.go
+++ b/protocol/x/clob/keeper/twap_order_state_test.go
@@ -2,21 +2,27 @@ package keeper_test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
+	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
+	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
+	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 )
 
 func TestTWAPOrderTriggerStoreOrderingSameOrderId(t *testing.T) {
 	ks := setupTestTWAPOrderState(t)
-
 	// Create test orders with same order ID but different timestamps
 	suborderId := types.OrderId{
 		SubaccountId: constants.Alice_Num0,
@@ -44,8 +50,8 @@ func TestTWAPOrderTriggerStoreOrderingSameOrderId(t *testing.T) {
 
 	// validate timestamps are in order
 	for ; iterator.Valid(); iterator.Next() {
-		timestamp := binary.BigEndian.Uint64(iterator.Key()[0:8])
-		require.Equal(t, ks.Ctx.BlockTime().Unix()+expectedOrder[index], int64(timestamp))
+		timestamp := types.TimeFromTriggerKey(iterator.Key())
+		require.Equal(t, ks.Ctx.BlockTime().Unix()+expectedOrder[index], timestamp)
 		index++
 	}
 	require.Equal(t, len(expectedOrder), index)
@@ -174,3 +180,434 @@ func setupTestTWAPOrderState(t *testing.T) (ks keepertest.ClobKeepersTestContext
 	)
 	return ks
 }
+
+func TestSetTWAPOrderPlacement(t *testing.T) {
+	tests := map[string]struct {
+		order             types.Order
+		blockHeight       uint32
+		expectedTotalLegs uint32
+		expectedQuantums  uint64
+	}{
+		"successfully sets TWAP order with 5 minute duration and 1 minute intervals": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: constants.Alice_Num0,
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_Twap,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 1000,
+				TwapParameters: &types.TwapParameters{
+					Duration: 300, // 5 minutes
+					Interval: 60,  // 1 minute
+				},
+			},
+			blockHeight:       100,
+			expectedTotalLegs: 5,
+			expectedQuantums:  1000,
+		},
+		"successfully sets TWAP order with 1 hour duration and 5 minute intervals": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: constants.Alice_Num0,
+					ClientId:     2,
+					OrderFlags:   types.OrderIdFlags_Twap,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_SELL,
+				Quantums: 2000,
+				TwapParameters: &types.TwapParameters{
+					Duration: 3600, // 1 hour
+					Interval: 300,  // 5 minutes
+				},
+			},
+			blockHeight:       200,
+			expectedTotalLegs: 12,
+			expectedQuantums:  2000,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Setup keeper state and test parameters
+			memClob := &mocks.MemClob{}
+			memClob.On("SetClobKeeper", mock.Anything).Return()
+			ks := keepertest.NewClobKeepersTestContextWithUninitializedMemStore(
+				t,
+				memClob,
+				&mocks.BankKeeper{},
+				&mocks.IndexerEventManager{},
+			)
+
+			// Set block time for consistent testing
+			ctx := ks.Ctx.WithBlockTime(time.Unix(1000, 0))
+
+			// Set the TWAP order placement
+			ks.ClobKeeper.SetTWAPOrderPlacement(ctx, tc.order, tc.blockHeight)
+
+			// Verify the order was stored correctly
+			storedOrder, found := ks.ClobKeeper.GetTwapOrderPlacement(ctx, tc.order.OrderId)
+			require.True(t, found, "TWAP order should be found in store")
+			require.Equal(t, tc.order, storedOrder.Order, "stored order should match input order")
+			require.Equal(t,
+				tc.expectedTotalLegs,
+				storedOrder.RemainingLegs,
+				"remaining legs should equal total legs initially",
+			)
+			require.Equal(t,
+				tc.expectedQuantums,
+				storedOrder.RemainingQuantums,
+				"remaining quantums should equal initial quantums",
+			)
+
+			// Verify the first suborder was created in trigger store
+			suborderId := types.OrderId{
+				SubaccountId: tc.order.OrderId.SubaccountId,
+				ClientId:     tc.order.OrderId.ClientId,
+				OrderFlags:   types.OrderIdFlags_TwapSuborder,
+				ClobPairId:   tc.order.OrderId.ClobPairId,
+			}
+			triggerPlacement, triggerTime, found := ks.ClobKeeper.GetTwapTriggerPlacement(ctx, suborderId)
+
+			require.True(t, found, "trigger placement should be found")
+			require.Equal(t, suborderId, triggerPlacement, "trigger placement should match suborderId")
+			require.Equal(t, int64(1000), triggerTime, "trigger time should match block time")
+		})
+	}
+}
+
+func TestGenerateSuborder(t *testing.T) {
+	tests := map[string]struct {
+		twapOrderPlacement types.TwapOrderPlacement
+		blockTime        int64
+		clobPair         types.ClobPair
+		expectedOrder    types.Order
+	}{
+		"buy order with positive price tolerance": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side: types.Order_SIDE_BUY,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration: 360,
+						Interval: 60,
+						PriceTolerance: 500_000, // 50% tolerance
+					},
+				},
+				RemainingLegs: 5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                     0,
+				StepBaseQuantums:      100,
+				SubticksPerTick:       100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side: types.Order_SIDE_BUY,
+				Quantums: 200,
+				Subticks: 1500,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003, // blockTime + TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET
+				},
+			},
+		},
+		"sell order with negative price tolerance": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side: types.Order_SIDE_SELL,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration: 360,
+						Interval: 60,
+						PriceTolerance: 500_000, // 50% tolerance
+					},
+				},
+				RemainingLegs: 5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                     0,
+				StepBaseQuantums:      100,
+				SubticksPerTick:       100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side: types.Order_SIDE_SELL,
+				Quantums: 200,
+				Subticks: 500,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003, // blockTime + TWAP_SUBORDER_GOOD_TIL_BLOCK_TIME_OFFSET
+				},
+			},
+		},
+		"buy order with 2.5% price tolerance and rounded up subticks": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side: types.Order_SIDE_BUY,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration: 360,
+						Interval: 60,
+						PriceTolerance: 25_000, // 2.5% tolerance
+					},
+				},
+				RemainingLegs: 5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                     0,
+				StepBaseQuantums:      100,
+				SubticksPerTick:       100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side: types.Order_SIDE_BUY,
+				Quantums: 200,
+				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+		"sell order with 2.5% price tolerance and rounded down subticks": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side: types.Order_SIDE_SELL,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration: 360,
+						Interval: 60,
+						PriceTolerance: 25_000, // 2.5% tolerance
+					},
+				},
+				RemainingLegs: 5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                     0,
+				StepBaseQuantums:      100,
+				SubticksPerTick:       100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side: types.Order_SIDE_SELL,
+				Quantums: 200,
+				Subticks: 970, // 1000 * (1 - 0.025) rounded down to nearest 10
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+		"buy order with 2.5% price tolerance with rounded up subticks and quantums": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side: types.Order_SIDE_BUY,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration: 360,
+						Interval: 60,
+						PriceTolerance: 25_000, // 2.5% tolerance
+					},
+				},
+				RemainingLegs: 6,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                     0,
+				StepBaseQuantums:      100,
+				SubticksPerTick:       100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side: types.Order_SIDE_BUY,
+				Quantums: 165, // 1000 / 6 = 166.67 rounded down to nearest 5 (step base quantums)
+				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+		"buy order with 2.5% price tolerance with rounded up subticks and max catchup quantums": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side: types.Order_SIDE_BUY,
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration: 360,
+						Interval: 60,
+						PriceTolerance: 25_000, // 2.5% tolerance
+					},
+				},
+				RemainingLegs: 1,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                     0,
+				StepBaseQuantums:      100,
+				SubticksPerTick:       100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side: types.Order_SIDE_BUY,
+				Quantums: 500, // (1000 / 6) * 3
+				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Setup keeper state and test parameters
+			memClob := &mocks.MemClob{}
+			indexerEventManager := &mocks.IndexerEventManager{}
+			clobKeeper := &mocks.MemClobKeeper{}
+
+			memClob.On("GetClobKeeper").Return(&clobKeeper)
+			memClob.On("SetClobKeeper", mock.Anything).Return()
+			memClob.On("CreateOrderbook", mock.Anything, mock.Anything).Return()
+			ks := keepertest.NewClobKeepersTestContextWithUninitializedMemStore(
+				t,
+				memClob,
+				&mocks.BankKeeper{},
+				indexerEventManager,
+			)
+
+			indexerEventManager.On(
+				"AddTxnEvent",
+				ks.Ctx,
+				indexerevents.SubtypePerpetualMarket,
+				indexerevents.PerpetualMarketEventVersion,
+				mock.Anything,
+			).Return()
+
+			// Set block time for consistent testing
+			ctx := ks.Ctx.WithBlockTime(time.Unix(tc.blockTime, 0))
+
+			keepertest.CreateTestPricesAndPerpetualMarkets(
+				t,
+				ks.Ctx,
+				ks.PerpetualsKeeper,
+				ks.PricesKeeper,
+				[]perptypes.Perpetual{
+					*perptest.GeneratePerpetual(
+						perptest.WithId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+						perptest.WithMarketId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+					),
+				},
+				[]pricestypes.MarketParamPrice{
+					*pricestest.GenerateMarketParamPrice(
+						pricestest.WithId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+						pricestest.WithPriceValue(100_000), // subticks = 1_000
+					),
+				},
+			)
+			
+			clobPair := *clobtest.GenerateClobPair(
+				clobtest.WithId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+				clobtest.WithPerpetualId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
+			)
+
+			keepertest.CreateTestClobPairs(t, ks.Ctx, ks.ClobKeeper, []types.ClobPair{clobPair})
+
+			// Generate the suborder
+			suborderId := types.OrderId{
+				SubaccountId: tc.twapOrderPlacement.Order.OrderId.SubaccountId,
+				ClientId:     tc.twapOrderPlacement.Order.OrderId.ClientId,
+				OrderFlags:   types.OrderIdFlags_TwapSuborder,
+				ClobPairId:   tc.twapOrderPlacement.Order.OrderId.ClobPairId,
+			}
+			generatedOrder := ks.ClobKeeper.GenerateSuborder(ctx, suborderId, tc.twapOrderPlacement, tc.blockTime)
+
+			// Verify the generated order matches expectations
+			require.Equal(t, tc.expectedOrder.OrderId, generatedOrder.OrderId)
+			require.Equal(t, tc.expectedOrder.Side, generatedOrder.Side)
+			require.Equal(t, tc.expectedOrder.GoodTilOneof, generatedOrder.GoodTilOneof)
+			require.Equal(t, tc.expectedOrder.Subticks, generatedOrder.Subticks)
+			require.Equal(t, tc.expectedOrder.Quantums, generatedOrder.Quantums)
+		})
+	}
+}
+

--- a/protocol/x/clob/keeper/twap_order_state_test.go
+++ b/protocol/x/clob/keeper/twap_order_state_test.go
@@ -6,19 +6,19 @@ import (
 	"testing"
 	"time"
 
+	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/mocks"
-	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	clobtest "github.com/dydxprotocol/v4-chain/protocol/testutil/clob"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
 	pricestest "github.com/dydxprotocol/v4-chain/protocol/testutil/prices"
-	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	perptypes "github.com/dydxprotocol/v4-chain/protocol/x/perpetuals/types"
 	pricestypes "github.com/dydxprotocol/v4-chain/protocol/x/prices/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
-	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTWAPOrderTriggerStoreOrderingSameOrderId(t *testing.T) {
@@ -280,9 +280,9 @@ func TestSetTWAPOrderPlacement(t *testing.T) {
 func TestGenerateSuborder(t *testing.T) {
 	tests := map[string]struct {
 		twapOrderPlacement types.TwapOrderPlacement
-		blockTime        int64
-		clobPair         types.ClobPair
-		expectedOrder    types.Order
+		blockTime          int64
+		clobPair           types.ClobPair
+		expectedOrder      types.Order
 	}{
 		"buy order with positive price tolerance": {
 			twapOrderPlacement: types.TwapOrderPlacement{
@@ -293,22 +293,22 @@ func TestGenerateSuborder(t *testing.T) {
 						OrderFlags:   types.OrderIdFlags_Twap,
 						ClobPairId:   0,
 					},
-					Side: types.Order_SIDE_BUY,
+					Side:     types.Order_SIDE_BUY,
 					Quantums: 1000,
 					TwapParameters: &types.TwapParameters{
-						Duration: 360,
-						Interval: 60,
+						Duration:       360,
+						Interval:       60,
 						PriceTolerance: 500_000, // 50% tolerance
 					},
 				},
-				RemainingLegs: 5,
+				RemainingLegs:     5,
 				RemainingQuantums: 1000,
 			},
 			blockTime: 1000,
 			clobPair: types.ClobPair{
-				Id:                     0,
-				StepBaseQuantums:      100,
-				SubticksPerTick:       100,
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
 				QuantumConversionExponent: -8,
 			},
 			expectedOrder: types.Order{
@@ -318,7 +318,7 @@ func TestGenerateSuborder(t *testing.T) {
 					OrderFlags:   types.OrderIdFlags_TwapSuborder,
 					ClobPairId:   0,
 				},
-				Side: types.Order_SIDE_BUY,
+				Side:     types.Order_SIDE_BUY,
 				Quantums: 200,
 				Subticks: 1500,
 				GoodTilOneof: &types.Order_GoodTilBlockTime{
@@ -335,22 +335,22 @@ func TestGenerateSuborder(t *testing.T) {
 						OrderFlags:   types.OrderIdFlags_Twap,
 						ClobPairId:   0,
 					},
-					Side: types.Order_SIDE_SELL,
+					Side:     types.Order_SIDE_SELL,
 					Quantums: 1000,
 					TwapParameters: &types.TwapParameters{
-						Duration: 360,
-						Interval: 60,
+						Duration:       360,
+						Interval:       60,
 						PriceTolerance: 500_000, // 50% tolerance
 					},
 				},
-				RemainingLegs: 5,
+				RemainingLegs:     5,
 				RemainingQuantums: 1000,
 			},
 			blockTime: 1000,
 			clobPair: types.ClobPair{
-				Id:                     0,
-				StepBaseQuantums:      100,
-				SubticksPerTick:       100,
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
 				QuantumConversionExponent: -8,
 			},
 			expectedOrder: types.Order{
@@ -360,7 +360,7 @@ func TestGenerateSuborder(t *testing.T) {
 					OrderFlags:   types.OrderIdFlags_TwapSuborder,
 					ClobPairId:   0,
 				},
-				Side: types.Order_SIDE_SELL,
+				Side:     types.Order_SIDE_SELL,
 				Quantums: 200,
 				Subticks: 500,
 				GoodTilOneof: &types.Order_GoodTilBlockTime{
@@ -377,22 +377,22 @@ func TestGenerateSuborder(t *testing.T) {
 						OrderFlags:   types.OrderIdFlags_Twap,
 						ClobPairId:   0,
 					},
-					Side: types.Order_SIDE_BUY,
+					Side:     types.Order_SIDE_BUY,
 					Quantums: 1000,
 					TwapParameters: &types.TwapParameters{
-						Duration: 360,
-						Interval: 60,
+						Duration:       360,
+						Interval:       60,
 						PriceTolerance: 25_000, // 2.5% tolerance
 					},
 				},
-				RemainingLegs: 5,
+				RemainingLegs:     5,
 				RemainingQuantums: 1000,
 			},
 			blockTime: 1000,
 			clobPair: types.ClobPair{
-				Id:                     0,
-				StepBaseQuantums:      100,
-				SubticksPerTick:       100,
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
 				QuantumConversionExponent: -8,
 			},
 			expectedOrder: types.Order{
@@ -402,7 +402,7 @@ func TestGenerateSuborder(t *testing.T) {
 					OrderFlags:   types.OrderIdFlags_TwapSuborder,
 					ClobPairId:   0,
 				},
-				Side: types.Order_SIDE_BUY,
+				Side:     types.Order_SIDE_BUY,
 				Quantums: 200,
 				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
 				GoodTilOneof: &types.Order_GoodTilBlockTime{
@@ -419,22 +419,22 @@ func TestGenerateSuborder(t *testing.T) {
 						OrderFlags:   types.OrderIdFlags_Twap,
 						ClobPairId:   0,
 					},
-					Side: types.Order_SIDE_SELL,
+					Side:     types.Order_SIDE_SELL,
 					Quantums: 1000,
 					TwapParameters: &types.TwapParameters{
-						Duration: 360,
-						Interval: 60,
+						Duration:       360,
+						Interval:       60,
 						PriceTolerance: 25_000, // 2.5% tolerance
 					},
 				},
-				RemainingLegs: 5,
+				RemainingLegs:     5,
 				RemainingQuantums: 1000,
 			},
 			blockTime: 1000,
 			clobPair: types.ClobPair{
-				Id:                     0,
-				StepBaseQuantums:      100,
-				SubticksPerTick:       100,
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
 				QuantumConversionExponent: -8,
 			},
 			expectedOrder: types.Order{
@@ -444,7 +444,7 @@ func TestGenerateSuborder(t *testing.T) {
 					OrderFlags:   types.OrderIdFlags_TwapSuborder,
 					ClobPairId:   0,
 				},
-				Side: types.Order_SIDE_SELL,
+				Side:     types.Order_SIDE_SELL,
 				Quantums: 200,
 				Subticks: 970, // 1000 * (1 - 0.025) rounded down to nearest 10
 				GoodTilOneof: &types.Order_GoodTilBlockTime{
@@ -461,22 +461,22 @@ func TestGenerateSuborder(t *testing.T) {
 						OrderFlags:   types.OrderIdFlags_Twap,
 						ClobPairId:   0,
 					},
-					Side: types.Order_SIDE_BUY,
+					Side:     types.Order_SIDE_BUY,
 					Quantums: 1000,
 					TwapParameters: &types.TwapParameters{
-						Duration: 360,
-						Interval: 60,
+						Duration:       360,
+						Interval:       60,
 						PriceTolerance: 25_000, // 2.5% tolerance
 					},
 				},
-				RemainingLegs: 6,
+				RemainingLegs:     6,
 				RemainingQuantums: 1000,
 			},
 			blockTime: 1000,
 			clobPair: types.ClobPair{
-				Id:                     0,
-				StepBaseQuantums:      100,
-				SubticksPerTick:       100,
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
 				QuantumConversionExponent: -8,
 			},
 			expectedOrder: types.Order{
@@ -486,8 +486,8 @@ func TestGenerateSuborder(t *testing.T) {
 					OrderFlags:   types.OrderIdFlags_TwapSuborder,
 					ClobPairId:   0,
 				},
-				Side: types.Order_SIDE_BUY,
-				Quantums: 165, // 1000 / 6 = 166.67 rounded down to nearest 5 (step base quantums)
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 165,  // 1000 / 6 = 166.67 rounded down to nearest 5 (step base quantums)
 				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
 				GoodTilOneof: &types.Order_GoodTilBlockTime{
 					GoodTilBlockTime: 1003,
@@ -503,22 +503,22 @@ func TestGenerateSuborder(t *testing.T) {
 						OrderFlags:   types.OrderIdFlags_Twap,
 						ClobPairId:   0,
 					},
-					Side: types.Order_SIDE_BUY,
+					Side:     types.Order_SIDE_BUY,
 					Quantums: 1000,
 					TwapParameters: &types.TwapParameters{
-						Duration: 360,
-						Interval: 60,
+						Duration:       360,
+						Interval:       60,
 						PriceTolerance: 25_000, // 2.5% tolerance
 					},
 				},
-				RemainingLegs: 1,
+				RemainingLegs:     1,
 				RemainingQuantums: 1000,
 			},
 			blockTime: 1000,
 			clobPair: types.ClobPair{
-				Id:                     0,
-				StepBaseQuantums:      100,
-				SubticksPerTick:       100,
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
 				QuantumConversionExponent: -8,
 			},
 			expectedOrder: types.Order{
@@ -528,8 +528,8 @@ func TestGenerateSuborder(t *testing.T) {
 					OrderFlags:   types.OrderIdFlags_TwapSuborder,
 					ClobPairId:   0,
 				},
-				Side: types.Order_SIDE_BUY,
-				Quantums: 500, // (1000 / 6) * 3
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 500,  // (1000 / 6) * 3
 				Subticks: 1030, // 1000 * (1 + 0.025) rounded up to nearest 10
 				GoodTilOneof: &types.Order_GoodTilBlockTime{
 					GoodTilBlockTime: 1003,
@@ -584,7 +584,7 @@ func TestGenerateSuborder(t *testing.T) {
 					),
 				},
 			)
-			
+
 			clobPair := *clobtest.GenerateClobPair(
 				clobtest.WithId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
 				clobtest.WithPerpetualId(tc.twapOrderPlacement.Order.OrderId.ClobPairId),
@@ -610,4 +610,3 @@ func TestGenerateSuborder(t *testing.T) {
 		})
 	}
 }
-

--- a/protocol/x/clob/keeper/twap_order_state_test.go
+++ b/protocol/x/clob/keeper/twap_order_state_test.go
@@ -536,6 +536,92 @@ func TestGenerateSuborder(t *testing.T) {
 				},
 			},
 		},
+		"limit twap buy order with 50% price tolerance": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side:     types.Order_SIDE_BUY,
+					Subticks: 800, // limit price for twap order
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration:       360,
+						Interval:       60,
+						PriceTolerance: 500_000, // 50% tolerance
+					},
+				},
+				RemainingLegs:     5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_BUY,
+				Quantums: 200,
+				Subticks: 800,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
+		"limit twap sell order with 50% price tolerance": {
+			twapOrderPlacement: types.TwapOrderPlacement{
+				Order: types.Order{
+					OrderId: types.OrderId{
+						SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+						ClientId:     1,
+						OrderFlags:   types.OrderIdFlags_Twap,
+						ClobPairId:   0,
+					},
+					Side:     types.Order_SIDE_SELL,
+					Subticks: 1200, // limit price for twap order
+					Quantums: 1000,
+					TwapParameters: &types.TwapParameters{
+						Duration:       360,
+						Interval:       60,
+						PriceTolerance: 500_000, // 50% tolerance
+					},
+				},
+				RemainingLegs:     5,
+				RemainingQuantums: 1000,
+			},
+			blockTime: 1000,
+			clobPair: types.ClobPair{
+				Id:                        0,
+				StepBaseQuantums:          100,
+				SubticksPerTick:           100,
+				QuantumConversionExponent: -8,
+			},
+			expectedOrder: types.Order{
+				OrderId: types.OrderId{
+					SubaccountId: satypes.SubaccountId{Owner: "owner", Number: 1},
+					ClientId:     1,
+					OrderFlags:   types.OrderIdFlags_TwapSuborder,
+					ClobPairId:   0,
+				},
+				Side:     types.Order_SIDE_SELL,
+				Quantums: 200,
+				Subticks: 1200,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{
+					GoodTilBlockTime: 1003,
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/protocol/x/clob/keeper/twap_order_state_test.go
+++ b/protocol/x/clob/keeper/twap_order_state_test.go
@@ -599,9 +599,15 @@ func TestGenerateSuborder(t *testing.T) {
 				OrderFlags:   types.OrderIdFlags_TwapSuborder,
 				ClobPairId:   tc.twapOrderPlacement.Order.OrderId.ClobPairId,
 			}
-			generatedOrder := ks.ClobKeeper.GenerateSuborder(ctx, suborderId, tc.twapOrderPlacement, tc.blockTime)
+			generatedOrder, isGenerated := ks.ClobKeeper.GenerateSuborder(
+				ctx,
+				suborderId,
+				tc.twapOrderPlacement,
+				tc.blockTime,
+			)
 
 			// Verify the generated order matches expectations
+			require.True(t, isGenerated)
 			require.Equal(t, tc.expectedOrder.OrderId, generatedOrder.OrderId)
 			require.Equal(t, tc.expectedOrder.Side, generatedOrder.Side)
 			require.Equal(t, tc.expectedOrder.GoodTilOneof, generatedOrder.GoodTilOneof)

--- a/protocol/x/clob/types/errors.go
+++ b/protocol/x/clob/types/errors.go
@@ -225,6 +225,11 @@ var (
 		48,
 		"This field has been deprecated",
 	)
+	ErrInvalidTwapOrderPlacement = errorsmod.Register(
+		ModuleName,
+		49,
+		"Invalid TWAP order placement",
+	)
 
 	// Liquidations errors.
 	ErrInvalidLiquidationsConfig = errorsmod.Register(

--- a/protocol/x/clob/types/keys.go
+++ b/protocol/x/clob/types/keys.go
@@ -65,6 +65,12 @@ const (
 	// information about when it was triggered.
 	TriggeredConditionalOrderKeyPrefix = PlacedStatefulOrderKeyPrefix + "T:"
 
+	// TWAPOrderKeyPrefix is the key to retrieve a TWAP order and information about when it was placed.
+	TWAPOrderKeyPrefix = "TWAP:"
+
+	// TWAPTriggerOrderKeyPrefix is the key to retrieve TWAP suborder information.
+	TWAPTriggerOrderKeyPrefix = "TWAP/T:"
+
 	// LongTermOrderPlacementKeyPrefix is the key to retrieve a long term order and information about
 	// when it was placed.
 	LongTermOrderPlacementKeyPrefix = PlacedStatefulOrderKeyPrefix + "L:"

--- a/protocol/x/clob/types/message_place_order.go
+++ b/protocol/x/clob/types/message_place_order.go
@@ -14,16 +14,16 @@ const (
 	MinTwapOrderInterval uint32 = 30
 
 	// the maximum interval in seconds for TWAP orders.
-	MaxTwapOrderInterval uint32 = 3600
+	MaxTwapOrderInterval uint32 = 3_600
 
 	// the minimum duration in seconds for TWAP orders.
 	MinTwapOrderDuration uint32 = 300 // 5 minutes
 
 	// the maximum duration in seconds for TWAP orders.
-	MaxTwapOrderDuration uint32 = 86400 // 24 hours
+	MaxTwapOrderDuration uint32 = 86_400 // 24 hours
 
-	// the maximum price tolerance for suborders in basis points.
-	MaxTwapOrderPriceTolerance uint32 = 10000
+	// the maximum price tolerance for suborders in ppm.
+	MaxTwapOrderPriceTolerance uint32 = 1_000_000
 )
 
 var _ sdk.Msg = &MsgPlaceOrder{}

--- a/protocol/x/clob/types/order.go
+++ b/protocol/x/clob/types/order.go
@@ -270,12 +270,21 @@ func (o *Order) GetTotalLegsTWAPOrder() uint32 {
 // GetTWAPTriggerKey returns the key for a TWAP trigger order.
 func GetTWAPTriggerKey(triggerTime int64, orderId OrderId) []byte {
 	// Write trigger time as big-endian uint64
-	timeBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(timeBytes, uint64(triggerTime))
+	timeBytes := TriggerTimeToBytes(triggerTime)
 
 	// Get marshaled orderId
 	orderIdBytes := orderId.ToStateKey()
 
 	// Combine time and orderId bytes
 	return append(timeBytes, orderIdBytes...)
+}
+
+func TriggerTimeToBytes(triggerTime int64) []byte {
+	timeBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(timeBytes, uint64(triggerTime))
+	return timeBytes
+}
+
+func TimeFromTriggerKey(triggerKey []byte) int64 {
+	return int64(binary.BigEndian.Uint64(triggerKey[0:8]))
 }

--- a/protocol/x/clob/types/order.go
+++ b/protocol/x/clob/types/order.go
@@ -288,3 +288,8 @@ func TriggerTimeToBytes(triggerTime int64) []byte {
 func TimeFromTriggerKey(triggerKey []byte) int64 {
 	return int64(binary.BigEndian.Uint64(triggerKey[0:8]))
 }
+
+// IsCompleted returns true if the TWAP order has no remaining legs to execute.
+func (t *TwapOrderPlacement) IsCompleted() bool {
+	return t.RemainingLegs == 0
+}

--- a/protocol/x/clob/types/order.pb.go
+++ b/protocol/x/clob/types/order.pb.go
@@ -833,9 +833,9 @@ type TwapParameters struct {
 	// whole number, a factor of the duration, and in the range
 	// [30 (30 seconds), 3600 (1 hour)].
 	Interval uint32 `protobuf:"varint,2,opt,name=interval,proto3" json:"interval,omitempty"`
-	// Price tolerance for each suborder. This will be applied to
+	// Price tolerance in ppm for each suborder. This will be applied to
 	// the oracle price each time a suborder is triggered. Must be
-	// be in the range [0, 10000).
+	// be in the range [0, 1_000_000).
 	PriceTolerance uint32 `protobuf:"varint,3,opt,name=price_tolerance,json=priceTolerance,proto3" json:"price_tolerance,omitempty"`
 }
 


### PR DESCRIPTION
### Changelist
This PR is dependent on #2779, #2780, and #2785.

This change floors/caps the subticks of the generated suborders for a twap order based on the subticks of passed in for the parent twap order, ensuring a limit price is maintained.

### Test Plan
Unit tests to ensure the order generation logic.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
