### PR TITLE
(perf) patch mangled timestamps from pg for from ISO

### DIFF
--- a/indexer/packages/postgres/src/db/pg-config.ts
+++ b/indexer/packages/postgres/src/db/pg-config.ts
@@ -13,5 +13,5 @@ const utcZone = {
 
 pg.types.setTypeParser(
   pg.types.builtins.TIMESTAMPTZ,
-  (val) => (val === null ? null : DateTime.fromSQL(val, utcZone).toISO()),
+  (val) => (val === null ? null : DateTime.fromISO(val.replace(' ', 'T'), utcZone).toISO()),
 );


### PR DESCRIPTION
### Changelist
The indexer database adapter is pg, which produces mangled/truncated milliseconds in timestamps and prints spaces between the date and time.

Currently, luxon.DateTime.fromSQL is used to minimize format sniffing.
luxon.DateTime.fromISO wasn't chosen as the timestamps are not ISO8601 compliant.

With this change, the timestamps are patched to fix the separator and then parsed with .fromISO, resulting in a 10x speedup on SQL timestamp microbenchmarks.

### Test Plan
Unit Test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of PostgreSQL TIMESTAMPTZ values to ensure accurate parsing and conversion of timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->