### PR TITLE
feat(api): don't strike users from /geoblock*, raise 403

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/compliance-v2-controller.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@dydxprotocol-indexer/postgres';
 import { getIpAddr } from '../../../../src/lib/utils';
 import { sendRequest } from '../../../helpers/helpers';
-import { RequestMethod } from '../../../../src/types';
+import { BlockedCode, RequestMethod } from '../../../../src/types';
 import { stats } from '@dydxprotocol-indexer/base';
 import { redis } from '@dydxprotocol-indexer/redis';
 import { ratelimitRedis } from '../../../../src/caches/rate-limiters';
@@ -19,7 +19,11 @@ import { DateTime } from 'luxon';
 import { ExtendedSecp256k1Signature, Secp256k1 } from '@cosmjs/crypto';
 import { verifyADR36Amino } from '@keplr-wallet/cosmos';
 import { getGeoComplianceReason, ComplianceAction } from '../../../../src/helpers/compliance/compliance-utils';
-import { isRestrictedCountryHeaders, isWhitelistedAddress } from '@dydxprotocol-indexer/compliance';
+import {
+  INDEXER_GEOBLOCKED_PAYLOAD,
+  isRestrictedCountryHeaders,
+  isWhitelistedAddress,
+} from '@dydxprotocol-indexer/compliance';
 import { toBech32 } from '@cosmjs/encoding';
 
 jest.mock('@dydxprotocol-indexer/compliance');
@@ -480,48 +484,21 @@ describe('ComplianceV2Controller', () => {
         expectedStatus: 200,
       });
 
+      // expect compliance status to be empty
       const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
       expect(data).toHaveLength(0);
 
-      expect(response.body.status).toEqual(ComplianceStatus.COMPLIANT);
+      // expect valid response
       expect(response.body.updatedAt).toBeDefined();
+      expect(response.body.status).toEqual(ComplianceStatus.COMPLIANT);
     });
 
-    it('should set status to BLOCKED for CONNECT action from a restricted country with no existing compliance status and no wallet', async () => {
+    it('should return 403 for CONNECT action from a restricted country with no existing compliance status', async () => {
       getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
       isRestrictedCountryHeadersSpy.mockReturnValue(true);
       await dbHelpers.clearData();
 
-      const response: any = await sendRequest({
-        type: RequestMethod.POST,
-        path: endpoint,
-        body,
-        expectedStatus: 200,
-      });
-
-      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).toEqual(expect.objectContaining({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.BLOCKED,
-        reason: ComplianceReason.US_GEO,
-      }));
-
-      expect(stats.increment).toHaveBeenCalledWith(
-        `${config.SERVICE_NAME}.compliance-v2-controller.${endpoint === geoblockEndpoint ? 'geo_block' : 'geo_block_keplr'}.compliance_status_changed.count`,
-        {
-          newStatus: ComplianceStatus.BLOCKED,
-        },
-      );
-
-      expect(response.body.status).toEqual(ComplianceStatus.BLOCKED);
-      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
-      expect(response.body.updatedAt).toBeDefined();
-    });
-
-    it('should set status to FIRST_STRIKE_CLOSE_ONLY for CONNECT action from a restricted country with no existing compliance status and a wallet', async () => {
-      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
-      isRestrictedCountryHeadersSpy.mockReturnValue(true);
+      expect(await ComplianceStatusTable.findAll({}, [], {})).toHaveLength(0);
 
       const response: any = await sendRequest({
         type: RequestMethod.POST,
@@ -530,25 +507,272 @@ describe('ComplianceV2Controller', () => {
           ...body,
           action: ComplianceAction.CONNECT,
         },
-        expectedStatus: 200,
+        expectedStatus: 403,
       });
 
-      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).toEqual(expect.objectContaining({
+      // Verify no database changes occurred
+      expect(await ComplianceStatusTable.findAll({}, [], {})).toHaveLength(0);
+
+      // Verify error response
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].msg).toEqual(INDEXER_GEOBLOCKED_PAYLOAD);
+      expect(response.body.errors[0].code).toEqual(BlockedCode.GEOBLOCKED);
+
+      // Verify no stats were incremented for status changes
+      expect(stats.increment).not.toHaveBeenCalledWith(
+        expect.stringContaining('compliance_status_changed'),
+        expect.any(Object),
+      );
+    });
+
+    it('should return 403 for CONNECT action from a restricted country with existing COMPLIANT status', async () => {
+      await ComplianceStatusTable.create({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.COMPLIANT,
+      });
+      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
+      isRestrictedCountryHeadersSpy.mockReturnValue(true);
+
+      const dataBefore: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+
+      expect(dataBefore).toHaveLength(1);
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: endpoint,
+        body: {
+          ...body,
+          action: ComplianceAction.CONNECT,
+        },
+        expectedStatus: 403,
+      });
+
+      // Verify no database changes occurred
+      const dataAfter: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+      expect(dataAfter).toHaveLength(1);
+      expect(dataAfter).toEqual(dataBefore);
+
+      // Verify error response
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].msg).toEqual(INDEXER_GEOBLOCKED_PAYLOAD);
+      expect(response.body.errors[0].code).toEqual(BlockedCode.GEOBLOCKED);
+    });
+
+    it('should return 403 for CONNECT action from a restricted country with existing FIRST_STRIKE status', async () => {
+      await ComplianceStatusTable.create({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.FIRST_STRIKE,
+        reason: ComplianceReason.US_GEO,
+      });
+      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
+      isRestrictedCountryHeadersSpy.mockReturnValue(true);
+
+      const dataBefore: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+
+      expect(dataBefore).toHaveLength(1);
+      const originalStatus = dataBefore[0].status;
+      const originalUpdatedAt = dataBefore[0].updatedAt;
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: endpoint,
+        body: {
+          ...body,
+          action: ComplianceAction.CONNECT,
+        },
+        expectedStatus: 403,
+      });
+
+      // Verify no database changes occurred
+      const dataAfter: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+
+      expect(dataAfter).toHaveLength(1);
+      expect(dataAfter[0].status).toEqual(originalStatus);
+      expect(dataAfter[0].updatedAt).toEqual(originalUpdatedAt);
+
+      // Verify error response
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].msg).toEqual(INDEXER_GEOBLOCKED_PAYLOAD);
+      expect(response.body.errors[0].code).toEqual(BlockedCode.GEOBLOCKED);
+    });
+
+    it('should return 403 for CONNECT action from a restricted country with existing CLOSE_ONLY status', async () => {
+      const createdAt: string = DateTime.utc().minus({ days: 1 }).toISO();
+      await ComplianceStatusTable.create({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.CLOSE_ONLY,
+        reason: ComplianceReason.US_GEO,
+        updatedAt: createdAt,
+      });
+      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
+      isRestrictedCountryHeadersSpy.mockReturnValue(true);
+
+      expect(await ComplianceStatusTable.findAll({}, [], {})).toHaveLength(1);
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: endpoint,
+        body: {
+          ...body,
+          action: ComplianceAction.CONNECT,
+        },
+        expectedStatus: 403,
+      });
+
+      // Verify no database changes occurred
+      const dataAfter: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+
+      expect(dataAfter).toHaveLength(1);
+      expect(dataAfter[0].status).toEqual(ComplianceStatus.CLOSE_ONLY);
+      expect(dataAfter[0].updatedAt).toEqual(createdAt);
+
+      // Verify error response
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].msg).toEqual(INDEXER_GEOBLOCKED_PAYLOAD);
+      expect(response.body.errors[0].code).toEqual(BlockedCode.GEOBLOCKED);
+    });
+
+    it('should return 403 for INVALID_SURVEY action from a restricted country', async () => {
+      await ComplianceStatusTable.create({
         address: testConstants.defaultAddress,
         status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
         reason: ComplianceReason.US_GEO,
-      }));
-      expect(stats.increment).toHaveBeenCalledWith(
-        `${config.SERVICE_NAME}.compliance-v2-controller.${endpoint === geoblockEndpoint ? 'geo_block' : 'geo_block_keplr'}.compliance_status_changed.count`,
-        {
-          newStatus: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
-        });
+      });
+      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
+      isRestrictedCountryHeadersSpy.mockReturnValue(true);
 
-      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY);
-      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
+      const dataBefore: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+
+      expect(dataBefore).toHaveLength(1);
+      const originalStatus = dataBefore[0].status;
+      const originalUpdatedAt = dataBefore[0].updatedAt;
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: endpoint,
+        body: {
+          ...body,
+          action: ComplianceAction.INVALID_SURVEY,
+        },
+        expectedStatus: 403,
+      });
+
+      // Verify no database changes occurred
+      const dataAfter: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+
+      expect(dataAfter).toHaveLength(1);
+      expect(dataAfter[0].status).toEqual(originalStatus);
+      expect(dataAfter[0].updatedAt).toEqual(originalUpdatedAt);
+
+      // Verify error response
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].msg).toEqual(INDEXER_GEOBLOCKED_PAYLOAD);
+      expect(response.body.errors[0].code).toEqual(BlockedCode.GEOBLOCKED);
+    });
+
+    it('should return 403 for VALID_SURVEY action from a restricted country', async () => {
+      await ComplianceStatusTable.create({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
+        reason: ComplianceReason.US_GEO,
+      });
+      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
+      isRestrictedCountryHeadersSpy.mockReturnValue(true);
+
+      const dataBefore: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+
+      expect(dataBefore).toHaveLength(1);
+      const originalStatus = dataBefore[0].status;
+      const originalUpdatedAt = dataBefore[0].updatedAt;
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: endpoint,
+        body: {
+          ...body,
+          action: ComplianceAction.VALID_SURVEY,
+        },
+        expectedStatus: 403,
+      });
+
+      // Verify no database changes occurred
+      const dataAfter: ComplianceStatusFromDatabase[] = await
+      ComplianceStatusTable.findAll({}, [], {});
+
+      expect(dataAfter).toHaveLength(1);
+      expect(dataAfter[0].status).toEqual(originalStatus);
+      expect(dataAfter[0].updatedAt).toEqual(originalUpdatedAt);
+
+      // Verify error response
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].msg).toEqual(INDEXER_GEOBLOCKED_PAYLOAD);
+      expect(response.body.errors[0].code).toEqual(BlockedCode.GEOBLOCKED);
+    });
+
+    it.each([
+      ComplianceStatus.FIRST_STRIKE,
+      ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
+    ])('should not mutate status for any action from a non-restricted country with existing compliance status FIRST_STRIKE or FIRST_STRIKE_CLOSE_ONLY', async (status: ComplianceStatus) => {
+      isRestrictedCountryHeadersSpy.mockReturnValue(false);
+
+      const complianceStatus: ComplianceStatusFromDatabase = {
+        address: testConstants.defaultAddress,
+        createdAt: DateTime.utc().toISO(),
+        updatedAt: DateTime.utc().toISO(),
+        status,
+      };
+
+      await ComplianceStatusTable.create(complianceStatus);
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: endpoint,
+        body,
+        expectedStatus: 200,
+      });
+
       expect(response.body.updatedAt).toBeDefined();
+      expect(response.body.status).toEqual(status);
+
+      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
+
+      expect(data).toHaveLength(1);
+      expect(data[0]).toEqual(expect.objectContaining(complianceStatus));
+    });
+
+    it('should leave status at BLOCKED for any action from a non-restricted country with existing compliance status BLOCKED', async () => {
+      isRestrictedCountryHeadersSpy.mockReturnValue(false);
+
+      await ComplianceStatusTable.create({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.BLOCKED,
+      });
+
+      const response: any = await sendRequest({
+        type: RequestMethod.POST,
+        path: endpoint,
+        body,
+        expectedStatus: 200,
+      });
+
+      expect(response.body.updatedAt).toBeDefined();
+      expect(response.body.status).toEqual(ComplianceStatus.BLOCKED);
+
+      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
+
+      expect(data).toHaveLength(1);
+      expect(data[0]).toEqual(expect.objectContaining({
+        address: testConstants.defaultAddress,
+        status: ComplianceStatus.BLOCKED,
+      }));
     });
 
     it('should set status to COMPLIANT for any action from a non-restricted country with no existing compliance status', async () => {
@@ -569,183 +793,6 @@ describe('ComplianceV2Controller', () => {
       }));
 
       expect(response.body.status).toEqual(ComplianceStatus.COMPLIANT);
-    });
-
-    it('should update status to FIRST_STRIKE_CLOSE_ONLY for CONNECT action from a restricted country with existing COMPLIANT status', async () => {
-      await ComplianceStatusTable.create({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.COMPLIANT,
-      });
-      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
-      isRestrictedCountryHeadersSpy.mockReturnValue(true);
-
-      const response: any = await sendRequest({
-        type: RequestMethod.POST,
-        path: endpoint,
-        body: {
-          ...body,
-          action: ComplianceAction.CONNECT,
-        },
-        expectedStatus: 200,
-      });
-
-      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).toEqual(expect.objectContaining({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
-        reason: ComplianceReason.US_GEO,
-      }));
-
-      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY);
-      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
-      expect(response.body.updatedAt).toBeDefined();
-    });
-
-    it('should update status to CLOSE_ONLY for CONNECT action from a restricted country with existing FIRST_STRIKE status', async () => {
-      await ComplianceStatusTable.create({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE,
-        reason: ComplianceReason.US_GEO,
-      });
-      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
-      isRestrictedCountryHeadersSpy.mockReturnValue(true);
-
-      const response: any = await sendRequest({
-        type: RequestMethod.POST,
-        path: endpoint,
-        body: {
-          ...body,
-          action: ComplianceAction.CONNECT,
-        },
-        expectedStatus: 200,
-      });
-
-      expect(stats.increment).toHaveBeenCalledWith(
-        `${config.SERVICE_NAME}.compliance-v2-controller.${endpoint === geoblockEndpoint ? 'geo_block' : 'geo_block_keplr'}.compliance_status_changed.count`,
-        {
-          newStatus: ComplianceStatus.CLOSE_ONLY,
-        });
-
-      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).toEqual(expect.objectContaining({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.CLOSE_ONLY,
-        reason: ComplianceReason.US_GEO,
-      }));
-
-      expect(response.body.status).toEqual(ComplianceStatus.CLOSE_ONLY);
-      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
-      expect(response.body.updatedAt).toBeDefined();
-    });
-
-    it('should return CLOSE_ONLY for CONNECT action from a restricted country with existing CLOSE_ONLY status', async () => {
-      const createdAt: string = DateTime.utc().minus({ days: 1 }).toISO();
-      await ComplianceStatusTable.create({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.CLOSE_ONLY,
-        reason: ComplianceReason.US_GEO,
-        updatedAt: createdAt,
-      });
-      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
-      isRestrictedCountryHeadersSpy.mockReturnValue(true);
-
-      const response: any = await sendRequest({
-        type: RequestMethod.POST,
-        path: endpoint,
-        body: {
-          ...body,
-          action: ComplianceAction.CONNECT,
-        },
-        expectedStatus: 200,
-      });
-      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).toEqual(expect.objectContaining({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.CLOSE_ONLY,
-        reason: ComplianceReason.US_GEO,
-        updatedAt: createdAt,
-      }));
-
-      expect(response.body.status).toEqual(ComplianceStatus.CLOSE_ONLY);
-      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
-      expect(response.body.updatedAt).toEqual(createdAt);
-    });
-
-    it('should update status to CLOSE_ONLY for INVALID_SURVEY action with existing FIRST_STRIKE_CLOSE_ONLY status', async () => {
-      await ComplianceStatusTable.create({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
-        reason: ComplianceReason.US_GEO,
-      });
-      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
-      isRestrictedCountryHeadersSpy.mockReturnValue(true);
-
-      const response: any = await sendRequest({
-        type: RequestMethod.POST,
-        path: endpoint,
-        body: {
-          ...body,
-          action: ComplianceAction.INVALID_SURVEY,
-        },
-        expectedStatus: 200,
-      });
-      expect(stats.increment).toHaveBeenCalledWith(
-        `${config.SERVICE_NAME}.compliance-v2-controller.${endpoint === geoblockEndpoint ? 'geo_block' : 'geo_block_keplr'}.compliance_status_changed.count`,
-        {
-          newStatus: ComplianceStatus.CLOSE_ONLY,
-        });
-
-      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).toEqual(expect.objectContaining({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.CLOSE_ONLY,
-        reason: ComplianceReason.US_GEO,
-      }));
-
-      expect(response.body.status).toEqual(ComplianceStatus.CLOSE_ONLY);
-      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
-      expect(response.body.updatedAt).toBeDefined();
-    });
-
-    it('should update status to FIRST_STRIKE for VALID_SURVEY action with existing FIRST_STRIKE_CLOSE_ONLY status', async () => {
-      await ComplianceStatusTable.create({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
-        reason: ComplianceReason.US_GEO,
-      });
-      getGeoComplianceReasonSpy.mockReturnValueOnce(ComplianceReason.US_GEO);
-      isRestrictedCountryHeadersSpy.mockReturnValue(true);
-
-      const response: any = await sendRequest({
-        type: RequestMethod.POST,
-        path: endpoint,
-        body: {
-          ...body,
-          action: ComplianceAction.VALID_SURVEY,
-        },
-        expectedStatus: 200,
-      });
-      expect(stats.increment).toHaveBeenCalledWith(
-        `${config.SERVICE_NAME}.compliance-v2-controller.${endpoint === geoblockEndpoint ? 'geo_block' : 'geo_block_keplr'}.compliance_status_changed.count`,
-        {
-          newStatus: ComplianceStatus.FIRST_STRIKE,
-        });
-
-      const data: ComplianceStatusFromDatabase[] = await ComplianceStatusTable.findAll({}, [], {});
-      expect(data).toHaveLength(1);
-      expect(data[0]).toEqual(expect.objectContaining({
-        address: testConstants.defaultAddress,
-        status: ComplianceStatus.FIRST_STRIKE,
-        reason: ComplianceReason.US_GEO,
-      }));
-
-      expect(response.body.status).toEqual(ComplianceStatus.FIRST_STRIKE);
-      expect(response.body.reason).toEqual(ComplianceReason.US_GEO);
-      expect(response.body.updatedAt).toBeDefined();
     });
   });
 });

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -7,6 +7,7 @@ import {
   GeoOriginHeaders,
   isRestrictedCountryHeaders,
   isWhitelistedAddress,
+  INDEXER_GEOBLOCKED_PAYLOAD,
 } from '@dydxprotocol-indexer/compliance';
 import {
   ComplianceReason,
@@ -18,7 +19,6 @@ import {
 } from '@dydxprotocol-indexer/postgres';
 import express from 'express';
 import { matchedData } from 'express-validator';
-import _ from 'lodash';
 import { DateTime } from 'luxon';
 import {
   Controller, Get, Path, Route,
@@ -28,7 +28,7 @@ import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceProvider } from '../../../helpers/compliance/compliance-clients';
 import {
-  ComplianceAction, getGeoComplianceReason, validateSignature, validateSignatureKeplr,
+  ComplianceAction, validateSignature, validateSignatureKeplr,
 } from '../../../helpers/compliance/compliance-utils';
 import { DYDX_ADDRESS_PREFIX } from '../../../lib/constants';
 import { create4xxResponse, handleControllerError } from '../../../lib/helpers';
@@ -38,17 +38,15 @@ import { CheckAddressSchema } from '../../../lib/validation/schemas';
 import { handleValidationErrors } from '../../../request-helpers/error-handler';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
 import {
-  ComplianceRequest, ComplianceV2Response, SetComplianceStatusRequest,
+  BlockedCode,
+  ComplianceRequest,
+  ComplianceV2Response,
+  SetComplianceStatusRequest,
 } from '../../../types';
 import { ComplianceControllerHelper } from './compliance-controller';
 
 const router: express.Router = express.Router();
 const controllerName: string = 'compliance-v2-controller';
-
-const COMPLIANCE_PROGRESSION: Partial<Record<ComplianceStatus, ComplianceStatus>> = {
-  [ComplianceStatus.COMPLIANT]: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
-  [ComplianceStatus.FIRST_STRIKE]: ComplianceStatus.CLOSE_ONLY,
-};
 
 @Route('compliance')
 class ComplianceV2Controller extends Controller {
@@ -285,6 +283,15 @@ async function checkCompliance(
     });
   }
 
+  if (isRestrictedCountryHeaders(req.headers as GeoOriginHeaders)) {
+    return create4xxResponse(
+      res,
+      INDEXER_GEOBLOCKED_PAYLOAD,
+      403,
+      { code: BlockedCode.GEOBLOCKED },
+    );
+  }
+
   const [
     complianceStatus,
     wallet,
@@ -333,7 +340,7 @@ async function checkCompliance(
 }
 
 function handleError(
-  error: Error, endpointName: string, message:string, req: express.Request, res: express.Response,
+  error: Error, endpointName: string, message: string, req: express.Request, res: express.Response,
 ): express.Response {
   logger.error({
     at: `ComplianceV2Controller POST /${endpointName}`,
@@ -351,29 +358,13 @@ function handleError(
 
 /**
  * If the address doesn't exist in the compliance table:
- * - if the request is from a restricted country:
- *  - if the action is CONNECT and no wallet, set the status to BLOCKED
- *  - if the action is CONNECT and wallet exists, set the status to FIRST_STRIKE_CLOSE_ONLY
+ * - if the request is from a restricted country
+ *  - the request must be blocked upstream
  * - else if the request is from a non-restricted country:
  *  - set the status to COMPLIANT
- *
- * if the address is COMPLIANT:
- * - the ONLY action should be CONNECT. VALID_SURVEY/INVALID_SURVEY are no-ops.
- * - if the request is from a restricted country:
- *  - set the status to FIRST_STRIKE_CLOSE_ONLY
- *
- * if the address is FIRST_STRIKE_CLOSE_ONLY:
- * - the ONLY actions should be VALID_SURVEY/INVALID_SURVEY/CONNECT. CONNECT
- * are no-ops.
- * - if the action is VALID_SURVEY:
- *   - set the status to FIRST_STRIKE
- * - if the action is INVALID_SURVEY:
- *   - set the status to CLOSE_ONLY
- *
- * if the address is FIRST_STRIKE:
- * - the ONLY action should be CONNECT. VALID_SURVEY/INVALID_SURVEY are no-ops.
- * - if the request is from a restricted country:
- *  - set the status to CLOSE_ONLY
+ *  - return compliant status
+ * If the address does exist in the compliance table:
+ * - return the existing status
  */
 // eslint-disable-next-line @typescript-eslint/require-await
 async function upsertComplianceStatus(
@@ -384,62 +375,13 @@ async function upsertComplianceStatus(
   complianceStatus: ComplianceStatusFromDatabase[],
   updatedAt: string,
 ): Promise<ComplianceStatusFromDatabase | undefined> {
+
   if (complianceStatus.length === 0) {
-    if (!isRestrictedCountryHeaders(req.headers as GeoOriginHeaders)) {
-      return ComplianceStatusTable.upsert({
-        address,
-        status: ComplianceStatus.COMPLIANT,
-        updatedAt,
-      });
-    }
-
-    // If address is restricted and is not onboarded then block
-    if (_.isUndefined(wallet)) {
-      return ComplianceStatusTable.upsert({
-        address,
-        status: ComplianceStatus.BLOCKED,
-        reason: getGeoComplianceReason(req.headers as GeoOriginHeaders)!,
-        updatedAt,
-      });
-    }
-
     return ComplianceStatusTable.upsert({
       address,
-      status: ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY,
-      reason: getGeoComplianceReason(req.headers as GeoOriginHeaders)!,
+      status: ComplianceStatus.COMPLIANT,
       updatedAt,
     });
-  }
-
-  if (
-    complianceStatus[0].status === ComplianceStatus.FIRST_STRIKE ||
-    complianceStatus[0].status === ComplianceStatus.COMPLIANT
-  ) {
-    if (
-      isRestrictedCountryHeaders(req.headers as GeoOriginHeaders) &&
-      action === ComplianceAction.CONNECT
-    ) {
-      return ComplianceStatusTable.update({
-        address,
-        status: COMPLIANCE_PROGRESSION[complianceStatus[0].status],
-        reason: getGeoComplianceReason(req.headers as GeoOriginHeaders)!,
-        updatedAt,
-      });
-    }
-  } else if (complianceStatus[0].status === ComplianceStatus.FIRST_STRIKE_CLOSE_ONLY) {
-    if (action === ComplianceAction.VALID_SURVEY) {
-      return ComplianceStatusTable.update({
-        address,
-        status: ComplianceStatus.FIRST_STRIKE,
-        updatedAt,
-      });
-    } else if (action === ComplianceAction.INVALID_SURVEY) {
-      return ComplianceStatusTable.update({
-        address,
-        status: ComplianceStatus.CLOSE_ONLY,
-        updatedAt,
-      });
-    }
   }
 
   return complianceStatus[0];

--- a/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
+++ b/indexer/services/comlink/src/lib/compliance-and-geo-check.ts
@@ -24,10 +24,10 @@ import { getIpAddr, isIndexerIp } from './utils';
  * Checks if the address in the request is blocked or not.
  *
  * IF the address is in the compliance_status table and has the status CLOSE_ONLY,
- * return data for the endpoint ELSE
- * IF the address has compliance_status of BLOCKED block access to the endpoint (return 403) ELSE
- * IF the origin country is restricted geography, block access to the endpoint (return 403) ELSE
  * return data for the endpoint
+ * ELSE IF the address has compliance_status of BLOCKED block access to the endpoint (return 403)
+ * ELSE IF the origin country is restricted geography, block access to the endpoint (return 403)
+ * ELSE return data for the endpoint
  * NOTE: This middleware must be used after `checkSchema` to ensure `matchData` can get the
  * address parameter from the request.
  */


### PR DESCRIPTION
## Summary

- Remove state-machine logic from compliance controller that automatically transitioned users through `COMPLIANT` → `FIRST_STRIKE_CLOSE_ONLY` → `CLOSE_ONLY` → `BLOCKED` based on connection attempts and surveys.
- Replace with fail-fast behavior: any non-whitelisted request from a restricted country returns `403 Forbidden` immediately, regardless of existing compliance status or action type.
- Existing compliance statuses in the database are now read-only; the controller no longer mutates them based on geo checks or survey actions.
- Requests from non-restricted countries with no existing status are still marked `COMPLIANT`; existing non-`COMPLIANT` statuses are returned as-is.

## Details

### API behavior changes

- **Restricted country requests**: All actions (`CONNECT`, `VALID_SURVEY`, `INVALID_SURVEY`) from restricted geolocations now return `403` with error code `BlockedCode.GEOBLOCKED` and payload `INDEXER_GEOBLOCKED_PAYLOAD`, before any database lookups or mutations.
- **Non-restricted country requests**:
  - New addresses → `COMPLIANT` status created in DB, `200` returned.
  - Existing addresses → current status returned unchanged, `200` returned (including `BLOCKED`, `FIRST_STRIKE`, `FIRST_STRIKE_CLOSE_ONLY`, `CLOSE_ONLY`).

## Risk & Impact

**Breaking change**: High impact on compliance enforcement.

- **Previous behavior**: Users from restricted countries with wallets could connect and transition through strike states via surveys; manual human review influenced state transitions.
- **New behavior**: All restricted-country requests are rejected immediately at the API layer. Survey actions no longer affect compliance state.
- **Data consistency**: Existing `FIRST_STRIKE`, `FIRST_STRIKE_CLOSE_ONLY`, and `CLOSE_ONLY` records in the database are preserved but no longer updated by this controller.
- **Rollout**: Requires coordination with compliance policy; any users relying on survey-based remediation will lose access immediately.

## Testing

- **Comprehensive test coverage** added/updated in `compliance-v2-controller.test.ts`:
  - New tests verify `403` response for all actions (`CONNECT`, `VALID_SURVEY`, `INVALID_SURVEY`) from restricted countries, regardless of pre-existing status (`COMPLIANT`, `FIRST_STRIKE`, `FIRST_STRIKE_CLOSE_ONLY`, `CLOSE_ONLY`, or none).
  - Tests confirm database is **not mutated** on geoblocked requests.
  - Parameterized test (`it.each`) verifies non-restricted requests return existing `FIRST_STRIKE`/`FIRST_STRIKE_CLOSE_ONLY` statuses unchanged.
  - Tests confirm `BLOCKED` status persists for non-restricted requests.
- Removed obsolete tests for state transitions (`COMPLIANT` → `FIRST_STRIKE_CLOSE_ONLY`, survey-based transitions).

## Reviewer Notes

- **Key change**: `upsertComplianceStatus()` is now effectively a no-op for existing addresses; all mutation logic removed.
- **Stats emission**: `compliance_status_changed` metrics are no longer emitted for geoblocked requests (verified in tests).
- **Manual QA**: Verify geoblocking behavior in staging with VPN/geo-spoofing for restricted countries; confirm existing survey flows are disabled.
