### PR TITLE
Change to warn instead of error for invalid ORRS

### DIFF
--- a/protocol/x/revshare/keeper/revshare.go
+++ b/protocol/x/revshare/keeper/revshare.go
@@ -327,10 +327,10 @@ func (k Keeper) getOrderRouterRevShares(
 	orderRouterRevShares := []types.RevShare{}
 	takerOrderRouterRevSharePpm, err := k.GetOrderRouterRevShare(ctx, fill.TakerOrderRouterAddr)
 	if err != nil {
-		k.Logger(ctx).Warn("order router rev share invalid for taker, ignoring",
-			"taker_order_router_addr", fill.TakerOrderRouterAddr,
-			"taker_addr", fill.TakerAddr,
-			"error", err,
+		k.Logger(ctx).Warn("order router rev share invalid for taker, ignoring ",
+			"taker_order_router_addr: ", fill.TakerOrderRouterAddr,
+			"taker_addr: ", fill.TakerAddr,
+			"error: ", err,
 		)
 	} else {
 		if fill.TakerOrderRouterAddr != "" {
@@ -350,10 +350,10 @@ func (k Keeper) getOrderRouterRevShares(
 
 	makerOrderRouterRevSharePpm, err := k.GetOrderRouterRevShare(ctx, fill.MakerOrderRouterAddr)
 	if err != nil {
-		k.Logger(ctx).Warn("order router rev share invalid for maker, ignoring",
-			"maker_order_router_addr", fill.MakerOrderRouterAddr,
-			"maker_addr", fill.MakerAddr,
-			"error", err,
+		k.Logger(ctx).Warn("order router rev share invalid for maker, ignoring ",
+			"maker_order_router_addr: ", fill.MakerOrderRouterAddr,
+			"maker_addr: ", fill.MakerAddr,
+			"error: ", err,
 		)
 	} else {
 		if fill.MakerOrderRouterAddr != "" {

--- a/protocol/x/revshare/keeper/revshare.go
+++ b/protocol/x/revshare/keeper/revshare.go
@@ -327,7 +327,11 @@ func (k Keeper) getOrderRouterRevShares(
 	orderRouterRevShares := []types.RevShare{}
 	takerOrderRouterRevSharePpm, err := k.GetOrderRouterRevShare(ctx, fill.TakerOrderRouterAddr)
 	if err != nil {
-		k.Logger(ctx).Warn("order router rev share invalid for taker: " + fill.TakerOrderRouterAddr)
+		k.Logger(ctx).Warn("order router rev share invalid for taker, ignoring",
+			"taker_order_router_addr", fill.TakerOrderRouterAddr,
+			"taker_addr", fill.TakerAddr,
+			"error", err,
+		)
 	} else {
 		if fill.TakerOrderRouterAddr != "" {
 			// Orders can have 2 rev share ids, we need to calculate each side separately
@@ -346,7 +350,11 @@ func (k Keeper) getOrderRouterRevShares(
 
 	makerOrderRouterRevSharePpm, err := k.GetOrderRouterRevShare(ctx, fill.MakerOrderRouterAddr)
 	if err != nil {
-		k.Logger(ctx).Warn("order router rev share invalid for maker: " + fill.MakerOrderRouterAddr)
+		k.Logger(ctx).Warn("order router rev share invalid for maker, ignoring",
+			"maker_order_router_addr", fill.MakerOrderRouterAddr,
+			"maker_addr", fill.MakerAddr,
+			"error", err,
+		)
 	} else {
 		if fill.MakerOrderRouterAddr != "" {
 			// maker ppm * max(0, maker)

--- a/protocol/x/revshare/keeper/revshare.go
+++ b/protocol/x/revshare/keeper/revshare.go
@@ -327,7 +327,7 @@ func (k Keeper) getOrderRouterRevShares(
 	orderRouterRevShares := []types.RevShare{}
 	takerOrderRouterRevSharePpm, err := k.GetOrderRouterRevShare(ctx, fill.TakerOrderRouterAddr)
 	if err != nil {
-		k.Logger(ctx).Error("order router rev share invalid for taker: " + fill.TakerOrderRouterAddr)
+		k.Logger(ctx).Warn("order router rev share invalid for taker: " + fill.TakerOrderRouterAddr)
 	} else {
 		if fill.TakerOrderRouterAddr != "" {
 			// Orders can have 2 rev share ids, we need to calculate each side separately
@@ -346,7 +346,7 @@ func (k Keeper) getOrderRouterRevShares(
 
 	makerOrderRouterRevSharePpm, err := k.GetOrderRouterRevShare(ctx, fill.MakerOrderRouterAddr)
 	if err != nil {
-		k.Logger(ctx).Error("order router rev share invalid for maker: " + fill.MakerOrderRouterAddr)
+		k.Logger(ctx).Warn("order router rev share invalid for maker: " + fill.MakerOrderRouterAddr)
 	} else {
 		if fill.MakerOrderRouterAddr != "" {
 			// maker ppm * max(0, maker)


### PR DESCRIPTION
### Changelist
* Change warning level

### Test Plan
* Unit tests

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Adjusted logging severity for rev-share lookup failures from error to warning to reduce log noise and avoid unnecessary alerts.
  - Enhanced warning messages with additional context (relevant addresses and error details) to improve troubleshooting.
  - No changes to behavior or results; rev-share calculations remain unaffected when lookups fail.
  - No public interfaces were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->