### PR TITLE
in perpetual markets endpoint, find all markets in one query instead of one query per market

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/market-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/market-table.test.ts
@@ -6,7 +6,7 @@ import {
   teardown,
 } from '../../src/helpers/db-helpers';
 import { UniqueViolationError } from 'objection';
-import { defaultMarket, defaultMarket2 } from '../helpers/constants';
+import { defaultMarket, defaultMarket2, defaultMarket3 } from '../helpers/constants';
 import Transaction from '../../src/helpers/transaction';
 
 describe('Market store', () => {
@@ -85,6 +85,52 @@ describe('Market store', () => {
       defaultMarket.id,
     );
     expect(market).toEqual(undefined);
+  });
+
+  describe('findByIds', () => {
+    it('Successfully finds markets by IDs', async () => {
+      await Promise.all([
+        MarketTable.create(defaultMarket),
+        MarketTable.create(defaultMarket2),
+        MarketTable.create(defaultMarket3),
+      ]);
+
+      const markets: MarketFromDatabase[] = await MarketTable.findByIds(
+        [defaultMarket.id, defaultMarket3.id],
+      );
+
+      expect(markets).toEqual([
+        expect.objectContaining(defaultMarket),
+        expect.objectContaining(defaultMarket3),
+      ]);
+    });
+
+    it('Successfully finds markets by empty IDs', async () => {
+      await Promise.all([
+        MarketTable.create(defaultMarket),
+        MarketTable.create(defaultMarket2),
+      ]);
+
+      const markets: MarketFromDatabase[] = await MarketTable.findByIds([]);
+
+      expect(markets).toEqual([]);
+    });
+
+    it('Successfully finds markets by non-existent ID', async () => {
+      await Promise.all([
+        MarketTable.create(defaultMarket),
+        MarketTable.create(defaultMarket2),
+        MarketTable.create(defaultMarket3),
+      ]);
+
+      const markets: MarketFromDatabase[] = await MarketTable.findByIds(
+        [defaultMarket2.id, 100],
+      );
+
+      expect(markets).toEqual([
+        expect.objectContaining(defaultMarket2),
+      ]);
+    });
   });
 
   it('Successfully updates a market', async () => {

--- a/indexer/packages/postgres/src/stores/market-table.ts
+++ b/indexer/packages/postgres/src/stores/market-table.ts
@@ -110,6 +110,19 @@ export async function findById(
     .returning('*');
 }
 
+export async function findByIds(
+  ids: number[],
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
+): Promise<MarketFromDatabase[]> {
+  const baseQuery: QueryBuilder<MarketModel> = setupBaseQuery<MarketModel>(
+    MarketModel,
+    options,
+  );
+  return baseQuery
+    .findByIds(ids)
+    .returning('*');
+}
+
 export async function findByPair(
   pair: string,
   options: Options = DEFAULT_POSTGRES_OPTIONS,


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
- added unit tests
- existing perpetual-markets-controller unit tests
- tested on staging

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved performance when fetching multiple markets by retrieving them in a single batch request instead of individual queries.
	- Added validation to ensure all requested market data is returned, with error handling for missing entries.

- **Tests**
	- Added comprehensive test cases to verify correct behavior when retrieving multiple markets by their IDs, including scenarios with empty and mixed ID arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->