### PR TITLE
Disable transactions for index migration

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250623170556_add_fills_createdAtHeight_idx.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250623170556_add_fills_createdAtHeight_idx.ts
@@ -12,3 +12,7 @@ export async function down(knex: Knex): Promise<void> {
     DROP INDEX CONCURRENTLY IF EXISTS fills_createdatheight_index;
   `);
 }
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
### Changelist
Disable transactions for index migration

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated migration configuration to specify that it should not run inside a transaction. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->