### PR TITLE
(fix) improve handling of unhealthy websockets connections

### DIFF
--- a/indexer/packages/kafka/src/websocket-helper.ts
+++ b/indexer/packages/kafka/src/websocket-helper.ts
@@ -116,5 +116,5 @@ export function createSubaccountWebsocketMessage(
     version: SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
   });
 
-  return Buffer.from(Uint8Array.from(SubaccountMessage.encode(subaccountMessage).finish()));
+  return Buffer.from(SubaccountMessage.encode(subaccountMessage).finish());
 }

--- a/indexer/packages/redis/src/caches/place-order.ts
+++ b/indexer/packages/redis/src/caches/place-order.ts
@@ -120,7 +120,8 @@ export async function placeOrder({
     getOrderDataCacheKey(redisOrder.order!.orderId!),
     getSubaccountOrderIdsCacheKey(redisOrder.order!.orderId!.subaccountId!),
     ORDER_EXPIRY_CACHE_KEY,
-    Buffer.from(Uint8Array.from(RedisOrder.encode(redisOrder).finish())).toString('binary'),
+    // TODO: use String to directly convert the UInt8Array to a string
+    Buffer.from(RedisOrder.encode(redisOrder).finish()).toString('binary'),
     getOrderExpiry(redisOrder.order!).toString(),
     OrderTable.orderIdToUuid(redisOrder.order!.orderId!),
     redisOrder.order!.orderId!.orderFlags === ORDER_FLAG_SHORT_TERM,

--- a/indexer/packages/redis/src/caches/stateful-order-updates-cache.ts
+++ b/indexer/packages/redis/src/caches/stateful-order-updates-cache.ts
@@ -53,7 +53,8 @@ export async function addStatefulOrderUpdate(
 
   return evalAsync(
     statefulOrderId,
-    Buffer.from(Uint8Array.from(OrderUpdateV1.encode(orderUpdate).finish())).toString('binary'),
+    // TODO: use String to directly convert the UInt8Array to a string
+    Buffer.from(OrderUpdateV1.encode(orderUpdate).finish()).toString('binary'),
     updateTimestamp,
   );
 }

--- a/indexer/packages/v4-proto-parser/src/order-helpers.ts
+++ b/indexer/packages/v4-proto-parser/src/order-helpers.ts
@@ -11,7 +11,7 @@ import { ORDER_FLAG_CONDITIONAL, ORDER_FLAG_LONG_TERM } from './constants';
  * @returns
  */
 export function getOrderIdHash(orderId: IndexerOrderId): Buffer {
-  const bytes: Buffer = Buffer.from(Uint8Array.from(IndexerOrderId.encode(orderId).finish()));
+  const bytes: Buffer = Buffer.from(IndexerOrderId.encode(orderId).finish());
   return createHash('sha256').update(bytes).digest();
 }
 

--- a/indexer/services/ender/src/lib/kafka-publisher.ts
+++ b/indexer/services/ender/src/lib/kafka-publisher.ts
@@ -213,7 +213,7 @@ export class KafkaPublisher {
         topic: KafkaTopics.TO_WEBSOCKETS_BLOCK_HEIGHT,
         messages: _.map(this.blockHeightMessages, (message: BlockHeightMessage) => {
           return {
-            value: Buffer.from(Uint8Array.from(BlockHeightMessage.encode(message).finish())),
+            value: Buffer.from(BlockHeightMessage.encode(message).finish()),
           };
         }),
       });
@@ -227,10 +227,10 @@ export class KafkaPublisher {
         messages: _.map(this.subaccountMessages, (message: SubaccountMessage) => {
           return {
             key: message.subaccountId !== undefined
-              ? Buffer.from(Uint8Array.from(
+              ? Buffer.from(
                 IndexerSubaccountId.encode(message.subaccountId).finish(),
-              )) : undefined,
-            value: Buffer.from(Uint8Array.from(SubaccountMessage.encode(message).finish())),
+              ) : undefined,
+            value: Buffer.from(SubaccountMessage.encode(message).finish()),
           };
         }),
       });
@@ -248,7 +248,7 @@ export class KafkaPublisher {
         topic: KafkaTopics.TO_WEBSOCKETS_MARKETS,
         messages: _.map(this.marketMessages, (message: MarketMessage) => {
           return {
-            value: Buffer.from(Uint8Array.from(MarketMessage.encode(message).finish())),
+            value: Buffer.from(MarketMessage.encode(message).finish()),
           };
         }),
       });
@@ -259,7 +259,7 @@ export class KafkaPublisher {
         topic: KafkaTopics.TO_WEBSOCKETS_CANDLES,
         messages: _.map(this.candleMessages, (message: CandleMessage) => {
           return {
-            value: Buffer.from(Uint8Array.from(CandleMessage.encode(message).finish())),
+            value: Buffer.from(CandleMessage.encode(message).finish()),
           };
         }),
       });
@@ -271,7 +271,7 @@ export class KafkaPublisher {
         messages: _.map(this.vulcanMessages, (message: VulcanMessage) => {
           return {
             key: message.key,
-            value: Buffer.from(Uint8Array.from(OffChainUpdateV1.encode(message.value).finish())),
+            value: Buffer.from(OffChainUpdateV1.encode(message.value).finish()),
             headers: message.headers,
           };
         }),
@@ -318,7 +318,7 @@ export class KafkaPublisher {
     const messages: ProducerMessage[] = _.chain(Object.values(groupedMergedTradeMessage))
       .map((tradeMessage: TradeMessage) => {
         return {
-          value: Buffer.from(Uint8Array.from(TradeMessage.encode(tradeMessage).finish())),
+          value: Buffer.from(TradeMessage.encode(tradeMessage).finish()),
         };
       })
       .value();

--- a/indexer/services/roundtable/src/helpers/websocket.ts
+++ b/indexer/services/roundtable/src/helpers/websocket.ts
@@ -104,9 +104,7 @@ export function compareAndHandleMarketsWebsocketMessage({
       version: MARKETS_WEBSOCKET_MESSAGE_VERSION,
     };
     const buffer: Buffer = Buffer.from(
-      Uint8Array.from(
-        MarketMessage.encode(marketMessage).finish(),
-      ),
+      MarketMessage.encode(marketMessage).finish(),
     );
 
     wrapBackgroundTask(publishToMarketsWebsocket(
@@ -145,5 +143,5 @@ export function getExpiredOffChainUpdateMessage(removedOrderId: IndexerOrderId):
       removalStatus: OrderRemoveV1_OrderRemovalStatus.ORDER_REMOVAL_STATUS_CANCELED,
     },
   });
-  return Buffer.from(Uint8Array.from(OffChainUpdateV1.encode(message).finish()));
+  return Buffer.from(OffChainUpdateV1.encode(message).finish());
 }

--- a/indexer/services/socks/__tests__/lib/invalid-message.test.ts
+++ b/indexer/services/socks/__tests__/lib/invalid-message.test.ts
@@ -1,9 +1,9 @@
-import { InvalidMessageHandler } from '../../src/lib/invalid-message';
+import { InvalidMessageHandler, RATE_LIMITED } from '../../src/lib/invalid-message';
 import { RateLimiter } from '../../src/lib/rate-limit';
 import { sendMessage } from '../../src/helpers/wss';
 import WebSocket from 'ws';
 import { WS_CLOSE_CODE_POLICY_VIOLATION } from '../../src/lib/constants';
-import { Connection, WebsocketEvents } from '../../src/types';
+import { Connection } from '../../src/types';
 
 jest.mock('../../src/lib/rate-limit');
 jest.mock('../../src/helpers/wss', () => ({
@@ -28,6 +28,7 @@ describe('InvalidMessageHandler', () => {
         removeAllListeners: jest.fn(),
       } as unknown as WebSocket,
       messageId: 1,
+      id: connectionId,
     };
   });
 
@@ -50,8 +51,7 @@ describe('InvalidMessageHandler', () => {
     expect(sendMessage).toHaveBeenCalled();
     expect(mockConnection.ws.close).toHaveBeenCalledWith(
       WS_CLOSE_CODE_POLICY_VIOLATION,
-      JSON.stringify({ message: 'Rate limited' }),
+      RATE_LIMITED,
     );
-    expect(mockConnection.ws.removeAllListeners).toHaveBeenCalledWith(WebsocketEvents.MESSAGE);
   });
 });

--- a/indexer/services/socks/src/helpers/from-kafka-helpers.ts
+++ b/indexer/services/socks/src/helpers/from-kafka-helpers.ts
@@ -40,10 +40,9 @@ export function getMessageToForward(
     throw new InvalidForwardMessageError('Got empty kafka message');
   }
 
-  const messageBinary: Uint8Array = new Uint8Array(message.value);
   switch (channel) {
     case Channel.V4_ACCOUNTS: {
-      const subaccountMessage: SubaccountMessage = SubaccountMessage.decode(messageBinary);
+      const subaccountMessage: SubaccountMessage = SubaccountMessage.decode(message.value);
       return {
         channel,
         id: getSubaccountMessageId(subaccountMessage),
@@ -52,7 +51,7 @@ export function getMessageToForward(
       };
     }
     case Channel.V4_CANDLES: {
-      const candleMessage: CandleMessage = CandleMessage.decode(messageBinary);
+      const candleMessage: CandleMessage = CandleMessage.decode(message.value);
       if (candleMessage.resolution === CandleMessage_Resolution.UNRECOGNIZED) {
         throw new InvalidForwardMessageError(`Unrecognized candle resolution: ${candleMessage.resolution}`);
       }
@@ -64,7 +63,7 @@ export function getMessageToForward(
       };
     }
     case Channel.V4_MARKETS: {
-      const marketMessage: MarketMessage = MarketMessage.decode(messageBinary);
+      const marketMessage: MarketMessage = MarketMessage.decode(message.value);
       return {
         channel,
         id: V4_MARKETS_ID,
@@ -73,7 +72,7 @@ export function getMessageToForward(
       };
     }
     case Channel.V4_ORDERBOOK: {
-      const orderbookMessage: OrderbookMessage = OrderbookMessage.decode(messageBinary);
+      const orderbookMessage: OrderbookMessage = OrderbookMessage.decode(message.value);
       return {
         channel,
         id: getTickerOrThrow(orderbookMessage.clobPairId),
@@ -82,7 +81,7 @@ export function getMessageToForward(
       };
     }
     case Channel.V4_TRADES: {
-      const tradeMessage: TradeMessage = TradeMessage.decode(messageBinary);
+      const tradeMessage: TradeMessage = TradeMessage.decode(message.value);
       return {
         channel,
         id: getTickerOrThrow(tradeMessage.clobPairId),
@@ -91,7 +90,7 @@ export function getMessageToForward(
       };
     }
     case Channel.V4_PARENT_ACCOUNTS: {
-      const subaccountMessage: SubaccountMessage = SubaccountMessage.decode(messageBinary);
+      const subaccountMessage: SubaccountMessage = SubaccountMessage.decode(message.value);
       return {
         channel,
         id: getParentSubaccountMessageId(subaccountMessage),
@@ -101,7 +100,7 @@ export function getMessageToForward(
       };
     }
     case Channel.V4_BLOCK_HEIGHT: {
-      const blockHeightMessage: BlockHeightMessage = BlockHeightMessage.decode(messageBinary);
+      const blockHeightMessage: BlockHeightMessage = BlockHeightMessage.decode(message.value);
       return {
         channel: Channel.V4_BLOCK_HEIGHT,
         id: V4_BLOCK_HEIGHT_ID,
@@ -121,11 +120,10 @@ export function getMessagesToForward(topic: string, message: KafkaMessage): Mess
   if (!message || !message.value) {
     throw new InvalidForwardMessageError('Got empty kafka message');
   }
-  const messageBinary: Uint8Array = new Uint8Array(message.value);
 
   switch (topic) {
     case WebsocketTopics.TO_WEBSOCKETS_CANDLES: {
-      const candleMessage: CandleMessage = CandleMessage.decode(messageBinary);
+      const candleMessage: CandleMessage = CandleMessage.decode(message.value);
       return [{
         channel: Channel.V4_CANDLES,
         id: getCandleMessageId(candleMessage),
@@ -134,7 +132,7 @@ export function getMessagesToForward(topic: string, message: KafkaMessage): Mess
       }];
     }
     case WebsocketTopics.TO_WEBSOCKETS_MARKETS: {
-      const marketMessage: MarketMessage = MarketMessage.decode(messageBinary);
+      const marketMessage: MarketMessage = MarketMessage.decode(message.value);
       return [{
         channel: Channel.V4_MARKETS,
         id: V4_MARKETS_ID,
@@ -143,7 +141,7 @@ export function getMessagesToForward(topic: string, message: KafkaMessage): Mess
       }];
     }
     case WebsocketTopics.TO_WEBSOCKETS_ORDERBOOKS: {
-      const orderbookMessage: OrderbookMessage = OrderbookMessage.decode(messageBinary);
+      const orderbookMessage: OrderbookMessage = OrderbookMessage.decode(message.value);
       return [{
         channel: Channel.V4_ORDERBOOK,
         id: getTickerOrThrow(orderbookMessage.clobPairId),
@@ -152,7 +150,7 @@ export function getMessagesToForward(topic: string, message: KafkaMessage): Mess
       }];
     }
     case WebsocketTopics.TO_WEBSOCKETS_TRADES: {
-      const tradeMessage: TradeMessage = TradeMessage.decode(messageBinary);
+      const tradeMessage: TradeMessage = TradeMessage.decode(message.value);
       return [{
         channel: Channel.V4_TRADES,
         id: getTickerOrThrow(tradeMessage.clobPairId),
@@ -161,7 +159,7 @@ export function getMessagesToForward(topic: string, message: KafkaMessage): Mess
       }];
     }
     case WebsocketTopics.TO_WEBSOCKETS_SUBACCOUNTS: {
-      const subaccountMessage: SubaccountMessage = SubaccountMessage.decode(messageBinary);
+      const subaccountMessage: SubaccountMessage = SubaccountMessage.decode(message.value);
       return [{
         channel: Channel.V4_ACCOUNTS,
         id: getSubaccountMessageId(subaccountMessage),
@@ -177,7 +175,7 @@ export function getMessagesToForward(topic: string, message: KafkaMessage): Mess
       }];
     }
     case WebsocketTopics.TO_WEBSOCKETS_BLOCK_HEIGHT: {
-      const blockHeightMessage: BlockHeightMessage = BlockHeightMessage.decode(messageBinary);
+      const blockHeightMessage: BlockHeightMessage = BlockHeightMessage.decode(message.value);
       return [{
         channel: Channel.V4_BLOCK_HEIGHT,
         id: V4_BLOCK_HEIGHT_ID,

--- a/indexer/services/socks/src/helpers/wss.ts
+++ b/indexer/services/socks/src/helpers/wss.ts
@@ -9,6 +9,40 @@ import {
 } from '../lib/constants';
 import { IncomingMessage, OutgoingMessage, WebsocketEvents } from '../types';
 
+function incrementSendErrorStats(instanceId: string, error: WssError): void {
+  stats.increment(
+    `${config.SERVICE_NAME}.ws_send.error`,
+    1,
+    config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
+    {
+      instance: instanceId,
+      code: error?.code,
+    },
+  );
+}
+
+function incrementStreamDestroyedErrorStats(instanceId: string): void {
+  stats.increment(
+    `${config.SERVICE_NAME}.ws_send.stream_destroyed_errors`,
+    1,
+    {
+      action: 'close',
+      instance: instanceId,
+    },
+  );
+}
+
+function incrementWriteEpipeErrorStats(instanceId: string): void {
+  stats.increment(
+    `${config.SERVICE_NAME}.ws_send.write_epipe_errors`,
+    1,
+    {
+      action: 'close',
+      instance: instanceId,
+    },
+  );
+}
+
 export class Wss {
   private wss: WebSocket.Server;
   private started: boolean;
@@ -116,35 +150,12 @@ export function sendMessageString(
   ws.send(message, (error) => {
     if (error) {
       const instanceId = getInstanceId();
-      stats.increment(
-        `${config.SERVICE_NAME}.ws_send.error`,
-        1,
-        config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
-        {
-          instance: instanceId,
-          code: (error as WssError)?.code,
-        },
-      );
+      incrementSendErrorStats(instanceId, error as WssError);
+      // Don't log to avoid bursts when clients disconnect abruptly
       if (error?.message.includes?.(ERR_WRITE_STREAM_DESTROYED)) {
-        // Don't log to avoid bursts when clients disconnect abruptly
-        stats.increment(
-          `${config.SERVICE_NAME}.ws_send.stream_destroyed_errors`,
-          1,
-          {
-            action: 'close',
-            instance: instanceId,
-          },
-        );
+        incrementStreamDestroyedErrorStats(instanceId);
       } else if (error?.message.includes?.('EPIPE')) {
-        // Don't log to avoid bursts when clients disconnect abruptly
-        stats.increment(
-          `${config.SERVICE_NAME}.ws_send.write_epipe_errors`,
-          1,
-          {
-            action: 'close',
-            instance: instanceId,
-          },
-        );
+        incrementWriteEpipeErrorStats(instanceId);
       } else {
         const errorLog = { // type is InfoObject in node-service-base
           at: 'wss#sendMessageString',
@@ -156,39 +167,18 @@ export function sendMessageString(
         logger.error(errorLog);
       }
       try {
-        // don't remove WebsocketEvents.CLOSE as it's handled in index#disconnect
-        ws.removeAllListeners(WebsocketEvents.MESSAGE);
-        ws.removeAllListeners(WebsocketEvents.PONG);
-        ws.removeAllListeners(WebsocketEvents.ERROR);
         ws.close(
           WS_CLOSE_CODE_ABNORMAL_CLOSURE,
-          `client returned ${error?.message} error`,
+          error?.message,
         );
       } catch (closeError) {
+        // These errors indicate the underlying Socket was destroyed
+        // Don't log an error as this can be expected when clients disconnect abruptly and
+        // can happen to multiple closes while the close handshake is going on
         if (closeError?.message.includes?.(ERR_WRITE_STREAM_DESTROYED)) {
-          // This error means the underlying Socket was destroyed
-          // Don't log an error as this can be expected when clients disconnect abruptly and
-          // can happen to multiple closes while the close handshake is going on
-          stats.increment(
-            `${config.SERVICE_NAME}.ws_send.stream_destroyed_errors`,
-            1,
-            {
-              action: 'close',
-              instance: instanceId,
-            },
-          );
+          incrementStreamDestroyedErrorStats(instanceId);
         } else if (closeError?.message.includes?.('EPIPE')) {
-          // This error means the underlying Socket was destroyed
-          // Don't log an error as this can be expected when clients disconnect abruptly and
-          // can happen to multiple closes while the close handshake is going on
-          stats.increment(
-            `${config.SERVICE_NAME}.ws_send.write_epipe_errors`,
-            1,
-            {
-              action: 'close',
-              instance: instanceId,
-            },
-          );
+          incrementWriteEpipeErrorStats(instanceId);
         } else {
           const closeErrorLog = {
             at: 'wss#sendMessageString',

--- a/indexer/services/socks/src/lib/constants.ts
+++ b/indexer/services/socks/src/lib/constants.ts
@@ -4,6 +4,8 @@ import { Channel, WebsocketTopics } from '../types';
 // 4000 - 4999 is reserved for private use
 // 1006 can't be used as it's not meant to be used by endpoints
 // Reference https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
+export const WS_CLOSE_GOING_AWAY: number = 1001;
+export const WS_CLOSE_HEARTBEAT_TIMEOUT: number = 1011;
 export const WS_CLOSE_CODE_ABNORMAL_CLOSURE: number = 4000;
 export const WS_CLOSE_CODE_POLICY_VIOLATION: number = 1008;
 export const WS_CLOSE_CODE_SERVICE_RESTART: number = 1012;

--- a/indexer/services/socks/src/types.ts
+++ b/indexer/services/socks/src/types.ts
@@ -126,6 +126,7 @@ export interface Connection {
   heartbeat?: NodeJS.Timeout,
   disconnect?: NodeJS.Timeout,
   countryCode?: string,
+  id: string,
 }
 
 export interface MessageToForward {

--- a/indexer/services/vulcan/src/handlers/handler.ts
+++ b/indexer/services/vulcan/src/handlers/handler.ts
@@ -57,7 +57,7 @@ export abstract class Handler {
       version: ORDERBOOKS_WEBSOCKET_MESSAGE_VERSION,
     });
 
-    return Buffer.from(Uint8Array.from(OrderbookMessage.encode(orderbookMessage).finish()));
+    return Buffer.from(OrderbookMessage.encode(orderbookMessage).finish());
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -128,9 +128,9 @@ export class OrderPlaceHandler extends Handler {
         await this.sendCachedOrderUpdate(orderUuid, headers);
       }
       const subaccountMessage: Message = {
-        key: Buffer.from(Uint8Array.from(
+        key: Buffer.from(
           IndexerSubaccountId.encode(redisOrder.order!.orderId!.subaccountId!).finish(),
-        )),
+        ),
         value: createSubaccountWebsocketMessage(
           redisOrder,
           dbOrder,
@@ -240,7 +240,7 @@ export class OrderPlaceHandler extends Handler {
     const orderUpdateMessage: Message = {
       key: getOrderIdHash(cachedOrderUpdate.orderId!),
       value: Buffer.from(
-        Uint8Array.from(OffChainUpdateV1.encode({ orderUpdate: cachedOrderUpdate }).finish()),
+        OffChainUpdateV1.encode({ orderUpdate: cachedOrderUpdate }).finish(),
       ),
       headers,
     };

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -235,9 +235,9 @@ export class OrderRemoveHandler extends Handler {
     }
 
     const subaccountMessage: Message = {
-      key: Buffer.from(Uint8Array.from(
+      key: Buffer.from(
         IndexerSubaccountId.encode(orderRemove.removedOrderId!.subaccountId!).finish(),
-      )),
+      ),
       value: this.createSubaccountWebsocketMessageFromPostgresOrder(
         order,
         orderRemove,
@@ -300,9 +300,9 @@ export class OrderRemoveHandler extends Handler {
           this.generateTimingStatsOptions('find_order'),
         );
         const subaccountMessage: Message = {
-          key: Buffer.from(Uint8Array.from(
+          key: Buffer.from(
             IndexerSubaccountId.encode(orderRemove.removedOrderId!.subaccountId!).finish(),
-          )),
+          ),
           value: this.createSubaccountWebsocketMessageFromOrderRemoveMessage(
             canceledOrder,
             orderRemove,
@@ -342,9 +342,9 @@ export class OrderRemoveHandler extends Handler {
     }
 
     const subaccountMessage: Message = {
-      key: Buffer.from(Uint8Array.from(
+      key: Buffer.from(
         IndexerSubaccountId.encode(orderRemove.removedOrderId!.subaccountId!).finish(),
-      )),
+      ),
       value: this.createSubaccountWebsocketMessageFromRemoveOrderResult(
         removeOrderResult,
         canceledOrder,
@@ -653,7 +653,7 @@ export class OrderRemoveHandler extends Handler {
       version: SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
     });
 
-    return Buffer.from(Uint8Array.from(SubaccountMessage.encode(subaccountMessage).finish()));
+    return Buffer.from(SubaccountMessage.encode(subaccountMessage).finish());
   }
 
   protected createSubaccountWebsocketMessageFromRemoveOrderResult(
@@ -715,7 +715,7 @@ export class OrderRemoveHandler extends Handler {
       version: SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
     });
 
-    return Buffer.from(Uint8Array.from(SubaccountMessage.encode(subaccountMessage).finish()));
+    return Buffer.from(SubaccountMessage.encode(subaccountMessage).finish());
   }
 
   protected createSubaccountWebsocketMessageFromPostgresOrder(
@@ -763,7 +763,7 @@ export class OrderRemoveHandler extends Handler {
       version: SUBACCOUNTS_WEBSOCKET_MESSAGE_VERSION,
     });
 
-    return Buffer.from(Uint8Array.from(SubaccountMessage.encode(subaccountMessage).finish()));
+    return Buffer.from(SubaccountMessage.encode(subaccountMessage).finish());
   }
 
   protected isStatefulOrderCancelation(


### PR DESCRIPTION
### Changelist
Publishing errors were caught on each attempt to send a message from a batch to a subscriber. Now, first error in publishing to a subscriber will break the publishing loop, minimizing redundant error generation.

Websockets that failed to respond to pings were terminated and cleaned up without an attempt to close the connection with an informative error.

remove unnecessary typed buffer conversions

minimize connection lookups by passing Connection and not id

add connectionId to `Connection`

extract metrics to methods for clarity

simplify error handling in wss send

add constants for websocket error codes

remove ad-hoc listener removal in InvalidMessageHandler

### Test Plan
Unit Tests

Run in internal environments and public testnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for message sending, including better tracking and suppression of expected connection errors.
- **Chores**
	- Cleaned up unnecessary debug logging and improved error propagation during message forwarding for more robust error reporting.
	- Simplified message encoding and decoding by removing redundant data conversions across multiple services for improved efficiency.
	- Enhanced WebSocket connection management with consistent use of connection objects and added heartbeat timeout handling.
	- Updated tests for WebSocket service to improve clarity and precision in connection lifecycle verification.
- **New Features**
	- Added new WebSocket close codes for going away and heartbeat timeout scenarios.
	- Introduced a standardized rate-limited close message constant for WebSocket connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->