### PR TITLE
feat(comlink): set request Geo-Origin-Country, Region, Status headers on responses

### DIFF
--- a/indexer/packages/compliance/__tests__/geoblocking/restrict-countries.test.ts
+++ b/indexer/packages/compliance/__tests__/geoblocking/restrict-countries.test.ts
@@ -1,17 +1,19 @@
+import { GeoOriginHeaders, GeoOriginStatus } from '../../src/types';
 import {
   isRestrictedCountryHeaders,
-  CountryHeaders,
   isWhitelistedAddress,
 } from '../../src/geoblocking/restrict-countries';
-import * as util from '../../src/geoblocking/util';
+import * as restrictCountries from '../../src/geoblocking/restrict-countries';
 import config from '../../src/config';
 
-const defaultHeaders: CountryHeaders = {
-  'cf-ipcountry': 'US',
+const defaultHeaders: GeoOriginHeaders = {
+  'geo-origin-country': 'FR',
+  'geo-origin-region': 'FR-75', // Paris
+  'geo-origin-status': GeoOriginStatus.OK,
 };
 
 describe('isRestrictedCountryHeaders', () => {
-  let isRestrictedCountrySpy: jest.SpyInstance;
+  let isRestrictedCountryHeadersSpy: jest.SpyInstance;
   const defaultEnabled: boolean = config.INDEXER_LEVEL_GEOBLOCKING_ENABLED;
 
   beforeAll(() => {
@@ -23,7 +25,7 @@ describe('isRestrictedCountryHeaders', () => {
   });
 
   beforeEach(() => {
-    isRestrictedCountrySpy = jest.spyOn(util, 'isRestrictedCountry');
+    isRestrictedCountryHeadersSpy = jest.spyOn(restrictCountries, 'isRestrictedCountryHeaders');
   });
 
   afterEach(() => {
@@ -32,14 +34,14 @@ describe('isRestrictedCountryHeaders', () => {
 
   it('does not reject headers from non-restricted countries', () => {
     // non-restricted country in header
-    isRestrictedCountrySpy.mockReturnValue(false);
+    isRestrictedCountryHeadersSpy.mockReturnValue(false);
 
     expect(isRestrictedCountryHeaders(defaultHeaders)).toEqual(false);
   });
 
   it('does reject headers with restricted country', () => {
     // restricted country in header
-    isRestrictedCountrySpy.mockReturnValue(true);
+    isRestrictedCountryHeadersSpy.mockReturnValue(true);
 
     expect(isRestrictedCountryHeaders(defaultHeaders)).toEqual(true);
   });

--- a/indexer/packages/compliance/src/geoblocking/restrict-countries.ts
+++ b/indexer/packages/compliance/src/geoblocking/restrict-countries.ts
@@ -1,29 +1,27 @@
 import { stats } from '@dydxprotocol-indexer/base';
 
 import config from '../config';
-import { isRestrictedCountry } from './util';
+import { GeoOriginHeaders, GeoOriginStatus } from '../types';
 
-export interface CountryHeaders {
-  'cf-ipcountry'?: string,
-}
-
-export function isRestrictedCountryHeaders(headers: CountryHeaders): boolean {
+export function isRestrictedCountryHeaders(headers: GeoOriginHeaders): boolean {
   if (config.INDEXER_LEVEL_GEOBLOCKING_ENABLED === false) {
     return false;
   }
 
-  const ipCountry: string | undefined = headers['cf-ipcountry'];
+  const geoStatus: string | undefined = headers['geo-origin-status'];
 
   if (
-    ipCountry === undefined ||
-    isRestrictedCountry(ipCountry)
+    geoStatus === undefined ||
+    geoStatus !== GeoOriginStatus.OK
   ) {
     stats.increment(
       `${config.SERVICE_NAME}.rejected_restricted_country`,
       1,
       undefined,
       {
-        country: String(ipCountry),
+        country: headers['geo-origin-country'] || '',
+        region: headers['geo-origin-region'] || '',
+        status: headers['geo-origin-status'] || '',
       },
     );
     return true;

--- a/indexer/packages/compliance/src/geoblocking/util.ts
+++ b/indexer/packages/compliance/src/geoblocking/util.ts
@@ -1,7 +1,0 @@
-import config from '../config';
-
-const RESTRICTED_COUNTRY_CODES: Set<string> = new Set(config.RESTRICTED_COUNTRIES.split(','));
-
-export function isRestrictedCountry(ipCountry: string): boolean {
-  return RESTRICTED_COUNTRY_CODES.has(ipCountry);
-}

--- a/indexer/packages/compliance/src/index.ts
+++ b/indexer/packages/compliance/src/index.ts
@@ -1,7 +1,6 @@
 export * from './clients/compliance-client';
 export * from './clients/clients';
 export * from './geoblocking/restrict-countries';
-export * from './geoblocking/util';
 export * from './types';
 export * from './config';
 export * from './constants';

--- a/indexer/packages/compliance/src/types.ts
+++ b/indexer/packages/compliance/src/types.ts
@@ -1,7 +1,17 @@
-/** Response from a compliance provider */
 export interface ComplianceClientResponse {
   address: string,
   chain?: string,
   blocked: boolean,
   riskScore?: string,
+}
+
+export interface GeoOriginHeaders extends Record<string, string | undefined> {
+  'geo-origin-country'?: string,
+  'geo-origin-region'?: string,
+  'geo-origin-status'?: string,
+}
+
+export enum GeoOriginStatus {
+  OK = 'ok',
+  RESTRICTED = 'restricted',
 }

--- a/indexer/services/comlink/__tests__/controllers/api/v4/skip-bridge-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/skip-bridge-controller.test.ts
@@ -1,3 +1,4 @@
+import { GeoOriginStatus } from '@dydxprotocol-indexer/compliance';
 import {
   dbHelpers,
   PermissionApprovalTable,
@@ -54,6 +55,12 @@ import * as skipHelpers from '../../../../src/helpers/skip-helper';
 import { RequestMethod } from '../../../../src/types';
 import { sendRequest } from '../../../helpers/helpers';
 
+const geoOriginHeaders = {
+  'geo-origin-country': 'AR', // Argentina
+  'geo-origin-region': 'AR-V', // Tierra del Fuego
+  'geo-origin-status': GeoOriginStatus.OK,
+};
+
 describe('skip-bridge-controller#V4', () => {
   beforeAll(async () => {
     await dbHelpers.migrate();
@@ -93,6 +100,7 @@ describe('skip-bridge-controller#V4', () => {
           type: RequestMethod.GET,
           path: `/v4/bridging/getDepositAddress/${testDydxAddress2}`,
           expectedStatus: 200,
+          headers: geoOriginHeaders,
         });
 
         expect(response.body).toEqual({

--- a/indexer/services/comlink/__tests__/helpers/geo-headers-middleware.test.ts
+++ b/indexer/services/comlink/__tests__/helpers/geo-headers-middleware.test.ts
@@ -1,0 +1,106 @@
+import { GeoOriginStatus } from '@dydxprotocol-indexer/compliance';
+import express from 'express';
+import request from 'supertest';
+
+import geoHeadersMiddleware from '../../src/request-helpers/geo-headers-middleware';
+
+describe('geoOriginHeadersMiddleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    app.use(geoHeadersMiddleware);
+
+    app.get('/test', (req: express.Request, res: express.Response) => {
+      res.json({ success: true });
+    });
+  });
+
+  it('reflect all geo headers when all are present', async () => {
+    const response = await request(app)
+      .get('/test')
+      .set('Geo-Origin-Country', 'US')
+      .set('Geo-Origin-Region', 'CA')
+      .set('Geo-Origin-Status', GeoOriginStatus.OK);
+
+    expect(response.headers['geo-origin-country']).toBe('US');
+    expect(response.headers['geo-origin-region']).toBe('CA');
+    expect(response.headers['geo-origin-status']).toBe(GeoOriginStatus.OK);
+  });
+
+  it('reflect only Geo-Origin-Country when only country header is present', async () => {
+    const response = await request(app)
+      .get('/test')
+      .set('Geo-Origin-Country', 'FR');
+
+    expect(response.headers['geo-origin-country']).toBe('FR');
+    expect(response.headers['geo-origin-region']).toBeUndefined();
+    expect(response.headers['geo-origin-status']).toBeUndefined();
+  });
+
+  it('reflect only Geo-Origin-Region when only region header is present', async () => {
+    const response = await request(app)
+      .get('/test')
+      .set('Geo-Origin-Region', 'NY');
+
+    expect(response.headers['geo-origin-country']).toBeUndefined();
+    expect(response.headers['geo-origin-region']).toBe('NY');
+    expect(response.headers['geo-origin-status']).toBeUndefined();
+  });
+
+  it('reflect only Geo-Origin-Status when only status header is present', async () => {
+    const response = await request(app)
+      .get('/test')
+      .set('Geo-Origin-Status', GeoOriginStatus.RESTRICTED);
+
+    expect(response.headers['geo-origin-country']).toBeUndefined();
+    expect(response.headers['geo-origin-region']).toBeUndefined();
+    expect(response.headers['geo-origin-status']).toBe(GeoOriginStatus.RESTRICTED);
+  });
+
+  it('should not set any headers when no geo headers are present', async () => {
+    const response = await request(app)
+      .get('/test');
+
+    expect(response.headers['geo-origin-country']).toBeUndefined();
+    expect(response.headers['geo-origin-region']).toBeUndefined();
+    expect(response.headers['geo-origin-status']).toBeUndefined();
+  });
+
+  it('reflect empty string when headers are set but empty', async () => {
+    const response = await request(app)
+      .get('/test')
+      .set('Geo-Origin-Country', '')
+      .set('Geo-Origin-Region', '')
+      .set('Geo-Origin-Status', '');
+
+    expect(response.headers['geo-origin-country']).toBe('');
+    expect(response.headers['geo-origin-region']).toBe('');
+    expect(response.headers['geo-origin-status']).toBe('');
+  });
+
+  it('handle mixed empty and non-empty headers', async () => {
+    const response = await request(app)
+      .get('/test')
+      .set('Geo-Origin-Country', 'GB')
+      .set('Geo-Origin-Region', '')
+      .set('Geo-Origin-Status', GeoOriginStatus.RESTRICTED);
+
+    expect(response.headers['geo-origin-country']).toBe('GB');
+    expect(response.headers['geo-origin-region']).toBe('');
+    expect(response.headers['geo-origin-status']).toBe(GeoOriginStatus.RESTRICTED);
+  });
+
+  it('handle case-sensitive header names correctly', async () => {
+    const response = await request(app)
+      .get('/test')
+      .set('geo-origin-country', 'DE') // lowercase
+      .set('GEO-ORIGIN-REGION', 'BE') // uppercase
+      .set('Geo-Origin-Status', GeoOriginStatus.OK); // mixed case
+
+    // Express normalizes header names, so these should all work
+    expect(response.headers['geo-origin-country']).toBe('DE');
+    expect(response.headers['geo-origin-region']).toBe('BE');
+    expect(response.headers['geo-origin-status']).toBe(GeoOriginStatus.OK);
+  });
+});

--- a/indexer/services/comlink/__tests__/helpers/helpers.ts
+++ b/indexer/services/comlink/__tests__/helpers/helpers.ts
@@ -85,12 +85,14 @@ export async function sendRequest({
   body,
   errorMsg,
   expectedStatus = 200,
+  headers,
 }: {
   type: RequestMethod,
   path: string,
   body?: {},
   errorMsg?: string,
   expectedStatus?: number,
+  headers?: Record<string, string>,
 }) {
   return sendRequestToApp({
     type,
@@ -99,6 +101,7 @@ export async function sendRequest({
     errorMsg,
     expressApp: app,
     expectedStatus,
+    headers,
   });
 }
 

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -4,7 +4,7 @@ import {
   TooManyRequestsError,
 } from '@dydxprotocol-indexer/base';
 import {
-  CountryHeaders,
+  GeoOriginHeaders,
   isRestrictedCountryHeaders,
   isWhitelistedAddress,
 } from '@dydxprotocol-indexer/compliance';
@@ -385,7 +385,7 @@ async function upsertComplianceStatus(
   updatedAt: string,
 ): Promise<ComplianceStatusFromDatabase | undefined> {
   if (complianceStatus.length === 0) {
-    if (!isRestrictedCountryHeaders(req.headers as CountryHeaders)) {
+    if (!isRestrictedCountryHeaders(req.headers as GeoOriginHeaders)) {
       return ComplianceStatusTable.upsert({
         address,
         status: ComplianceStatus.COMPLIANT,
@@ -398,7 +398,7 @@ async function upsertComplianceStatus(
       return ComplianceStatusTable.upsert({
         address,
         status: ComplianceStatus.BLOCKED,
-        reason: getGeoComplianceReason(req.headers as CountryHeaders)!,
+        reason: getGeoComplianceReason(req.headers as GeoOriginHeaders)!,
         updatedAt,
       });
     }
@@ -406,7 +406,7 @@ async function upsertComplianceStatus(
     return ComplianceStatusTable.upsert({
       address,
       status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
-      reason: getGeoComplianceReason(req.headers as CountryHeaders)!,
+      reason: getGeoComplianceReason(req.headers as GeoOriginHeaders)!,
       updatedAt,
     });
   }
@@ -416,13 +416,13 @@ async function upsertComplianceStatus(
     complianceStatus[0].status === ComplianceStatus.COMPLIANT
   ) {
     if (
-      isRestrictedCountryHeaders(req.headers as CountryHeaders) &&
+      isRestrictedCountryHeaders(req.headers as GeoOriginHeaders) &&
       action === ComplianceAction.CONNECT
     ) {
       return ComplianceStatusTable.update({
         address,
         status: COMPLIANCE_PROGRESSION[complianceStatus[0].status],
-        reason: getGeoComplianceReason(req.headers as CountryHeaders)!,
+        reason: getGeoComplianceReason(req.headers as GeoOriginHeaders)!,
         updatedAt,
       });
     }

--- a/indexer/services/comlink/src/helpers/compliance/compliance-utils.ts
+++ b/indexer/services/comlink/src/helpers/compliance/compliance-utils.ts
@@ -2,7 +2,7 @@ import {
   ExtendedSecp256k1Signature, Secp256k1, ripemd160, sha256,
 } from '@cosmjs/crypto';
 import { toBech32 } from '@cosmjs/encoding';
-import { CountryHeaders, isRestrictedCountryHeaders } from '@dydxprotocol-indexer/compliance';
+import { GeoOriginHeaders, isRestrictedCountryHeaders } from '@dydxprotocol-indexer/compliance';
 import { ComplianceReason } from '@dydxprotocol-indexer/postgres';
 import { verifyADR36Amino } from '@keplr-wallet/cosmos';
 import express from 'express';
@@ -25,8 +25,10 @@ export enum AccountVerificationRequiredAction {
   UPDATE_CODE = 'UPDATE_CODE',
 }
 
+// TODO: deprecate this pattern.
+// Only the origin is pertinent, so store country or region, rather than encoding them.
 export function getGeoComplianceReason(
-  headers: CountryHeaders,
+  headers: GeoOriginHeaders,
 ): ComplianceReason | undefined {
   if (isRestrictedCountryHeaders(headers)) {
     const country: string | undefined = headers['cf-ipcountry'];

--- a/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
+++ b/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
@@ -1,5 +1,5 @@
 import {
-  CountryHeaders,
+  GeoOriginHeaders,
   isRestrictedCountryHeaders,
   INDEXER_GEOBLOCKED_PAYLOAD,
   INDEXER_COMPLIANCE_BLOCKED_PAYLOAD,
@@ -80,7 +80,7 @@ export async function complianceAndGeoCheck(
     }
   }
 
-  if (isRestrictedCountryHeaders(req.headers as CountryHeaders)) {
+  if (isRestrictedCountryHeaders(req.headers as GeoOriginHeaders)) {
     return create4xxResponse(
       res,
       INDEXER_GEOBLOCKED_PAYLOAD,

--- a/indexer/services/comlink/src/request-helpers/geo-headers-middleware.ts
+++ b/indexer/services/comlink/src/request-helpers/geo-headers-middleware.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+
+export default function geoHeadersMiddleware(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): void {
+  const country = req.headers['geo-origin-country'];
+  if (country !== undefined) {
+    res.set('Geo-Origin-Country', country);
+  }
+
+  const region = req.headers['geo-origin-region'];
+  if (region !== undefined) {
+    res.set('Geo-Origin-Region', region);
+  }
+
+  const status = req.headers['geo-origin-status'];
+  if (status !== undefined) {
+    res.set('Geo-Origin-Status', status);
+  }
+
+  next();
+}

--- a/indexer/services/comlink/src/request-helpers/server.ts
+++ b/indexer/services/comlink/src/request-helpers/server.ts
@@ -8,6 +8,7 @@ import swaggerUi from 'swagger-ui-express';
 import * as swaggerJson from '../../public/swagger.json';
 import config from '../config';
 import { logErrors } from './error-handler';
+import geoHeadersMiddleware from './geo-headers-middleware';
 import RequestLogger from './request-logger';
 import resBodyCapture from './res-body-capture';
 
@@ -15,6 +16,8 @@ export default function server(
   indexV4?: express.Router,
 ): Express {
   const app: Express = express();
+
+  app.use(geoHeadersMiddleware);
 
   app.use(responseTime({ suffix: false }));
 

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -3,6 +3,7 @@ import { Channel, OutgoingMessageType } from '../../src/types';
 import { Subscriptions } from '../../src/lib/subscription';
 import { sendMessage, sendMessageString } from '../../src/helpers/wss';
 import { RateLimiter } from '../../src/lib/rate-limit';
+import { GeoOriginStatus } from '@dydxprotocol-indexer/compliance';
 import {
   blockHeightRefresher,
   CandleResolution,
@@ -99,7 +100,11 @@ describe('Subscriptions', () => {
     [Channel.V4_BLOCK_HEIGHT]: ['v4/height'],
   };
   const initialMessage: Object = ['a', 'b'];
-  const country: string = 'AR';
+  const geoOriginHeaders = {
+    'geo-origin-country': 'AR', // Argentina
+    'geo-origin-region': 'AR-V', // Tierra del Fuego
+    'geo-origin-status': GeoOriginStatus.OK,
+  };
 
   beforeAll(async () => {
     await dbHelpers.migrate();
@@ -162,7 +167,7 @@ describe('Subscriptions', () => {
         initialMsgId,
         id,
         false,
-        country,
+        geoOriginHeaders,
       );
 
       expect(sendMessageStringMock).toHaveBeenCalledTimes(1);
@@ -182,9 +187,7 @@ describe('Subscriptions', () => {
         for (const urlPattern of urlPatterns) {
           expect(axiosRequestMock).toHaveBeenCalledWith(expect.objectContaining({
             url: expect.stringMatching(RegExp(urlPattern)),
-            headers: {
-              'cf-ipcountry': country,
-            },
+            headers: geoOriginHeaders,
           }));
         }
       } else {
@@ -385,7 +388,7 @@ describe('Subscriptions', () => {
         initialMsgId,
         mockSubaccountId,
         false,
-        country,
+        geoOriginHeaders,
       );
 
       expect(sendMessageMock).toHaveBeenCalledTimes(1);
@@ -414,7 +417,7 @@ describe('Subscriptions', () => {
         initialMsgId,
         mockSubaccountId,
         false,
-        country,
+        geoOriginHeaders,
       );
 
       expect(sendMessageStringMock).toHaveBeenCalledTimes(1);
@@ -452,7 +455,7 @@ describe('Subscriptions', () => {
         initialMsgId,
         id,
         false,
-        country,
+        geoOriginHeaders,
       );
       subscriptions.unsubscribe(
         connectionId,
@@ -472,7 +475,7 @@ describe('Subscriptions', () => {
         initialMsgId,
         mockSubaccountId,
         false,
-        country,
+        geoOriginHeaders,
       );
       subscriptions.unsubscribe(
         connectionId,
@@ -500,7 +503,7 @@ describe('Subscriptions', () => {
         initialMsgId,
         invalidSubaccountId,
         false,
-        country,
+        geoOriginHeaders,
       );
 
       expect(sendMessageMock).toHaveBeenCalledTimes(1);

--- a/indexer/services/socks/src/helpers/header-utils.ts
+++ b/indexer/services/socks/src/helpers/header-utils.ts
@@ -1,8 +1,12 @@
-import { CountryHeaders } from '@dydxprotocol-indexer/compliance';
+import { GeoOriginHeaders } from '@dydxprotocol-indexer/compliance';
 
 import { IncomingMessage } from '../types';
 
-export function getCountry(req: IncomingMessage): string | undefined {
-  const countryHeaders: CountryHeaders = req.headers as CountryHeaders;
-  return countryHeaders['cf-ipcountry'];
+export function getGeoOriginHeaders(req: IncomingMessage): GeoOriginHeaders {
+  const geoOriginHeaders = req.headers as GeoOriginHeaders;
+  return {
+    'geo-origin-country': geoOriginHeaders['geo-origin-country'],
+    'geo-origin-region': geoOriginHeaders['geo-origin-region'],
+    'geo-origin-status': geoOriginHeaders['geo-origin-status'],
+  } as GeoOriginHeaders;
 }

--- a/indexer/services/socks/src/types.ts
+++ b/indexer/services/socks/src/types.ts
@@ -1,5 +1,6 @@
 import { IncomingMessage as IncomingMessageHttp } from 'http';
 
+import { GeoOriginHeaders } from '@dydxprotocol-indexer/compliance';
 import express from 'express';
 import WebSocket from 'ws';
 
@@ -125,7 +126,7 @@ export interface Connection {
   messageId: number,
   heartbeat?: NodeJS.Timeout,
   disconnect?: NodeJS.Timeout,
-  countryCode?: string,
+  geoOriginHeaders?: GeoOriginHeaders,
   id: string,
 }
 

--- a/indexer/services/socks/src/websocket/index.ts
+++ b/indexer/services/socks/src/websocket/index.ts
@@ -6,7 +6,7 @@ import {
 import WebSocket from 'ws';
 
 import config from '../config';
-import { getCountry } from '../helpers/header-utils';
+import { getGeoOriginHeaders } from '../helpers/header-utils';
 import { createConnectedMessage, createErrorMessage, createUnsubscribedMessage } from '../helpers/message';
 import { sendMessage, Wss } from '../helpers/wss';
 import { ERR_INVALID_WEBSOCKET_FRAME, WS_CLOSE_CODE_SERVICE_RESTART, WS_CLOSE_HEARTBEAT_TIMEOUT } from '../lib/constants';
@@ -92,8 +92,8 @@ export class Index {
     this.connections[connectionId] = {
       ws,
       messageId: 0,
-      countryCode: getCountry(req),
       id: connectionId,
+      geoOriginHeaders: getGeoOriginHeaders(req),
     } as Connection;
     const connection: Connection = this.connections[connectionId];
 
@@ -287,7 +287,7 @@ export class Index {
           connection.messageId,
           subscribeMessage.id,
           subscribeMessage.batched,
-          connection.countryCode,
+          connection.geoOriginHeaders,
         ).catch((error: Error) => logger.error({
           at: 'Subscription#subscribe',
           message: `Subscribing threw error: ${error.message}`,


### PR DESCRIPTION
### Changelist
For all comlink api's, if any Geo-Origin headers are present, apply them to the responses to reflect them to clients:
- Geo-Origin-Country
- Geo-Origin-Region
- Geo-Origin-Status

Modify geo-blocking logic to condition restriction on geo-origin-status and not ipcountry.

### Test Plan

#### Unit Tests
Added tests for header propagation, case-insensitivity, empty values, and geoblocking behavior.

#### Live Tests
Deployed to internal environments and testnet.

Validated origin blocking through origins faked with Cloudflare.