### PR TITLE
Revert "[ENG-1509] Fix /v4/fills/parentSubaccount query performance (…

### DIFF
--- a/indexer/packages/postgres/src/stores/subaccount-table.ts
+++ b/indexer/packages/postgres/src/stores/subaccount-table.ts
@@ -2,7 +2,7 @@ import { IndexerSubaccountId } from '@dydxprotocol-indexer/v4-protos';
 import { PartialModelObject, QueryBuilder } from 'objection';
 
 import config from '../config';
-import { BUFFER_ENCODING_UTF_8, DEFAULT_POSTGRES_OPTIONS, MAX_PARENT_SUBACCOUNTS } from '../constants';
+import { BUFFER_ENCODING_UTF_8, DEFAULT_POSTGRES_OPTIONS } from '../constants';
 import {
   verifyAllRequiredFields,
   setupBaseQuery,
@@ -200,36 +200,4 @@ export async function deleteById(
   await SubaccountModel.query(
     Transaction.get(options.txId),
   ).deleteById(id);
-}
-
-/**
- * Retrieves all subaccount IDs associated with a parent subaccount.
- * A subaccount is considered a child of the parent if it has the same address
- * and its subaccount number follows the modulo relationship with the parent.
- *
- * @param parentSubaccount The parent subaccount object with address and subaccountNumber
- * @param options Query options including transaction ID
- * @returns A promise that resolves to an array of subaccount ID strings
- */
-export async function findIdsForParentSubaccount(
-  parentSubaccount: {
-    address: string,
-    subaccountNumber: number,
-  },
-  options: Options = DEFAULT_POSTGRES_OPTIONS,
-): Promise<string[]> {
-  // Get all subaccounts for the address
-  const subaccounts = await findAll(
-    { address: parentSubaccount.address },
-    [],
-    options,
-  );
-
-  // Filter for subaccounts that match the parent relationship
-  // (subaccountNumber - parentSubaccountNumber) % MAX_PARENT_SUBACCOUNTS = 0
-  return subaccounts
-    .filter((subaccount) => (subaccount.subaccountNumber - parentSubaccount.subaccountNumber) %
-     MAX_PARENT_SUBACCOUNTS === 0,
-    )
-    .map((subaccount) => subaccount.id);
 }


### PR DESCRIPTION
…backport #3279) (#3281)"

This reverts commit 3ff1e43e23d03a87efd95e143f0a78fde1f9e106.

### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.
