### PR TITLE
Removed datadog container from localnet

### DIFF
--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -365,12 +365,12 @@ localnet-init:
 localnet-compose-up:
 	@echo "Launching localnet at commit ${GIT_COMMIT_HASH}"
 	@docker build . -t local:dydxprotocol -f testing/testnet-local/Dockerfile --no-cache
-	@docker compose -f docker-compose.yml up --force-recreate $(ARGS)
+	@docker compose -f docker-compose.yml -f docker-compose.local.yml up --force-recreate $(ARGS)
 
 localnet-compose-upd:
 	@echo "Launching localnet at commit ${GIT_COMMIT_HASH}"
 	@docker build . -t local:dydxprotocol -f testing/testnet-local/Dockerfile --no-cache
-	@docker compose -f docker-compose.yml up --force-recreate -d $(ARGS)
+	@docker compose -f docker-compose.yml -f docker-compose.local.yml up --force-recreate -d $(ARGS)
 
 build-e2etest-image:
 	@echo "Build e2e test image at commit ${GIT_COMMIT_HASH}"
@@ -383,10 +383,10 @@ e2etest-build-image: localnet-init build-e2etest-image
 
 # Continue the localnet with the same chain state.
 localnet-continue:
-	@docker compose -f docker-compose.yml up $(ARGS)
+	@docker compose -f docker-compose.yml -f docker-compose.local.yml up $(ARGS)
 
 localnet-stop:
-	@docker compose -f docker-compose.yml down
+	@docker compose -f docker-compose.yml -f docker-compose.local.yml down
 
 .PHONY: all build-linux install format lint \
 	go-mod-cache draw-deps clean build build-contract-tests-hooks \

--- a/protocol/docker-compose.local.yml
+++ b/protocol/docker-compose.local.yml
@@ -1,0 +1,6 @@
+version: "3"
+
+services:
+  datadog-agent:
+    profiles:
+      - dont-start 


### PR DESCRIPTION
### Changelist
Removed datadog container from localnet starts. 

### Test Plan
Ran `make localnet-start` and noted that DataDog agent wasn't started. 

<img width="1157" alt="Screenshot 2025-05-20 at 2 37 22 PM" src="https://github.com/user-attachments/assets/ed2007d6-d36c-48b6-af7f-36797770191e" />

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
