### PR TITLE
(fix) auxo: stop ender prior to db upgrade

### DIFF
--- a/indexer/services/auxo/src/constants.ts
+++ b/indexer/services/auxo/src/constants.ts
@@ -25,4 +25,9 @@ export const ECS_SERVICE_NAMES: EcsServiceNames[] = [
   EcsServiceNames.VULCAN,
 ];
 
+export const ECS_DB_WRITER_SERVICE_NAMES: EcsServiceNames[] = [
+  EcsServiceNames.ENDER,
+  EcsServiceNames.ROUNDTABLE,
+];
+
 export const SERVICE_NAME_SUFFIX: string = 'service-container';


### PR DESCRIPTION
### Changelist
During a recent deployment, auxo deployed a DB migration while ender was running.
This change will cause auxo to stop the ender service after bazooka upgrade, and prior to db, kafka, and service upgrades.
In a normal successful upgrade, ender will restart under the new image with 1 task.
If there is an error during upgrade after ender is stopped, ender will be restarted on the current image with 1 task.

### Test Plan
Unit tests and execution in internal environments and public testnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic stopping and restarting of database writer services during upgrades to ensure smooth database migration and service reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->