### PR TITLE
(perf) use luxon.DateTime.fromSQL vs moment()

### DIFF
--- a/indexer/packages/postgres/package.json
+++ b/indexer/packages/postgres/package.json
@@ -47,7 +47,6 @@
     "lodash": "^4.17.21",
     "long": "^5.2.1",
     "luxon": "^3.0.1",
-    "moment": "^2.29.4",
     "objection": "^2.2.16",
     "objection-unique": "^1.2.2",
     "pg": "^8.7.3",

--- a/indexer/packages/postgres/src/db/pg-config.ts
+++ b/indexer/packages/postgres/src/db/pg-config.ts
@@ -1,12 +1,17 @@
-import moment from 'moment';
 import pg from 'pg';
+import { DateTime } from 'luxon';
 
 /**
  * we need to add this line, because the default type parser
  * changes all datetime objects to javascript dates, when we
  * need all dates returned with iso strings
  */
+
+const utcZone = {
+  zone: "utc",
+}
+
 pg.types.setTypeParser(
   pg.types.builtins.TIMESTAMPTZ,
-  (val) => (val === null ? null : moment(val).toISOString()),
+  (val) => (val === null ? null : DateTime.fromSQL(val, utcZone).toISO()),
 );

--- a/indexer/packages/postgres/src/db/pg-config.ts
+++ b/indexer/packages/postgres/src/db/pg-config.ts
@@ -1,5 +1,5 @@
-import pg from 'pg';
 import { DateTime } from 'luxon';
+import pg from 'pg';
 
 /**
  * we need to add this line, because the default type parser
@@ -8,8 +8,8 @@ import { DateTime } from 'luxon';
  */
 
 const utcZone = {
-  zone: "utc",
-}
+  zone: 'utc',
+};
 
 pg.types.setTypeParser(
   pg.types.builtins.TIMESTAMPTZ,

--- a/indexer/pnpm-lock.yaml
+++ b/indexer/pnpm-lock.yaml
@@ -205,7 +205,6 @@ importers:
       lodash: ^4.17.21
       long: ^5.2.1
       luxon: ^3.0.1
-      moment: ^2.29.4
       objection: ^2.2.16
       objection-unique: ^1.2.2
       pg: ^8.7.3
@@ -222,7 +221,6 @@ importers:
       lodash: 4.17.21
       long: 5.2.1
       luxon: 3.0.1
-      moment: 2.29.4
       objection: 2.2.18_knex@0.21.21
       objection-unique: 1.2.2_objection@2.2.18
       pg: 8.7.3
@@ -12927,10 +12925,6 @@ packages:
 
   /module-details-from-path/1.0.3:
     resolution: {integrity: sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==}
-    dev: false
-
-  /moment/2.29.4:
-    resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
     dev: false
 
   /ms/2.0.0:


### PR DESCRIPTION
### Changelist
Comlink spends much of its time parsing postgres timestamp values and rendering them to ISO strings.
This was performed with the top-level moment() function, that needs to sniff the format for each value.
luxon's DateTime.fromSQL method is intended for database timestamp parsing.

### Test Plan
Unit Test

Run in internal environments and public testnet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Replaced the timestamp parsing library to improve date handling consistency.
  - Removed an unused dependency to streamline the package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->