### PR TITLE
add rollback option to bazooka

### DIFF
--- a/indexer/packages/postgres/src/helpers/db-helpers.ts
+++ b/indexer/packages/postgres/src/helpers/db-helpers.ts
@@ -166,7 +166,7 @@ export async function reset() {
   await rollback();
 }
 
-async function rollback() {
+export async function rollback() {
   await knexPrimary.migrate.rollback({ loadExtensions: ['.js'] });
 }
 

--- a/indexer/services/bazooka/__tests__/index.test.ts
+++ b/indexer/services/bazooka/__tests__/index.test.ts
@@ -80,6 +80,7 @@ describe('index', () => {
     it('smoke test', async () => {
       await handler({
         migrate: false,
+        rollback: false,
         clear_db: false,
         reset_db: false,
         create_kafka_topics: false,
@@ -92,6 +93,17 @@ describe('index', () => {
     it.each([
       [{
         migrate: false,
+        rollback: true,
+        clear_db: false,
+        reset_db: false,
+        create_kafka_topics: false,
+        clear_kafka_topics: false,
+        clear_redis: false,
+        force: false,
+      } as APIGatewayEvent & BazookaEventJson],
+      [{
+        migrate: false,
+        rollback: false,
         clear_db: true,
         reset_db: false,
         create_kafka_topics: false,
@@ -101,6 +113,7 @@ describe('index', () => {
       } as APIGatewayEvent & BazookaEventJson],
       [{
         migrate: false,
+        rollback: false,
         clear_db: false,
         reset_db: true,
         create_kafka_topics: false,
@@ -110,6 +123,7 @@ describe('index', () => {
       } as APIGatewayEvent & BazookaEventJson],
       [{
         migrate: false,
+        rollback: false,
         clear_db: false,
         reset_db: false,
         create_kafka_topics: false,
@@ -119,6 +133,7 @@ describe('index', () => {
       } as APIGatewayEvent & BazookaEventJson],
       [{
         migrate: false,
+        rollback: false,
         clear_db: false,
         reset_db: false,
         create_kafka_topics: false,


### PR DESCRIPTION
### Changelist
Bazooka could execute migrations but only the forward/up path.

To maximize availability by facilitating rapid recovery from faults during deployments with confluent migrations, a rollback option is added to execute the back/down path.

### Test Plan
tested on staging with a dummy migration file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to rollback the latest database migration via a new Bazooka event flag, with progress logging.

* **Tests**
  * Expanded test coverage to validate behavior with and without the rollback flag.

* **Chores**
  * Enabled CI builds for a dedicated feature branch.
  * Introduced a migration that creates a temporary table for validating migration workflows.
  * Exposed internal rollback utility for operational use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->