### PR TITLE
socks: upgrade ws to 8.18.3

### DIFF
--- a/indexer/pnpm-lock.yaml
+++ b/indexer/pnpm-lock.yaml
@@ -791,7 +791,7 @@ importers:
       tsconfig-paths: ^4.0.0
       typescript: ^4.7.4
       utf-8-validate: ^6.0.5
-      ws: ^8.16.0
+      ws: 8.18.3
     dependencies:
       '@dydxprotocol-indexer/base': link:../../packages/base
       '@dydxprotocol-indexer/compliance': link:../../packages/compliance
@@ -812,7 +812,7 @@ importers:
       nocache: 3.0.4
       response-time: 2.3.2
       utf-8-validate: 6.0.5
-      ws: 8.16.0_314410bbf163529a0116337fe6a5d0f1
+      ws: 8.18.3_314410bbf163529a0116337fe6a5d0f1
     devDependencies:
       '@dydxprotocol-indexer/dev': link:../../packages/dev
       '@types/body-parser': 1.19.2
@@ -15710,8 +15710,8 @@ packages:
         optional: true
     dev: false
 
-  /ws/8.16.0_314410bbf163529a0116337fe6a5d0f1:
-    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
+  /ws/8.18.3_314410bbf163529a0116337fe6a5d0f1:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/indexer/services/socks/package.json
+++ b/indexer/services/socks/package.json
@@ -36,7 +36,7 @@
     "nocache": "^3.0.4",
     "response-time": "^2.3.2",
     "utf-8-validate": "^6.0.5",
-    "ws": "^8.16.0"
+    "ws": "8.18.3"
   },
   "devDependencies": {
     "@dydxprotocol-indexer/dev": "workspace:^0.0.1",


### PR DESCRIPTION
upgrade socks to measure mitigation of heap pressure generated by send

### Changelist
upgrade socks ws to 8.18.3

### Test Plan
Unit tests and running in internal networks and testnet.