### PR TITLE
feat(comlink): Per-route rate limiters for candles, orders, fills, ...

### DIFF
--- a/indexer/services/comlink/__tests__/lib/rate-limit.test.ts
+++ b/indexer/services/comlink/__tests__/lib/rate-limit.test.ts
@@ -2,7 +2,25 @@ import { redis } from '@dydxprotocol-indexer/redis';
 import { IncomingHttpHeaders } from 'http';
 import config from '../../src/config';
 import { rateLimiterMiddleware } from '../../src/lib/rate-limit';
-import { ratelimitRedis, getReqRateLimiter } from '../../src/caches/rate-limiters';
+import {
+  ratelimitRedis,
+  defaultRateLimiter,
+  ordersRateLimiter,
+  fillsRateLimiter,
+  candlesRateLimiter,
+  sparklinesRateLimiter,
+  historicalPnlRateLimiter,
+  pnlRateLimiter,
+  fundingRateLimiter,
+  getDefaultRateLimiter,
+  getOrdersRateLimiter,
+  getFillsRateLimiter,
+  getCandlesRateLimiter,
+  getSparklinesRateLimiter,
+  getHistoricalPnlRateLimiter,
+  getPnlRateLimiter,
+  getFundingRateLimiter,
+} from '../../src/caches/rate-limiters';
 import * as utils from '../../src/lib/utils';
 
 describe('rateLimit', () => {
@@ -38,50 +56,450 @@ describe('rateLimit', () => {
     config.RATE_LIMIT_ENABLED = false;
   });
 
-  it('consumes points for external request', async () => {
-    req.headers = defaultHeaders;
+  describe('getReqRateLimiter', () => {
+    it('consumes points for external request', async () => {
+      req.headers = defaultHeaders;
 
-    await rateLimiterMiddleware(getReqRateLimiter)(req, res, next);
+      await rateLimiterMiddleware(defaultRateLimiter)(req, res, next);
 
-    expect(res.status).not.toHaveBeenCalled();
-    expect(res.set).toHaveBeenCalledTimes(1);
-    expect(res.set).toHaveBeenCalledWith({
-      'RateLimit-Remaining': config.RATE_LIMIT_GET_POINTS - 1,
-      'RateLimit-Reset': expect.any(Number),
-      'RateLimit-Limit': config.RATE_LIMIT_GET_POINTS,
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_GET_POINTS - 1,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_GET_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
     });
-    expect(next).toHaveBeenCalledTimes(1);
+
+    it('consumes no points for internal request', async () => {
+      isIndexerIpSpy.mockReturnValueOnce(true);
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(defaultRateLimiter)(req, res, next);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_GET_POINTS,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_GET_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets response code to 429 if rate limit exceeded', async () => {
+      req.headers = defaultHeaders;
+      for (let i = 0; i < config.RATE_LIMIT_GET_POINTS + 1; i++) {
+        await rateLimiterMiddleware(defaultRateLimiter)(req, res, next);
+      }
+
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenNthCalledWith(1, 429);
+      expect(res.set).toHaveBeenCalledTimes(config.RATE_LIMIT_GET_POINTS + 1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': 0,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_GET_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_GET_POINTS);
+    });
+
+    it('respects config changes to rate limit points', async () => {
+      const originalPoints = config.RATE_LIMIT_GET_POINTS;
+      config.RATE_LIMIT_GET_POINTS = 5;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getDefaultRateLimiter())(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': expect.any(Number),
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_GET_POINTS,
+      });
+
+      config.RATE_LIMIT_GET_POINTS = originalPoints;
+    });
   });
 
-  it('consumes no points for internal request', async () => {
-    isIndexerIpSpy.mockReturnValueOnce(true);
-    req.headers = defaultHeaders;
+  describe('ordersRateLimiter', () => {
+    it('consumes points for external request', async () => {
+      req.headers = defaultHeaders;
 
-    await rateLimiterMiddleware(getReqRateLimiter)(req, res, next);
-    expect(res.status).not.toHaveBeenCalled();
-    expect(res.set).toHaveBeenCalledTimes(1);
-    expect(res.set).toHaveBeenCalledWith({
-      'RateLimit-Remaining': config.RATE_LIMIT_GET_POINTS,
-      'RateLimit-Reset': expect.any(Number),
-      'RateLimit-Limit': config.RATE_LIMIT_GET_POINTS,
+      await rateLimiterMiddleware(ordersRateLimiter)(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_ORDERS_POINTS - 1,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_ORDERS_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
     });
-    expect(next).toHaveBeenCalledTimes(1);
+
+    it('sets response code to 429 if rate limit exceeded', async () => {
+      req.headers = defaultHeaders;
+      for (let i = 0; i < config.RATE_LIMIT_ORDERS_POINTS + 1; i++) {
+        await rateLimiterMiddleware(ordersRateLimiter)(req, res, next);
+      }
+
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenNthCalledWith(1, 429);
+      expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_ORDERS_POINTS);
+    });
+
+    it('respects config changes to orders rate limit', async () => {
+      const originalPoints = config.RATE_LIMIT_ORDERS_POINTS;
+      config.RATE_LIMIT_ORDERS_POINTS = 10;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getOrdersRateLimiter())(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': expect.any(Number),
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_ORDERS_POINTS,
+      });
+
+      config.RATE_LIMIT_ORDERS_POINTS = originalPoints;
+    });
   });
 
-  it('sets response code to 429 if rate limit exceeded', async () => {
-    req.headers = defaultHeaders;
-    for (let i = 0; i < config.RATE_LIMIT_GET_POINTS + 1; i++) {
-      await rateLimiterMiddleware(getReqRateLimiter)(req, res, next);
-    }
+  describe('fillsRateLimiter', () => {
+    it('consumes points for external request', async () => {
+      req.headers = defaultHeaders;
 
-    expect(res.status).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenNthCalledWith(1, 429);
-    expect(res.set).toHaveBeenCalledTimes(config.RATE_LIMIT_GET_POINTS + 1);
-    expect(res.set).toHaveBeenCalledWith({
-      'RateLimit-Remaining': 0,
-      'RateLimit-Reset': expect.any(Number),
-      'RateLimit-Limit': config.RATE_LIMIT_GET_POINTS,
+      await rateLimiterMiddleware(fillsRateLimiter)(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_FILLS_POINTS - 1,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_FILLS_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
     });
-    expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_GET_POINTS);
+
+    it('sets response code to 429 if rate limit exceeded', async () => {
+      req.headers = defaultHeaders;
+      for (let i = 0; i < config.RATE_LIMIT_FILLS_POINTS + 1; i++) {
+        await rateLimiterMiddleware(fillsRateLimiter)(req, res, next);
+      }
+
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenNthCalledWith(1, 429);
+      expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_FILLS_POINTS);
+    });
+
+    it('respects config changes to fills rate limit', async () => {
+      const originalPoints = config.RATE_LIMIT_FILLS_POINTS;
+      config.RATE_LIMIT_FILLS_POINTS = 15;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getFillsRateLimiter())(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': expect.any(Number),
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_FILLS_POINTS,
+      });
+
+      config.RATE_LIMIT_FILLS_POINTS = originalPoints;
+    });
+  });
+
+  describe('candlesRateLimiter', () => {
+    it('consumes points for external request', async () => {
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(candlesRateLimiter)(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_CANDLES_POINTS - 1,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_CANDLES_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets response code to 429 if rate limit exceeded', async () => {
+      req.headers = defaultHeaders;
+      for (let i = 0; i < config.RATE_LIMIT_CANDLES_POINTS + 1; i++) {
+        await rateLimiterMiddleware(candlesRateLimiter)(req, res, next);
+      }
+
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenNthCalledWith(1, 429);
+      expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_CANDLES_POINTS);
+    });
+
+    it('respects config changes to candles rate limit', async () => {
+      const originalPoints = config.RATE_LIMIT_CANDLES_POINTS;
+      config.RATE_LIMIT_CANDLES_POINTS = 500;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getCandlesRateLimiter())(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': expect.any(Number),
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_CANDLES_POINTS,
+      });
+
+      config.RATE_LIMIT_CANDLES_POINTS = originalPoints;
+    });
+  });
+
+  describe('sparklinesRateLimiter', () => {
+    it('consumes points for external request', async () => {
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(sparklinesRateLimiter)(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_SPARKLINES_POINTS - 1,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_SPARKLINES_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets response code to 429 if rate limit exceeded', async () => {
+      req.headers = defaultHeaders;
+      for (let i = 0; i < config.RATE_LIMIT_SPARKLINES_POINTS + 1; i++) {
+        await rateLimiterMiddleware(sparklinesRateLimiter)(req, res, next);
+      }
+
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenNthCalledWith(1, 429);
+      expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_SPARKLINES_POINTS);
+    });
+
+    it('respects config changes to sparklines rate limit', async () => {
+      const originalPoints = config.RATE_LIMIT_SPARKLINES_POINTS;
+      config.RATE_LIMIT_SPARKLINES_POINTS = 50;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getSparklinesRateLimiter())(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': expect.any(Number),
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_SPARKLINES_POINTS,
+      });
+
+      config.RATE_LIMIT_SPARKLINES_POINTS = originalPoints;
+    });
+  });
+
+  describe('historicalPnlRateLimiter', () => {
+    it('consumes points for external request', async () => {
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(historicalPnlRateLimiter)(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_HISTORICAL_PNL_POINTS - 1,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_HISTORICAL_PNL_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets response code to 429 if rate limit exceeded', async () => {
+      req.headers = defaultHeaders;
+      for (let i = 0; i < config.RATE_LIMIT_HISTORICAL_PNL_POINTS + 1; i++) {
+        await rateLimiterMiddleware(historicalPnlRateLimiter)(req, res, next);
+      }
+
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenNthCalledWith(1, 429);
+      expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_HISTORICAL_PNL_POINTS);
+    });
+
+    it('respects config changes to historical pnl rate limit', async () => {
+      const originalPoints = config.RATE_LIMIT_HISTORICAL_PNL_POINTS;
+      config.RATE_LIMIT_HISTORICAL_PNL_POINTS = 25;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getHistoricalPnlRateLimiter())(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': expect.any(Number),
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_HISTORICAL_PNL_POINTS,
+      });
+
+      config.RATE_LIMIT_HISTORICAL_PNL_POINTS = originalPoints;
+    });
+  });
+
+  describe('pnlRateLimiter', () => {
+    it('consumes points for external request', async () => {
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(pnlRateLimiter)(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_PNL_POINTS - 1,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_PNL_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets response code to 429 if rate limit exceeded', async () => {
+      req.headers = defaultHeaders;
+      for (let i = 0; i < config.RATE_LIMIT_PNL_POINTS + 1; i++) {
+        await rateLimiterMiddleware(pnlRateLimiter)(req, res, next);
+      }
+
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenNthCalledWith(1, 429);
+      expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_PNL_POINTS);
+    });
+
+    it('respects config changes to pnl rate limit', async () => {
+      const originalPoints = config.RATE_LIMIT_PNL_POINTS;
+      config.RATE_LIMIT_PNL_POINTS = 30;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getPnlRateLimiter())(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': expect.any(Number),
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_PNL_POINTS,
+      });
+
+      config.RATE_LIMIT_PNL_POINTS = originalPoints;
+    });
+  });
+
+  describe('fundingRateLimiter', () => {
+    it('consumes points for external request', async () => {
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(fundingRateLimiter)(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.set).toHaveBeenCalledTimes(1);
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_FUNDING_POINTS - 1,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_FUNDING_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets response code to 429 if rate limit exceeded', async () => {
+      req.headers = defaultHeaders;
+      for (let i = 0; i < config.RATE_LIMIT_FUNDING_POINTS + 1; i++) {
+        await rateLimiterMiddleware(fundingRateLimiter)(req, res, next);
+      }
+
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenNthCalledWith(1, 429);
+      expect(next).toHaveBeenCalledTimes(config.RATE_LIMIT_FUNDING_POINTS);
+    });
+
+    it('respects config changes to funding rate limit', async () => {
+      const originalPoints = config.RATE_LIMIT_FUNDING_POINTS;
+      config.RATE_LIMIT_FUNDING_POINTS = 20;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getFundingRateLimiter())(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': expect.any(Number),
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_FUNDING_POINTS,
+      });
+
+      config.RATE_LIMIT_FUNDING_POINTS = originalPoints;
+    });
+  });
+
+  describe('rate limiter duration configuration', () => {
+    it('respects config changes to duration for get requests', async () => {
+      const originalDuration = config.RATE_LIMIT_GET_DURATION_SECONDS;
+      config.RATE_LIMIT_GET_DURATION_SECONDS = 5;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getDefaultRateLimiter())(req, res, next);
+
+      const resetTime = res.set.mock.calls[0][0]['RateLimit-Reset'];
+      const currentTime = Date.now();
+      const expectedResetWindow = config.RATE_LIMIT_GET_DURATION_SECONDS * 1000;
+
+      expect(resetTime - currentTime).toBeLessThanOrEqual(expectedResetWindow);
+      expect(resetTime - currentTime).toBeGreaterThan(0);
+
+      config.RATE_LIMIT_GET_DURATION_SECONDS = originalDuration;
+    });
+
+    it('respects config changes to duration for orders', async () => {
+      const originalDuration = config.RATE_LIMIT_ORDERS_DURATION_SECONDS;
+      config.RATE_LIMIT_ORDERS_DURATION_SECONDS = 20;
+
+      req.headers = defaultHeaders;
+
+      await rateLimiterMiddleware(getOrdersRateLimiter())(req, res, next);
+
+      const resetTime = res.set.mock.calls[0][0]['RateLimit-Reset'];
+      const currentTime = Date.now();
+      const expectedResetWindow = config.RATE_LIMIT_ORDERS_DURATION_SECONDS * 1000;
+
+      expect(resetTime - currentTime).toBeLessThanOrEqual(expectedResetWindow);
+      expect(resetTime - currentTime).toBeGreaterThan(0);
+
+      config.RATE_LIMIT_ORDERS_DURATION_SECONDS = originalDuration;
+    });
+  });
+
+  describe('internal vs external IP handling', () => {
+    it('treats internal IPs differently across all rate limiters', async () => {
+      isIndexerIpSpy.mockReturnValue(true);
+      req.headers = defaultHeaders;
+
+      const rateLimiters = [
+        defaultRateLimiter,
+        ordersRateLimiter,
+        fillsRateLimiter,
+        candlesRateLimiter,
+        sparklinesRateLimiter,
+        historicalPnlRateLimiter,
+        pnlRateLimiter,
+        fundingRateLimiter,
+      ];
+
+      for (const limiter of rateLimiters) {
+        await rateLimiterMiddleware(limiter)(req, res, next);
+
+        // Internal IPs should not consume points
+        const remainingPoints = res.set.mock.calls[res.set.mock.calls.length - 1][0]['RateLimit-Remaining'];
+        const limitPoints = res.set.mock.calls[res.set.mock.calls.length - 1][0]['RateLimit-Limit'];
+
+        expect(remainingPoints).toBe(limitPoints);
+      }
+    });
   });
 });

--- a/indexer/services/comlink/src/caches/rate-limiters.ts
+++ b/indexer/services/comlink/src/caches/rate-limiters.ts
@@ -11,27 +11,114 @@ export const ratelimitRedis: {
   config.RATE_LIMIT_REDIS_URL, config.REDIS_RECONNECT_TIMEOUT_MS,
 );
 
+export function getDefaultRateLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_GET_POINTS,
+    duration: config.RATE_LIMIT_GET_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/get`,
+  });
+}
+
 // Generic rate limiter for all GET requests, limits per IP
-export const getReqRateLimiter: RateLimiterRedis = new RateLimiterRedis({
-  storeClient: ratelimitRedis.client,
-  points: config.RATE_LIMIT_GET_POINTS,
-  duration: config.RATE_LIMIT_GET_DURATION_SECONDS,
-  keyPrefix: `${config.SERVICE_NAME}/get`,
-});
+export const defaultRateLimiter: RateLimiterRedis = getDefaultRateLimiter();
 
 // Rate-limiter for /screen endpoint querying a compliance provider, limits per IP
-export const screenProviderLimiter: RateLimiterRedis = new RateLimiterRedis({
-  storeClient: ratelimitRedis.client,
-  points: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_POINTS,
-  duration: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_DURATION_SECONDS,
-  keyPrefix: `${config.SERVICE_NAME}/screen_providers`,
-});
+export function getScreenProviderLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_POINTS,
+    duration: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/screen_providers`,
+  });
+}
+export const screenProviderLimiter: RateLimiterRedis = getScreenProviderLimiter();
 
 // Rate-limiter for /screen endpoint querying a compliance provider, limits the total calls made
 // across all IPs
-export const screenProviderGlobalLimiter: RateLimiterRedis = new RateLimiterRedis({
-  storeClient: ratelimitRedis.client,
-  points: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_POINTS,
-  duration: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_DURATION_SECONDS,
-  keyPrefix: `${config.SERVICE_NAME}/screen_providers_global`,
-});
+export function getScreenProviderGlobalLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_POINTS,
+    duration: config.RATE_LIMIT_SCREEN_QUERY_PROVIDER_GLOBAL_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/screen_providers_global`,
+  });
+}
+export const screenProviderGlobalLimiter: RateLimiterRedis = getScreenProviderGlobalLimiter();
+
+// Rate-limiter for /orders endpoint, limits per IP
+export function getOrdersRateLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_ORDERS_POINTS,
+    duration: config.RATE_LIMIT_ORDERS_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/orders`,
+  });
+}
+export const ordersRateLimiter: RateLimiterRedis = getOrdersRateLimiter();
+
+// Rate-limiter for /fills endpoint, limits per IP
+export function getFillsRateLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_FILLS_POINTS,
+    duration: config.RATE_LIMIT_FILLS_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/fills`,
+  });
+}
+export const fillsRateLimiter: RateLimiterRedis = getFillsRateLimiter();
+
+// Rate-limiter for /candles endpoint, limits per IP
+export function getCandlesRateLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_CANDLES_POINTS,
+    duration: config.RATE_LIMIT_CANDLES_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/candles`,
+  });
+}
+export const candlesRateLimiter: RateLimiterRedis = getCandlesRateLimiter();
+
+// Rate-limiter for /sparklines endpoint, limits per IP
+export function getSparklinesRateLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_SPARKLINES_POINTS,
+    duration: config.RATE_LIMIT_SPARKLINES_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/sparklines`,
+  });
+}
+export const sparklinesRateLimiter: RateLimiterRedis = getSparklinesRateLimiter();
+
+// Rate-limiter for /historical-pnl endpoint, limits per IP
+export function getHistoricalPnlRateLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_HISTORICAL_PNL_POINTS,
+    duration: config.RATE_LIMIT_HISTORICAL_PNL_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/historical_pnl`,
+  });
+}
+export const historicalPnlRateLimiter: RateLimiterRedis = getHistoricalPnlRateLimiter();
+
+// Rate-limiter for /pnl endpoint, limits per IP
+export function getPnlRateLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_PNL_POINTS,
+    duration: config.RATE_LIMIT_PNL_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/pnl`,
+  });
+}
+export const pnlRateLimiter: RateLimiterRedis = getPnlRateLimiter();
+
+// Rate-limiter for /funding endpoint, limits per IP
+export function getFundingRateLimiter(): RateLimiterRedis {
+  return new RateLimiterRedis({
+    storeClient: ratelimitRedis.client,
+    points: config.RATE_LIMIT_FUNDING_POINTS,
+    duration: config.RATE_LIMIT_FUNDING_DURATION_SECONDS,
+    keyPrefix: `${config.SERVICE_NAME}/funding`,
+  });
+}
+export const fundingRateLimiter: RateLimiterRedis = getFundingRateLimiter();

--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -57,6 +57,23 @@ export const configSchema = {
   // Expose setting compliance status, only set to true in dev/staging.
   EXPOSE_SET_COMPLIANCE_ENDPOINT: parseBoolean({ default: false }),
 
+  // TODO review and finalize per-route rate limits
+  // Rate limits for costly endpoints
+  RATE_LIMIT_ORDERS_POINTS: parseInteger({ default: 100 }),
+  RATE_LIMIT_ORDERS_DURATION_SECONDS: parseInteger({ default: 10 }),
+  RATE_LIMIT_FILLS_POINTS: parseInteger({ default: 100 }),
+  RATE_LIMIT_FILLS_DURATION_SECONDS: parseInteger({ default: 10 }),
+  RATE_LIMIT_CANDLES_POINTS: parseInteger({ default: 1000 }),
+  RATE_LIMIT_CANDLES_DURATION_SECONDS: parseInteger({ default: 10 }),
+  RATE_LIMIT_SPARKLINES_POINTS: parseInteger({ default: 100 }),
+  RATE_LIMIT_SPARKLINES_DURATION_SECONDS: parseInteger({ default: 10 }),
+  RATE_LIMIT_HISTORICAL_PNL_POINTS: parseInteger({ default: 100 }),
+  RATE_LIMIT_HISTORICAL_PNL_DURATION_SECONDS: parseInteger({ default: 10 }),
+  RATE_LIMIT_PNL_POINTS: parseInteger({ default: 100 }),
+  RATE_LIMIT_PNL_DURATION_SECONDS: parseInteger({ default: 10 }),
+  RATE_LIMIT_FUNDING_POINTS: parseInteger({ default: 100 }),
+  RATE_LIMIT_FUNDING_DURATION_SECONDS: parseInteger({ default: 10 }),
+
   // Affiliates config
   VOLUME_ELIGIBILITY_THRESHOLD: parseInteger({ default: 10_000 }),
 

--- a/indexer/services/comlink/src/controllers/api/v4/addresses-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/addresses-controller.ts
@@ -47,7 +47,7 @@ import {
   Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { AccountVerificationRequiredAction, validateSignature, validateSignatureKeplr } from '../../../helpers/compliance/compliance-utils';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
@@ -378,7 +378,7 @@ class AddressesController extends Controller {
 
 router.get(
   '/:address',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   addressesCacheControlMiddleware,
   ...CheckAddressSchema,
   handleValidationErrors,
@@ -418,7 +418,7 @@ router.get(
 
 router.get(
   '/:address/subaccountNumber/:subaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   addressesCacheControlMiddleware,
   ...CheckSubaccountSchema,
   handleValidationErrors,
@@ -463,7 +463,7 @@ router.get(
 
 router.get(
   '/:address/parentSubaccountNumber/:parentSubaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   addressesCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   handleValidationErrors,
@@ -563,7 +563,7 @@ router.post(
 
 router.post(
   '/:address/testNotification',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   noCacheControlMiddleware,
   ...CheckAddressSchema,
   handleValidationErrors,

--- a/indexer/services/comlink/src/controllers/api/v4/affiliates-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/affiliates-controller.ts
@@ -16,7 +16,7 @@ import {
   Post,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { AccountVerificationRequiredAction, validateSignature, validateSignatureKeplr } from '../../../helpers/compliance/compliance-utils';
 import { InvalidParamError, NotFoundError, UnexpectedServerError } from '../../../lib/errors';
@@ -282,7 +282,7 @@ class AffiliatesController extends Controller {
 
 router.get(
   '/metadata',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   affiliatesMetadataCacheControlMiddleware,
   ...checkSchema({
     address: {
@@ -322,7 +322,7 @@ router.get(
 
 router.get(
   '/address',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   affiliatesCacheControlMiddleware,
   ...checkSchema({
     referralCode: {
@@ -468,7 +468,7 @@ router.post(
 
 router.get(
   '/snapshot',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   affiliatesCacheControlMiddleware,
   ...checkSchema({
     addressFilter: {
@@ -554,7 +554,7 @@ router.get(
 
 router.get(
   '/total_volume',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   affiliatesCacheControlMiddleware,
   ...checkSchema({
     address: {

--- a/indexer/services/comlink/src/controllers/api/v4/asset-positions-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/asset-positions-controller.ts
@@ -23,7 +23,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import { NotFoundError } from '../../../lib/errors';
@@ -281,7 +281,7 @@ async function adjustAssetPositionsWithFunding(
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   assetPositionsCacheControlMiddleware,
   ...CheckSubaccountSchema,
   handleValidationErrors,
@@ -324,7 +324,7 @@ router.get(
 
 router.get(
   '/parentSubaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   assetPositionsCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   handleValidationErrors,

--- a/indexer/services/comlink/src/controllers/api/v4/candles-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/candles-controller.ts
@@ -8,7 +8,7 @@ import {
   Controller, Get, Path, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { candlesRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
@@ -52,7 +52,7 @@ class CandleController extends Controller {
 
 router.get(
   '/perpetualMarkets/:ticker',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(candlesRateLimiter),
   candlesCacheControlMiddleware,
   ...CheckLimitSchema,
   ...CheckTickerParamSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-controller.ts
@@ -18,7 +18,7 @@ import {
 } from 'tsoa';
 
 import {
-  getReqRateLimiter,
+  defaultRateLimiter,
   screenProviderGlobalLimiter,
   screenProviderLimiter,
 } from '../../../caches/rate-limiters';
@@ -120,7 +120,7 @@ export class ComplianceControllerHelper extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   ...checkSchema({
     address: {
       in: ['query'],

--- a/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/compliance-v2-controller.ts
@@ -24,7 +24,7 @@ import {
   Controller, Get, Path, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceProvider } from '../../../helpers/compliance/compliance-clients';
 import {
@@ -133,7 +133,7 @@ class ComplianceV2Controller extends Controller {
 
 router.get(
   '/screen/:address',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   ...CheckAddressSchema,
   handleValidationErrors,
   ExportResponseCodeStats({ controllerName }),

--- a/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
@@ -21,7 +21,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { fillsRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import { NotFoundError } from '../../../lib/errors';
@@ -183,7 +183,7 @@ class FillsController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(fillsRateLimiter),
   fillsCacheControlMiddleware,
   ...CheckSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtSchema,
@@ -265,7 +265,7 @@ router.get(
 
 router.get(
   '/parentSubaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(fillsRateLimiter),
   fillsCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/funding-payments-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/funding-payments-controller.ts
@@ -14,7 +14,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { fundingRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import {
@@ -162,7 +162,7 @@ export class FundingPaymentController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(fundingRateLimiter),
   fundingPaymentsCacheControlMiddleware,
   ...CheckSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtAndOnOrAfterSchema,
@@ -218,7 +218,7 @@ router.get(
 
 router.get(
   '/parentSubaccount',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(fundingRateLimiter),
   fundingPaymentsCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtAndOnOrAfterSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/height-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/height-controller.ts
@@ -3,7 +3,7 @@ import { BlockTable, BlockFromDatabase } from '@dydxprotocol-indexer/postgres';
 import express from 'express';
 import { Controller, Get, Route } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { NotFoundError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
@@ -32,7 +32,7 @@ class HeightController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {
     const start: number = Date.now();

--- a/indexer/services/comlink/src/controllers/api/v4/historical-block-trading-rewards-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-block-trading-rewards-controller.ts
@@ -13,7 +13,7 @@ import {
   Controller, Get, Path, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
@@ -57,7 +57,7 @@ class HistoricalBlockTradingRewardsController extends Controller {
 
 router.get(
   '/:address',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   historicalBlockTradingRewardsCacheControlMiddleware,
   ...CheckHistoricalBlockTradingRewardsSchema,
   handleValidationErrors,

--- a/indexer/services/comlink/src/controllers/api/v4/historical-funding-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-funding-controller.ts
@@ -15,7 +15,7 @@ import {
   Controller, Get, Path, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { NotFoundError } from '../../../lib/errors';
 import { handleControllerError } from '../../../lib/helpers';
@@ -82,7 +82,7 @@ class HistoricalFundingController extends Controller {
 
 router.get(
   '/:ticker',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   historicalFundingCacheControlMiddleware,
   ...CheckLimitSchema,
   ...CheckTickerParamSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-pnl-controller.ts
@@ -16,7 +16,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { historicalPnlRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import { NotFoundError } from '../../../lib/errors';
@@ -179,7 +179,7 @@ class HistoricalPnlController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(historicalPnlRateLimiter),
   historicalPnlCacheControlMiddleware,
   ...CheckSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtAndOnOrAfterSchema,
@@ -233,7 +233,7 @@ router.get(
 
 router.get(
   '/parentSubaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(historicalPnlRateLimiter),
   historicalPnlCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtAndOnOrAfterSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/historical-trading-reward-aggregations-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/historical-trading-reward-aggregations-controller.ts
@@ -14,7 +14,7 @@ import {
   Controller, Get, Path, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { handleControllerError } from '../../../lib/helpers';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
@@ -59,7 +59,7 @@ class HistoricalTradingRewardAggregationsController extends Controller {
 
 router.get(
   '/:address',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   historicalTradingRewardAggregationsCacheControlMiddleware,
   ...CheckHistoricalBlockTradingRewardsSchema,
   ...checkSchema({

--- a/indexer/services/comlink/src/controllers/api/v4/orderbook-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orderbook-controller.ts
@@ -7,7 +7,7 @@ import {
   Controller, Get, Path, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { redisReadOnlyClient } from '../../../helpers/redis/redis-controller';
 import { NotFoundError } from '../../../lib/errors';
@@ -55,7 +55,7 @@ class OrderbookController extends Controller {
 
 router.get(
   '/perpetualMarket/:ticker',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   orderbookCacheControlMiddleware,
   ...checkSchema({
     ticker: {

--- a/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/orders-controller.ts
@@ -29,7 +29,7 @@ import {
   Controller, Get, Path, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { ordersRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { redisReadOnlyClient } from '../../../helpers/redis/redis-controller';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
@@ -336,7 +336,7 @@ class OrdersController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(ordersRateLimiter),
   ordersCacheControlMiddleware,
   ...CheckSubaccountSchema,
   ...CheckLimitSchema,
@@ -464,7 +464,7 @@ router.get(
 
 router.get(
   '/parentSubaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(ordersRateLimiter),
   ordersCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   ...CheckLimitSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/perpetual-markets-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/perpetual-markets-controller.ts
@@ -19,7 +19,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { InvalidParamError, NotFoundError } from '../../../lib/errors';
 import {
@@ -143,7 +143,7 @@ class PerpetualMarketsController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   perpetualMarketsCacheControlMiddleware,
   ...CheckLimitSchema,
   ...CheckTickerOptionalQuerySchema,

--- a/indexer/services/comlink/src/controllers/api/v4/perpetual-positions-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/perpetual-positions-controller.ts
@@ -27,7 +27,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import { NotFoundError } from '../../../lib/errors';
@@ -300,7 +300,7 @@ async function adjustPerpetualPositionsWithUpdatedFunding(
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   perpetualPositionsCacheControlMiddleware,
   ...CheckSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtSchema,
@@ -365,7 +365,7 @@ router.get(
 
 router.get(
   '/parentSubaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   perpetualPositionsCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/pnl-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/pnl-controller.ts
@@ -14,10 +14,13 @@ import express from 'express';
 import { matchedData } from 'express-validator';
 import _ from 'lodash';
 import {
-  Controller, Get, Query, Route,
+  Controller,
+  Get,
+  Query,
+  Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { pnlRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import { NotFoundError } from '../../../lib/errors';
@@ -192,7 +195,7 @@ class PnlController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(pnlRateLimiter),
   pnlCacheControlMiddleware,
   ...CheckSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtAndOnOrAfterSchema,
@@ -259,7 +262,7 @@ router.get(
 
 router.get(
   '/parentSubaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(pnlRateLimiter),
   pnlCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtAndOnOrAfterSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/social-trading-controller.ts
@@ -14,7 +14,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { NotFoundError } from '../../../lib/errors';
 import { checkIfValidDydxAddress, handleControllerError } from '../../../lib/helpers';
@@ -72,7 +72,7 @@ class SocialTradingController extends Controller {
 }
 
 router.get('/search',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   socialTradingCacheControlMiddleware,
   ...checkSchema({
     searchParam: {

--- a/indexer/services/comlink/src/controllers/api/v4/sparklines-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/sparklines-controller.ts
@@ -14,7 +14,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { sparklinesRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { SPARKLINE_TIME_PERIOD_TO_RESOLUTION_MAP, SPARKLINE_TIME_PERIOD_TO_LOOKBACK_MAP } from '../../../lib/constants';
 import { handleControllerError } from '../../../lib/helpers';
@@ -57,7 +57,7 @@ class SparklinesController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(sparklinesRateLimiter),
   sparklinesCacheControlMiddleware,
   ...checkSchema({
     timePeriod: {

--- a/indexer/services/comlink/src/controllers/api/v4/time-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/time-controller.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import { DateTime } from 'luxon';
 import { Controller, Get, Route } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { rateLimiterMiddleware } from '../../../lib/rate-limit';
 import ExportResponseCodeStats from '../../../request-helpers/export-response-code-stats';
@@ -28,7 +28,7 @@ class TimeController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   timeCacheControlMiddleware,
   ExportResponseCodeStats({ controllerName }),
   (_req: express.Request, res: express.Response) => {

--- a/indexer/services/comlink/src/controllers/api/v4/trades-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/trades-controller.ts
@@ -18,7 +18,7 @@ import {
   Controller, Get, Path, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { NotFoundError } from '../../../lib/errors';
 import {
@@ -90,7 +90,7 @@ class TradesController extends Controller {
 
 router.get(
   '/perpetualMarket/:ticker',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   tradesCacheControlMiddleware,
   ...CheckLimitAndCreatedBeforeOrAtSchema,
   ...CheckPaginationSchema,

--- a/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
@@ -23,7 +23,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { complianceAndGeoCheck } from '../../../lib/compliance-and-geo-check';
 import { NotFoundError } from '../../../lib/errors';
@@ -297,7 +297,7 @@ class TransfersController extends Controller {
 
 router.get(
   '/',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   transfersCacheControlMiddleware,
   ...CheckSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtSchema,
@@ -347,7 +347,7 @@ router.get(
 
 router.get(
   '/parentSubaccountNumber',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   transfersCacheControlMiddleware,
   ...CheckParentSubaccountSchema,
   ...CheckLimitAndCreatedBeforeOrAtSchema,
@@ -400,7 +400,7 @@ router.get(
 
 router.get(
   '/between',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   transfersCacheControlMiddleware,
   ...CheckTransferBetweenSchema,
   handleValidationErrors,

--- a/indexer/services/comlink/src/controllers/api/v4/turnkey-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/turnkey-controller.ts
@@ -9,7 +9,7 @@ import {
 } from 'tsoa';
 import { Address, checksumAddress, recoverMessageAddress } from 'viem';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import config from '../../../config';
 import { addAddressesToAlchemyWebhook } from '../../../helpers/alchemy-helpers';
 import { PolicyEngine } from '../../../helpers/policy-engine';
@@ -283,7 +283,7 @@ export class TurnkeyController extends Controller {
 
 router.post(
   '/signin',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   ...CheckSignInSchema,
   handleValidationErrors,
   ExportResponseCodeStats({ controllerName }),
@@ -326,7 +326,7 @@ router.post(
 
 router.post(
   '/uploadAddress',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   ...CheckUploadDydxAddressSchema,
   handleValidationErrors,
   ExportResponseCodeStats({ controllerName }),
@@ -356,7 +356,7 @@ router.post(
 
 router.get(
   '/appleLoginRedirect',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   ...CheckAppleLoginRedirectSchema,
   handleValidationErrors,
   ExportResponseCodeStats({ controllerName }),

--- a/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/vault-controller.ts
@@ -43,7 +43,7 @@ import {
   Controller, Get, Query, Route,
 } from 'tsoa';
 
-import { getReqRateLimiter } from '../../../caches/rate-limiters';
+import { defaultRateLimiter } from '../../../caches/rate-limiters';
 import { getVaultStartPnl } from '../../../caches/vault-start-pnl';
 import config from '../../../config';
 import { redisClient, redisReadOnlyClient } from '../../../helpers/redis/redis-controller';
@@ -357,7 +357,7 @@ class VaultController extends Controller {
 
 router.get(
   '/v1/megavault/historicalPnl',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   vaultCacheControlMiddleware,
   ...checkSchema({
     resolution: {
@@ -401,7 +401,7 @@ router.get(
 
 router.get(
   '/v1/vaults/historicalPnl',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   vaultCacheControlMiddleware,
   ...checkSchema({
     resolution: {
@@ -445,7 +445,7 @@ router.get(
 
 router.get(
   '/v1/megavault/positions',
-  rateLimiterMiddleware(getReqRateLimiter),
+  rateLimiterMiddleware(defaultRateLimiter),
   vaultCacheControlMiddleware,
   ExportResponseCodeStats({ controllerName }),
   async (req: express.Request, res: express.Response) => {


### PR DESCRIPTION
### **Summary**

This change introduces granular, endpoint-specific Redis-backed rate limiters across several high-traffic public endpoints in the **Comlink** service. Each endpoint now enforces its own independent rate limit policy (points, duration, and prefix) to prevent request flooding and to isolate rate-limit exhaustion per route, reducing cross-endpoint interference.

## **Changes**

### **New Endpoint-Specific Limiters**
Added dedicated `RateLimiterRedis` instances in  
`src/caches/rate-limiters.ts` for:
- `/orders` → `ordersRateLimiter`
- `/fills` → `fillsRateLimiter`
- `/candles` → `candlesRateLimiter`
- `/sparklines` → `sparklinesRateLimiter`
- `/historical-pnl` → `historicalPnlRateLimiter`
- `/pnl` → `pnlRateLimiter`
- `/fundingPayments` → `fundingRateLimiter`

Each limiter uses its own configurable key prefix and rate parameters.

### **Configuration**
Extended `configSchema` with new per-route rate-limit parameters:

RATE_LIMIT_<ENDPOINT>POINTS
RATE_LIMIT<ENDPOINT>_DURATION_SECONDS

(Defaults set to 100–1000 requests per 10 seconds depending on endpoint.)

This ensures each API path applies its own limiter instance before executing business logic or cache middleware.

## **Testing**

### Unit tests
- Rate-limit allowance and blocking behavior
- Header verification (`ratelimit-limit`, `ratelimit-remaining`, `retry-after`)
- IP-based isolation
- Per-endpoint configuration validation
- Behavior under `RATE_LIMIT_ENABLED` toggling

### Live tests
Deployed to internal networks and testnet.