### PR TITLE
fix(socks): calculate subscriptions.channel_size metric dynamically and consistently

### DIFF
--- a/indexer/packages/dev/package.json
+++ b/indexer/packages/dev/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4",
     "jest": "^28.1.2",
+    "jest-extended":"^6.0.0",
     "typescript": "^4.7.4"
   },
   "repository": {

--- a/indexer/pnpm-lock.yaml
+++ b/indexer/pnpm-lock.yaml
@@ -103,6 +103,7 @@ importers:
       eslint-plugin-react: ^7.21.5
       eslint-plugin-react-hooks: ^4
       jest: ^28.1.2
+      jest-extended: ^6.0.0
       typescript: ^4.7.4
     dependencies:
       dotenv-flow: 3.2.0
@@ -120,6 +121,7 @@ importers:
       eslint-plugin-react: 7.30.1_eslint@8.19.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.19.0
       jest: 28.1.2_@types+node@18.0.3
+      jest-extended: 6.0.0_jest@28.1.2+typescript@4.7.4
       typescript: 4.7.4
 
   packages/example-package:
@@ -831,6 +833,7 @@ importers:
       express: ^4.18.1
       express-request-id: ^1.4.0
       jest: ^28.1.2
+      jest-extended: ^6.0.0
       kafkajs: 2.2.4
       lodash: ^4.17.21
       nocache: ^3.0.4
@@ -873,6 +876,7 @@ importers:
       '@types/response-time': 2.3.5
       '@types/ws': 8.5.10
       jest: 28.1.2_e1489a60da1bfeaddb37cf23d6a3b371
+      jest-extended: 6.0.0_jest@28.1.2+typescript@4.7.4
       ts-node: 10.8.2_4ea55324100c26d4019c6e6bcc89fac6
       tsconfig-paths: 4.0.0
       typescript: 4.7.4
@@ -6480,17 +6484,18 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@jest/schemas/28.0.2:
-    resolution: {integrity: sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.23.5
-
   /@jest/schemas/28.1.3:
     resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@sinclair/typebox': 0.24.51
+
+  /@jest/schemas/29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
 
   /@jest/source-map/28.1.2:
     resolution: {integrity: sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==}
@@ -6567,7 +6572,7 @@ packages:
     resolution: {integrity: sha512-vRXVqSg1VhDnB8bWcmvLzmg0Bt9CRKVgHPXqYwvWMX3TvAjeO+nRuK6+VdTKCtWOvYlmkF/HqNAL/z+N3B53Kw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@jest/schemas': 28.0.2
+      '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 24.1.0
@@ -7161,11 +7166,12 @@ packages:
     deprecated: This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates.
     dev: false
 
-  /@sinclair/typebox/0.23.5:
-    resolution: {integrity: sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==}
-
   /@sinclair/typebox/0.24.51:
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
+
+  /@sinclair/typebox/0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
 
   /@sinonjs/commons/1.8.3:
     resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
@@ -10338,6 +10344,11 @@ packages:
   /diff-sequences/28.1.1:
     resolution: {integrity: sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+
+  /diff-sequences/29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
 
   /diff/4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -13646,7 +13657,7 @@ packages:
       pretty-format: 28.1.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.8.2_5faceb518d942d9e0d26e6d93b1febee
+      ts-node: 10.8.2_2dd5d46eecda2aef953638919121af58
     transitivePeerDependencies:
       - supports-color
 
@@ -13778,6 +13789,16 @@ packages:
       jest-get-type: 28.0.2
       pretty-format: 28.1.1
 
+  /jest-diff/29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+    dev: true
+
   /jest-docblock/28.1.1:
     resolution: {integrity: sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -13805,9 +13826,29 @@ packages:
       jest-mock: 28.1.1
       jest-util: 28.1.1
 
+  /jest-extended/6.0.0_jest@28.1.2+typescript@4.7.4:
+    resolution: {integrity: sha512-SM249N/q33YQ9XE8E06qZSnFuuV4GQFx7WrrmIj4wQUAP43jAo6budLT482jdBhf8ASwUiEEfJNjej0UusYs5A==}
+    engines: {node: ^18.12.0 || ^20.9.0 || ^22.11.0 || >=23.0.0}
+    peerDependencies:
+      jest: '>=27.2.5'
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      jest:
+        optional: true
+    dependencies:
+      jest: 28.1.2_@types+node@18.0.3
+      jest-diff: 29.7.0
+      typescript: 4.7.4
+    dev: true
+
   /jest-get-type/28.0.2:
     resolution: {integrity: sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+
+  /jest-get-type/29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
 
   /jest-haste-map/28.1.1:
     resolution: {integrity: sha512-ZrRSE2o3Ezh7sb1KmeLEZRZ4mgufbrMwolcFHNRSjKZhpLa8TdooXOOFlSwoUzlbVs1t0l7upVRW2K7RWGHzbQ==}
@@ -15847,6 +15888,15 @@ packages:
       ansi-styles: 5.2.0
       react-is: 18.2.0
 
+  /pretty-format/29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
+
   /promise.any/2.0.5:
     resolution: {integrity: sha512-aM+D4cv0Sjkc90Qhg19XH8Mo5aw28YWqPTFWFkaOpE80MuPbjH/brgI7NI4YGWbcS3suOa0xjJrYznet7lSHhw==}
     engines: {node: '>= 0.4'}
@@ -17544,6 +17594,7 @@ packages:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
 
   /ts-node/10.8.2_64708740079a51ed2e240ab651df249f:
     resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}

--- a/indexer/services/socks/package.json
+++ b/indexer/services/socks/package.json
@@ -51,6 +51,7 @@
     "@types/response-time": "^2.3.5",
     "@types/ws": "^8.5.10",
     "jest": "^28.1.2",
+    "jest-extended":"^6.0.0",
     "ts-node": "^10.8.2",
     "tsconfig-paths": "^4.0.0",
     "typescript": "^4.7.4"

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -55,7 +55,7 @@ export const configSchema = {
   }),
 
   // Metrics
-  LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS: parseInteger({ default: 60 * 1000 }), // 1 minute
+  SUBSCRIPTION_METRIC_INTERVAL_MS: parseInteger({ default: 60 * 1000 }), // 1 minute
 
   // Per-Channel Limits
   V4_ACCOUNTS_CHANNEL_LIMIT: parseInteger({ default: 256 }),


### PR DESCRIPTION
### Summary
This change refactors the `Subscriptions` module to emit metrics dynamically and fixes calculation of the channel sizes following websocket disconnects.

### Changes
#### Metrics
  - Renamed `LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS` → `SUBSCRIPTION_METRIC_INTERVAL_MS`
  - Replaced `emitLargestSubscriberMetric` with `emitSubscriptionMetrics` to compute both:
    - `largest_subscriber` gauge — maximum number of subscriptions per channel across connections
    - `subscriptions.channel_size` gauge — total active subscriptions per channel
  - Removed `subscribedIdsPerChannel` and immediate metric emission in favor of periodic dynamic calculation

#### Subscription Logic
  - Simplified unsubscribe and cleanup logic for batched and non-batched subscriptions.
  - Normalized ID validation, initial response generation, and error handling for clarity and consistency.

### Testing
  - Added `jest-extended` for extended matcher support in unit tests.
  - Updated `subscriptions.test.ts` to validate both `largest_subscriber` and `subscriptions.channel_size` emissions.
  - Consolidated repetitive test logic for channel coverage and improved assertion clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved subscription handling with per-connection and per-channel visibility for clearer state and metrics.

- Refactor
  - Renamed configuration key from LARGEST_SUBSCRIBER_METRIC_INTERVAL_MS to SUBSCRIPTION_METRIC_INTERVAL_MS.
  - Metric emission and timing aligned with the new subscription interval and per-channel counts.

- Tests
  - Added coverage for invalid subaccount scenarios and multi-channel subscriptions; streamlined test flows and assertions.
  - Enabled extended matchers for clearer expectations.

- Chores
  - Updated dev test tooling to include extended matcher support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->