### PR TITLE
add hex to bech32 script

### DIFF
--- a/protocol/scripts/hex_to_bech32/hex_to_bech32.go
+++ b/protocol/scripts/hex_to_bech32/hex_to_bech32.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	MinAddrLen = 20
+	MaxAddrLen = 32
+)
+
+/*
+main converts a hexadecimal address to bech32
+
+Usage:
+
+	go run scripts/bech32_to_hex/bech32_to_hex.go \
+		-address <bech32_address>
+*/
+func main() {
+	// ------------ FLAGS ------------
+	var hexAddress string
+	flag.StringVar(&hexAddress, "address", "0xda49e72c3577cc08bbe5b64d4a89e8e808e22f28", "hexadecimal address")
+	flag.Parse()
+
+	fmt.Println("Using the following configuration (modifiable via flags):")
+	fmt.Println("address:", hexAddress)
+	fmt.Println()
+
+	// ------------ LOGIC ------------
+	hexAddress = strings.TrimPrefix(hexAddress, "0x")
+
+	bytes, err := hex.DecodeString(hexAddress)
+	if err != nil {
+		panic(err)
+	}
+	address := PadOrTruncateAddress(bytes)
+	bech32Address := sdk.MustBech32ifyAddressBytes("dydx", address)
+
+	// ------------ OUTPUT ------------
+	fmt.Println(bech32Address)
+}
+
+func PadOrTruncateAddress(address []byte) []byte {
+	if len(address) > MaxAddrLen {
+		return address[:MaxAddrLen]
+	} else if len(address) < MinAddrLen {
+		return append(address, make([]byte, MinAddrLen-len(address))...)
+	}
+	return address
+}

--- a/protocol/scripts/hex_to_bech32/hex_to_bech32.go
+++ b/protocol/scripts/hex_to_bech32/hex_to_bech32.go
@@ -19,17 +19,17 @@ main converts a hexadecimal address to bech32
 
 Usage:
 
-	go run scripts/bech32_to_hex/bech32_to_hex.go \
-		-address <bech32_address>
+	go run scripts/hex_to_bech32/hex_to_bech32.go \
+		-hex <bech32_address>
 */
 func main() {
 	// ------------ FLAGS ------------
 	var hexAddress string
-	flag.StringVar(&hexAddress, "address", "0xda49e72c3577cc08bbe5b64d4a89e8e808e22f28", "hexadecimal address")
+	flag.StringVar(&hexAddress, "hex", "0xda49e72c3577cc08bbe5b64d4a89e8e808e22f28", "hexadecimal address")
 	flag.Parse()
 
 	fmt.Println("Using the following configuration (modifiable via flags):")
-	fmt.Println("address:", hexAddress)
+	fmt.Println("hex address:", hexAddress)
 	fmt.Println()
 
 	// ------------ LOGIC ------------


### PR DESCRIPTION
### Changelist
add helper script to convert a hex address to bech32 address. useful for looking into bridge events

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line tool to convert hexadecimal addresses into Bech32-encoded addresses with a "dydx" prefix. Users can specify the input address and receive the converted result directly in the terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->