### PR TITLE
Remove unused environments from github actions

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -93,49 +93,6 @@ jobs:
               }
             }
 
-  deploy-to-dev3:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'  # without this, ignite fails.
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_VALIDATOR_DEV3 }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_VALIDATOR_DEV3 }}
-          aws-region: us-east-2
-
-      - name: Get Commit Hash
-        run: echo "git_hash=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
-
-      - name: Print Commit Hash
-        run: echo "Git short commit hash is ${{ env.git_hash }}"
-
-      - name: Deploy to dev3 environment using Orb lambda
-        id: dev3-deploy
-        uses: dydxprotocol/invoke-aws-lambda@master
-        with:
-          HTTP_TIMEOUT: 600000  # Ten minutes in milliseconds
-          MAX_RETRIES: 3
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_VALIDATOR_DEV3 }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_VALIDATOR_DEV3 }}
-          REGION: us-east-2
-          FunctionName: orb_lambda_function
-          Payload: |
-            {
-              "imageTag": "${{ env.git_hash }}",
-              "options": {
-                "job": "deploy-network-service",
-                "postToSlack": true,
-                "username": "Github",
-                "isCi": true
-              }
-            }
-
   deploy-to-dev4:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -166,49 +123,6 @@ jobs:
           MAX_RETRIES: 3
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_VALIDATOR_DEV4 }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_VALIDATOR_DEV4 }}
-          REGION: us-east-2
-          FunctionName: orb_lambda_function
-          Payload: |
-            {
-              "imageTag": "${{ env.git_hash }}",
-              "options": {
-                "job": "deploy-network-service",
-                "postToSlack": true,
-                "username": "Github",
-                "isCi": true
-              }
-            }
-
-  deploy-to-dev5:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'  # without this, ignite fails.
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_VALIDATOR_DEV5 }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_VALIDATOR_DEV5 }}
-          aws-region: us-east-2
-
-      - name: Get Commit Hash
-        run: echo "git_hash=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
-
-      - name: Print Commit Hash
-        run: echo "Git short commit hash is ${{ env.git_hash }}"
-
-      - name: Deploy to dev5 environment using Orb lambda
-        id: dev5-deploy
-        uses: dydxprotocol/invoke-aws-lambda@master
-        with:
-          HTTP_TIMEOUT: 600000  # Ten minutes in milliseconds
-          MAX_RETRIES: 3
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_VALIDATOR_DEV5 }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_VALIDATOR_DEV5 }}
           REGION: us-east-2
           FunctionName: orb_lambda_function
           Payload: |


### PR DESCRIPTION
### Changelist
* Dev3 & 5 are unused. Don't automatically run github actions for them

### Test Plan
* Tested locally

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deployment steps for two development environments from the automated deployment process. Other deployment environments remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->