### PR TITLE
[ENG-4] Add cross-margin launch for listings

### DIFF
--- a/protocol/x/listing/keeper/listing.go
+++ b/protocol/x/listing/keeper/listing.go
@@ -135,7 +135,7 @@ func (k Keeper) CreatePerpetual(
 			int32(marketMapDetails.Ticker.Decimals))
 
 	marketType := perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED
-	if metadata.CrossLaunch == true {
+	if metadata.CrossLaunch {
 		marketType = perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS
 	}
 

--- a/protocol/x/listing/keeper/listing.go
+++ b/protocol/x/listing/keeper/listing.go
@@ -134,6 +134,11 @@ func (k Keeper) CreatePerpetual(
 		(int32(math.Floor(math.Log10(float64(metadata.ReferencePrice)))) -
 			int32(marketMapDetails.Ticker.Decimals))
 
+	marketType := perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED
+	if metadata.CrossLaunch == true {
+		marketType = perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS
+	}
+
 	// Create a new perpetual
 	perpetual, err := k.PerpetualsKeeper.CreatePerpetual(
 		ctx,
@@ -143,7 +148,7 @@ func (k Keeper) CreatePerpetual(
 		atomicResolution,
 		types.DefaultFundingPpm,
 		types.LiquidityTier_IML_5x,
-		perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED,
+		marketType,
 	)
 	if err != nil {
 		return 0, err

--- a/protocol/x/listing/keeper/listing_test.go
+++ b/protocol/x/listing/keeper/listing_test.go
@@ -190,10 +190,12 @@ func TestCreatePerpetual(t *testing.T) {
 					require.Equal(t, int32(-5), perpetual.Params.AtomicResolution)
 					require.Equal(t, int32(types.DefaultFundingPpm), perpetual.Params.DefaultFundingPpm)
 					require.Equal(t, uint32(types.LiquidityTier_IML_5x), perpetual.Params.LiquidityTier)
-					require.Equal(
-						t, perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED,
-						perpetual.Params.MarketType,
-					)
+
+					expectedMarketType := perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_ISOLATED
+					if tc.crossLaunch {
+						expectedMarketType = perpetualtypes.PerpetualMarketType_PERPETUAL_MARKET_TYPE_CROSS
+					}
+					require.Equal(t, expectedMarketType, perpetual.Params.MarketType)
 				}
 			},
 		)

--- a/protocol/x/listing/keeper/listing_test.go
+++ b/protocol/x/listing/keeper/listing_test.go
@@ -104,12 +104,19 @@ func TestCreatePerpetual(t *testing.T) {
 	tests := map[string]struct {
 		ticker         string
 		referencePrice uint64
+		crossLaunch    bool
 
 		expectedErr error
 	}{
 		"success": {
 			ticker:         "TEST-USD",
 			referencePrice: 1000000000, // $1000
+			expectedErr:    nil,
+		},
+		"success - cross launch": {
+			ticker:         "TEST-USD",
+			referencePrice: 1000000000, // $1000
+			crossLaunch:    true,
 			expectedErr:    nil,
 		},
 		"failure - reference price 0": {
@@ -138,6 +145,7 @@ func TestCreatePerpetual(t *testing.T) {
 						ReferencePrice: tc.referencePrice,
 						Liquidity:      0,
 						AggregateIDs:   nil,
+						CrossLaunch:    tc.crossLaunch,
 					},
 				)
 				require.NoError(t, err)


### PR DESCRIPTION
### Changelist

* Update `listings` module to create a new perpetual as cross-margin if the `crossLaunch` field is set in Market Map's `metadataJSON`

### Test Plan

* Tests pass

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Perpetual market creation now dynamically sets the market type based on the cross launch flag.
- **Tests**
  - Added and updated test cases to verify correct market type assignment for both isolated and cross launch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->