### PR TITLE
[Bridging] Make $50-$100 deposits slow to not pay fees

### DIFF
--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -125,6 +125,8 @@ export const configSchema = {
   BASE_WEBHOOK_ID: parseString({ default: 'wh_lpjn5gnwj0ll0gap' }),
   OPTIMISM_WEBHOOK_ID: parseString({ default: 'wh_7eo900bsg8rkvo6z' }),
   SOLANA_WEBHOOK_ID: parseString({ default: 'wh_eqxyotjv478gscpo' }),
+  // minimum threshold we need to hit for go fast to be free.
+  ETHEREUM_GO_FAST_FREE_MINIMUM: parseInteger({ default: 100 }),
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Changelist
Make $50-$100 deposits slow to not pay fees. Currently there is a ~$2.5 fee for ethereum go fast deposit. Rather it be slow and not get charged.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptive routing on Ethereum mainnet: “Go Fast” is automatically disabled for small USDC amounts to reduce cost.
  * New configurable minimum USDC threshold lets operators control when fast routing is used.
  * Chain handling expanded to include Ethereum mainnet so the above behavior applies there.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->