### PR TITLE
[ENG-899] Add dYdX.trade email domain to Turnkey Emails.

### DIFF
--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -107,7 +107,7 @@ export const configSchema = {
   SOLANA_SPONSOR_PUBLIC_KEY: parseString({ default: '' }),
   SKIP_SLIPPAGE_TOLERANCE_PERCENTAGE: parseString({ default: '0' }),
   TURNKEY_EMAIL_SENDER_ADDRESS: parseString({ default: 'notifications@mail.dydx.trade' }),
-  TURNKEY_EMAIL_SENDER_NAME: parseString({ default: 'dydx Notifications' }),
+  TURNKEY_EMAIL_SENDER_NAME: parseString({ default: 'dYdX Notifications' }),
   // Alchemy auth token for the skip bridge.
   ALCHEMY_AUTH_TOKEN: parseString({ default: '' }),
   ALCHEMY_API_KEY: parseString({ default: '' }),

--- a/indexer/services/comlink/src/lib/turnkey-helpers.ts
+++ b/indexer/services/comlink/src/lib/turnkey-helpers.ts
@@ -280,6 +280,8 @@ export class TurnkeyHelpers {
     const emailAuthResponse = await this.turnkeyApiClient.emailAuth({
       email: lowerEmail,
       targetPublicKey,
+      sendFromEmailAddress: config.TURNKEY_EMAIL_SENDER_ADDRESS,
+      sendFromEmailSenderName: config.TURNKEY_EMAIL_SENDER_NAME,
       emailCustomization: {
         appName: TURNKEY_EMAIL_CUSTOMIZATION.APP_NAME,
         logoUrl: TURNKEY_EMAIL_CUSTOMIZATION.LOGO_URL,


### PR DESCRIPTION
### Changelist


### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email sign-in messages now use a configured sender address and display name, improving branding and clarity in inboxes.
* **Chores**
  * Updated the default email sender name to “dYdX Notifications.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->