### PR TITLE
perf(ender): add long open interest index for candles updates

### DIFF
--- a/indexer/packages/postgres/src/db/migrations/migration_files/20260112170004_create_long_open_interest_index.ts
+++ b/indexer/packages/postgres/src/db/migrations/migration_files/20260112170004_create_long_open_interest_index.ts
@@ -1,0 +1,17 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY perpetual_positions_oi_open_idx ON perpetual_positions ("perpetualId", side) INCLUDE (size) WHERE status = 'OPEN';
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX CONCURRENTLY IF EXISTS "perpetual_positions_oi_open_idx";
+    `);
+}
+
+export const config = {
+  transaction: false,
+};


### PR DESCRIPTION
## Summary

- Adds a new database index on the `perpetual_positions` table to optimize open interest queries filtered by perpetual ID, side, and open status.

## Details

**Database schema:**
- New partial index `perpetual_positions_oi_open_idx` on columns `(perpetualId, side)` with `INCLUDE (size)` and `WHERE status = 'OPEN'`
- Index includes `size` as a covering column to enable index-only scans for aggregation queries.
- Migration configured with `transaction: false` to allow concurrent index creation
- Down migration drops the index with `CONCURRENTLY IF EXISTS` for safe rollback

## Risk & Impact

**Low to medium risk:**
- Concurrent index creation avoids table locks during deployment, enabling zero-downtime migration
- Index improves query performance for open interest calculations (aggregating size by perpetual for long positions)
- Adds storage overhead for the partial index (limited to *open* positions only)
- No changes to application logic or data; purely an optimization layer

## Testing

No tests added; this is a database migration that will be verified through:
- Migration execution success in staging/production
- Query performance monitoring post-deployment

Deployed to testnet and internal-mainnet to validate performance improvement.