### PR TITLE
[CT-1365] Safely Handle Exceptions to TWAP Suborders

### DIFF
--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -1,8 +1,8 @@
 package keeper
 
 import (
-	"runtime/debug"
 	"math/big"
+	"runtime/debug"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"math/big"
-	"runtime/debug"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"runtime/debug"
 	"math/big"
 
 	errorsmod "cosmossdk.io/errors"
@@ -411,11 +412,16 @@ func (k Keeper) safeHandleMsgPlaceOrder(
 		// recover stops a panicking goroutine and returns the error if present
 		// this will help us catch any exceptions resulting from order placement
 		if r := recover(); r != nil {
+			var orderId any
+			if msg != nil {
+				orderId = msg.Order.OrderId
+			}
 			k.Logger(ctx).Error(
 				"panic recovered in HandleMsgPlaceOrder for twap suborder",
 				"panic", r,
-				"orderId", msg.Order.OrderId,
+				"orderId", orderId,
 				"isStateful", isStateful,
+				"stack", string(debug.Stack()),
 			)
 			err = errorsmod.Wrapf(
 				types.ErrInvalidPlaceOrder,

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -419,7 +419,7 @@ func (k Keeper) safeHandleMsgPlaceOrder(
 			"isStateful", isStateful,
 			"stack", fmt.Sprintf("%+v", err),
 		)
-		
+
 		return err
 	}
 

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"math/big"
 
 	errorsmod "cosmossdk.io/errors"
@@ -411,10 +412,16 @@ func (k Keeper) safeHandleMsgPlaceOrder(
 	if err = abci.RunCached(ctx, func(ctx sdk.Context) error {
 		return k.HandleMsgPlaceOrder(ctx, msg, isStateful)
 	}); err != nil {
+		var orderId any
+		if msg != nil {
+			orderId = msg.Order.OrderId
+		}
 		k.Logger(ctx).Error(
-			"error recovered in HandleMsgPlaceOrder for twap suborder",
-			"error", err,
-			"order", msg.Order,
+			"failed to handle TWAP suborder placement via HandleMsgPlaceOrder (panic recovered or error)",
+			"cause", err,
+			"orderId", orderId,
+			"isStateful", isStateful,
+			"stack", fmt.Sprintf("%+v", err),
 		)
 
 		err = errorsmod.Wrapf(

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -409,28 +409,26 @@ func (k Keeper) safeHandleMsgPlaceOrder(
 	msg *types.MsgPlaceOrder,
 	isStateful bool,
 ) (err error) {
-	if err = abci.RunCached(ctx, func(ctx sdk.Context) error {
+	err = abci.RunCached(ctx, func(ctx sdk.Context) error {
 		return k.HandleMsgPlaceOrder(ctx, msg, isStateful)
-	}); err != nil {
-		var orderId any
-		if msg != nil {
-			orderId = msg.Order.OrderId
-		}
-		k.Logger(ctx).Error(
-			"failed to handle TWAP suborder placement via HandleMsgPlaceOrder (panic recovered or error)",
-			"cause", err,
-			"orderId", orderId,
-			"isStateful", isStateful,
-			"stack", fmt.Sprintf("%+v", err),
-		)
+	})
 
-		err = errorsmod.Wrapf(
-			types.ErrInvalidPlaceOrder,
-			"error in HandleMsgPlaceOrder: %v",
-			err,
-		)
-		return err
+	if err == nil {
+		return nil
 	}
 
-	return nil
+	var orderId any
+	if msg != nil {
+		orderId = msg.Order.OrderId
+	}
+
+	k.Logger(ctx).Error(
+		"failed to handle TWAP suborder placement via HandleMsgPlaceOrder (panic recovered or error)",
+		"cause", err,
+		"orderId", orderId,
+		"isStateful", isStateful,
+		"stack", fmt.Sprintf("%+v", err),
+	)
+
+	return err
 }

--- a/protocol/x/clob/keeper/twap_order_state.go
+++ b/protocol/x/clob/keeper/twap_order_state.go
@@ -206,7 +206,7 @@ func (k Keeper) GenerateAndPlaceTriggeredTwapSuborders(ctx sdk.Context) {
 			)
 
 			// place triggered suborder
-			err := k.HandleMsgPlaceOrder(ctx, &types.MsgPlaceOrder{Order: *op.suborderToPlace}, true)
+			err := k.safeHandleMsgPlaceOrder(ctx, &types.MsgPlaceOrder{Order: *op.suborderToPlace}, true)
 			if err != nil {
 				// TODO: (anmol) emit indexer event (TWAP error)
 				k.DeleteTWAPOrderPlacement(ctx, op.twapOrderPlacement.Order.GetOrderId())
@@ -397,4 +397,33 @@ func (k Keeper) GenerateSuborder(
 	}
 
 	return &order, true
+}
+
+// safeHandleMsgPlaceOrder safely calls HandleMsgPlaceOrder with panic recovery.
+// This is used in end blockers where panics should be caught and logged rather than
+// causing the entire block to fail.
+func (k Keeper) safeHandleMsgPlaceOrder(
+	ctx sdk.Context,
+	msg *types.MsgPlaceOrder,
+	isStateful bool,
+) (err error) {
+	defer func() {
+		// recover stops a panicking goroutine and returns the error if present
+		// this will help us catch any exceptions resulting from order placement
+		if r := recover(); r != nil {
+			k.Logger(ctx).Error(
+				"panic recovered in HandleMsgPlaceOrder for twap suborder",
+				"panic", r,
+				"orderId", msg.Order.OrderId,
+				"isStateful", isStateful,
+			)
+			err = errorsmod.Wrapf(
+				types.ErrInvalidPlaceOrder,
+				"panic in HandleMsgPlaceOrder: %v",
+				r,
+			)
+		}
+	}()
+
+	return k.HandleMsgPlaceOrder(ctx, msg, isStateful)
 }


### PR DESCRIPTION
### Changelist
In TWAP order execution, we call HandleMsgPlaceOrder for suborders. While unexpected, we should ensure that the code does not panic since this is executed during the EndBlocker. To do so, let's wrap the function call with a recover, log the error, and simply proceed with the EndBlocker if we do run into an error.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improves stability of TWAP-triggered order placement by recovering from unexpected panics during end-block processing, preventing rare node crashes.
  * Converts placement panics into handled errors so failed TWAP orders and associated trigger entries are reliably cleaned up, avoiding stuck or inconsistent states.
  * Adds richer contextual logging for placement failures to aid troubleshooting while preserving normal success behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->