### PR TITLE
[Alchemy] Webhook not registering addresses

### DIFF
--- a/indexer/services/comlink/public/api-documentation.md
+++ b/indexer/services/comlink/public/api-documentation.md
@@ -3932,7 +3932,8 @@ fetch(`${baseURL}/turnkey/signin`,
   "apiKeyId": "string",
   "userId": "string",
   "session": "string",
-  "salt": "string"
+  "salt": "string",
+  "alreadyExists": true
 }
 ```
 
@@ -6635,7 +6636,8 @@ or
   "apiKeyId": "string",
   "userId": "string",
   "session": "string",
-  "salt": "string"
+  "salt": "string",
+  "alreadyExists": true
 }
 
 ```
@@ -6650,6 +6652,7 @@ or
 |userId|string|false|none|none|
 |session|string|false|none|none|
 |salt|string|true|none|none|
+|alreadyExists|boolean|false|none|none|
 
 ## SigninMethod
 

--- a/indexer/services/comlink/public/swagger.json
+++ b/indexer/services/comlink/public/swagger.json
@@ -1636,6 +1636,9 @@
           },
           "salt": {
             "type": "string"
+          },
+          "alreadyExists": {
+            "type": "boolean"
           }
         },
         "required": [

--- a/indexer/services/comlink/src/controllers/api/v4/turnkey-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/turnkey-controller.ts
@@ -184,9 +184,10 @@ export class TurnkeyController extends Controller {
       try {
         const resp = await this.turnkeyHelpers.socialSignin(provider, oidcToken, targetPublicKey);
         return {
+          alreadyExists: resp.alreadyExists,
           session: resp.session,
-          salt: resp.salt,
-          dydxAddress: resp.dydxAddress || '',
+          salt: resp.salt || '',
+          dydxAddress: resp.dydxAddress,
         };
       } catch (error) {
         throw TurnkeyHelpers.wrapTurnkeyError(error, 'Social signin failed');

--- a/indexer/services/comlink/src/controllers/api/v4/turnkey-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/turnkey-controller.ts
@@ -11,6 +11,7 @@ import { Address, checksumAddress, recoverMessageAddress } from 'viem';
 
 import { getReqRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
+import { addAddressesToAlchemyWebhook } from '../../../helpers/alchemy-helpers';
 import { PolicyEngine } from '../../../helpers/policy-engine';
 import { TurnkeyError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
@@ -126,6 +127,9 @@ export class TurnkeyController extends Controller {
     if (user.dydx_address) {
       throw new TurnkeyError('Dydx address already uploaded');
     }
+
+    // alchemy webhook upload.
+    await addAddressesToAlchemyWebhook(user.evm_address, user.svm_address);
 
     await TurnkeyUsersTable.updateDydxAddressByEvmAddress(user.evm_address, dydxAddress);
 

--- a/indexer/services/comlink/src/lib/turnkey-helpers.ts
+++ b/indexer/services/comlink/src/lib/turnkey-helpers.ts
@@ -8,7 +8,7 @@ import { Address, checksumAddress } from 'viem';
 
 import config from '../config';
 import { TURNKEY_EMAIL_CUSTOMIZATION } from '../constants';
-import { addAddressesToAlchemyWebhook, getSmartAccountAddress } from '../helpers/alchemy-helpers';
+import { getSmartAccountAddress } from '../helpers/alchemy-helpers';
 import {
   CreateSuborgParams,
   GetSuborgParams,
@@ -195,10 +195,6 @@ export class TurnkeyHelpers {
       created_at: new Date().toISOString(),
     });
 
-    // need to also add the svm and evm addresses to the alchemy hook
-    if (evmAddress && svmAddress) {
-      await addAddressesToAlchemyWebhook(evmAddress, svmAddress);
-    }
     return {
       subOrgId: subOrg.subOrganizationId,
       salt,

--- a/indexer/services/comlink/src/lib/turnkey-helpers.ts
+++ b/indexer/services/comlink/src/lib/turnkey-helpers.ts
@@ -313,6 +313,17 @@ export class TurnkeyHelpers {
     });
 
     if (!suborg) {
+      suborg = await this.getSuborg({
+        email: extractedEmail,
+      });
+      if (suborg) {
+        return {
+          alreadyExists: true,
+        };
+      }
+    }
+
+    if (!suborg) {
       suborg = await this.createSuborg({
         providerName: provider,
         oidcToken,

--- a/indexer/services/comlink/src/types.ts
+++ b/indexer/services/comlink/src/types.ts
@@ -799,6 +799,7 @@ export interface TurnkeyAuthResponse {
   userId?: string,
   session?: string,
   salt: string,
+  alreadyExists?: boolean,
 }
 
 export interface TurnkeyCreateSuborgResponse {


### PR DESCRIPTION
### Changelist
Since front end retries the uploadAddress endpoint if it fails. We're adding the address upload to Alchemy so that it guarantees the web hook registers the address.

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Triggers external webhook when uploading addresses to reduce missed notifications.

* **New Features**
  * Social sign-in now returns alreadyExists and normalizes salt and address fields for consistent responses.

* **Refactor**
  * Streamlined webhook registration flow to improve reliability.

* **Documentation**
  * Public API docs and schema updated to include the new alreadyExists field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->