### PR TITLE
upgrade cosmos-sdk dependency to include security patch ISA-2025-005

### DIFF
--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -476,7 +476,7 @@ replace (
 	// TODO(CT-1343): Remove and fix properly by backporting upstream fix to cometbft fork.
 	github.com/cometbft/cometbft-db => github.com/cometbft/cometbft-db v0.12.0
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250113155252-f00c500eaff3
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250708185419-6e18b66778df
 	github.com/cosmos/iavl => github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85
 )
 

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -958,8 +958,8 @@ github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dydxprotocol/cometbft v0.38.6-0.20250203202601-3ab07f44e83a h1:5YMBn6k8mj9NvbJ+HVFfclkdOkaZW3zK8l3QV4rFZ1A=
 github.com/dydxprotocol/cometbft v0.38.6-0.20250203202601-3ab07f44e83a/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250113155252-f00c500eaff3 h1:F9zv2Yvn7wurRAbC1mrZ/c/7GyWp1ux7uLxk3ZPHLH0=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250113155252-f00c500eaff3/go.mod h1:z/5+LD4MJzLqbe+fBCWI2pZLnQbOlzSM82snAw2zceg=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250708185419-6e18b66778df h1:+XYfVDBw6J16qCc194xI8lF/vDDFysjo/Li/va3wHYc=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250708185419-6e18b66778df/go.mod h1:z/5+LD4MJzLqbe+fBCWI2pZLnQbOlzSM82snAw2zceg=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d h1:HgLu1FD2oDFzlKW6/+SFXlH5Os8cwNTbplQIrQOWx8w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85 h1:5B/yGZyTBX/OZASQQMnk6Ms/TZja56MYd8OBaVc0Mho=


### PR DESCRIPTION
### Changelist
upgrade cosmos-sdk dependency to [this commit](https://github.com/dydxprotocol/cosmos-sdk/commit/6e18b66778df57a0d3a3b57e1b937d383a65dd69) in our fork of cosmos-sdk, which backports security patch in advisory https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-p22h-3m2v-cmgh

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying Cosmos SDK dependency to a newer version for improved stability and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->