### PR TITLE
fix: disable `MsgVerifyInvariant`

### DIFF
--- a/protocol/app/msgs/normal_msgs.go
+++ b/protocol/app/msgs/normal_msgs.go
@@ -6,7 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
-	crisis "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govbeta "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
@@ -53,10 +52,6 @@ var (
 		"/cosmos.bank.v1beta1.Supply":               nil,
 
 		// consensus
-
-		// crisis
-		"/cosmos.crisis.v1beta1.MsgVerifyInvariant":         &crisis.MsgVerifyInvariant{},
-		"/cosmos.crisis.v1beta1.MsgVerifyInvariantResponse": nil,
 
 		// crypto
 		"/cosmos.crypto.ed25519.PrivKey":            nil,

--- a/protocol/app/msgs/normal_msgs_test.go
+++ b/protocol/app/msgs/normal_msgs_test.go
@@ -33,10 +33,6 @@ func TestNormalMsgs_Key(t *testing.T) {
 
 		// consensus
 
-		// crisis
-		"/cosmos.crisis.v1beta1.MsgVerifyInvariant",
-		"/cosmos.crisis.v1beta1.MsgVerifyInvariantResponse",
-
 		// crypto
 		"/cosmos.crypto.ed25519.PrivKey",
 		"/cosmos.crypto.ed25519.PubKey",

--- a/protocol/app/msgs/unsupported_msgs.go
+++ b/protocol/app/msgs/unsupported_msgs.go
@@ -2,6 +2,7 @@ package msgs
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	crisis "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govbeta "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
@@ -37,5 +38,11 @@ var (
 		// MsgUpdateParams is deprecated since v6.x and replaced by MsgUpdateDefaultQuotingParams.
 		// nolint:staticcheck
 		"/dydxprotocol.vault.MsgUpdateParams": &vaulttypes.MsgUpdateParams{},
+
+		// Disable MsgVerifyInvariant in the crisis module, since:
+		// 1. We currently do not rely on crisis module for any invariant assertion.
+		// 2. MsgVerifyInvariant can potentially be abused to consume massive compute.
+		"/cosmos.crisis.v1beta1.MsgVerifyInvariant":         &crisis.MsgVerifyInvariant{},
+		"/cosmos.crisis.v1beta1.MsgVerifyInvariantResponse": nil,
 	}
 )

--- a/protocol/app/msgs/unsupported_msgs_test.go
+++ b/protocol/app/msgs/unsupported_msgs_test.go
@@ -11,6 +11,10 @@ import (
 
 func TestUnsupportedMsgSamples_Key(t *testing.T) {
 	expectedMsgs := []string{
+		// crisis
+		"/cosmos.crisis.v1beta1.MsgVerifyInvariant",
+		"/cosmos.crisis.v1beta1.MsgVerifyInvariantResponse",
+
 		"/cosmos.gov.v1.MsgCancelProposal",
 		"/cosmos.gov.v1.MsgCancelProposalResponse",
 		"/cosmos.gov.v1beta1.MsgSubmitProposal",

--- a/protocol/lib/ante/unsupported_msgs.go
+++ b/protocol/lib/ante/unsupported_msgs.go
@@ -2,6 +2,7 @@ package ante
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	crisis "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govbeta "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
@@ -25,7 +26,8 @@ func IsUnsupportedMsg(msg sdk.Msg) bool {
 		// nolint:staticcheck
 		*vaulttypes.MsgSetVaultQuotingParams,
 		// nolint:staticcheck
-		*vaulttypes.MsgUpdateParams:
+		*vaulttypes.MsgUpdateParams,
+		*crisis.MsgVerifyInvariant:
 		return true
 	}
 	return false


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled support for specific crisis module messages to prevent potential misuse and excessive resource consumption.

* **Tests**
  * Updated tests to reflect the disabling of the crisis module messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->