### PR TITLE
Add Postgres helper to calculate net funding payments between blocks

### DIFF
--- a/indexer/packages/postgres/__tests__/stores/funding-payments-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/funding-payments-table.test.ts
@@ -171,7 +171,7 @@ describe('funding payments store', () => {
     ]);
 
     const netPayments = await
-    FundingPaymentsTable.getNetFundingPaymentsBetweenBockHeightsForSubaccount(
+    FundingPaymentsTable.getNetFundingPaymentsBetweenBlockHeightsForSubaccount(
       defaultSubaccountId,
       '10',
       '30',
@@ -203,7 +203,7 @@ describe('funding payments store', () => {
     ]);
 
     const netPayments = await
-    FundingPaymentsTable.getNetFundingPaymentsBetweenBockHeightsForSubaccount(
+    FundingPaymentsTable.getNetFundingPaymentsBetweenBlockHeightsForSubaccount(
       defaultSubaccountId,
       '10',
       '30',
@@ -278,7 +278,7 @@ describe('funding payments store', () => {
 
     // Test with defaultSubaccountId
     const netPayments1 = await
-    FundingPaymentsTable.getNetFundingPaymentsBetweenBockHeightsForSubaccount(
+    FundingPaymentsTable.getNetFundingPaymentsBetweenBlockHeightsForSubaccount(
       defaultSubaccountId,
       '10',
       '30',
@@ -289,7 +289,7 @@ describe('funding payments store', () => {
 
     // Test with defaultSubaccountId2
     const netPayments2 = await
-    FundingPaymentsTable.getNetFundingPaymentsBetweenBockHeightsForSubaccount(
+    FundingPaymentsTable.getNetFundingPaymentsBetweenBlockHeightsForSubaccount(
       defaultSubaccountId2,
       '10',
       '30',
@@ -324,7 +324,7 @@ describe('funding payments store', () => {
 
     // Test case 1: No payments in the specified block height range
     const netPaymentsOutsideRange = await
-    FundingPaymentsTable.getNetFundingPaymentsBetweenBockHeightsForSubaccount(
+    FundingPaymentsTable.getNetFundingPaymentsBetweenBlockHeightsForSubaccount(
       defaultSubaccountId,
       '10',
       '40',
@@ -335,7 +335,7 @@ describe('funding payments store', () => {
 
     // Test case 2: No payments for this subaccount
     const netPaymentsNonExistentSubaccount = await
-    FundingPaymentsTable.getNetFundingPaymentsBetweenBockHeightsForSubaccount(
+    FundingPaymentsTable.getNetFundingPaymentsBetweenBlockHeightsForSubaccount(
       defaultSubaccountId3,
       '10',
       '60',


### PR DESCRIPTION
### Changelist
Add `getNetFundingPaymentsBetweenBockHeightsForSubaccount` which calculates the net funding payments a subaccount receives in a time period.

### Test Plan
- Test funding payments of different subaccounts
- Test funding payments of difference size/sign
- Test no funding payments found

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to calculate net funding payments for a specific subaccount within a given block height range.
* **Tests**
  * Introduced comprehensive tests to ensure accurate calculation of net funding payments, including handling of boundary cases and scenarios with no payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->