### PR TITLE
[ENG-217] Create store for turnkey users. 

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/turnkey-users-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/turnkey-users-table.test.ts
@@ -1,0 +1,129 @@
+import { TurnkeyUserFromDatabase } from '../../src/types';
+import { clearData, migrate, teardown } from '../../src/helpers/db-helpers';
+import * as TurnkeyUserTable from '../../src/stores/turnkey-users-table';
+
+describe('TurnkeyUser store', () => {
+  beforeAll(async () => {
+    await migrate();
+  });
+
+  afterEach(async () => {
+    await clearData();
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  const defaultTurnkeyUser1 = {
+    suborgId: 'suborg-1',
+    username: 'user1',
+    email: 'user1@example.com',
+    svmAddress: 'SVM123456789',
+    evmAddress: '0x1234567890abcdef1234567890abcdef12345678',
+    salt: 'salt1',
+    dydxAddress: 'dydx1abc123',
+    createdAt: '2023-01-01T00:00:00.000Z',
+  };
+
+  const defaultTurnkeyUser2 = {
+    suborgId: 'suborg-2',
+    username: 'user2',
+    email: 'user2@example.com',
+    svmAddress: 'SVM987654321',
+    evmAddress: '0x9876543210fedcba9876543210fedcba98765432',
+    salt: 'salt2',
+    dydxAddress: 'dydx1xyz789',
+    createdAt: '2023-01-02T00:00:00.000Z',
+  };
+
+  it('Successfully creates a TurnkeyUser', async () => {
+    const createdUser = await TurnkeyUserTable.create(defaultTurnkeyUser1);
+    expect(createdUser).toEqual(expect.objectContaining(defaultTurnkeyUser1));
+  });
+
+  it('Successfully upserts a TurnkeyUser', async () => {
+    await TurnkeyUserTable.upsert(defaultTurnkeyUser1);
+    const user = await TurnkeyUserTable.findByEvmAddress(defaultTurnkeyUser1.evmAddress);
+    expect(user).toEqual(expect.objectContaining(defaultTurnkeyUser1));
+
+    // Update with upsert
+    const updatedUser = {
+      ...defaultTurnkeyUser1,
+      username: 'updated_user1',
+      email: 'updated_user1@example.com',
+    };
+    await TurnkeyUserTable.upsert(updatedUser);
+    const updatedResult = await TurnkeyUserTable.findByEvmAddress(defaultTurnkeyUser1.evmAddress);
+    expect(updatedResult).toEqual(expect.objectContaining(updatedUser));
+  });
+
+  describe('findByEvmAddress', () => {
+    it('Successfully finds a TurnkeyUser by EVM address', async () => {
+      await TurnkeyUserTable.create(defaultTurnkeyUser1);
+      await TurnkeyUserTable.create(defaultTurnkeyUser2);
+
+      const user: TurnkeyUserFromDatabase | undefined = await TurnkeyUserTable.findByEvmAddress(
+        defaultTurnkeyUser1.evmAddress,
+      );
+
+      expect(user).toEqual(expect.objectContaining(defaultTurnkeyUser1));
+    });
+
+    it('Returns undefined when TurnkeyUser not found by EVM address', async () => {
+      await TurnkeyUserTable.create(defaultTurnkeyUser1);
+
+      const user: TurnkeyUserFromDatabase | undefined = await TurnkeyUserTable.findByEvmAddress(
+        '0xnonexistent1234567890abcdef1234567890abcdef',
+      );
+
+      expect(user).toBeUndefined();
+    });
+  });
+
+  describe('findBySvmAddress', () => {
+    it('Successfully finds a TurnkeyUser by SVM address', async () => {
+      await TurnkeyUserTable.create(defaultTurnkeyUser1);
+      await TurnkeyUserTable.create(defaultTurnkeyUser2);
+
+      const user: TurnkeyUserFromDatabase | undefined = await TurnkeyUserTable.findBySvmAddress(
+        defaultTurnkeyUser2.svmAddress,
+      );
+
+      expect(user).toEqual(expect.objectContaining(defaultTurnkeyUser2));
+    });
+
+    it('Returns undefined when TurnkeyUser not found by SVM address', async () => {
+      await TurnkeyUserTable.create(defaultTurnkeyUser1);
+
+      const user: TurnkeyUserFromDatabase | undefined = await TurnkeyUserTable.findBySvmAddress(
+        'SVMnonexistent123456789',
+      );
+
+      expect(user).toBeUndefined();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('Handles case sensitivity for EVM addresses', async () => {
+      await TurnkeyUserTable.create(defaultTurnkeyUser1);
+
+      // Test with uppercase version of the address
+      const upperCaseEvmAddress = defaultTurnkeyUser1.evmAddress.toUpperCase();
+      const user = await TurnkeyUserTable.findByEvmAddress(upperCaseEvmAddress);
+
+      // This should not find the user as EVM addresses are case-sensitive in the database
+      expect(user).toBeUndefined();
+    });
+
+    it('Handles empty string searches', async () => {
+      await TurnkeyUserTable.create(defaultTurnkeyUser1);
+
+      const userByEmptyEvm = await TurnkeyUserTable.findByEvmAddress('');
+      const userByEmptySvm = await TurnkeyUserTable.findBySvmAddress('');
+
+      expect(userByEmptyEvm).toBeUndefined();
+      expect(userByEmptySvm).toBeUndefined();
+    });
+  });
+});

--- a/indexer/packages/postgres/src/db/migrations/migration_files/20250709170936_create_turnkey_users.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20250709170936_create_turnkey_users.ts
@@ -1,0 +1,24 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex
+    .schema
+    .createTable('turnkey_users', (table) => {
+      table.text('suborgId').primary(); // Primary key
+      table.text('username').nullable(); // optional
+      table.text('email').nullable(); // optional
+      table.text('svmAddress').notNullable(); // indexed
+      table.text('evmAddress').notNullable(); // indexed
+      table.text('salt').notNullable(); // used to generate dydx keypair when combining the onboarding signature
+      table.text('dydxAddress').nullable();
+      table.timestamp('createdAt').notNullable();
+
+      // Indexes
+      table.index(['svmAddress'], 'idx_turnkey_users_svm_address');
+      table.index(['evmAddress'], 'idx_turnkey_users_evm_address');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTableIfExists('turnkey_users');
+}

--- a/indexer/packages/postgres/src/helpers/db-helpers.ts
+++ b/indexer/packages/postgres/src/helpers/db-helpers.ts
@@ -11,6 +11,7 @@ const layer2Tables = [
   'subaccount_usernames',
   'leaderboard_pnl',
   'funding_payments',
+  'turnkey_users',
 ];
 
 const layer1Tables = [

--- a/indexer/packages/postgres/src/models/turnkey-user-model.ts
+++ b/indexer/packages/postgres/src/models/turnkey-user-model.ts
@@ -1,0 +1,68 @@
+import BaseModel from './base-model';
+
+export default class TurnkeyUserModel extends BaseModel {
+  static get tableName() {
+    return 'turnkey_users';
+  }
+
+  static get idColumn() {
+    return 'suborgId';
+  }
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: [
+        'suborgId',
+        'svmAddress',
+        'evmAddress',
+        'salt',
+        'dydxAddress',
+        'createdAt',
+      ],
+      properties: {
+        suborgId: { type: 'string' },
+        username: { type: ['string', 'null'] },
+        email: { type: ['string', 'null'] },
+        svmAddress: { type: 'string' },
+        evmAddress: { type: 'string' },
+        salt: { type: 'string' },
+        dydxAddress: { type: 'string' },
+        createdAt: { type: 'string' },
+      },
+    };
+  }
+
+  /**
+   * A mapping from column name to JSON conversion expected.
+   * See getSqlConversionForDydxModelTypes for valid conversions.
+   */
+  static get sqlToJsonConversions() {
+    return {
+      suborgId: 'string',
+      username: 'string',
+      email: 'string',
+      svmAddress: 'string',
+      evmAddress: 'string',
+      salt: 'string',
+      dydxAddress: 'string',
+      createdAt: 'string',
+    };
+  }
+
+  suborgId!: string;
+
+  username?: string;
+
+  email?: string;
+
+  svmAddress!: string;
+
+  evmAddress!: string;
+
+  salt!: string;
+
+  dydxAddress?: string;
+
+  createdAt!: string;
+}

--- a/indexer/packages/postgres/src/stores/turnkey-users-table.ts
+++ b/indexer/packages/postgres/src/stores/turnkey-users-table.ts
@@ -1,0 +1,60 @@
+import { QueryBuilder } from 'objection';
+
+import { DEFAULT_POSTGRES_OPTIONS } from '../constants';
+import { setupBaseQuery } from '../helpers/stores-helpers';
+import Transaction from '../helpers/transaction';
+import TurnkeyUserModel from '../models/turnkey-user-model';
+import {
+  Options,
+  TurnkeyUserColumns,
+  TurnkeyUserCreateObject,
+  TurnkeyUserFromDatabase,
+} from '../types';
+
+export async function findByEvmAddress(
+  evmAddress: string,
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
+): Promise<TurnkeyUserFromDatabase | undefined> {
+  const baseQuery: QueryBuilder<TurnkeyUserModel> = setupBaseQuery<TurnkeyUserModel>(
+    TurnkeyUserModel,
+    options,
+  );
+  return baseQuery
+    .where(TurnkeyUserColumns.evmAddress, evmAddress)
+    .first()
+    .returning('*');
+}
+
+export async function findBySvmAddress(
+  svmAddress: string,
+  options: Options = DEFAULT_POSTGRES_OPTIONS,
+): Promise<TurnkeyUserFromDatabase | undefined> {
+  const baseQuery: QueryBuilder<TurnkeyUserModel> = setupBaseQuery<TurnkeyUserModel>(
+    TurnkeyUserModel,
+    options,
+  );
+  return baseQuery
+    .where(TurnkeyUserColumns.svmAddress, svmAddress)
+    .first()
+    .returning('*');
+}
+
+export async function create(
+  turnkeyUserToCreate: TurnkeyUserCreateObject,
+  options: Options = { txId: undefined },
+): Promise<TurnkeyUserFromDatabase> {
+  return TurnkeyUserModel.query(
+    Transaction.get(options.txId),
+  ).insert(turnkeyUserToCreate).returning('*');
+}
+
+export async function upsert(
+  turnkeyUserToUpsert: TurnkeyUserCreateObject,
+  options: Options = { txId: undefined },
+): Promise<TurnkeyUserFromDatabase> {
+  const turnkeyUsers: TurnkeyUserModel[] = await TurnkeyUserModel.query(
+    Transaction.get(options.txId),
+  ).upsert(turnkeyUserToUpsert).returning('*');
+  // should only ever be one turnkey user
+  return turnkeyUsers[0];
+}

--- a/indexer/packages/postgres/src/types/db-model-types.ts
+++ b/indexer/packages/postgres/src/types/db-model-types.ts
@@ -336,6 +336,17 @@ export interface FundingPaymentsFromDatabase {
   fundingIndex: string,
 }
 
+export interface TurnkeyUserFromDatabase {
+  suborgId: string,
+  username?: string,
+  email?: string,
+  svmAddress: string,
+  evmAddress: string,
+  salt: string,
+  dydxAddress?: string,
+  createdAt: string,
+}
+
 export type SubaccountAssetNetTransferMap = { [subaccountId: string]:
 { [assetId: string]: string }, };
 export type SubaccountToPerpetualPositionsMap = { [subaccountId: string]:

--- a/indexer/packages/postgres/src/types/index.ts
+++ b/indexer/packages/postgres/src/types/index.ts
@@ -35,4 +35,5 @@ export * from './affiliate-info-types';
 export * from './firebase-notification-token-types';
 export * from './vault-types';
 export * from './funding-payments-types';
+export * from './turnkey-user-types';
 export { PositionSide } from './position-types';

--- a/indexer/packages/postgres/src/types/query-types.ts
+++ b/indexer/packages/postgres/src/types/query-types.ts
@@ -90,6 +90,7 @@ export enum QueryableField {
   STARTED_AT_HEIGHT_BEFORE_OR_AT = 'startedAtHeightBeforeOrAt',
   REASON = 'reason',
   USERNAME = 'username',
+  EMAIL = 'email',
   TIMESPAN = 'timeSpan',
   RANK = 'rank',
   AFFILIATE_ADDRESS = 'affiliateAddress',
@@ -100,6 +101,10 @@ export enum QueryableField {
   PARENT_SUBACCOUNT = 'parentSubaccount',
   DISTINCT_FIELDS = 'distinctFields',
   ZERO_PAYMENTS = 'zeroPayments',
+  SUBORG_ID = 'suborgId',
+  SVM_ADDRESS = 'svmAddress',
+  EVM_ADDRESS = 'evmAddress',
+  DYDX_ADDRESS = 'dydxAddress',
 }
 
 export interface QueryConfig {
@@ -379,4 +384,9 @@ export interface FundingPaymentsQueryConfig extends QueryConfig {
   [QueryableField.CREATED_ON_OR_AFTER]?: string,
   [QueryableField.PARENT_SUBACCOUNT]?: ParentSubaccount,
   [QueryableField.ZERO_PAYMENTS]?: boolean,
+}
+
+export interface TurnkeyUserQueryConfig extends QueryConfig {
+  [QueryableField.SVM_ADDRESS]?: string,
+  [QueryableField.EVM_ADDRESS]?: string,
 }

--- a/indexer/packages/postgres/src/types/turnkey-user-types.ts
+++ b/indexer/packages/postgres/src/types/turnkey-user-types.ts
@@ -1,0 +1,23 @@
+/* ------- TURNKEY USER TYPES ------- */
+
+export interface TurnkeyUserCreateObject {
+  suborgId: string,
+  username?: string,
+  email?: string,
+  svmAddress: string,
+  evmAddress: string,
+  salt: string,
+  dydxAddress: string,
+  createdAt: string,
+}
+
+export enum TurnkeyUserColumns {
+  suborgId = 'suborgId',
+  username = 'username',
+  email = 'email',
+  svmAddress = 'svmAddress',
+  evmAddress = 'evmAddress',
+  salt = 'salt',
+  dydxAddress = 'dydxAddress',
+  createdAt = 'createdAt',
+}


### PR DESCRIPTION
### Changelist
[ENG-217](https://linear.app/dydx/issue/ENG-217/create-store-for-turnkey-users)
 Creates the following
```
CREATE TABLE turnkey_users (
  suborgId TEXT PRIMARY KEY, -- need to know since otherwise we won't know which wallet to sign with for api user.
  username TEXT,             -- optional
  email TEXT,                -- optional, for marketing
  svm_address TEXT,          -- indexed
  evm_address TEXT,          -- indexed
  salt TEXT,                 -- used to generate dydx keypair when combining the onboarding signature
  dydx_address TEXT,
  created_at TIMESTAMP
);
CREATE INDEX idx_turnkey_users_svm_address ON turnkey_users (svm_address);
CREATE INDEX idx_turnkey_users_evm_address ON turnkey_users (evm_address);
```

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
