### PR TITLE
Update full_node_streaming_manager.go

### DIFF
--- a/protocol/streaming/full_node_streaming_manager.go
+++ b/protocol/streaming/full_node_streaming_manager.go
@@ -220,7 +220,15 @@ func doFilterTakerOrderBySubaccount(
 	takerOrder *clobtypes.StreamUpdate_TakerOrder,
 	subaccountIds []satypes.SubaccountId,
 ) bool {
-	return slices.Contains(subaccountIds, takerOrder.TakerOrder.GetOrder().OrderId.SubaccountId)
+	if takerOrder == nil || takerOrder.TakerOrder == nil {
+            return false
+        }
+
+        order := takerOrder.TakerOrder.GetOrder()
+        if order == nil {
+            return false
+        }
+        return slices.Contains(subaccountIds, order.OrderId.SubaccountId)
 }
 
 func doFilterOrderFillBySubaccount(


### PR DESCRIPTION
grpc kills node : log:

dydxprotocold[722958]: panic: runtime error: invalid memory address or nil pointer dereference
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x330c01b]
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: goroutine 2978 [running]:
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: github.com/dydxprotocol/v4-chain/protocol/streaming.doFilterTakerOrderBySubaccount(...)
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         github.com/dydxprotocol/v4-chain/protocol/streaming/full_node_streaming_manager.go:223
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: github.com/dydxprotocol/v4-chain/protocol/streaming.doFilterStreamUpdateBySubaccount(0xc01ef1f090?, {0xc01b115428, 0x1, 0x7a14f827e108?})
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         github.com/dydxprotocol/v4-chain/protocol/streaming/full_node_streaming_manager.go:276 +0x7b
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: github.com/dydxprotocol/v4-chain/protocol/streaming.FilterStreamUpdateBySubaccount({0xc025f9f888?, 0xc001d7e0f0?, 0x1?}, {0xc01b115428, 0x1, 0x1}, {0x48f63a8, 0xc0007896c0})
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         github.com/dydxprotocol/v4-chain/protocol/streaming/full_node_streaming_manager.go:294 +0xf2
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: github.com/dydxprotocol/v4-chain/protocol/streaming.(*FullNodeStreamingManagerImpl).Subscribe(0xc005b6c400, {0x0, 0x0, 0x0}, {0xc00f8e65f0, 0x1, 0x1}, {0x0, 0x0, 0x0}, ...)
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         github.com/dydxprotocol/v4-chain/protocol/streaming/full_node_streaming_manager.go:391 +0xbf6
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper.Keeper.StreamOrderbookUpdates({{0x490ddd0, 0xc0013e9250}, {0x48b6cb0, 0xc001464b40}, {0x48b6d00, 0xc0017e4970}, {0x48b6cd8, 0xc0017e4900}, 0xc001d7f1d0, {0x493fef0, ...}, ...}, ...)
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         github.com/dydxprotocol/v4-chain/protocol/x/clob/keeper/grpc_stream_orderbook.go:11 +0x1a4
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: github.com/dydxprotocol/v4-chain/protocol/x/clob/types._Query_StreamOrderbookUpdates_Handler({0x3fb9320, 0xc0013a5208}, {0x48f6d80, 0xc01867a2d0})
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         github.com/dydxprotocol/v4-chain/protocol/x/clob/types/query.pb.go:1923 +0x107
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: google.golang.org/grpc.(*Server).processStreamingRPC(0xc00172e200, {0x48ea788, 0xc0186769c0}, {0x490a800, 0xc0061bf380}, 0xc019520d80, 0xc0134146c0, 0x6d77ee0, 0x0)
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         google.golang.org/grpc@v1.68.1/server.go:1688 +0x1208
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: google.golang.org/grpc.(*Server).handleStream(0xc00172e200, {0x490a800, 0xc0061bf380}, 0xc019520d80)
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         google.golang.org/grpc@v1.68.1/server.go:1809 +0xe3a
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: google.golang.org/grpc.(*Server).serveStreams.func2.1()
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         google.golang.org/grpc@v1.68.1/server.go:1029 +0x7f
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]: created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 2976
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 dydxprotocold[722958]:         google.golang.org/grpc@v1.68.1/server.go:1040 +0x125
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 systemd[1]: dydxprotocold.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Jul 16 20:48:41 4862ddfdc3eec1ae19750f5a135d58f4 systemd[1]: dydxprotocold.service: Failed with result 'exit-code'.

### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by adding safeguards to prevent potential errors when filtering orders, ensuring smoother operation and reducing the chance of unexpected issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->