### PR TITLE
(fix) auxo service name string formatting

### DIFF
--- a/indexer/services/auxo/src/index.ts
+++ b/indexer/services/auxo/src/index.ts
@@ -470,7 +470,8 @@ async function startDBWriterServices(
 ): Promise<void> {
   logger.info({
     at: 'index#startDBWriterServices',
-    message: `Starting database writer services: ${Object.keys(dbWriterTaskCounts)}`,
+    message: 'Starting database writer services',
+    taskCounts: dbWriterTaskCounts,
   });
   const ecsPrefix: string = `${event.prefix}-indexer-${event.regionAbbrev}`;
   await Promise.all(
@@ -487,7 +488,8 @@ async function startDBWriterServices(
 
   logger.info({
     at: 'index#startDBWriterServices',
-    message: `Started database writer services: ${Object.keys(dbWriterTaskCounts)}`,
+    message: 'Started database writer services',
+    taskCounts: dbWriterTaskCounts,
   });
 }
 
@@ -636,7 +638,7 @@ async function getRunningTaskCounts(
       throw new Error(`No running task count found for ${service}`);
     }
     // Extract service name from full service name (e.g., 'prefix-indexer-region-ender' -> 'ender')
-    const shortServiceName = service.serviceName.split('-').pop()!;
+    const shortServiceName = service.serviceName.replace(`${ecsPrefix}-`, '');
     runningTaskCounts[shortServiceName] = service.runningCount;
   }
   return runningTaskCounts;


### PR DESCRIPTION
### Changelist
Use Object.keys() for logging and also format keys in runningTaskCounts dictionary to match the service enums.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling and consistency of ECS service names in service updates and queries.
  * Improved logging clarity for task counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->