### PR TITLE
metrics(ender): refine processing and publishing metrics

### DIFF
--- a/indexer/services/ender/src/lib/kafka-publisher.ts
+++ b/indexer/services/ender/src/lib/kafka-publisher.ts
@@ -185,6 +185,7 @@ export class KafkaPublisher {
   }
 
   public async publish() {
+    const start = Date.now();
     const allTopicKafkaMessages:
     TopicKafkaMessages[] = this.generateAllTopicKafkaMessages();
 
@@ -203,6 +204,11 @@ export class KafkaPublisher {
           return batchProducer.flush();
         },
       ),
+    );
+    stats.timing(
+      `${config.SERVICE_NAME}.kafka_publish.timing`,
+      Date.now() - start,
+      STATS_NO_SAMPLING,
     );
   }
 


### PR DESCRIPTION
## Summary

- Add granular timing metrics for event handling and Kafka publishing operations
- Move Kafka producer message contents from INFO to DEBUG logging to reduce noise
- Add TODOs documenting known issues with inaccurate metrics

## Details

### Logging

- Split `BatchKafkaProducer.sendBatch()` logging: basic metadata at INFO, full message payloads at DEBUG

### Metrics

- **Block processor**: Added `handle_events.timing` metric to measure total event handler processing time
- **Kafka publisher**: Added `kafka_publish.timing` metric to measure actual message publishing duration.
- **Timing fix**: Moved `start` timestamp in `processEvents()` to before SQL event processing (previously only measured event handler timing, not full processing)
- Documented that `kafka_batch_send_time` is incorrect—it measures promise creation, not actual send completion

## Risk & Impact

Low risk: observability-only changes.

- No functional behavior changes to business logic
- Logging volume at INFO level reduced
- New metrics added without removal of existing ones
- Timing measurement changes may affect alerting thresholds if they exist for related metrics

## Testing

- No new tests added; changes are purely instrumentation.
- Deployed to testnet and internal mainnet.