### PR TITLE
feat(comlink): add cache-control config for /affiliates/metadata

### DIFF
--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -70,6 +70,7 @@ export const configSchema = {
   // Cache-Control directives
   CACHE_CONTROL_DIRECTIVE_ADDRESSES: parseString({ default: 'public, max-age=1' }),
   CACHE_CONTROL_DIRECTIVE_AFFILIATES: parseString({ default: 'public, max-age=10' }),
+  CACHE_CONTROL_DIRECTIVE_AFFILIATES_METADATA: parseString({ default: 'no-cache' }),
   CACHE_CONTROL_DIRECTIVE_ASSET_POSITIONS: parseString({ default: 'public, max-age=1' }),
   CACHE_CONTROL_DIRECTIVE_CANDLES: parseString({ default: 'public, max-age=1' }),
   // omit compliance

--- a/indexer/services/comlink/src/controllers/api/v4/affiliates-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/affiliates-controller.ts
@@ -44,6 +44,9 @@ const controllerName: string = 'affiliates-controller';
 const affiliatesCacheControlMiddleware = cacheControlMiddleware(
   config.CACHE_CONTROL_DIRECTIVE_AFFILIATES,
 );
+const affiliatesMetadataCacheControlMiddleware = cacheControlMiddleware(
+  config.CACHE_CONTROL_DIRECTIVE_AFFILIATES_METADATA,
+);
 
 // TODO(OTE-731): replace api stubs with real logic
 @Route('affiliates')
@@ -280,7 +283,7 @@ class AffiliatesController extends Controller {
 router.get(
   '/metadata',
   rateLimiterMiddleware(getReqRateLimiter),
-  affiliatesCacheControlMiddleware,
+  affiliatesMetadataCacheControlMiddleware,
   ...checkSchema({
     address: {
       in: ['query'],


### PR DESCRIPTION
### Changelist
prevent caching affiliate metadata to promptly update referallCode queries following changes

### Test Plan
unit tests and deployment to internal environments and public testnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a dedicated cache-control setting for the Affiliates metadata API, enabling finer-grained caching configuration.
  - Default behavior for the metadata endpoint is now no-cache, ensuring the freshest responses.
  - Other Affiliates endpoints are unaffected; only the metadata route uses the new directive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->