### PR TITLE
optimize parent subaccount query and replace subaccounts index (address) with (address, subaccountNumber)

### DIFF
--- a/indexer/packages/postgres/src/constants.ts
+++ b/indexer/packages/postgres/src/constants.ts
@@ -126,8 +126,9 @@ export const DEFAULT_POSTGRES_OPTIONS : Options = config.USE_READ_REPLICA
     readReplica: true,
   } : {};
 
+// The maximum number of parent subaccounts per address.
 export const MAX_PARENT_SUBACCOUNTS: number = 128;
-
+// The maximum number of child subaccounts per parent subaccount.
 export const CHILD_SUBACCOUNT_MULTIPLIER: number = 1000;
 
 // From https://github.com/dydxprotocol/v4-chain/blob/protocol/v7.0.0-dev0/protocol/app/module_accounts_test.go#L41

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250505153439_replace_subaccounts_address_idx_with_address_subaccountnumber_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250505153439_replace_subaccounts_address_idx_with_address_subaccountnumber_idx.ts
@@ -1,0 +1,28 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS subaccounts_address_index;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS subaccounts_address_subaccountnumber_index
+      ON subaccounts(address, "subaccountNumber")
+      INCLUDE (id);
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS subaccounts_address_subaccountnumber_index;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS subaccounts_address_index
+      ON subaccounts (address);
+  `);
+}
+
+export const config = {
+  transaction: false,
+};

--- a/indexer/packages/postgres/src/lib/parent-subaccount-helpers.ts
+++ b/indexer/packages/postgres/src/lib/parent-subaccount-helpers.ts
@@ -28,14 +28,10 @@ export function getSubaccountQueryForParent(parentSubaccount: {
     .select('id as subaccountId')
     .from('subaccounts')
     .where('address', parentSubaccount.address)
-    .whereRaw(
-      `"subaccountNumber" IN (
-        SELECT generate_series(
-          ?,
-          ? + ${MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER},
-          ${MAX_PARENT_SUBACCOUNTS}
-        )
-      )`,
-      [parentSubaccount.subaccountNumber, parentSubaccount.subaccountNumber],
+    .andWhere('subaccountNumber', '>=', parentSubaccount.subaccountNumber)
+    .andWhere('subaccountNumber', '<=', parentSubaccount.subaccountNumber + MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER)
+    .andWhereRaw(
+      '("subaccountNumber" - ?) % ? = 0',
+      [parentSubaccount.subaccountNumber, MAX_PARENT_SUBACCOUNTS],
     );
 }

--- a/indexer/packages/postgres/src/lib/parent-subaccount-helpers.ts
+++ b/indexer/packages/postgres/src/lib/parent-subaccount-helpers.ts
@@ -28,8 +28,6 @@ export function getSubaccountQueryForParent(parentSubaccount: {
     .select('id as subaccountId')
     .from('subaccounts')
     .where('address', parentSubaccount.address)
-    .andWhere('subaccountNumber', '>=', parentSubaccount.subaccountNumber)
-    .andWhere('subaccountNumber', '<=', parentSubaccount.subaccountNumber + MAX_PARENT_SUBACCOUNTS * CHILD_SUBACCOUNT_MULTIPLIER)
     .andWhereRaw(
       '("subaccountNumber" - ?) % ? = 0',
       [parentSubaccount.subaccountNumber, MAX_PARENT_SUBACCOUNTS],


### PR DESCRIPTION
### Changelist
generate series takes a long time. save in absolute latency is small but this is invoked for every parent subaccount query

previous query
- without new index
  - address with 125 subaccounts: ~0.7ms
  - address with 40 subaccounts: ~0.67ms
- with new index: ~0.6ms

new query
- without new index:
  - address with 125 subaccounts: ~0.16ms
  - address with 40 subaccounts: ~0.07ms
  - address with 20 subaccounts: ~0.05ms
- with new index: ~0.08ms

### Test Plan
- existing unit tests on correctness of this query
- tested on internal mainnet FE and indexer API response

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database query logic for subaccount retrieval, resulting in more efficient filtering and performance.
- **Chores**
  - Updated database indexing strategy for subaccounts to enhance query speed and reliability.
  - Added descriptive comments to constants for better code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->