### PR TITLE
pipeline redis queries in orders/parentSubaccount endpoint

### DIFF
--- a/indexer/packages/redis/__tests__/caches/constants.ts
+++ b/indexer/packages/redis/__tests__/caches/constants.ts
@@ -15,9 +15,11 @@ import { DateTime } from 'luxon';
 export const address: string = 'dydxprotocol174e000tqwvszgjxs7yaj844e0m9s6f0m45ws7q';
 export const subaccountNumber: number = 0;
 export const subaccountNumber2: number = 2;
+export const subaccountNumber3: number = 3;
 export const clientId: number = 12;
 export const subaccountUuid: string = SubaccountTable.uuid(address, subaccountNumber);
 export const subaccountUuid2: string = SubaccountTable.uuid(address, subaccountNumber2);
+export const subaccountUuid3: string = SubaccountTable.uuid(address, subaccountNumber3);
 export const orderId: IndexerOrderId = {
   subaccountId: {
     owner: address,
@@ -77,6 +79,28 @@ export const secondRedisOrder: RedisOrder = {
       ...order.orderId,
       clientId: order.orderId!.clientId + 1,
       clobPairId: 0,
+      orderFlags: ORDER_FLAG_SHORT_TERM,
+    },
+  },
+};
+export const redisOrderSubaccount3: RedisOrder = {
+  ...redisOrder,
+  id: OrderTable.uuid(
+    subaccountUuid3,
+    (clientId + 2).toString(),
+    '1',
+    ORDER_FLAG_SHORT_TERM.toString(),
+  ),
+  order: {
+    ...order,
+    orderId: {
+      ...order.orderId,
+      subaccountId: {
+        owner: address,
+        number: subaccountNumber3,
+      },
+      clientId: clientId + 2,
+      clobPairId: 1,
       orderFlags: ORDER_FLAG_SHORT_TERM,
     },
   },

--- a/indexer/packages/redis/__tests__/caches/subaccount-order-ids-cache.test.ts
+++ b/indexer/packages/redis/__tests__/caches/subaccount-order-ids-cache.test.ts
@@ -1,18 +1,31 @@
 import {
+  redisOrder,
+  redisOrderSubaccount3,
+  secondRedisOrder,
+  subaccountUuid,
+  subaccountUuid2,
+  subaccountUuid3,
+} from './constants';
+import {
   redis as client,
 } from '../helpers/utils';
-import { SubaccountTable } from '@dydxprotocol-indexer/postgres';
-import { getOrderIdsForSubaccount } from '../../src/caches/subaccount-order-ids-cache';
+import { getOrderIdsForSubaccount, getOrderIdsForSubaccounts } from '../../src/caches/subaccount-order-ids-cache';
 import { placeOrder } from '../../src/caches/place-order';
-import {
-  address, redisOrder, secondRedisOrder, subaccountNumber,
-} from './constants';
+import { deleteAllAsync } from '../../src/helpers/redis';
 
 describe('subaccountOrderIdsCache', () => {
+  beforeEach(async () => {
+    await deleteAllAsync(client);
+  });
+
+  afterEach(async () => {
+    await deleteAllAsync(client);
+  });
+
   describe('getOrderIdsForSubaccount', () => {
     it('gets empty list for subaccount with no orders', async () => {
       const orderIds: string[] = await getOrderIdsForSubaccount(
-        SubaccountTable.uuid(address, subaccountNumber),
+        subaccountUuid,
         client,
       );
 
@@ -32,7 +45,7 @@ describe('subaccountOrderIdsCache', () => {
       ]);
 
       const orderIds: string[] = await getOrderIdsForSubaccount(
-        SubaccountTable.uuid(address, subaccountNumber),
+        subaccountUuid,
         client,
       );
 
@@ -40,5 +53,50 @@ describe('subaccountOrderIdsCache', () => {
       expect(orderIds).toContain(redisOrder.id);
       expect(orderIds).toContain(secondRedisOrder.id);
     });
+  });
+
+  describe('getOrderIdsForSubaccounts', () => {
+    it('gets empty lists for a list of subaccounts with no orders', async () => {
+      const subaccountOrderIds: Record<string, string[]> = await getOrderIdsForSubaccounts(
+        [subaccountUuid, subaccountUuid2],
+        client,
+      );
+
+      expect(subaccountOrderIds).toEqual({
+        [subaccountUuid]: [],
+        [subaccountUuid2]: [],
+      });
+    });
+
+    it('gets order ids for a list of subaccounts', async () => {
+      await Promise.all([
+        // Place two orders for subaccount 0.
+        placeOrder({
+          redisOrder,
+          client,
+        }),
+        placeOrder({
+          redisOrder: secondRedisOrder,
+          client,
+        }),
+        // Place one order for subaccount 3.
+        placeOrder({
+          redisOrder: redisOrderSubaccount3,
+          client,
+        }),
+      ]);
+
+      const subaccountOrderIds: Record<string, string[]> = await getOrderIdsForSubaccounts(
+        [subaccountUuid, subaccountUuid2, subaccountUuid3],
+        client,
+      );
+
+      expect(subaccountOrderIds).toEqual({
+        [subaccountUuid]: [redisOrder.id, secondRedisOrder.id],
+        [subaccountUuid2]: [],
+        [subaccountUuid3]: [redisOrderSubaccount3.id],
+      });
+    });
+
   });
 });

--- a/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
@@ -656,17 +656,14 @@ async function getRedisOrderMapForSubaccountIds(
     return {};
   }
 
-  const subaccountOrderIds: string[] = (await Promise.all(
-    subaccountIds.map((subaccountId) => {
-      return SubaccountOrderIdsCache.getOrderIdsForSubaccount(
-        subaccountId,
-        redisClient,
-      );
-    }),
-  )).flat();
+  const subaccountToOrderIds = await SubaccountOrderIdsCache.getOrderIdsForSubaccounts(
+    subaccountIds,
+    redisClient,
+  );
+  const orderIds: string[] = _.flatten(_.values(subaccountToOrderIds));
 
   const nullableRedisOrders: (RedisOrder | null)[] = await Promise.all(
-    _.map(subaccountOrderIds, (orderId: string) => OrdersCache.getOrder(orderId, redisClient)),
+    _.map(orderIds, (orderId: string) => OrdersCache.getOrder(orderId, redisClient)),
   );
   const redisOrders: RedisOrder[] = _.filter(
     nullableRedisOrders,


### PR DESCRIPTION
### Changelist
as we derive 1000 subaccount IDs in this parentSubaccount endpoint and fetch from redis for each of them, makes sense to pipeline them

### Test Plan
- existing unit tests for `orders-controller`
- added unit tests
- tested on staging
- once merged, will deploy and monitor and testnet / internal mainnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving order IDs for multiple subaccounts in a single, efficient batch operation.

- **Tests**
  - Enhanced test coverage to include scenarios for batch retrieval of order IDs across multiple subaccounts.
  - Improved test reliability by ensuring Redis state is cleared before and after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->