### PR TITLE
(fix) raise roundtable heap limit to 6G

### DIFF
--- a/indexer/services/roundtable/package.json
+++ b/indexer/services/roundtable/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "build/index",
   "scripts": {
-    "start": "node --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
+    "start": "node --max-semi-space-size=512 --max-old-space-size=6000 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
     "build": "rm -rf build/ && tsc && cp -r src/scripts build/src/",
     "build:prod": "pnpm run build",
     "build:watch": "pnpm run build -- --watch",


### PR DESCRIPTION
### Changelist
Roundtable is crashing on OOM during the create-pnl-ticks task.
This change raises the heap limits.

### Test Plan
Deploy to internal environments and public testnet.