### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/protocol/lib/math.go
+++ b/protocol/lib/math.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"sort"
+	"slices"
 
 	"golang.org/x/exp/constraints"
 )
@@ -182,7 +182,7 @@ func Median[V uint64 | uint32 | int64 | int32](input []V) (V, error) {
 
 	inputCopy := make([]V, l)
 	copy(inputCopy, input)
-	sort.Slice(inputCopy, func(i, j int) bool { return inputCopy[i] < inputCopy[j] })
+	slices.Sort(inputCopy)
 
 	midIdx := l / 2
 

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"slices"
 	"sort"
 	"time"
 
@@ -615,7 +616,7 @@ func (k Keeper) GetRemoveSampleTailsFunc(
 
 		end := int64(len(premiums)) - topRemoval
 
-		sort.Slice(premiums, func(i, j int) bool { return premiums[i] < premiums[j] })
+		slices.Sort(premiums)
 
 		return premiums[bottomRemoval:end]
 	}

--- a/protocol/x/prices/client/testutil/util.go
+++ b/protocol/x/prices/client/testutil/util.go
@@ -1,7 +1,7 @@
 package testutil
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/client/types"
 )
@@ -12,9 +12,7 @@ func GetTickersSortedByMarketId(marketToMarketConfig map[uint32]types.MarketConf
 	for marketId := range marketToMarketConfig {
 		marketIds = append(marketIds, marketId)
 	}
-	sort.Slice(marketIds, func(i, j int) bool {
-		return marketIds[i] < marketIds[j]
-	})
+	slices.Sort(marketIds)
 
 	// Get a list of tickers sorted by their corresponding `marketId`.
 	tickers := make([]string, 0, len(marketToMarketConfig))


### PR DESCRIPTION
### Changelist
[Describe or list the changes made in this PR]


There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.



### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal sorting logic across math utilities, perpetuals processing, and pricing client helpers to use standardized library routines.
  * Improves readability and maintainability while aligning with current language best practices.
  * No changes to public APIs, configuration, or user-facing behavior; result ordering remains identical.
  * Minor internal cleanup only; functionality, outputs, and error handling are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->