### PR TITLE
(build) trigger indexer builds for mainnet and testnet on release

### DIFF
--- a/.github/workflows/indexer-build-and-push-mainnet.yml
+++ b/.github/workflows/indexer-build-and-push-mainnet.yml
@@ -12,6 +12,10 @@ on: # yamllint disable-line rule:truthy
       - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/indexer/v0.1.x
       - 'release/indexer/v[0-9]+.x'  # e.g. release/indexer/v1.x
     # TODO(DEC-837): Customize github build and push to ECR by service with paths
+  release:
+    types: [created, published]
+
+
 
 jobs:
   # Build and push to mainnet

--- a/.github/workflows/indexer-build-and-push-testnet.yml
+++ b/.github/workflows/indexer-build-and-push-testnet.yml
@@ -12,6 +12,8 @@ on: # yamllint disable-line rule:truthy
       - 'release/indexer/v[0-9]+.[0-9]+.x'  # e.g. release/indexer/v0.1.x
       - 'release/indexer/v[0-9]+.x'  # e.g. release/indexer/v1.x
     # TODO(DEC-837): Customize github build and push to ECR by service with paths
+  release:
+    types: [created, published]
 
 jobs:
   # Build and push to public-testnet


### PR DESCRIPTION
### Changelist
Add release trigger for created and published events for both internal mainnet and public testnet indexer builds.

No change to protocol workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automation workflows to run when a release is created or published, in addition to existing triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->