### PR TITLE
drop unused fills table indices

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250506164832_drop_unused_fills_idxs.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250506164832_drop_unused_fills_idxs.ts
@@ -1,0 +1,64 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS fills_clobPairId_createdAtHeight_partial;
+  `);
+
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS fills_clobpairid_createdat_index;
+  `);
+
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS fills_orderid_index;
+  `);
+
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS fills_subaccountid_createdat_index;
+  `);
+
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS fills_subaccountid_index;
+  `);
+
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS fills_type_index;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS fills_clobPairId_createdAtHeight_partial
+      ON fills("clobPairId", "createdAtHeight")
+      WHERE liquidity = 'TAKER';
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS fills_clobpairid_createdat_index
+      ON fills("clobPairId", "createdAt");
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS fills_orderid_index
+      ON fills("orderId");
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS fills_subaccountid_createdat_index
+      ON fills("subaccountId", "createdAt");
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS fills_subaccountid_index
+      ON fills("subaccountId");
+  `);
+
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS fills_type_index
+      ON fills(type);
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
these indices are either unused or are duplicates with existing ones

### Test Plan
- tested on internal mainnet
- tested on testnet and no increased latency on fills queries

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed several unused database indexes to improve performance.
  - Ensured the ability to restore these indexes if needed in the future.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->