### PR TITLE
refactor(comlink): Separate readonly and primary Redis on comlink

### DIFF
--- a/.github/workflows/indexer-reusable-build-and-run-with-pg-redis-kafka.yml
+++ b/.github/workflows/indexer-reusable-build-and-run-with-pg-redis-kafka.yml
@@ -63,4 +63,5 @@ jobs:
         env:
           DB_PORT: 5432
           REDIS_URL: redis://localhost:6379
+          REDIS_READONLY_URL: redis://localhost:6379
           RATE_LIMIT_REDIS_URL: redis://localhost:6379

--- a/indexer/packages/redis/src/config.ts
+++ b/indexer/packages/redis/src/config.ts
@@ -13,6 +13,9 @@ export const redisConfigSchema = {
   REDIS_URL: parseString({
     default: 'redis://localhost:6382',
   }),
+  REDIS_READONLY_URL: parseString({
+    default: 'redis://localhost:6382',
+  }),
   REDIS_RECONNECT_TIMEOUT_MS: parseInteger({ default: 500 }),
   REDIS_RECONNECT_ATTEMPT_ERROR_THRESHOLD: parseInteger({ default: 10 }),
 };

--- a/indexer/services/comlink/src/controllers/api/v4/orderbook-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orderbook-controller.ts
@@ -9,7 +9,7 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
-import { redisClient } from '../../../helpers/redis/redis-controller';
+import { redisReadOnlyClient } from '../../../helpers/redis/redis-controller';
 import { NotFoundError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
@@ -38,7 +38,7 @@ class OrderbookController extends Controller {
 
     const orderbookLevels: OrderbookLevels = await OrderbookLevelsCache.getOrderBookLevels(
       ticker,
-      redisClient,
+      redisReadOnlyClient,
       {
         sortSides: true,
         uncrossBook: true,

--- a/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
@@ -31,7 +31,7 @@ import {
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
-import { redisClient } from '../../../helpers/redis/redis-controller';
+import { redisReadOnlyClient } from '../../../helpers/redis/redis-controller';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import { NotFoundError } from '../../../lib/errors';
 import {
@@ -297,7 +297,7 @@ class OrdersController extends Controller {
       RedisOrder | null,
     ] = await Promise.all([
       OrderTable.findById(orderId),
-      OrdersCache.getOrder(orderId, redisClient),
+      OrdersCache.getOrder(orderId, redisReadOnlyClient),
     ]);
 
     // Get subaccount number and subaccountId from either Redis or Postgres
@@ -658,12 +658,12 @@ async function getRedisOrderMapForSubaccountIds(
 
   const subaccountToOrderIds = await SubaccountOrderIdsCache.getOrderIdsForSubaccounts(
     subaccountIds,
-    redisClient,
+    redisReadOnlyClient,
   );
   const orderIds: string[] = _.flatten(_.values(subaccountToOrderIds));
 
   const nullableRedisOrders: (RedisOrder | null)[] = await Promise.all(
-    _.map(orderIds, (orderId: string) => OrdersCache.getOrder(orderId, redisClient)),
+    _.map(orderIds, (orderId: string) => OrdersCache.getOrder(orderId, redisReadOnlyClient)),
   );
   const redisOrders: RedisOrder[] = _.filter(
     nullableRedisOrders,

--- a/indexer/services/comlink/src/helpers/redis/redis-controller.ts
+++ b/indexer/services/comlink/src/helpers/redis/redis-controller.ts
@@ -5,6 +5,7 @@ import {
 
 import config from '../../config';
 
+// Primary Redis client
 const res: {
   client: RedisClient,
   connect: () => Promise<void>,
@@ -12,3 +13,12 @@ const res: {
 
 export const redisClient: RedisClient = res.client;
 export const connect = res.connect;
+
+// Read-only Redis client
+const resReadOnly: {
+  client: RedisClient,
+  connect: () => Promise<void>,
+} = redisLib.createRedisClient(config.REDIS_READONLY_URL, config.REDIS_RECONNECT_TIMEOUT_MS);
+
+export const redisReadOnlyClient: RedisClient = resReadOnly.client;
+export const connectReadOnly = resReadOnly.connect;

--- a/indexer/services/comlink/src/helpers/redis/redis-controller.ts
+++ b/indexer/services/comlink/src/helpers/redis/redis-controller.ts
@@ -5,7 +5,7 @@ import {
 
 import config from '../../config';
 
-// Primary Redis client
+// Primary read-write Redis client
 const res: {
   client: RedisClient,
   connect: () => Promise<void>,

--- a/indexer/services/comlink/src/index.ts
+++ b/indexer/services/comlink/src/index.ts
@@ -8,7 +8,7 @@ import { perpetualMarketRefresher, liquidityTierRefresher } from '@dydxprotocol-
 import { startVaultStartPnlCache } from './caches/vault-start-pnl';
 import config from './config';
 import IndexV4 from './controllers/api/index-v4';
-import { connect as connectToRedis } from './helpers/redis/redis-controller';
+import { connect as connectToRedis, connectReadOnly as connectToRedisReadOnly } from './helpers/redis/redis-controller';
 import Server from './request-helpers/server';
 
 process.on('SIGTERM', () => {
@@ -50,6 +50,12 @@ async function start() {
   logger.info({
     at: 'index#start',
     message: `Connected to redis at ${config.REDIS_URL}`,
+  });
+
+  await connectToRedisReadOnly();
+  logger.info({
+    at: 'index#start',
+    message: `Connected to read-only redis at ${config.REDIS_READONLY_URL}`,
   });
 
   startServer();


### PR DESCRIPTION
### Changelist
[Context](https://dydx-team.slack.com/archives/C0653294N6R/p1746041877992099?thread_ts=1745934303.768259&cid=C0653294N6R)

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for connecting to a dedicated read-only Redis instance, configurable via a new environment variable.
- **Chores**
	- Updated caching logic across several endpoints to use the read-only Redis client for cache reads, improving separation of read and write operations.
	- Added logging for successful connections to both primary and read-only Redis instances.
	- Added the read-only Redis URL environment variable to the CI workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->