### PR TITLE
[Turnkey] Use turnkey signer as master for approvals

### DIFF
--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -113,8 +113,7 @@ export const configSchema = {
   BRIDGE_THRESHOLD_USDC: parseInteger({ default: 20 }),
   CALL_POLICY_VALUE_LIMIT: parseBigInt({ default: BigInt(100_000_000_000) }),
   // on-chain signer to kick off the skip bridge.
-  MASTER_SIGNER_PUBLIC: parseString({ default: '' }),
-  MASTER_SIGNER_PRIVATE: parseString({ default: '' }),
+  APPROVAL_SIGNER_PUBLIC_ADDRESS: parseString({ default: '0x3FC11ff27e5373c88EA142d2EdF5492d0839980B' }),
   // if policy approvals are enabled.
   APPROVAL_ENABLED: parseBoolean({ default: true }),
 

--- a/indexer/services/comlink/src/helpers/policy-engine.ts
+++ b/indexer/services/comlink/src/helpers/policy-engine.ts
@@ -160,7 +160,7 @@ async function getApprovalForAvalanche(turnkeyAccount: LocalAccount, dydxAddress
 
   // Create an "empty account" as the signer -- you only need the public
   // key (address) to do this.
-  const emptyAccount = addressToEmptyAccount(config.MASTER_SIGNER_PUBLIC as `0x${string}`);
+  const emptyAccount = addressToEmptyAccount(config.APPROVAL_SIGNER_PUBLIC_ADDRESS as `0x${string}`);
   const emptySessionKeySigner = await toECDSASigner({ signer: emptyAccount });
 
   const permissionPlugin = await toPermissionValidator(publicClients[avalanche.id.toString()], {
@@ -191,7 +191,7 @@ async function getApprovalFor7702Evm(
 ) {
   const callPolicy = await callPolicyByChainId[chainId](dydxAddress);
   const kernelVersion = KERNEL_V3_3;
-  const emptyAccount = addressToEmptyAccount(config.MASTER_SIGNER_PUBLIC as `0x${string}`);
+  const emptyAccount = addressToEmptyAccount(config.APPROVAL_SIGNER_PUBLIC_ADDRESS as `0x${string}`);
   const emptySessionKeySigner = await toECDSASigner({ signer: emptyAccount });
   const permissionPlugin = await toPermissionValidator(publicClients[chainId], {
     entryPoint,

--- a/indexer/services/comlink/src/helpers/skip-helper.ts
+++ b/indexer/services/comlink/src/helpers/skip-helper.ts
@@ -24,10 +24,10 @@ import {
 } from '../lib/smart-contract-constants';
 import { getAddress, publicClients } from './alchemy-helpers';
 
-const turnkeySenderClient = new Turnkey({
+const turnkeyClient = new Turnkey({
   apiBaseUrl: config.TURNKEY_API_BASE_URL as string,
-  apiPublicKey: config.TURNKEY_API_SENDER_PUBLIC_KEY as string,
-  apiPrivateKey: config.TURNKEY_API_SENDER_PRIVATE_KEY as string,
+  apiPublicKey: config.TURNKEY_API_PUBLIC_KEY as string,
+  apiPrivateKey: config.TURNKEY_API_PRIVATE_KEY as string,
   defaultOrganizationId: config.TURNKEY_ORGANIZATION_ID,
 });
 
@@ -303,13 +303,11 @@ export async function getKernelAccount(
   fromAddress: string,
   suborgId: string,
 ): Promise<CreateKernelAccountReturnType<EntryPointVersion>> {
-  // Initialize a Turnkey-powered Viem Account
-  // needs to sign with eoa address.
+  // Initialize the turnkey delegated signer account.
   const turnkeyAccount = await createAccount({
     // @ts-ignore
-    client: turnkeySenderClient.apiClient(),
-    organizationId: suborgId,
-    signWith: fromAddress,
+    client: turnkeyClient.apiClient(),
+    signWith: config.APPROVAL_SIGNER_PUBLIC_ADDRESS,
   });
   // if smart account approval is enabled, use the session key + approval to sign for txs.
   // use the permissioned master key as  a signer.

--- a/indexer/services/comlink/src/helpers/skip-helper.ts
+++ b/indexer/services/comlink/src/helpers/skip-helper.ts
@@ -6,16 +6,14 @@ import type { Transaction, VersionedTransaction } from '@solana/web3.js';
 import { Turnkey } from '@turnkey/sdk-server';
 import { TurnkeySigner } from '@turnkey/solana';
 import { createAccount } from '@turnkey/viem';
-import { signerToEcdsaValidator } from '@zerodev/ecdsa-validator';
 import { deserializePermissionAccount } from '@zerodev/permissions';
 import { toECDSASigner } from '@zerodev/permissions/signers';
-import { createKernelAccount, CreateKernelAccountReturnType } from '@zerodev/sdk';
+import { CreateKernelAccountReturnType } from '@zerodev/sdk';
 import { KERNEL_V3_1, KERNEL_V3_3 } from '@zerodev/sdk/constants';
 import { decode, fromWords } from 'bech32';
 import bs58 from 'bs58';
 import { encodeFunctionData, type Hex } from 'viem';
 import type { EntryPointVersion, SmartAccountImplementation } from 'viem/account-abstraction';
-import { privateKeyToAccount } from 'viem/accounts';
 import { avalanche } from 'viem/chains';
 
 import config from '../config';
@@ -313,55 +311,28 @@ export async function getKernelAccount(
     organizationId: suborgId,
     signWith: fromAddress,
   });
-
-  if (config.APPROVAL_ENABLED) {
-    // if smart account approval is enabled, use the session key + approval to sign for txs.
-    // use the permissioned master key as a signer.
-    const privateKeyAccount = privateKeyToAccount(config.MASTER_SIGNER_PRIVATE as `0x${string}`);
-    const sessionKeySigner = await toECDSASigner({
-      signer: privateKeyAccount,
-    });
-    let kernelVersion = KERNEL_V3_3;
-    if (chainId === avalanche.id.toString()) {
-      kernelVersion = KERNEL_V3_1;
-    }
-
-    const row = await PermissionApprovalTable.findBySuborgIdAndChainId(suborgId, chainId);
-    if (!row) {
-      throw new Error(`No approval found for suborg ${suborgId} and chain ${chainId}`);
-    }
-    const sessionKeyAccount = await deserializePermissionAccount(
-      publicClients[chainId],
-      entryPoint,
-      kernelVersion,
-      row.approval,
-      sessionKeySigner,
-    );
-    return sessionKeyAccount;
-  }
-  if (chainId === avalanche.id.toString()) {
-    // Construct a validator
-    const ecdsaValidator = await signerToEcdsaValidator(publicClients[chainId], {
-      signer: turnkeyAccount,
-      entryPoint,
-      kernelVersion: KERNEL_V3_1,
-    });
-
-    // kernel account
-    const account = await createKernelAccount(publicClients[chainId], {
-      entryPoint,
-      plugins: {
-        sudo: ecdsaValidator,
-      },
-      kernelVersion: KERNEL_V3_1,
-    });
-    return account;
-  }
-  return createKernelAccount(publicClients[chainId], {
-    entryPoint,
-    eip7702Account: turnkeyAccount,
-    kernelVersion: KERNEL_V3_3,
+  // if smart account approval is enabled, use the session key + approval to sign for txs.
+  // use the permissioned master key as  a signer.
+  const sessionKeySigner = await toECDSASigner({
+    signer: turnkeyAccount,
   });
+  let kernelVersion = KERNEL_V3_3;
+  if (chainId === avalanche.id.toString()) {
+    kernelVersion = KERNEL_V3_1;
+  }
+
+  const row = await PermissionApprovalTable.findBySuborgIdAndChainId(suborgId, chainId);
+  if (!row) {
+    throw new Error(`No approval found for suborg ${suborgId} and chain ${chainId}`);
+  }
+  const sessionKeyAccount = await deserializePermissionAccount(
+    publicClients[chainId],
+    entryPoint,
+    kernelVersion,
+    row.approval,
+    sessionKeySigner,
+  );
+  return sessionKeyAccount;
 }
 
 // for a dydx address, this returns the noble forwarding address of the dydx address.


### PR DESCRIPTION
### Changelist
Approvals on chain is how we get permissions from the user to kick off the auto bridge transaction. These approvals require us to dedicate a signer to sign on behalf of the user. This PR changes the signer from a private key we own to a turnkey key.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Single public address used for approval signing with a default provided.

- Refactor
  - Approval flow now uses session-key–based signing.
  - Account construction standardized to use stored permission records.
  - Kernel version selection per chain retained.

- Bug Fixes
  - More reliable approval generation and clearer errors when permissions are missing.

- Chores
  - Removed legacy private-key–based signing path and related config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->