### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/protocol/lib/collections.go
+++ b/protocol/lib/collections.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 )
 
@@ -155,10 +156,5 @@ func MergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
 
 // Check if slice contains a particular value
 func SliceContains[T comparable](list []T, value T) bool {
-	for _, v := range list {
-		if v == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, value)
 }

--- a/protocol/lib/metrics/lib.go
+++ b/protocol/lib/metrics/lib.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"slices"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -98,12 +99,7 @@ func isAllowedExecutionMode(
 	allowedModes []sdk.ExecMode,
 ) bool {
 	contextExecMode := ctx.ExecMode()
-	for _, mode := range allowedModes {
-		if contextExecMode == mode {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowedModes, contextExecMode)
 }
 
 func EmitTelemetryWithLabelsForExecMode(


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
