### PR TITLE
fix(postgres): query master for latest block to avoid replication lag

### DIFF
--- a/indexer/packages/postgres/src/constants.ts
+++ b/indexer/packages/postgres/src/constants.ts
@@ -125,6 +125,9 @@ export const DEFAULT_POSTGRES_OPTIONS : Options = config.USE_READ_REPLICA
   ? {
     readReplica: true,
   } : {};
+export const USE_MASTER_POSTGRES_OPTIONS : Options = {
+  readReplica: false,
+};
 
 // The maximum number of parent subaccounts per address.
 export const MAX_PARENT_SUBACCOUNTS: number = 128;

--- a/indexer/packages/postgres/src/stores/block-table.ts
+++ b/indexer/packages/postgres/src/stores/block-table.ts
@@ -1,7 +1,7 @@
 import { logger } from '@dydxprotocol-indexer/base';
 import { QueryBuilder } from 'objection';
 
-import { DEFAULT_POSTGRES_OPTIONS } from '../constants';
+import { DEFAULT_POSTGRES_OPTIONS, USE_MASTER_POSTGRES_OPTIONS } from '../constants';
 import { setupBaseQuery, verifyAllRequiredFields } from '../helpers/stores-helpers';
 import Transaction from '../helpers/transaction';
 import BlockModel from '../models/block-model';
@@ -110,7 +110,7 @@ export async function findByBlockHeight(
 }
 
 export async function getLatest(
-  options: Options = DEFAULT_POSTGRES_OPTIONS,
+  options: Options = USE_MASTER_POSTGRES_OPTIONS,
 ): Promise<BlockFromDatabase> {
   const baseQuery: QueryBuilder<BlockModel> = setupBaseQuery<BlockModel>(
     BlockModel,


### PR DESCRIPTION
# fix: query master DB for latest block to avoid replication lag

## Summary

- Changed `getLatest()` in `block-table.ts` to default to reading from the master database instead of read replica
- Introduced new `USE_MASTER_POSTGRES_OPTIONS` constant that explicitly disables read replica routing
- Prevents stale data issues when querying for the most recent block in the presence of replication lag

## Details

**Rationale**
- Latest block queries are time-sensitive and particularly vulnerable to replication lag
- Reading stale block data from a replica can cause incorrect indexing behavior or API responses
- Other block queries (e.g., by height) retain the existing replica routing behavior

## Risk & Impact

**Low-to-medium risk:**
- Increases load on master database for `getLatest()` calls; callers relying on this method will now hit master
- If `getLatest()` is called frequently (e.g., in tight loops or high-volume API paths), this could degrade master performance
- No breaking API changes; existing callers can still override the default by passing explicit options
- No data model or migration changes

## Testing

No new tests added; existing coverage reused. The change is a default parameter value swap with no new logic.

Deployed to testnet and internal-mainnet.