### PR TITLE
Do not default to null to speed up migration

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250514151100_add_builder_fees_to_orders_and_fills.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250514151100_add_builder_fees_to_orders_and_fills.ts
@@ -2,13 +2,13 @@ import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable('orders', (table) => {
-    table.string('builderAddress').nullable().defaultTo(null);
-    table.string('feePpm').nullable().defaultTo(null);
+    table.string('builderAddress').nullable();
+    table.string('feePpm').nullable();
   });
 
   await knex.schema.alterTable('fills', (table) => {
-    table.string('builderAddress').nullable().defaultTo(null);
-    table.string('builderFee').nullable().defaultTo(null);
+    table.string('builderAddress').nullable();
+    table.string('builderFee').nullable();
   });
 }
 


### PR DESCRIPTION
### Changelist
Defaulting to null is potentially slowing down the indexer db migration. Removing it to allow existing columns to use undefined.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
