### PR TITLE
set default lock multiplier of funding and pnl roundtable task to 3

### DIFF
--- a/indexer/services/roundtable/src/config.ts
+++ b/indexer/services/roundtable/src/config.ts
@@ -165,8 +165,10 @@ export const configSchema = {
   UNCROSS_ORDERBOOK_LOCK_MULTIPLIER: parseInteger({ default: 1 }),
   PNL_TICK_UPDATE_LOCK_MULTIPLIER: parseInteger({ default: 20 }),
   SUBACCOUNT_USERNAME_GENERATOR_LOCK_MULTIPLIER: parseInteger({ default: 5 }),
-  UPDATE_FUNDING_PAYMENTS_LOCK_MULTIPLIER: parseInteger({ default: 720 }),
-  UPDATE_PNL_LOCK_MULTIPLIER: parseInteger({ default: 720 }),
+  // for initial backfill of funding payments that processes from genesis, can configure this to be a higher value
+  UPDATE_FUNDING_PAYMENTS_LOCK_MULTIPLIER: parseInteger({ default: 3 }),
+  // for initial backfill of PNL that processes from genesis, can configure this to be a higher value
+  UPDATE_PNL_LOCK_MULTIPLIER: parseInteger({ default: 3 }),
 
   // Maximum number of running tasks - set this equal to PG_POOL_MIN in .env, default is 2
   MAX_CONCURRENT_RUNNING_TASKS: parseInteger({ default: 2 }),


### PR DESCRIPTION
### Changelist
set default lock multiplier to 3 so that by default, locks timeout after 3 minutes. current 720 was set for initial backfill purposes but instead we should just override from 3 to 720 for initial backfill

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
