### PR TITLE
(chore) Normalize branches for push and build to ECR

### DIFF
--- a/.github/workflows/indexer-build-and-push-mainnet.yml
+++ b/.github/workflows/indexer-build-and-push-mainnet.yml
@@ -1,6 +1,11 @@
 name: Indexer Build & Push Images to AWS ECR for Mainnet
 
 on: # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+      - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/indexer/v0.1.x
+      - 'release/indexer/v[0-9]+.x'  # e.g. release/indexer/v1.x
   push:
     branches:
       - main

--- a/.github/workflows/indexer-build-and-push-testnet.yml
+++ b/.github/workflows/indexer-build-and-push-testnet.yml
@@ -1,6 +1,11 @@
 name: Indexer Build & Push Images to AWS ECR for Testnet Branch
 
 on: # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+      - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/indexer/v0.1.x
+      - 'release/indexer/v[0-9]+.x'  # e.g. release/indexer/v1.x
   push:
     branches:
       - main

--- a/.github/workflows/protocol-build-and-push-mainnet.yml
+++ b/.github/workflows/protocol-build-and-push-mainnet.yml
@@ -2,11 +2,13 @@ name: Protocol Build & Push Image to AWS ECR
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
-      branches:
-        - 'release/protocol/v[0-9]+.[0-9]+.x'  # e.g. release/protocol/v0.1.x
-        - 'release/protocol/v[0-9]+.x'  # e.g. release/protocol/v1.x
+    branches:
+      - main
+      - 'release/protocol/v[0-9]+.[0-9]+.x'  # e.g. release/protocol/v0.1.x
+      - 'release/protocol/v[0-9]+.x'  # e.g. release/protocol/v1.x
   push:
     branches:
+      - main
       - 'release/protocol/v[0-9]+.[0-9]+.x'  # e.g. release/protocol/v0.1.x
       - 'release/protocol/v[0-9]+.x'  # e.g. release/protocol/v1.x
 

--- a/.github/workflows/protocol-build-and-push-testnet.yml
+++ b/.github/workflows/protocol-build-and-push-testnet.yml
@@ -2,11 +2,13 @@ name: Protocol Build & Push Image to AWS ECR
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
-      branches:
-        - 'release/protocol/v[0-9]+.[0-9]+.x'  # e.g. release/protocol/v0.1.x
-        - 'release/protocol/v[0-9]+.x'  # e.g. release/protocol/v1.x
+    branches:
+      - main
+      - 'release/protocol/v[0-9]+.[0-9]+.x'  # e.g. release/protocol/v0.1.x
+      - 'release/protocol/v[0-9]+.x'  # e.g. release/protocol/v1.x
   push:
     branches:
+      - main
       - 'release/protocol/v[0-9]+.[0-9]+.x'  # e.g. release/protocol/v0.1.x
       - 'release/protocol/v[0-9]+.x'  # e.g. release/protocol/v1.x
 


### PR DESCRIPTION
For testnet and mainnet, trigger build and push to AWS ECR on pull requests and push to:
- main
- release/$SERVICE/v$Y.x
- release/$SERVICE/v$Y.$Z.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow triggers to run build and push processes on both push and pull request events for main and release branches, improving validation and automation for mainnet and testnet deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->