### PR TITLE
metrics(socks): add largest subscription per channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,19 @@
+# proto
 .gen
 .proto-export
 .proto-export-deps
-v4-proto-py/build
-v4-proto-py/dist
-v4-proto-py/v4_proto.egg-info/
-v4-proto-py/v4_proto
 v4-proto-js/build
 v4-proto-js/node_modules
 v4-proto-js/src
-v4-proto-rs/target
+v4-proto-py/build
+v4-proto-py/dist
+v4-proto-py/v4_proto
+v4-proto-py/v4_proto.egg-info/
 v4-proto-rs/Cargo.lock
+v4-proto-rs/target
 
+# dev
+**/.DS_Store
+.aider*
 .idea
 .vscode
-**/.DS_Store

--- a/indexer/packages/base/src/instance-id.ts
+++ b/indexer/packages/base/src/instance-id.ts
@@ -10,7 +10,12 @@ export function getInstanceId(): string {
   return INSTANCE_ID;
 }
 
-export async function setInstanceId(): Promise<void> {
+export async function setInstanceId(instanceId? : string): Promise<void> {
+  if (instanceId !== undefined) {
+    INSTANCE_ID = instanceId;
+    return;
+  }
+
   if (INSTANCE_ID !== '') {
     return;
   }

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -11,10 +11,15 @@ import {
   MAX_PARENT_SUBACCOUNTS,
   blockHeightRefresher,
 } from '@dydxprotocol-indexer/postgres';
-import { btcTicker, invalidChannel, invalidTicker } from '../constants';
+import {
+  btcTicker, ethTicker, invalidChannel, invalidTicker,
+} from '../constants';
 import { axiosRequest } from '../../src/lib/axios';
-import { AxiosSafeServerError, makeAxiosSafeServerError } from '@dydxprotocol-indexer/base';
+import {
+  AxiosSafeServerError, makeAxiosSafeServerError, stats, setInstanceId,
+} from '@dydxprotocol-indexer/base';
 import { BlockedError } from '../../src/lib/errors';
+import config from '../../src/config';
 
 jest.mock('ws');
 jest.mock('../../src/helpers/wss');
@@ -32,9 +37,11 @@ describe('Subscriptions', () => {
   const connectionId: string = 'connectionId';
   const initialMsgId: number = 1;
   const defaultId: string = 'id';
+  const defaultId1: string = 'id1';
   const mockSubaccountId: string = 'address/0';
+  const mockSubaccountId1: string = 'address/1';
   const invalidCandleResolution: string = 'candleResolution';
-  const validIds: Record<Channel, string> = {
+  const singleIds: Record<Channel, string> = {
     [Channel.V4_ACCOUNTS]: mockSubaccountId,
     [Channel.V4_CANDLES]: `${btcTicker}/${CandleResolution.ONE_DAY}`,
     [Channel.V4_MARKETS]: defaultId,
@@ -43,8 +50,16 @@ describe('Subscriptions', () => {
     [Channel.V4_PARENT_ACCOUNTS]: mockSubaccountId,
     [Channel.V4_BLOCK_HEIGHT]: defaultId,
   };
-  const invalidIdsMap:
-  Record<Exclude<Channel, Channel.V4_MARKETS | Channel.V4_BLOCK_HEIGHT>, string[]> = {
+  const multipleIds: Record<Channel, string[]> = {
+    [Channel.V4_ACCOUNTS]: [mockSubaccountId, mockSubaccountId1],
+    [Channel.V4_CANDLES]: [`${btcTicker}/${CandleResolution.ONE_DAY}`, `${btcTicker}/${CandleResolution.ONE_DAY}`],
+    [Channel.V4_MARKETS]: [defaultId, defaultId1],
+    [Channel.V4_ORDERBOOK]: [btcTicker, ethTicker],
+    [Channel.V4_TRADES]: [btcTicker, ethTicker],
+    [Channel.V4_PARENT_ACCOUNTS]: [mockSubaccountId, mockSubaccountId1],
+    [Channel.V4_BLOCK_HEIGHT]: [defaultId, defaultId1],
+  };
+  const invalidIdsMap: Record<Channel, string[]> = {
     [Channel.V4_ACCOUNTS]: [invalidTicker],
     [Channel.V4_CANDLES]: [
       `${invalidTicker}/${CandleResolution.ONE_DAY}`,
@@ -54,6 +69,8 @@ describe('Subscriptions', () => {
     [Channel.V4_ORDERBOOK]: [invalidTicker],
     [Channel.V4_TRADES]: [invalidTicker],
     [Channel.V4_PARENT_ACCOUNTS]: [`address/${MAX_PARENT_SUBACCOUNTS}`],
+    [Channel.V4_BLOCK_HEIGHT]: ['unused'],
+    [Channel.V4_MARKETS]: ['unused'],
   };
   const initialResponseUrlPatterns: Record<Channel, string[] | undefined> = {
     [Channel.V4_ACCOUNTS]: [
@@ -82,6 +99,8 @@ describe('Subscriptions', () => {
       perpetualMarketRefresher.updatePerpetualMarkets(),
       blockHeightRefresher.updateBlockHeight(),
     ]);
+    config.SERVICE_NAME = 'socks-test';
+    await setInstanceId('test-instance-id');
   });
 
   afterAll(async () => {
@@ -90,6 +109,7 @@ describe('Subscriptions', () => {
   });
 
   beforeEach(() => {
+    jest.useFakeTimers();
     (WebSocket as unknown as jest.Mock).mockClear();
     subscriptions = new Subscriptions();
     subscriptions.start(jest.fn());
@@ -102,15 +122,19 @@ describe('Subscriptions', () => {
     axiosRequestMock.mockImplementation(() => (JSON.stringify(initialMessage)));
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe('subscribe', () => {
     it.each([
-      [Channel.V4_ACCOUNTS, validIds[Channel.V4_ACCOUNTS]],
-      [Channel.V4_CANDLES, validIds[Channel.V4_CANDLES]],
-      [Channel.V4_MARKETS, validIds[Channel.V4_MARKETS]],
-      [Channel.V4_ORDERBOOK, validIds[Channel.V4_ORDERBOOK]],
-      [Channel.V4_TRADES, validIds[Channel.V4_TRADES]],
-      [Channel.V4_PARENT_ACCOUNTS, validIds[Channel.V4_PARENT_ACCOUNTS]],
-      [Channel.V4_BLOCK_HEIGHT, validIds[Channel.V4_BLOCK_HEIGHT]],
+      [Channel.V4_ACCOUNTS, singleIds[Channel.V4_ACCOUNTS]],
+      [Channel.V4_CANDLES, singleIds[Channel.V4_CANDLES]],
+      [Channel.V4_MARKETS, singleIds[Channel.V4_MARKETS]],
+      [Channel.V4_ORDERBOOK, singleIds[Channel.V4_ORDERBOOK]],
+      [Channel.V4_TRADES, singleIds[Channel.V4_TRADES]],
+      [Channel.V4_PARENT_ACCOUNTS, singleIds[Channel.V4_PARENT_ACCOUNTS]],
+      [Channel.V4_BLOCK_HEIGHT, singleIds[Channel.V4_BLOCK_HEIGHT]],
     ])('handles valid subscription request to channel %s', async (
       channel: Channel,
       id: string,
@@ -321,12 +345,12 @@ describe('Subscriptions', () => {
 
   describe('unsubscribe', () => {
     it.each([
-      [Channel.V4_ACCOUNTS, validIds[Channel.V4_ACCOUNTS]],
-      [Channel.V4_CANDLES, validIds[Channel.V4_CANDLES]],
-      [Channel.V4_MARKETS, validIds[Channel.V4_MARKETS]],
-      [Channel.V4_ORDERBOOK, validIds[Channel.V4_ORDERBOOK]],
-      [Channel.V4_TRADES, validIds[Channel.V4_TRADES]],
-      [Channel.V4_BLOCK_HEIGHT, validIds[Channel.V4_BLOCK_HEIGHT]],
+      [Channel.V4_ACCOUNTS, singleIds[Channel.V4_ACCOUNTS]],
+      [Channel.V4_CANDLES, singleIds[Channel.V4_CANDLES]],
+      [Channel.V4_MARKETS, singleIds[Channel.V4_MARKETS]],
+      [Channel.V4_ORDERBOOK, singleIds[Channel.V4_ORDERBOOK]],
+      [Channel.V4_TRADES, singleIds[Channel.V4_TRADES]],
+      [Channel.V4_BLOCK_HEIGHT, singleIds[Channel.V4_BLOCK_HEIGHT]],
     ])('handles valid unsubscription request to channel %s', async (
       channel: Channel,
       id: string,
@@ -380,14 +404,14 @@ describe('Subscriptions', () => {
           channel,
           connectionId,
           initialMsgId,
-          validIds[channel],
+          singleIds[channel],
           false,
         );
       }));
 
       for (const channel of Object.values(Channel)) {
-        expect(subscriptions.subscriptions[channel][validIds[channel]]).toHaveLength(1);
-        expect(subscriptions.subscriptions[channel][validIds[channel]]).toContainEqual(
+        expect(subscriptions.subscriptions[channel][singleIds[channel]]).toHaveLength(1);
+        expect(subscriptions.subscriptions[channel][singleIds[channel]]).toContainEqual(
           expect.objectContaining({ connectionId }),
         );
       }
@@ -398,9 +422,162 @@ describe('Subscriptions', () => {
       subscriptions.remove(connectionId);
 
       for (const channel of Object.values(Channel)) {
-        expect(subscriptions.subscriptions[channel][validIds[channel]]).toHaveLength(0);
+        expect(subscriptions.subscriptions[channel][singleIds[channel]]).toHaveLength(0);
       }
       expect(subscriptions.subscriptionLists[connectionId]).toBeUndefined();
+    });
+  });
+
+  describe('emitLargestSubscriberMetric', () => {
+
+    it('emits metrics for largest subscriber per channel', async () => {
+      const statsSpy = jest.spyOn(stats, 'gauge');
+
+      // Subscribe connection 1 to multiple channels
+      await subscriptions.subscribe(
+        mockWs,
+        Channel.V4_ACCOUNTS,
+        'connection1',
+        initialMsgId,
+        singleIds[Channel.V4_ACCOUNTS],
+        false,
+      );
+      await subscriptions.subscribe(
+        mockWs,
+        Channel.V4_TRADES,
+        'connection1',
+        initialMsgId,
+        singleIds[Channel.V4_TRADES],
+        false,
+      );
+      await subscriptions.subscribe(
+        mockWs,
+        Channel.V4_ORDERBOOK,
+        'connection1',
+        initialMsgId,
+        singleIds[Channel.V4_ORDERBOOK],
+        false,
+      );
+
+      // verify metrics emitted for each channel with subscriptions
+      // accounts: 1
+      expect(statsSpy).toHaveBeenCalledWith(
+        `${config.SERVICE_NAME}.subscriptions.channel_size`,
+        1,
+        {
+          channel: Channel.V4_ACCOUNTS,
+          instance: 'test-instance-id',
+        },
+      );
+      // trades: 1
+      expect(statsSpy).toHaveBeenCalledWith(
+        `${config.SERVICE_NAME}.subscriptions.channel_size`,
+        1,
+        {
+          channel: Channel.V4_TRADES,
+          instance: 'test-instance-id',
+        },
+      );
+      // orders: 1
+      expect(statsSpy).toHaveBeenCalledWith(
+        `${config.SERVICE_NAME}.subscriptions.channel_size`,
+        1,
+        {
+          channel: Channel.V4_ORDERBOOK,
+          instance: 'test-instance-id',
+        },
+      );
+      jest.advanceTimersByTime(config.LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS);
+      // accounts: 1
+      expect(statsSpy).toHaveBeenCalledWith(
+        `${config.SERVICE_NAME}.subscriptions.channel_size`,
+        1,
+        {
+          channel: Channel.V4_ACCOUNTS,
+          instance: 'test-instance-id',
+        },
+      );
+
+      // trades: 1
+      expect(statsSpy).toHaveBeenCalledWith(
+        `${config.SERVICE_NAME}.subscriptions.channel_size`,
+        1,
+        {
+          channel: Channel.V4_TRADES,
+          instance: 'test-instance-id',
+        },
+      );
+
+      // books: 1
+      expect(statsSpy).toHaveBeenCalledWith(
+        `${config.SERVICE_NAME}.subscriptions.channel_size`,
+        1,
+        {
+          channel: Channel.V4_ORDERBOOK,
+          instance: 'test-instance-id',
+        },
+      );
+
+      // Subscribe connection 2 to fewer channels
+      // for each id in multipleIds[Channel.V4_ACCOUNTS], subscribe to the channel
+      for (const id of multipleIds[Channel.V4_ACCOUNTS]) {
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ACCOUNTS,
+          'connection2',
+          initialMsgId,
+          id,
+          false,
+        );
+      }
+      // for each id in multipleIds[Channel.V4_TRADES], subscribe to the channel
+      for (const id of multipleIds[Channel.V4_TRADES]) {
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_TRADES,
+          'connection2',
+          initialMsgId,
+          id,
+          false,
+        );
+      }
+
+      // Advance timers to trigger metric emission
+      jest.advanceTimersByTime(config.LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS);
+
+      // accounts: 2
+      expect(statsSpy).toHaveBeenCalledWith(
+        `${config.SERVICE_NAME}.subscriptions.channel_size`,
+        2,
+        {
+          channel: Channel.V4_ACCOUNTS,
+          instance: 'test-instance-id',
+        },
+      );
+
+      // orders: 2
+      expect(statsSpy).toHaveBeenCalledWith(
+        `${config.SERVICE_NAME}.subscriptions.channel_size`,
+        2,
+        {
+          channel: Channel.V4_TRADES,
+          instance: 'test-instance-id',
+        },
+      );
+    });
+
+    it('does not emit metrics when no subscriptions exist', () => {
+      const statsSpy = jest.spyOn(stats, 'gauge');
+
+      // Advance timers to trigger metric emission
+      jest.advanceTimersByTime(config.LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS);
+
+      // Should not emit any largest_subscriber metrics
+      expect(statsSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('largest_subscriber'),
+        expect.anything(),
+        expect.anything(),
+      );
     });
   });
 });

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -53,6 +53,9 @@ export const configSchema = {
   KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS: parseNumber({
     default: 3_000,
   }),
+
+  // Metrics
+  LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS: parseInteger({ default: 60 * 1000 }), // 1 minute
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -53,6 +53,8 @@ export class Subscriptions {
   // Tracks the # of ids per channel socks will forward messages for
   // Make public to access in tests
   public subscribedIdsPerChannel: { [channel: string]: Set<string> };
+  private largestSubscriberMetricsInterval?: NodeJS.Timeout;
+  public subsByChannelByConnectionId: { [channel: string]: { [connectionId: string]: number } };
 
   private subscribeRateLimiter: RateLimiter;
 
@@ -67,11 +69,17 @@ export class Subscriptions {
       durationMs: config.RATE_LIMIT_SUBSCRIBE_DURATION_MS,
     });
     this.subscribedIdsPerChannel = {};
+    this.subsByChannelByConnectionId = {};
     this.forwardMessage = undefined;
   }
 
   public start(forwardMessage: (message: MessageToForward, connectionId: string) => number): void {
     this.forwardMessage = forwardMessage;
+
+    this.largestSubscriberMetricsInterval = setInterval(
+      () => this.emitLargestSubscriberMetric(),
+      config.LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS,
+    );
   }
 
   /**
@@ -299,6 +307,10 @@ export class Subscriptions {
         instance: getInstanceId(),
       },
     );
+
+    this.subsByChannelByConnectionId[channel] ??= {};
+    this.subsByChannelByConnectionId[channel][connectionId] ??= 0;
+    this.subsByChannelByConnectionId[channel][connectionId] += 1;
   }
 
   /**
@@ -315,6 +327,10 @@ export class Subscriptions {
     channel: Channel,
     id?: string,
   ): void {
+
+    this.subsByChannelByConnectionId[channel] ??= {};
+    this.subsByChannelByConnectionId[channel][connectionId] ??= 0;
+
     const subscriptionId: string = this.normalizeSubscriptionId(channel, id);
     if (this.subscriptionLists[connectionId]) {
       this.subscriptionLists[connectionId] = this.subscriptionLists[connectionId].filter(
@@ -342,6 +358,10 @@ export class Subscriptions {
           (e: SubscriptionInfo) => (e.connectionId !== connectionId),
         );
       subscribedConnections += this.batchedSubscriptions[channel][subscriptionId].length;
+    }
+
+    if (this.subsByChannelByConnectionId[channel][connectionId] > 0) {
+      this.subsByChannelByConnectionId[channel][connectionId] -= 1;
     }
 
     // If 0 connections are subscribed to the id for this channel after this unsubscribe, socks will
@@ -523,7 +543,7 @@ export class Subscriptions {
         const {
           ticker,
           resolution,
-        } : {
+        }: {
           ticker: string,
           resolution?: CandleResolution,
         } = this.parseCandleChannelId(id);
@@ -549,7 +569,7 @@ export class Subscriptions {
       const {
         address,
         subaccountNumber,
-      } : {
+      }: {
         address: string,
         subaccountNumber: string,
       } = this.parseSubaccountChannelId(id);
@@ -561,11 +581,7 @@ export class Subscriptions {
         subaccountsResponse,
         ordersResponse,
         currentBestEffortCanceledOrdersResponse,
-      ]: [
-        string,
-        string,
-        string,
-      ] = await Promise.all([
+      ]: string[] = await Promise.all([
         axiosRequest({
           method: RequestMethod.GET,
           url: `${COMLINK_URL}/v4/addresses/${address}/subaccountNumber/${subaccountNumber}`,
@@ -641,7 +657,7 @@ export class Subscriptions {
       const {
         address,
         subaccountNumber,
-      } : {
+      }: {
         address: string,
         subaccountNumber: string,
       } = this.parseSubaccountChannelId(id);
@@ -653,11 +669,7 @@ export class Subscriptions {
         subaccountsResponse,
         ordersResponse,
         currentBestEffortCanceledOrdersResponse,
-      ]: [
-        string,
-        string,
-        string,
-      ] = await Promise.all([
+      ]: string[] = await Promise.all([
         axiosRequest({
           method: RequestMethod.GET,
           url: `${COMLINK_URL}/v4/addresses/${address}/parentSubaccountNumber/${subaccountNumber}`,
@@ -739,8 +751,7 @@ export class Subscriptions {
     const parts: string[] = id.split('/');
     const ticker: string = parts[0];
     const resolutionString: string = parts[1];
-    const resolution:
-    CandleResolution | undefined = Object.values(CandleResolution)
+    const resolution: CandleResolution | undefined = Object.values(CandleResolution)
       .find((cr) => cr === resolutionString);
     return { ticker, resolution };
   }
@@ -777,5 +788,57 @@ export class Subscriptions {
       },
       transformResponse: (res) => res, // Disables JSON parsing
     });
+  }
+
+  private emitLargestSubscriberMetric(): void {
+    const maxSubscriptionsByChannel: { [channel: string]: number } = {};
+    const maxIdByChannel: { [channel: string]: string } = {};
+
+    Object.entries(this.subsByChannelByConnectionId).forEach(
+      ([channel, subscribedIdsByConnectionId]) => {
+        let maxId: string = '';
+        let maxSubscriptions: number = 0;
+        Object.entries(subscribedIdsByConnectionId).forEach(([connectionId, subscriptions]) => {
+          if (subscriptions > (maxSubscriptions || 0)) {
+            maxSubscriptions = subscriptions;
+            maxId = connectionId;
+          }
+        });
+        maxIdByChannel[channel] = maxId;
+        maxSubscriptionsByChannel[channel] = maxSubscriptions;
+      });
+
+    Object.entries(maxSubscriptionsByChannel).forEach(([channel, count]) => {
+      stats.gauge(
+        `${config.SERVICE_NAME}.largest_subscriber`,
+        count,
+        {
+          instance: getInstanceId(),
+          channel,
+        },
+      );
+    });
+
+    if (Object.keys(maxSubscriptionsByChannel).length > 0) {
+      logger.info({
+        at: 'Subscriptions#emitLargestSubscriberMetric',
+        message: 'Max subscriptions by channel',
+        maxSubscriptionsByChannel,
+      });
+    }
+
+    if (Object.keys(maxIdByChannel).length > 0) {
+      logger.info({
+        at: 'Subscriptions#emitLargestSubscriberMetric',
+        message: 'Max id by channel',
+        maxIdByChannel,
+      });
+    }
+  }
+
+  public stop(): void {
+    if (this.largestSubscriberMetricsInterval !== undefined) {
+      clearInterval(this.largestSubscriberMetricsInterval);
+    }
   }
 }


### PR DESCRIPTION
## Changes
This PR enhances the **socks** service observability by introducing a new periodic metric that reports the **largest subscriber per channel**.
It helps identify imbalanced load or oversubscription patterns across websocket channels, improving visibility and long-term stability.

- Adds periodic "largest subscriber" metric with a configurable interval for improved observability:
    
    socks.largest_subscriber{channel, instance}

    Reports the highest subscription count (number of channel subscriptions) held by any single connection per channel.

- Introduced configuration:
    
    LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS = 60_000  // default 1 minute

- Added `Subscriptions#subsByChannelByConnectionId` to track per-connection subscription counts per channel.

- Implemented `emitLargestSubscriberMetric()`:
  - Computes the largest subscriber on each channel.
  - Emits the gauge metric via `stats.gauge` with tags `{ channel, instance }`.
  - Logs the max subscription counts and connection IDs per channel for debugging.

- Added graceful shutdown on SIGINT

- Add optional override for explicitly setting the service instance ID to simplify testing

## Testing
### Unit tests
  `indexer/services/socks/__tests__/lib/subscriptions.test.ts`:
  - Verifies metrics are emitted correctly when subscriptions exist.
  - Ensures no "largest_subscriber" metrics are emitted when there are zero subscriptions.
  - Uses fake timers to test interval-driven metric behavior.
  - Validates `stats.gauge` invocations (with expected `channel` and `instance` tags).
### Live testing
 - Testnet
 - Mainnet