### PR TITLE
[BUG2-313] Correct fill notification to use fill size/price rather than order

### DIFF
--- a/indexer/services/ender/__tests__/helpers/notification-functions.test.ts
+++ b/indexer/services/ender/__tests__/helpers/notification-functions.test.ts
@@ -3,8 +3,8 @@ import {
   sendOrderTriggeredNotification,
 } from '../../src/helpers/notifications/notifications-functions';
 import {
-  dbHelpers, FillFromDatabase, FillType, Liquidity,
-  OrderFromDatabase, OrderSide,
+  dbHelpers, FillFromDatabase,
+  OrderFromDatabase,
   PerpetualMarketFromDatabase,
   PerpetualMarketStatus,
   PerpetualMarketType,
@@ -94,7 +94,7 @@ describe('notification functions', () => {
         clobPairId: String(defaultMarket.id),
         size: '5',
         price: '100.25',
-        quoteAmount: '0',
+        quoteAmount: '501.25',
         eventId: Buffer.from('1'),
         transactionHash: '0x1234567890abcdef',
         createdAt: new Date().toISOString(),

--- a/indexer/services/ender/__tests__/helpers/notification-functions.test.ts
+++ b/indexer/services/ender/__tests__/helpers/notification-functions.test.ts
@@ -3,8 +3,8 @@ import {
   sendOrderTriggeredNotification,
 } from '../../src/helpers/notifications/notifications-functions';
 import {
-  dbHelpers,
-  OrderFromDatabase,
+  dbHelpers, FillFromDatabase, FillType, Liquidity,
+  OrderFromDatabase, OrderSide,
   PerpetualMarketFromDatabase,
   PerpetualMarketStatus,
   PerpetualMarketType,
@@ -85,16 +85,31 @@ describe('notification functions', () => {
         updatedAt: new Date().toISOString(),
         updatedAtHeight: '900001',
       } as OrderFromDatabase;
+      const mockFill: FillFromDatabase = {
+        id: '1',
+        subaccountId: defaultSubaccountId,
+        side: 'BUY',
+        liquidity: 'TAKER',
+        type: 'LIMIT',
+        clobPairId: String(defaultMarket.id),
+        size: '5',
+        price: '100.25',
+        quoteAmount: '0',
+        eventId: Buffer.from('1'),
+        transactionHash: '0x1234567890abcdef',
+        createdAt: new Date().toISOString(),
+        createdAtHeight: '900001',
+      } as FillFromDatabase;
 
-      await sendOrderFilledNotification(mockOrder, mockMarket);
+      await sendOrderFilledNotification(mockOrder, mockMarket, mockFill);
 
       // Assert that createNotification was called with correct arguments
       expect(createNotification).toHaveBeenCalledWith(
         NotificationType.ORDER_FILLED,
         {
-          AMOUNT: '10',
+          AMOUNT: '5',
           MARKET: 'BTC-USD',
-          AVERAGE_PRICE: '100.50',
+          AVERAGE_PRICE: '100.25',
         },
       );
 

--- a/indexer/services/ender/src/handlers/order-fills/order-handler.ts
+++ b/indexer/services/ender/src/handlers/order-fills/order-handler.ts
@@ -120,7 +120,7 @@ export class OrderHandler extends AbstractOrderFillHandler<OrderFillWithLiquidit
 
     // If order is filled, send a notification to firebase
     if (order.status === OrderStatus.FILLED) {
-      await sendOrderFilledNotification(order, perpetualMarket);
+      await sendOrderFilledNotification(order, perpetualMarket, fill);
     }
 
     // If the order is stateful and fully-filled, send an order removal to vulcan. We only do this

--- a/indexer/services/ender/src/helpers/notifications/notifications-functions.ts
+++ b/indexer/services/ender/src/helpers/notifications/notifications-functions.ts
@@ -11,6 +11,7 @@ import {
   SubaccountFromDatabase,
   SubaccountTable,
   FirebaseNotificationTokenTable,
+  FillFromDatabase,
 } from '@dydxprotocol-indexer/postgres';
 
 import config from '../../config';
@@ -18,6 +19,7 @@ import config from '../../config';
 export async function sendOrderFilledNotification(
   order: OrderFromDatabase,
   market: PerpetualMarketFromDatabase,
+  fill: FillFromDatabase,
 ) {
   const start = Date.now();
   try {
@@ -36,9 +38,9 @@ export async function sendOrderFilledNotification(
     const notification = createNotification(
       NotificationType.ORDER_FILLED,
       {
-        [NotificationDynamicFieldKey.AMOUNT]: order.size.toString(),
+        [NotificationDynamicFieldKey.AMOUNT]: fill.size,
         [NotificationDynamicFieldKey.MARKET]: market.ticker,
-        [NotificationDynamicFieldKey.AVERAGE_PRICE]: order.price,
+        [NotificationDynamicFieldKey.AVERAGE_PRICE]: fill.price,
       },
     );
 


### PR DESCRIPTION
### Changelist
The fill notifications to firebase were using the size and price on the order instead of the actual fill

### Test Plan
Modified existing tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Order fill notifications now display the actual fill size and price, ensuring more accurate notification details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->