### PR TITLE
Fix(orderbook): Fix to-indexer order replacement logic

### DIFF
--- a/protocol/x/clob/memclob/memclob.go
+++ b/protocol/x/clob/memclob/memclob.go
@@ -501,16 +501,14 @@ func (m *MemClobPriceTimePriority) PlaceOrder(
 		// create an order removal message first so we can remove the original price level from the orderbook.
 		// TODO (CT-884): send OrderReplaceV1 message for replacement orders and add order-replace-handler to Vulcan
 		orderId := order.OrderId
-		if existingOrder, found := orderbook.getOrder(orderId); found {
-			if order.Subticks != existingOrder.Subticks {
-				if message, success := off_chain_updates.CreateOrderRemoveMessageWithReason(
-					ctx,
-					orderId,
-					indexersharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_REPLACED,
-					ocutypes.OrderRemoveV1_ORDER_REMOVAL_STATUS_BEST_EFFORT_CANCELED,
-				); success {
-					offchainUpdates.AddRemoveMessage(orderId, message)
-				}
+		if _, found := orderbook.getOrder(orderId); found {
+			if message, success := off_chain_updates.CreateOrderRemoveMessageWithReason(
+				ctx,
+				orderId,
+				indexersharedtypes.OrderRemovalReason_ORDER_REMOVAL_REASON_REPLACED,
+				ocutypes.OrderRemoveV1_ORDER_REMOVAL_STATUS_BEST_EFFORT_CANCELED,
+			); success {
+				offchainUpdates.AddRemoveMessage(orderId, message)
 			}
 		}
 		if message, success := off_chain_updates.CreateOrderPlaceMessage(

--- a/protocol/x/clob/memclob/memclob_place_order_reduce_only_test.go
+++ b/protocol/x/clob/memclob/memclob_place_order_reduce_only_test.go
@@ -1385,7 +1385,6 @@ func TestPlaceOrder_ReduceOnly(t *testing.T) {
 				tc.expectedCancelledReduceOnlyOrders,
 				// TODO(IND-261): Add tests for replaced reduce-only orders.
 				false,
-				false,
 			)
 		})
 	}
@@ -1668,7 +1667,6 @@ func TestPlaceOrder_LongTermReduceOnlyRemovals(t *testing.T) {
 				tc.expectedExistingMatches,
 				tc.expectedNewMatches,
 				tc.expectedCancelledReduceOnlyOrders,
-				false,
 				false,
 			)
 		})

--- a/protocol/x/clob/memclob/memclob_place_order_test.go
+++ b/protocol/x/clob/memclob/memclob_place_order_test.go
@@ -306,7 +306,6 @@ func TestPlaceOrder_AddOrderToOrderbook(t *testing.T) {
 				ordersOnBook = append(ordersOnBook, &order)
 			}
 
-			expectedReplacementOrderPriceChanged := false
 			for _, matchableOrder := range ordersOnBook {
 				// Note we assume these are regular orders since liquidation orders cannot rest on
 				// the book.
@@ -316,9 +315,6 @@ func TestPlaceOrder_AddOrderToOrderbook(t *testing.T) {
 				matchableOrderOrder := matchableOrder.MustGetOrder()
 				if tc.expectedToReplaceOrder && matchableOrderOrder.OrderId == tc.order.OrderId &&
 					tc.order.MustCmpReplacementOrder(&matchableOrderOrder) > 0 {
-					if matchableOrderOrder.Subticks != tc.order.Subticks {
-						expectedReplacementOrderPriceChanged = true
-					}
 					continue
 				}
 
@@ -370,7 +366,6 @@ func TestPlaceOrder_AddOrderToOrderbook(t *testing.T) {
 				[]expectedMatch{},
 				[]types.OrderId{},
 				tc.expectedToReplaceOrder,
-				expectedReplacementOrderPriceChanged,
 			)
 		})
 	}
@@ -2200,7 +2195,6 @@ func TestPlaceOrder_MatchOrders_PreexistingMatches(t *testing.T) {
 				tc.expectedNewMatches,
 				[]types.OrderId{},
 				tc.expectedToReplaceOrder,
-				false,
 			)
 		})
 	}
@@ -3169,7 +3163,6 @@ func TestPlaceOrder_PostOnly(t *testing.T) {
 				[]expectedMatch{},
 				[]types.OrderId{},
 				false,
-				false,
 			)
 		})
 	}
@@ -3312,7 +3305,6 @@ func TestPlaceOrder_ImmediateOrCancel(t *testing.T) {
 				[]expectedMatch{},
 				tc.expectedCollatCheck,
 				[]types.OrderId{},
-				false,
 				false,
 			)
 		})

--- a/protocol/x/clob/memclob/memclob_test_util.go
+++ b/protocol/x/clob/memclob/memclob_test_util.go
@@ -1292,7 +1292,6 @@ func assertPlaceOrderOffchainMessages(
 	expectedNewMatches []expectedMatch,
 	expectedCancelledReduceOnlyOrders []types.OrderId,
 	expectedToReplaceOrder bool,
-	expectedReplacementOrderPriceChanged bool,
 ) {
 	actualOffchainMessages := offchainUpdates.GetMessages()
 	expectedOffchainMessages := []msgsender.Message{}
@@ -1301,18 +1300,16 @@ func assertPlaceOrderOffchainMessages(
 	// If there are no errors expected, an order place message should be sent.
 	if expectedErr == nil || doesErrorProduceOffchainMessages(expectedErr) {
 		if expectedToReplaceOrder {
-			if expectedReplacementOrderPriceChanged {
-				removeMessage := off_chain_updates.MustCreateOrderRemoveMessageWithReason(
-					ctx,
-					order.OrderId,
-					indexershared.OrderRemovalReason_ORDER_REMOVAL_REASON_REPLACED,
-					ocutypes.OrderRemoveV1_ORDER_REMOVAL_STATUS_BEST_EFFORT_CANCELED,
-				)
-				expectedOffchainMessages = append(
-					expectedOffchainMessages,
-					removeMessage,
-				)
-			}
+			removeMessage := off_chain_updates.MustCreateOrderRemoveMessageWithReason(
+				ctx,
+				order.OrderId,
+				indexershared.OrderRemovalReason_ORDER_REMOVAL_REASON_REPLACED,
+				ocutypes.OrderRemoveV1_ORDER_REMOVAL_STATUS_BEST_EFFORT_CANCELED,
+			)
+			expectedOffchainMessages = append(
+				expectedOffchainMessages,
+				removeMessage,
+			)
 		}
 		placeMessage := off_chain_updates.MustCreateOrderPlaceMessage(
 			ctx,


### PR DESCRIPTION
### Changelist
This previous [change](https://github.com/dydxprotocol/v4-chain/pull/1593/files) refactored the way order replacement is handled, and moved the responsibility from indexer to indexer full node. Full node needs to send a `remove` message before `place` in the case of an order replacement. However, this logic wasn't applied to the case where an order is replaced at the same price level. This issue results in incorrect orderbook on indexer, and is the root cause of abnormally deep orderbook for majors where order replacement is heavily used.

[Context thread](https://dydx-team.slack.com/archives/C06EMK1746T/p1746565019449449?thread_ts=1742850384.243169&cid=C06EMK1746T)


### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order replacement handling to ensure removal messages are always generated for existing orders, enhancing consistency in off-chain updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->