### PR TITLE
(perf) precompute DateTime's for candles

### DIFF
--- a/indexer/packages/postgres/src/db/helpers.ts
+++ b/indexer/packages/postgres/src/db/helpers.ts
@@ -1,10 +1,8 @@
 import { logger } from '@dydxprotocol-indexer/base';
 import Big from 'big.js';
-import { DateTime } from 'luxon';
 
-import { NUM_SECONDS_IN_CANDLE_RESOLUTIONS, ONE_MILLION } from '../constants';
+import { ONE_MILLION } from '../constants';
 import {
-  CandleResolution,
   FundingIndexMap, MarketFromDatabase,
   PerpetualMarketFromDatabase,
   PerpetualPositionFromDatabase,
@@ -122,16 +120,4 @@ export function getTransferType(
     }
   }
   throw new Error(`Transfer ${transfer.id} does not involve subaccount ${subaccountId}`);
-}
-
-export function calculateNormalizedCandleStartTime(
-  time: DateTime,
-  resolution: CandleResolution,
-): DateTime {
-  const epochSeconds: number = Math.floor(time.toUTC().toSeconds());
-  const normalizedTimeSeconds: number = epochSeconds - (
-    epochSeconds % NUM_SECONDS_IN_CANDLE_RESOLUTIONS[resolution]
-  );
-
-  return DateTime.fromSeconds(normalizedTimeSeconds).toUTC();
 }

--- a/indexer/services/ender/__tests__/lib/candles-generator.test.ts
+++ b/indexer/services/ender/__tests__/lib/candles-generator.test.ts
@@ -17,7 +17,6 @@ import {
   testConstants,
   testMocks,
   Transaction,
-  helpers,
 } from '@dydxprotocol-indexer/postgres';
 import { CandleMessage, CandleMessage_Resolution } from '@dydxprotocol-indexer/v4-protos';
 import Big from 'big.js';
@@ -40,7 +39,7 @@ import { ORDERBOOK_MID_PRICES_CACHE_KEY_PREFIX } from '@dydxprotocol-indexer/red
 import { DateTime, Settings } from 'luxon';
 
 describe('candleHelper', () => {
-  const startedAt: DateTime = helpers.calculateNormalizedCandleStartTime(
+  const startedAt: DateTime = CandlesGenerator.calculateNormalizedCandleStartTime(
     testConstants.createdDateTime,
     CandleResolution.ONE_MINUTE,
   );
@@ -95,7 +94,7 @@ describe('candleHelper', () => {
     orderbookMidPriceClose: undefined,
     orderbookMidPriceOpen: undefined,
   };
-  const previousStartedAt: IsoString = helpers.calculateNormalizedCandleStartTime(
+  const previousStartedAt: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
     testConstants.createdDateTime.minus({ minutes: 1 }),
     CandleResolution.ONE_MINUTE,
   ).toISO();
@@ -137,7 +136,7 @@ describe('candleHelper', () => {
     const expectedCandles: CandleFromDatabase[] = _.map(
       Object.values(CandleResolution),
       (resolution: CandleResolution) => {
-        const currentStartedAt: IsoString = helpers.calculateNormalizedCandleStartTime(
+        const currentStartedAt: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
           testConstants.createdDateTime,
           resolution,
         ).toISO();
@@ -185,7 +184,7 @@ describe('candleHelper', () => {
     const expectedCandles: CandleFromDatabase[] = _.map(
       Object.values(CandleResolution),
       (resolution: CandleResolution) => {
-        const currentStartedAt: IsoString = helpers.calculateNormalizedCandleStartTime(
+        const currentStartedAt: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
           testConstants.createdDateTime,
           resolution,
         ).toISO();
@@ -219,7 +218,7 @@ describe('candleHelper', () => {
     const orderbookMidPriceOpen = '8000';
     await Promise.all(
       _.map(Object.values(CandleResolution), (resolution: CandleResolution) => {
-        const currentStartedAt: IsoString = helpers.calculateNormalizedCandleStartTime(
+        const currentStartedAt: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
           testConstants.createdDateTime,
           resolution,
         ).toISO();
@@ -255,7 +254,7 @@ describe('candleHelper', () => {
     const expectedCandles: CandleFromDatabase[] = _.map(
       Object.values(CandleResolution),
       (resolution: CandleResolution) => {
-        const currentStartedAt: IsoString = helpers.calculateNormalizedCandleStartTime(
+        const currentStartedAt: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
           testConstants.createdDateTime,
           resolution,
         ).toISO();
@@ -490,7 +489,7 @@ describe('candleHelper', () => {
     const orderbookMidPriceClose = '7500';
     const orderbookMidPriceOpen = '8000';
     // Set candle start time to be far in the past to ensure all candles are new
-    const startTime: IsoString = helpers.calculateNormalizedCandleStartTime(
+    const startTime: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
       testConstants.createdDateTime.minus({ minutes: 100 }),
       CandleResolution.ONE_MINUTE,
     ).toUTC().toISO();
@@ -556,7 +555,7 @@ describe('candleHelper', () => {
     const expectedCandles: CandleFromDatabase[] = _.map(
       Object.values(CandleResolution),
       (resolution: CandleResolution) => {
-        const currentStartedAt: IsoString = helpers.calculateNormalizedCandleStartTime(
+        const currentStartedAt: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
           testConstants.createdDateTime,
           resolution,
         ).toISO();
@@ -593,7 +592,7 @@ describe('candleHelper', () => {
     const orderbookMidPriceClose = '7500';
     const orderbookMidPriceOpen = '8000';
     // Set candle start time to be far in the past to ensure all candles are new
-    const startTime: IsoString = helpers.calculateNormalizedCandleStartTime(
+    const startTime: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
       testConstants.createdDateTime.minus({ minutes: 100 }),
       CandleResolution.ONE_MINUTE,
     ).toISO();
@@ -656,7 +655,7 @@ describe('candleHelper', () => {
     const expectedCandles: CandleFromDatabase[] = _.map(
       Object.values(CandleResolution),
       (resolution: CandleResolution) => {
-        const currentStartedAt: IsoString = helpers.calculateNormalizedCandleStartTime(
+        const currentStartedAt: IsoString = CandlesGenerator.calculateNormalizedCandleStartTime(
           testConstants.createdDateTime,
           resolution,
         ).toISO();

--- a/indexer/services/scripts/src/helpers/pnl-validation-helpers.ts
+++ b/indexer/services/scripts/src/helpers/pnl-validation-helpers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import {
   FillTable,
   FundingIndexMap,

--- a/indexer/services/scripts/src/helpers/util.ts
+++ b/indexer/services/scripts/src/helpers/util.ts
@@ -1,6 +1,4 @@
-/**
- * Helper for running an async script.
- */
+/* eslint-disable no-console */
 export function runAsyncScript(script: () => Promise<void>): void {
   script()
     .then(() => {

--- a/indexer/services/scripts/src/print-candle-time-boundaries.ts
+++ b/indexer/services/scripts/src/print-candle-time-boundaries.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { CandleResolution, NUM_SECONDS_IN_CANDLE_RESOLUTIONS } from '@dydxprotocol-indexer/postgres';
 import { DateTime } from 'luxon';
 import yargs from 'yargs';


### PR DESCRIPTION
### Changelist
For each market with trades in the block, and each candle resolution (7), ender computes the DateTime for the last candle boundary.

Given that all trades in a block are offset to the same DateTime for a given resolution, instead precompute the candle resolution DateTimes.

Refactor references to duplicate calculateNormalizedCandleStartTime method in postgres package and remove duplicated code.

(lint) Disable no-console checks for scripts to eliminate eslint warnings.

### Test Plan
Unit Tests

Run and validate ender within internal environments and public testnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved performance and consistency of candle time calculations by caching normalized candle start times and updating internal handling of time zones.
- **Tests**
	- Updated tests to use the revised candle start time calculation method.
- **Chores**
	- Enabled console logging in several scripts by disabling linting restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->