### PR TITLE
fix close position order by not replaying fully filled reduce-only IOC orders

### DIFF
--- a/protocol/testutil/constants/orders.go
+++ b/protocol/testutil/constants/orders.go
@@ -757,6 +757,13 @@ var (
 		Subticks:     50_000_000_000,
 		GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 10},
 	}
+	Order_Carl_Num0_Id0_Clob0_Buy2BTC_Price50000_GTB10 = clobtypes.Order{
+		OrderId:      clobtypes.OrderId{SubaccountId: Carl_Num0, ClientId: 0, ClobPairId: 0},
+		Side:         clobtypes.Order_SIDE_BUY,
+		Quantums:     200_000_000,
+		Subticks:     50_000_000_000,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 10},
+	}
 	Order_Carl_Num0_Id2_Clob0_Buy1BTC_Price50500_GTB10 = clobtypes.Order{
 		OrderId:      clobtypes.OrderId{SubaccountId: Carl_Num0, ClientId: 2, ClobPairId: 0},
 		Side:         clobtypes.Order_SIDE_BUY,

--- a/protocol/testutil/constants/orders.go
+++ b/protocol/testutil/constants/orders.go
@@ -1276,6 +1276,15 @@ var (
 		TimeInForce:  clobtypes.Order_TIME_IN_FORCE_IOC,
 		ReduceOnly:   true,
 	}
+	Order_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO = clobtypes.Order{
+		OrderId:      clobtypes.OrderId{SubaccountId: Alice_Num1, ClientId: 0, ClobPairId: 0},
+		Side:         clobtypes.Order_SIDE_SELL,
+		Quantums:     100_000_000,
+		Subticks:     50_000_000_000,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlock{GoodTilBlock: 20},
+		TimeInForce:  clobtypes.Order_TIME_IN_FORCE_IOC,
+		ReduceOnly:   true,
+	}
 
 	// Reduce-only orders.
 	Order_Alice_Num1_Id1_Clob0_Sell10_Price15_GTB20_RO = clobtypes.Order{

--- a/protocol/x/clob/e2e/reduce_only_orders_test.go
+++ b/protocol/x/clob/e2e/reduce_only_orders_test.go
@@ -4,7 +4,11 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/types"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/msgsender"
+	"github.com/dydxprotocol/v4-chain/protocol/indexer/off_chain_updates"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/encoding"
@@ -511,6 +515,206 @@ func TestReduceOnlyOrderFailure(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestClosePositionOrder(t *testing.T) {
+	tApp := testapp.NewTestAppBuilder(t).Build()
+	ctx := tApp.InitChain()
+
+	CheckTx_PlaceOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10 := testapp.MustMakeCheckTx(
+		ctx,
+		tApp.App,
+		testapp.MustMakeCheckTxOptions{
+			AccAddressForSigning: constants.Carl_Num0.Owner,
+		},
+		clobtypes.NewMsgPlaceOrder(
+			constants.Order_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10,
+		),
+	)
+	CheckTx_PlaceOrder_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO := testapp.MustMakeCheckTx(
+		ctx,
+		tApp.App,
+		testapp.MustMakeCheckTxOptions{
+			AccAddressForSigning: constants.Alice_Num1.Owner,
+		},
+		clobtypes.NewMsgPlaceOrder(
+			constants.Order_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO,
+		),
+	)
+
+	tests := map[string]struct {
+		subaccounts []satypes.Subaccount
+		orders      []clobtypes.Order
+
+		expectedOrderOnMemClob   map[clobtypes.OrderId]bool
+		expectedOrderFillAmount  map[clobtypes.OrderId]uint64
+		expectedSubaccounts      []satypes.Subaccount
+		expectedOffchainMessages []msgsender.Message
+	}{
+		"Close position order (IOC reduce-only) fully matches short term order same block, maker order fully filled": {
+			subaccounts: []satypes.Subaccount{
+				constants.Carl_Num0_100000USD,
+				// Initialize Alice subaccount 1 with a 1 BTC long position.
+				constants.Alice_Num1_1BTC_Long_500_000USD,
+			},
+			orders: []clobtypes.Order{
+				// 1. an order from Carl that buys 1 BTC at price 50_000
+				constants.Order_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10,
+				// 2. an order from Alice that closes their position by selling 1 BTC at price 50_000
+				constants.Order_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO,
+			},
+
+			expectedOrderOnMemClob: map[clobtypes.OrderId]bool{
+				constants.Order_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10.OrderId:          false,
+				constants.Order_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO.OrderId: false,
+			},
+			expectedOrderFillAmount: map[clobtypes.OrderId]uint64{
+				constants.Order_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10.OrderId:          100_000_000,
+				constants.Order_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO.OrderId: 100_000_000,
+			},
+			expectedSubaccounts: []satypes.Subaccount{
+				{
+					Id: &constants.Carl_Num0,
+					AssetPositions: []*satypes.AssetPosition{
+						testutil.CreateSingleAssetPosition(
+							0,
+							// 100_000 usdc - 50_000 (from buying 1 btc) + 5.5 usdc maker fee
+							big.NewInt(50_005_500_000),
+						),
+					},
+					PerpetualPositions: []*satypes.PerpetualPosition{
+						testutil.CreateSinglePerpetualPosition(
+							0,
+							big.NewInt(100_000_000),
+							big.NewInt(0),
+							big.NewInt(0),
+						),
+					},
+				},
+				{
+					Id: &constants.Alice_Num1,
+					AssetPositions: []*satypes.AssetPosition{
+						testutil.CreateSingleAssetPosition(
+							0,
+							// 500_000 usdc + 50_000 (from selling 1 btc) - 25 usdc taker fee
+							big.NewInt(549_975_000_000),
+						),
+					},
+					PerpetualPositions: []*satypes.PerpetualPosition{},
+				},
+			},
+			expectedOffchainMessages: []msgsender.Message{
+				// 1. Order place of Carl's order
+				// 2. Order update of Carl's order with 0 fill amount
+				// 3. Order place of Alice's order
+				// 4. Order update that Carl's order is fully filled
+				// 5. Order update that Alice's order is fully filled
+				off_chain_updates.MustCreateOrderPlaceMessage(
+					ctx,
+					constants.Order_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10,
+				).AddHeader(msgsender.MessageHeader{
+					Key:   msgsender.TransactionHashHeaderKey,
+					Value: tmhash.Sum(CheckTx_PlaceOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10.Tx),
+				}),
+				off_chain_updates.MustCreateOrderUpdateMessage(
+					ctx,
+					constants.Order_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10.OrderId,
+					0,
+				).AddHeader(msgsender.MessageHeader{
+					Key:   msgsender.TransactionHashHeaderKey,
+					Value: tmhash.Sum(CheckTx_PlaceOrder_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10.Tx),
+				}),
+				off_chain_updates.MustCreateOrderPlaceMessage(
+					ctx,
+					constants.Order_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO,
+				).AddHeader(msgsender.MessageHeader{
+					Key:   msgsender.TransactionHashHeaderKey,
+					Value: tmhash.Sum(CheckTx_PlaceOrder_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO.Tx),
+				}),
+				off_chain_updates.MustCreateOrderUpdateMessage(
+					ctx,
+					constants.Order_Carl_Num0_Id0_Clob0_Buy1BTC_Price50000_GTB10.OrderId,
+					100_000_000,
+				).AddHeader(msgsender.MessageHeader{
+					Key:   msgsender.TransactionHashHeaderKey,
+					Value: tmhash.Sum(CheckTx_PlaceOrder_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO.Tx),
+				}),
+				off_chain_updates.MustCreateOrderUpdateMessage(
+					ctx,
+					constants.Order_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO.OrderId,
+					100_000_000,
+				).AddHeader(msgsender.MessageHeader{
+					Key:   msgsender.TransactionHashHeaderKey,
+					Value: tmhash.Sum(CheckTx_PlaceOrder_Alice_Num1_Id0_Clob0_Sell1BTC_Price50000_GTB20_IOC_RO.Tx),
+				}),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			msgSender := msgsender.NewIndexerMessageSenderInMemoryCollector()
+
+			tApp := testapp.NewTestAppBuilder(t).
+				WithAppOptions(map[string]interface{}{
+					indexer.MsgSenderInstanceForTest: msgSender,
+				}).
+				WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+					genesis = testapp.DefaultGenesis()
+					testapp.UpdateGenesisDocWithAppStateForModule(
+						&genesis,
+						func(genesisState *satypes.GenesisState) {
+							genesisState.Subaccounts = tc.subaccounts
+						},
+					)
+					testapp.UpdateGenesisDocWithAppStateForModule(
+						&genesis,
+						func(genesisState *perptypes.GenesisState) {
+							genesisState.Params = constants.PerpetualsGenesisParams
+							genesisState.LiquidityTiers = constants.LiquidityTiers
+							genesisState.Perpetuals = []perptypes.Perpetual{
+								constants.BtcUsd_20PercentInitial_10PercentMaintenance,
+								constants.EthUsd_20PercentInitial_10PercentMaintenance,
+							}
+						},
+					)
+					return genesis
+				}).Build()
+			ctx := tApp.InitChain()
+
+			// Place orders.
+			for _, order := range tc.orders {
+				for _, checkTx := range testapp.MustMakeCheckTxsWithClobMsg(
+					ctx,
+					tApp.App,
+					*clobtypes.NewMsgPlaceOrder(order),
+				) {
+					resp := tApp.CheckTx(checkTx)
+					require.Conditionf(t, resp.IsOK, "Expected CheckTx to succeed. Response: %+v", resp)
+				}
+			}
+
+			ctx = tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+
+			// Verify expectations.
+			for orderId, exists := range tc.expectedOrderOnMemClob {
+				_, existsOnMemclob := tApp.App.ClobKeeper.MemClob.GetOrder(orderId)
+				require.Equal(t, exists, existsOnMemclob)
+			}
+
+			for orderId, expectedFillAmount := range tc.expectedOrderFillAmount {
+				exists, fillAmount, _ := tApp.App.ClobKeeper.GetOrderFillAmount(ctx, orderId)
+				require.True(t, exists)
+				require.Equal(t, expectedFillAmount, fillAmount.ToUint64())
+			}
+
+			require.ElementsMatch(
+				t,
+				tc.expectedOffchainMessages,
+				msgSender.GetOffchainMessages(),
+			)
 		})
 	}
 }

--- a/protocol/x/clob/e2e/reduce_only_orders_test.go
+++ b/protocol/x/clob/e2e/reduce_only_orders_test.go
@@ -564,7 +564,7 @@ func TestClosePositionOrder(t *testing.T) {
 		expectedSubaccounts      []satypes.Subaccount
 		expectedOffchainMessages []msgsender.Message
 	}{
-		"Close position order (IOC reduce-only) fully matches short term order same block, maker order fully filled, match in block": {
+		"Close position order (IOC reduce-only) fully filled, maker order fully filled, match in block": {
 			subaccounts: []satypes.Subaccount{
 				constants.Carl_Num0_100000USD,
 				// Initialize Alice subaccount 1 with a 1 BTC long position.
@@ -663,7 +663,7 @@ func TestClosePositionOrder(t *testing.T) {
 				}),
 			},
 		},
-		"Close position order (IOC reduce-only) fully matches short term order same block, maker order partially filled, match in block": {
+		"Close position order (IOC reduce-only) fully filled, maker order partially filled, match in block": {
 			subaccounts: []satypes.Subaccount{
 				constants.Carl_Num0_100000USD,
 				// Initialize Alice subaccount 1 with a 1 BTC long position.
@@ -768,7 +768,7 @@ func TestClosePositionOrder(t *testing.T) {
 				),
 			},
 		},
-		"Close position order (IOC reduce-only) fully matches short term order same block, maker order fully filled, match not in block": {
+		"Close position order (IOC reduce-only) fully filled, maker order fully filled, match not in block": {
 			subaccounts: []satypes.Subaccount{
 				constants.Carl_Num0_100000USD,
 				// Initialize Alice subaccount 1 with a 1 BTC long position.


### PR DESCRIPTION
### Changelist
Previously, a cancelled msg is sent before (and sometimes after) filled msg in websocket as when a fully-filled close position order is replayed in PrepareCheckState, `x/clob` considers that order in need to be resized instead of fully-filled

### Test Plan
- e2e test added (which fails before this change as there's an additional `orderRemove` offchain update with reason `REDUCE_ONLY_RESIZE`)
- tested manually on staging

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new predefined buy and reduce-only sell orders to the order constants.
  - Introduced an end-to-end test for closing a position using an IOC reduce-only sell order, verifying order matching, fills, and account updates.

- **Bug Fixes**
  - Enhanced order validation to check remaining order size earlier during replacements for improved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->