### PR TITLE
(bug) don't remove CLOSE event handler on websocket send error

### DIFF
--- a/indexer/pnpm-lock.yaml
+++ b/indexer/pnpm-lock.yaml
@@ -756,10 +756,10 @@ importers:
       '@types/lodash': ^4.14.182
       '@types/node': ^18.19.31
       '@types/response-time': ^2.3.5
-      '@types/uuid': ^8.3.4
       '@types/ws': ^8.5.10
       axios: ^1.2.1
       body-parser: ^1.20.0
+      bufferutil: ^4.0.9
       cors: ^2.8.5
       dd-trace: ^3.32.1
       dotenv-flow: ^3.2.0
@@ -773,7 +773,7 @@ importers:
       ts-node: ^10.8.2
       tsconfig-paths: ^4.0.0
       typescript: ^4.7.4
-      uuid: ^8.3.2
+      utf-8-validate: ^6.0.5
       ws: ^8.16.0
     dependencies:
       '@dydxprotocol-indexer/base': link:../../packages/base
@@ -783,6 +783,7 @@ importers:
       '@dydxprotocol-indexer/v4-protos': link:../../packages/v4-protos
       axios: 1.2.1
       body-parser: 1.20.0
+      bufferutil: 4.0.9
       cors: 2.8.5
       dd-trace: 3.32.1
       dotenv-flow: 3.2.0
@@ -792,8 +793,8 @@ importers:
       lodash: 4.17.21
       nocache: 3.0.4
       response-time: 2.3.2
-      uuid: 8.3.2
-      ws: 8.16.0
+      utf-8-validate: 6.0.5
+      ws: 8.16.0_314410bbf163529a0116337fe6a5d0f1
     devDependencies:
       '@dydxprotocol-indexer/dev': link:../../packages/dev
       '@types/body-parser': 1.19.2
@@ -804,7 +805,6 @@ importers:
       '@types/lodash': 4.14.182
       '@types/node': 18.19.31
       '@types/response-time': 2.3.5
-      '@types/uuid': 8.3.4
       '@types/ws': 8.5.10
       jest: 28.1.2_e1489a60da1bfeaddb37cf23d6a3b371
       ts-node: 10.8.2_4ea55324100c26d4019c6e6bcc89fac6
@@ -8121,6 +8121,14 @@ packages:
       ieee754: 1.2.1
     dev: false
 
+  /bufferutil/4.0.9:
+    resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
+    engines: {node: '>=6.14.2'}
+    requiresBuild: true
+    dependencies:
+      node-gyp-build: 4.6.0
+    dev: false
+
   /byline/5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
@@ -15389,6 +15397,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /utf-8-validate/6.0.5:
+    resolution: {integrity: sha512-EYZR+OpIXp9Y1eG1iueg8KRsY8TuT8VNgnanZ0uA3STqhHQTLwbl+WX76/9X5OY12yQubymBpaBSmMPkSTQcKA==}
+    engines: {node: '>=6.14.2'}
+    requiresBuild: true
+    dependencies:
+      node-gyp-build: 4.6.0
+    dev: false
+
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: false
@@ -15659,7 +15675,7 @@ packages:
         optional: true
     dev: false
 
-  /ws/8.16.0:
+  /ws/8.16.0_314410bbf163529a0116337fe6a5d0f1:
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -15670,6 +15686,9 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 6.0.5
     dev: false
 
   /xml2js/0.5.0:

--- a/indexer/services/socks/__tests__/websocket/index.test.ts
+++ b/indexer/services/socks/__tests__/websocket/index.test.ts
@@ -1,10 +1,10 @@
+import crypto from 'node:crypto';
 import { Index } from '../../src/websocket/index';
 import WebSocket from 'ws';
 import { Wss, sendMessage } from '../../src/helpers/wss';
 import { Subscriptions } from '../../src/lib/subscription';
 import { IncomingMessage } from 'http';
 import { Socket } from 'net';
-import { v4 } from 'uuid';
 import {
   IncomingMessageType,
   OutgoingMessageType,
@@ -15,7 +15,7 @@ import {
 import { InvalidMessageHandler } from '../../src/lib/invalid-message';
 import { COUNTRY_HEADER_KEY } from '@dydxprotocol-indexer/compliance';
 
-jest.mock('uuid');
+jest.mock('node:crypto');
 jest.mock('../../src/helpers/wss');
 jest.mock('../../src/lib/subscription');
 jest.mock('../../src/lib/invalid-message');
@@ -63,7 +63,7 @@ describe('Index', () => {
 
   describe('connection', () => {
     it('adds connection to index, sends connection message, and attaches handlers', () => {
-      (v4 as unknown as jest.Mock).mockReturnValueOnce(connectionId);
+      (crypto.randomUUID as unknown as jest.Mock).mockReturnValueOnce(connectionId);
       mockConnect(websocket, new IncomingMessage(new Socket()));
 
       // Test that the connection is tracked.
@@ -93,7 +93,7 @@ describe('Index', () => {
   describe('handlers', () => {
     beforeEach(() => {
       // Connect to the index before starting each test.
-      (v4 as unknown as jest.Mock).mockReturnValueOnce(connectionId);
+      (crypto.randomUUID as unknown as jest.Mock).mockReturnValueOnce(connectionId);
       const incomingMessage: IncomingMessage = new IncomingMessage(new Socket());
       incomingMessage.headers[COUNTRY_HEADER_KEY] = countryCode;
       mockConnect(websocket, incomingMessage);

--- a/indexer/services/socks/package.json
+++ b/indexer/services/socks/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "build/index",
   "scripts": {
-    "start": "node --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
+    "start": "node --max-semi-space-size=256 --max-old-space-size=2624 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
     "build": "rm -rf build/ && tsc",
     "build:prod": "pnpm run build",
     "build:watch": "pnpm run build -- --watch",
@@ -23,6 +23,7 @@
     "@dydxprotocol-indexer/v4-protos": "workspace:^0.0.1",
     "axios": "^1.2.1",
     "body-parser": "^1.20.0",
+    "bufferutil": "^4.0.9",
     "cors": "^2.8.5",
     "dd-trace": "^3.32.1",
     "dotenv-flow": "^3.2.0",
@@ -32,7 +33,7 @@
     "lodash": "^4.17.21",
     "nocache": "^3.0.4",
     "response-time": "^2.3.2",
-    "uuid": "^8.3.2",
+    "utf-8-validate": "^6.0.5",
     "ws": "^8.16.0"
   },
   "devDependencies": {
@@ -45,7 +46,6 @@
     "@types/lodash": "^4.14.182",
     "@types/node": "^18.19.31",
     "@types/response-time": "^2.3.5",
-    "@types/uuid": "^8.3.4",
     "@types/ws": "^8.5.10",
     "jest": "^28.1.2",
     "ts-node": "^10.8.2",

--- a/indexer/services/socks/src/lib/message-forwarder.ts
+++ b/indexer/services/socks/src/lib/message-forwarder.ts
@@ -58,7 +58,7 @@ export class MessageForwarder {
     this.started = false;
     this.stopped = false;
     this.messageBuffer = {};
-    this.batchSending = setTimeout(() => {}, MAX_TIMEOUT_INTEGER);
+    this.batchSending = setTimeout(() => { }, MAX_TIMEOUT_INTEGER);
   }
 
   public start(): void {
@@ -290,7 +290,7 @@ export class MessageForwarder {
 
     // Buffer messages if the subscription is for batched messages
     if (this.subscriptions.batchedSubscriptions[message.channel] &&
-       this.subscriptions.batchedSubscriptions[message.channel][message.id]) {
+      this.subscriptions.batchedSubscriptions[message.channel][message.id]) {
       const bufferKey: string = this.getMessageBufferKey(
         message.channel,
         message.id,
@@ -385,16 +385,16 @@ export class MessageForwarder {
       batchedMessages,
       (c) => c.version,
     );
-    _.forEach(batchedVersionedMessages, (versionedMsgs, version) => {
-      const batchedMessagesBySubaccountNumber: _.Dictionary<VersionedContents[]> = _.groupBy(
-        versionedMsgs,
-        (c) => c.subaccountNumber,
-      );
-      _.forEach(batchedMessagesBySubaccountNumber, (msgs, subaccountNumberKey) => {
-        const subaccountNumber: number | undefined = Number.isNaN(Number(subaccountNumberKey))
-          ? undefined
-          : Number(subaccountNumberKey);
-        try {
+    try {
+      _.forEach(batchedVersionedMessages, (versionedMsgs, version) => {
+        const batchedMessagesBySubaccountNumber: _.Dictionary<VersionedContents[]> = _.groupBy(
+          versionedMsgs,
+          (c) => c.subaccountNumber,
+        );
+        _.forEach(batchedMessagesBySubaccountNumber, (msgs, subaccountNumberKey) => {
+          const subaccountNumber: number | undefined = Number.isNaN(Number(subaccountNumberKey))
+            ? undefined
+            : Number(subaccountNumberKey);
           this.forwardToClientBatch(
             msgs,
             batchedSubscriber.connectionId,
@@ -403,16 +403,17 @@ export class MessageForwarder {
             version,
             subaccountNumber,
           );
-        } catch (error) {
-          logger.error({
-            at: 'message-forwarder#forwardBatchedMessages',
-            message: error.message,
-            connectionId: batchedSubscriber.connectionId,
-            error,
-          });
-        }
+        });
       });
-    });
+    } catch (error) {
+      // catch error outside of loop to stop forwarding messages
+      logger.error({
+        at: 'message-forwarder#forwardBatchedMessages',
+        message: error.message,
+        connectionId: batchedSubscriber.connectionId,
+        error,
+      });
+    }
   }
 
   public forwardToClientBatch(

--- a/indexer/services/socks/src/websocket/index.ts
+++ b/indexer/services/socks/src/websocket/index.ts
@@ -1,7 +1,8 @@
+import { randomUUID } from 'node:crypto';
+
 import {
   InfoObject, getInstanceId, logger, safeJsonStringify, stats,
 } from '@dydxprotocol-indexer/base';
-import { v4 as uuidv4 } from 'uuid';
 import WebSocket from 'ws';
 
 import config from '../config';
@@ -90,7 +91,7 @@ export class Index {
    */
   private onConnection(ws: WebSocket, req: IncomingMessage): void {
 
-    const connectionId: string = uuidv4();
+    const connectionId: string = randomUUID();
 
     this.connections[connectionId] = {
       ws,


### PR DESCRIPTION
### Changelist

#### Don't remove CLOSE event handler on websocket send error
 bug: close event handler was removed on ping/pong failure disconnect
 this prevented removal of connection from subscription and connection maps

#### Skip logging error if stream was destroyed
 avoid excessive logging during socket disconnection
 mitigate misbehaving clients

#### Stop publishing batched messages on error and log
 do not attempt to send remaining batch messages on publishing errors

#### Add bufferutil and utf-8-validate for performance
 recommended by ws and automatically enabled
 binary polyfills for handling and validating strings

#### Use node:crypto for v4 uuid
 since we only use v4's, we don't need a third-party dep

#### Raise semi space and old space size in start script
 a node application with these components can utilize 1-2cpu effectively
 typical memory provisioned by vendors is 2-8Gib/cpu
 based on a 4Gib host:
  256 Mib datadog sidecar container reservation
  960 Mib application container system reservation
  256 Mib semi space to handle object generation rate at load
  2624 Mib old heap to utilize minimum expected available resources

### Test Plan

Verify websocket is disconnected and no more than one send to closed websocket error is generated following failure of client to respond to heartbeat.

Run in testnet and internal environments and validated behavior under heavy misbehaving load