### PR TITLE
[Eng-1179] RPC endpoint to use Alchemy.

### DIFF
--- a/indexer/services/comlink/src/controllers/api/v4/skip-bridge-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/skip-bridge-controller.ts
@@ -42,7 +42,7 @@ import {
   chains,
   getEOAAddressFromSmartAccountAddress,
   isSupportedEVMChainId,
-  getRPCEndpoint,
+  getZeroDevRPCEndpoint,
   publicClients,
   alchemyNetworkToChainIdMap,
 } from '../../../helpers/alchemy-helpers';
@@ -502,14 +502,14 @@ class BridgeController extends Controller {
 
     const zerodevPaymaster = createZeroDevPaymasterClient({
       chain: chains[chainId],
-      transport: http(getRPCEndpoint(chainId)),
+      transport: http(getZeroDevRPCEndpoint(chainId)),
     });
 
     const kernelClient = createKernelAccountClient({
       account,
       chain: chains[chainId],
       client: publicClients[chainId],
-      bundlerTransport: http(getRPCEndpoint(chainId)),
+      bundlerTransport: http(getZeroDevRPCEndpoint(chainId)),
       paymaster: zerodevPaymaster,
       userOperation: {
         estimateFeesPerGas: async ({ bundlerClient }) => {

--- a/indexer/services/comlink/src/helpers/alchemy-helpers.ts
+++ b/indexer/services/comlink/src/helpers/alchemy-helpers.ts
@@ -47,9 +47,17 @@ export const chains: Record<string, Chain> = {
   [optimism.id.toString()]: optimism,
 };
 
+export const chainInAlchemy: Record<string, string> = {
+  [mainnet.id.toString()]: 'eth-mainnet',
+  [arbitrum.id.toString()]: 'arb-mainnet',
+  [avalanche.id.toString()]: 'avax-mainnet',
+  [base.id.toString()]: 'base-mainnet',
+  [optimism.id.toString()]: 'opt-mainnet',
+};
+
 export const publicClients = Object.keys(chains).reduce((acc, chainId) => {
   acc[chainId] = createPublicClient({
-    transport: http(getRPCEndpoint(chainId)),
+    transport: http(getAlchemyRPCEndpoint(chainId)),
     chain: chains[chainId],
   });
   return acc;
@@ -216,7 +224,7 @@ async function registerAddressWithAlchemyWebhookWithRetry(
  */
 export async function getSmartAccountAddress(address: string): Promise<string> {
   const publicAvalancheClient = createPublicClient({
-    transport: http(getRPCEndpoint(avalanche.id.toString())),
+    transport: http(getAlchemyRPCEndpoint(avalanche.id.toString())),
     chain: avalanche,
   });
 
@@ -265,11 +273,18 @@ export function isSupportedEVMChainId(chainId: string): boolean {
   return Object.keys(chains).includes(chainId);
 }
 
-export function getRPCEndpoint(chainId: string): string {
+export function getZeroDevRPCEndpoint(chainId: string): string {
   if (!isSupportedEVMChainId(chainId)) {
     throw new Error(`Unsupported chainId: ${chainId}`);
   }
   return `${config.ZERODEV_API_BASE_URL}/${config.ZERODEV_API_KEY}/chain/${chainId}`;
+}
+
+export function getAlchemyRPCEndpoint(chainId: string): string {
+  if (!isSupportedEVMChainId(chainId)) {
+    throw new Error(`Unsupported chainId: ${chainId}`);
+  }
+  return `https://${chainInAlchemy[chainId]}.g.alchemy.com/v2/${config.ALCHEMY_API_KEY}`;
 }
 
 // TODO: Verify that this function is 1000% correct. @RUI and @TYLER and @JARED


### PR DESCRIPTION
### Changelist
Advised by zerodev to use Alchemy for rpc provider instead of them because their rpc endpoint is not meant to be used as a public client.

Tests were done on these addresses
EVM minus Avax -> 0x9A1400A921A3f3C0d7Fe8c1830B36B4fB7E176e4
Avax -> 0x06b887FDB7820bb8D90a52b6D2B1A023817493F7


### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved RPC endpoint handling for blockchain network integration, including enhanced support for Ethereum, Arbitrum, Avalanche, Base, and Optimism networks through updated endpoint management infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->