### PR TITLE
verbose logging for py and js releases

### DIFF
--- a/.github/workflows/protocol-release.yml
+++ b/.github/workflows/protocol-release.yml
@@ -119,7 +119,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          twine upload -r pypi dist/*
+          twine upload --verbose -r pypi dist/*
 
   v4-proto-js-release:
     runs-on: ubuntu-latest

--- a/v4-proto-js/scripts/publish-if-not-exists.sh
+++ b/v4-proto-js/scripts/publish-if-not-exists.sh
@@ -16,9 +16,9 @@ if [ $? -eq 0 ]; then
 	set -e
 	# Publish with pre-release tag if it exists. Otherwise publish as latest (default tag)
 	if [ -z "$TAG" ]; then
-		npm publish
+		npm publish --loglevel verbose
 	else
-		npm publish --tag $TAG
+		npm publish --tag $TAG --loglevel verbose
 	fi
 else
 	echo "skipping publish, package $NAME@$VERSION already published"


### PR DESCRIPTION
### Changelist
verbose logging to help debugging when these publishes fail

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased verbosity of package publishing processes to provide more detailed output during uploads to PyPI and npm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->