### PR TITLE
perf(socks): reduce young heap, remove old heap size override

### DIFF
--- a/indexer/services/socks/package.json
+++ b/indexer/services/socks/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "build/index",
   "scripts": {
-    "start": "node --max-semi-space-size=512 --max-old-space-size=2368 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
+    "start": "node --max-semi-space-size=64 --heapsnapshot-signal=SIGUSR2 -r dd-trace/init -r dotenv-flow/config build/src/index.js",
     "build": "rm -rf build/ && tsc",
     "build:prod": "pnpm run build",
     "build:watch": "pnpm run build -- --watch",


### PR DESCRIPTION
### Changelist

Reduce semi-space size to 64MiB (x3)

Remove old space size override. Old heap size will be managed automatically by node. Instance memory configuration will constrain maximum heap size.

### Test Plan
Unit tests and deployment to internal networks and public testnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->