### PR TITLE
Add market as query parameter (alias to ticker) to v4/PerpetualMarkets

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-markets-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-markets-controller.test.ts
@@ -162,20 +162,20 @@ describe('perpetual-markets-controller#V4', () => {
       );
     });
 
-    it('Returns 404 with unknown ticker or market', async () => {
+    it('Returns 400 with unknown ticker or market', async () => {
       let response: request.Response = await sendRequest({
         type: RequestMethod.GET,
         path: `/v4/perpetualMarkets?${getQueryString({ ticker: invalidTicker })}`,
-        expectedStatus: 404,
+        expectedStatus: 400,
       });
-      expect(response.body.error).toContain('Not Found');
+      expect(response.body.errors[0].msg).toContain('ticker must be a valid ticker');
 
       response = await sendRequest({
         type: RequestMethod.GET,
         path: `/v4/perpetualMarkets?${getQueryString({ market: invalidTicker })}`,
-        expectedStatus: 404,
+        expectedStatus: 400,
       });
-      expect(response.body.error).toContain('Not Found');
+      expect(response.body.errors[0].msg).toContain('ticker must be a valid ticker');
     });
 
     it('Returns 400 when both ticker and market are provided', async () => {

--- a/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-markets-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/perpetual-markets-controller.test.ts
@@ -162,14 +162,77 @@ describe('perpetual-markets-controller#V4', () => {
       );
     });
 
-    it('Returns 404 with unknown ticker', async () => {
-      const response: request.Response = await sendRequest({
+    it('Returns 404 with unknown ticker or market', async () => {
+      let response: request.Response = await sendRequest({
         type: RequestMethod.GET,
-        path: `/v4/perpetualMarkets/${invalidTicker}`,
+        path: `/v4/perpetualMarkets?${getQueryString({ ticker: invalidTicker })}`,
         expectedStatus: 404,
       });
-
       expect(response.body.error).toContain('Not Found');
+
+      response = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/perpetualMarkets?${getQueryString({ market: invalidTicker })}`,
+        expectedStatus: 404,
+      });
+      expect(response.body.error).toContain('Not Found');
+    });
+
+    it('Returns 400 when both ticker and market are provided', async () => {
+      const response: request.Response = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/perpetualMarkets?${getQueryString({
+          ticker: testConstants.defaultPerpetualMarket.ticker,
+          market: testConstants.defaultPerpetualMarket.ticker
+        })}`,
+        expectedStatus: 400,
+      });
+
+      expect(response.body.errors[0].msg).toContain('Only one of ticker or market may be provided');
+    });
+
+    it('Market parameter functions the same as ticker parameter', async () => {
+      // Get response using ticker parameter
+      const tickerResponse: request.Response = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/perpetualMarkets?${getQueryString({
+          ticker: testConstants.defaultPerpetualMarket.ticker
+        })}`,
+      });
+
+      // Get response using market parameter
+      const marketResponse: request.Response = await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/perpetualMarkets?${getQueryString({
+          market: testConstants.defaultPerpetualMarket.ticker
+        })}`,
+      });
+
+      // Only one market should be returned in both cases
+      const perpetualMarket: PerpetualMarketFromDatabase | undefined =
+        await PerpetualMarketTable.findByTicker(testConstants.defaultPerpetualMarket.ticker);
+      const market: MarketFromDatabase | undefined =
+        await MarketTable.findById(testConstants.defaultPerpetualMarket.marketId);
+      const liquidityTier: LiquidityTiersFromDatabase | undefined =
+        await LiquidityTiersTable.findById(testConstants.defaultPerpetualMarket.liquidityTierId);
+
+      // Verify both responses contain the same data
+      expectResponseWithMarkets(
+        tickerResponse,
+        [perpetualMarket!],
+        [liquidityTier!],
+        [market!],
+      );
+
+      expectResponseWithMarkets(
+        marketResponse,
+        [perpetualMarket!],
+        [liquidityTier!],
+        [market!],
+      );
+
+      // The response bodies should be identical
+      expect(tickerResponse.body).toEqual(marketResponse.body);
     });
   });
 });

--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -2767,6 +2767,7 @@ fetch(`${baseURL}/perpetualMarkets`,
 |---|---|---|---|---|
 |limit|query|number(double)|false|none|
 |ticker|query|string|false|none|
+|market|query|string|false|none|
 
 > Example responses
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -3226,6 +3226,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "market",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ]
       }

--- a/indexer/services/comlink/src/controllers/api/v4/perpetual-markets-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/perpetual-markets-controller.ts
@@ -9,7 +9,6 @@ import {
   LiquidityTiersMap,
   LiquidityTiersFromDatabase,
   PerpetualMarketWithMarket,
-  perpetualMarketRefresher
 } from '@dydxprotocol-indexer/postgres';
 import express from 'express';
 import {

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -217,6 +217,10 @@ export const CheckTickerOptionalQuerySchema = checkSchema({
   ticker: checkTickerOptionalQuerySchema,
 });
 
+export const CheckMarketOptionalQuerySchema = checkSchema({
+  market: checkTickerOptionalQuerySchema,
+});
+
 export const CheckHistoricalBlockTradingRewardsSchema = checkSchema({
   ...checkAddressSchemaRecord,
   ...limitSchemaRecord,

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -508,7 +508,9 @@ export interface TradeRequest extends LimitAndCreatedBeforeRequest, PaginationRe
   ticker: string,
 }
 
-export interface PerpetualMarketRequest extends LimitRequest, TickerRequest {}
+export interface PerpetualMarketRequest extends LimitRequest, TickerRequest {
+  market?: string,
+}
 
 export interface PnlTicksRequest
   extends SubaccountRequest, LimitAndCreatedBeforeAndAfterRequest, PaginationRequest {}


### PR DESCRIPTION
### Changelist
Adding `market` as a valid parameter, ex. `v4/perpetualMarkets?market=BTC-US`D.
It should not be used in conjunction with ticker, but otherwise it behaves the exact same way.

Motivation for this PR:

> this works: https://indexer.dydx.trade/v4/perpetualMarkets?ticker=BTC-USD
> 
> but this does not: [https://indexer.dydx.trade/v4/perpetualMarkets?market=BTC-USD](https://indexer.dydx.trade/v4/perpetualMarkets?ticker=BTC-USD)
> 
> Given that we use 'market' everywhere else in the API, please add support for 'market' as alias for 'ticker' on this and any other endpoint that only uses ticker. This change will make our API consistent with the other endpoints that only support 'market'.

### Test Plan
- `market` should only accepts valid value
- `market` should not be defined alongside ticker
- `market` should act as a filter

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
