### PR TITLE
update cosmos-sdk and cometbft version to enable proposer set reduction

### DIFF
--- a/protocol/app/msgs/all_msgs.go
+++ b/protocol/app/msgs/all_msgs.go
@@ -131,6 +131,8 @@ var (
 		"/cosmos.staking.v1beta1.MsgDelegateResponse":                  {},
 		"/cosmos.staking.v1beta1.MsgEditValidator":                     {},
 		"/cosmos.staking.v1beta1.MsgEditValidatorResponse":             {},
+		"/cosmos.staking.v1beta1.MsgSetProposers":                      {},
+		"/cosmos.staking.v1beta1.MsgSetProposersResponse":              {},
 		"/cosmos.staking.v1beta1.MsgUndelegate":                        {},
 		"/cosmos.staking.v1beta1.MsgUndelegateResponse":                {},
 		"/cosmos.staking.v1beta1.MsgUpdateParams":                      {},

--- a/protocol/app/msgs/internal_msgs.go
+++ b/protocol/app/msgs/internal_msgs.go
@@ -85,6 +85,8 @@ var (
 		"/cosmos.slashing.v1beta1.MsgUpdateParamsResponse": nil,
 
 		// staking
+		"/cosmos.staking.v1beta1.MsgSetProposers":         &staking.MsgSetProposers{},
+		"/cosmos.staking.v1beta1.MsgSetProposersResponse": nil,
 		"/cosmos.staking.v1beta1.MsgUpdateParams":         &staking.MsgUpdateParams{},
 		"/cosmos.staking.v1beta1.MsgUpdateParamsResponse": nil,
 

--- a/protocol/app/msgs/internal_msgs_test.go
+++ b/protocol/app/msgs/internal_msgs_test.go
@@ -54,6 +54,8 @@ func TestInternalMsgSamples_Gov_Key(t *testing.T) {
 		"/cosmos.slashing.v1beta1.MsgUpdateParamsResponse",
 
 		// staking
+		"/cosmos.staking.v1beta1.MsgSetProposers",
+		"/cosmos.staking.v1beta1.MsgSetProposersResponse",
 		"/cosmos.staking.v1beta1.MsgUpdateParams",
 		"/cosmos.staking.v1beta1.MsgUpdateParamsResponse",
 

--- a/protocol/app/testdata/default_genesis_state.json
+++ b/protocol/app/testdata/default_genesis_state.json
@@ -495,6 +495,7 @@
     "validators": [],
     "delegations": [],
     "unbonding_delegations": [],
+    "proposers": [],
     "redelegations": [],
     "exported": false
   },

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -470,13 +470,13 @@ replace (
 	// Use dYdX fork of Cosmos SDK/store
 	cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d
 	// Use dYdX fork of CometBFT
-	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250203202601-3ab07f44e83a
+	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d
 	// Fixes the issue that `tx_search` resolves to a single entry, due to an cometbft-db interface
 	// change in v0.13.0+.
 	// TODO(CT-1343): Remove and fix properly by backporting upstream fix to cometbft fork.
 	github.com/cometbft/cometbft-db => github.com/cometbft/cometbft-db v0.12.0
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250708185419-6e18b66778df
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250806215633-4297c0f3e7b1
 	github.com/cosmos/iavl => github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85
 )
 

--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -470,13 +470,13 @@ replace (
 	// Use dYdX fork of Cosmos SDK/store
 	cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d
 	// Use dYdX fork of CometBFT
-	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d
+	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf
 	// Fixes the issue that `tx_search` resolves to a single entry, due to an cometbft-db interface
 	// change in v0.13.0+.
 	// TODO(CT-1343): Remove and fix properly by backporting upstream fix to cometbft fork.
 	github.com/cometbft/cometbft-db => github.com/cometbft/cometbft-db v0.12.0
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250806215633-4297c0f3e7b1
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250807152116-6f31ad979963
 	github.com/cosmos/iavl => github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85
 )
 

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -956,10 +956,10 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250203202601-3ab07f44e83a h1:5YMBn6k8mj9NvbJ+HVFfclkdOkaZW3zK8l3QV4rFZ1A=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250203202601-3ab07f44e83a/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250708185419-6e18b66778df h1:+XYfVDBw6J16qCc194xI8lF/vDDFysjo/Li/va3wHYc=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250708185419-6e18b66778df/go.mod h1:z/5+LD4MJzLqbe+fBCWI2pZLnQbOlzSM82snAw2zceg=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d h1:/zByifT+6mJcShhwOqBc0olJzTPsN01Vo4dGC6f3EKs=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250806215633-4297c0f3e7b1 h1:pj/AgEHFEOmWB0sbjTE/CMNru1GHieiqdrjOVhkA5Uk=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250806215633-4297c0f3e7b1/go.mod h1:U6uXK7mzUm1rZLXxac3wKYQZfG0hBIterjBavgSrH6w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d h1:HgLu1FD2oDFzlKW6/+SFXlH5Os8cwNTbplQIrQOWx8w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85 h1:5B/yGZyTBX/OZASQQMnk6Ms/TZja56MYd8OBaVc0Mho=

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -956,10 +956,10 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d h1:/zByifT+6mJcShhwOqBc0olJzTPsN01Vo4dGC6f3EKs=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250806215633-4297c0f3e7b1 h1:pj/AgEHFEOmWB0sbjTE/CMNru1GHieiqdrjOVhkA5Uk=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250806215633-4297c0f3e7b1/go.mod h1:U6uXK7mzUm1rZLXxac3wKYQZfG0hBIterjBavgSrH6w=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf h1:vXv/PaoaX7rliUZc+lNQImTGgVqJd5E/+oBmiiFuZ2c=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250807152116-6f31ad979963 h1:wQ9/y+bTIzrTM+a5fXyPXlO/eBJ9eNTjaDEgtFc6Tds=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20250807152116-6f31ad979963/go.mod h1:eH8zy3vkucEABErRjoIYul87+Pzw25xOP+fEoGjV0do=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d h1:HgLu1FD2oDFzlKW6/+SFXlH5Os8cwNTbplQIrQOWx8w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85 h1:5B/yGZyTBX/OZASQQMnk6Ms/TZja56MYd8OBaVc0Mho=

--- a/protocol/lib/ante/internal_msg.go
+++ b/protocol/lib/ante/internal_msg.go
@@ -65,6 +65,7 @@ func IsInternalMsg(msg sdk.Msg) bool {
 		*slashing.MsgUpdateParams,
 
 		// staking
+		*staking.MsgSetProposers,
 		*staking.MsgUpdateParams,
 
 		// upgrade

--- a/protocol/scripts/genesis/sample_pregenesis.json
+++ b/protocol/scripts/genesis/sample_pregenesis.json
@@ -4018,6 +4018,7 @@
         "min_commission_rate": "0.05",
         "unbonding_time": "2592000s"
       },
+      "proposers": [],
       "redelegations": [],
       "unbonding_delegations": [],
       "validators": []


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new staking message types related to proposers.
  * Introduced a "proposers" field in the staking section of genesis configuration files.

* **Tests**
  * Updated test coverage to include the new staking message types.

* **Chores**
  * Updated dependency versions for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->