### PR TITLE
Reduce default liquidation daemon frequency from 1.6s -> 0.8s

### DIFF
--- a/protocol/daemons/flags/flags.go
+++ b/protocol/daemons/flags/flags.go
@@ -107,7 +107,7 @@ func GetDefaultDaemonFlags() DaemonFlags {
 			},
 			Liquidation: LiquidationFlags{
 				Enabled:           true,
-				LoopDelayMs:       1_600,
+				LoopDelayMs:       800,
 				QueryPageLimit:    1_000,
 				ResponsePageLimit: 2_000,
 			},


### PR DESCRIPTION
### Changelist

Change the default liquidation daemon loop delay to `800ms`, which is inline with the current block time (~760ms). Note: current liquidation task duration [< 600ms](https://app.datadoghq.com/dashboard/fbc-gkh-ywa/v4-clob?fromUser=true&refresh_mode=paused&tpl_var_ecs_cluster%5B0%5D=*&tpl_var_env%5B0%5D=mainnet&tpl_var_service%5B0%5D=*&tpl_var_validator_name%5B0%5D=*&from_ts=1757177871647&to_ts=1759769871647&live=false&tile_focus=2017160974125406). 

If the task duration exceeds 800ms, then the behavior is that a new task will simply immediately fire off when the previous task returns (no overlapping task; no multi-round catchup). See loop [code](https://github.com/dydxprotocol/v4-chain/blob/7be3a40804c6bcda50cdc9550fa114f2e3ef1858/protocol/daemons/liquidation/client/client.go#L127-L139)

This change can be applied by validators on a rolling basis.


### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the default loop delay for the liquidation background process from 1600 ms to 800 ms, improving responsiveness of liquidation detection and execution under default settings.
  * Users may notice faster updates to positions and liquidation-related status during volatile conditions.
  * No functional changes to flags or behavior beyond the timing adjustment; minor increase in background processing frequency may slightly raise resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->