### PR TITLE
add orders table index (subaccountId, status, goodTilBlock, goodTilBlockTime)

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250502154753_add_orders_subaccountid_status_goodtilblock_goodtilblocktime_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250502154753_add_orders_subaccountid_status_goodtilblock_goodtilblocktime_index.ts
@@ -1,4 +1,4 @@
-import * as Knex from "knex";
+import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250502154753_add_orders_subaccountid_status_goodtilblock_goodtilblocktime_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250502154753_add_orders_subaccountid_status_goodtilblock_goodtilblocktime_index.ts
@@ -1,0 +1,23 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS orders_subaccountid_status_goodtilblock_goodtilblocktime_index
+      ON orders (
+        "subaccountId",
+        status,
+        "goodTilBlock" DESC,
+        "goodTilBlockTime" DESC
+      );
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS orders_subaccountid_status_goodtilblock_goodtilblocktime_index;
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
most of top 5 orders queries, in terms of total time or latency, will benefit significantly as they all filter / sort on `subaccountId`, `status`, `goodTilBlock`, and `goodTilBlockTime`. Some example queries I tested went from ~600ms to ~0.05ms

### Test Plan
tested on testnet

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved database performance by adding a new index to the orders table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->