### PR TITLE
drop unused orders_clobpairid_side_price_index

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250509125707_drop_orders_clobpairid_side_price_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250509125707_drop_orders_clobpairid_side_price_idx.ts
@@ -1,0 +1,18 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS orders_clobpairid_side_price_index;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS orders_clobpairid_side_price_index
+      ON orders("clobPairId", side, price);
+  `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
this index is extremely large and not used at all. dropping to make db easier to maintain and improve write latency to orders table

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated database migration to remove a specific index from the orders table, with the ability to restore it if needed. This change ensures smoother database operations during index modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->