### PR TITLE
TEMPORARY FIX: SKIP ALL LIQUIDATIONS FOR CLOB PAIR 181

### DIFF
--- a/protocol/x/clob/keeper/liquidations.go
+++ b/protocol/x/clob/keeper/liquidations.go
@@ -122,17 +122,21 @@ func (k Keeper) LiquidateSubaccountsAgainstOrderbook(
 			return nil, err
 		}
 
-		optimisticallyFilledQuantums, _, err := k.PlacePerpetualLiquidation(ctx, *liquidationOrder)
-		// Exception for liquidation which conflicts with clob pair status. This is expected for liquidations generated
-		// for subaccounts with open positions in final settlement markets.
-		if err != nil && !errors.Is(err, types.ErrLiquidationConflictsWithClobPairStatus) {
-			log.ErrorLogWithError(
-				ctx,
-				"Failed to liquidate subaccount",
-				err,
-				"liquidationOrder", *liquidationOrder,
-			)
-			return nil, err
+		optimisticallyFilledQuantums := satypes.BaseQuantums(0)
+		// TEMPORARY: ONLY FOR FARTCOIN (CLOB PAIR ID 181) SKIP LIQUIDATIONS AND GO TO DELEVERAGING
+		if !(liquidationOrder.GetClobPairId().ToUint32() == 181) {
+			optimisticallyFilledQuantums, _, err = k.PlacePerpetualLiquidation(ctx, *liquidationOrder)
+			// Exception for liquidation which conflicts with clob pair status. This is expected for liquidations generated
+			// for subaccounts with open positions in final settlement markets.
+			if err != nil && !errors.Is(err, types.ErrLiquidationConflictsWithClobPairStatus) {
+				log.ErrorLogWithError(
+					ctx,
+					"Failed to liquidate subaccount",
+					err,
+					"liquidationOrder", *liquidationOrder,
+				)
+				return nil, err
+			}
 		}
 
 		if optimisticallyFilledQuantums == 0 {


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily pauses liquidations for a specific market to maintain stability; deleveraging may still occur. Other markets are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->