### PR TITLE
[Bridging] Update bridge information table creation logic. 

### DIFF
--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -112,7 +112,7 @@ export const configSchema = {
   ZERODEV_API_KEY: parseString({ default: '' }),
   ZERODEV_API_BASE_URL: parseString({ default: 'https://rpc.zerodev.app/api/v3' }),
   BRIDGE_THRESHOLD_USDC: parseInteger({ default: 20 }),
-  CALL_POLICY_VALUE_LIMIT: parseBigInt({ default: BigInt(100_000_000_000) }),
+  CALL_POLICY_VALUE_LIMIT: parseBigInt({ default: BigInt(100_000_000_000_000_000_000) }),
   // on-chain signer to kick off the skip bridge.
   APPROVAL_SIGNER_PUBLIC_ADDRESS: parseString({ default: '0x3FC11ff27e5373c88EA142d2EdF5492d0839980B' }),
   // if policy approvals are enabled.


### PR DESCRIPTION
### Changelist
Bridge information table does not need a loading state. Kind of useless since the bridge hasn't kicked off yet and duplicate events are getting created.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined bridge tracking to create records with the transaction hash at initiation, improving reliability and reducing race conditions across EVM and Solana flows.
* **Chores**
  * Increased the default call policy value limit to support significantly larger transaction amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->