### PR TITLE
perf: tune heaps for ender, comlink, socks, vulcan, roundtable

### DIFF
--- a/indexer/services/comlink/package.json
+++ b/indexer/services/comlink/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "build/index",
   "scripts": {
-    "start": "node --max-semi-space-size=512 --max-old-space-size=2368 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
+    "start": "node --max-semi-space-size=128 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
     "dev": "node -r dotenv-flow/config build/src/index.js",
     "build": "rm -rf build/ && tsc && pnpm run swagger && pnpm run gen-markdown",
     "build:dev": "rm -rf build/ && tsc",

--- a/indexer/services/ender/package.json
+++ b/indexer/services/ender/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "build/index",
   "scripts": {
-    "start": "node --max-semi-space-size=256 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
+    "start": "node --max-semi-space-size=128 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
     "build": "rm -rf build/ && tsc && cp -r src/scripts build/src/scripts",
     "build:prod": "pnpm run build",
     "build:watch": "rm -rf build/ && tsc --watch && cp -r src/scripts build/src/scripts",

--- a/indexer/services/roundtable/package.json
+++ b/indexer/services/roundtable/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "build/index",
   "scripts": {
-    "start": "node --max-semi-space-size=512 --max-old-space-size=6000 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
+    "start": "node --max-semi-space-size=128 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
     "build": "rm -rf build/ && tsc && cp -r src/scripts build/src/",
     "build:prod": "pnpm run build",
     "build:watch": "pnpm run build -- --watch",

--- a/indexer/services/socks/package.json
+++ b/indexer/services/socks/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "build/index",
   "scripts": {
-    "start": "node --max-semi-space-size=512 --max-old-space-size=2368 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
+    "start": "node --max-semi-space-size=128 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
     "build": "rm -rf build/ && tsc",
     "build:prod": "pnpm run build",
     "build:watch": "pnpm run build -- --watch",

--- a/indexer/services/vulcan/package.json
+++ b/indexer/services/vulcan/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "build/src/index",
   "scripts": {
-    "start": "node --max-semi-space-size=256 --max-old-space-size=2624 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
+    "start": "node --max-semi-space-size=128 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
     "build": "rm -rf build/ && tsc",
     "build:prod": "pnpm run build",
     "build:watch": "pnpm run build -- --watch",


### PR DESCRIPTION
lower roundtable semi space size to maximize heap

raise streaming service semi space sizes to maximize throughput

### Changelist
raise semi-space size to 1GiB (3GiB of total young heap) and remove old heap specification for:
- comlink
- ender
- socks
- vulcan
the old space spec is removed as the service has likely failed if we can't prevent promotion out of young heap at load

lower semi-space size to 128MiB and raise old space size to 6128 MiB
- roundtable processes in long-running batches
- desire to maximize total allocatable heap to mitigate PnL ticks excessive memory utilization and reliability issues

### Test Plan
Unit tests and running in internal environments and public testnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized memory usage by adjusting runtime settings across multiple services, improving performance and resource management without affecting user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->