### PR TITLE
replace candles (ticker, resolution) index with (ticker, resolution, startedat desc)

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250425155808_replace_candles_ticker_resolution_idx_with_ticker_resolution_startedat_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250425155808_replace_candles_ticker_resolution_idx_with_ticker_resolution_startedat_idx.ts
@@ -1,0 +1,27 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS candles_ticker_resolution_index;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS candles_ticker_resolution_startedat_index
+      ON candles (ticker, resolution, "startedAt" DESC);
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS candles_ticker_resolution_startedat_index;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS candles_ticker_resolution_index
+      ON candles (ticker, resolution);
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
current `(ticker, resolution)` index is insufficient and inefficient. `(ticker, resolution, startedat)` is a lot faster for candles queries we run/

see details in [slack thread](https://dydx-team.slack.com/archives/C08N89SEYNR/p1745598387500109)

### Test Plan
tested on testnet (with large candles table). see slack thread above

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved database indexing for the candles table to enhance query performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->