### PR TITLE
perf(ender:candles): precompute strings, simpler getCandle

### DIFF
--- a/indexer/services/ender/src/caches/candle-cache.ts
+++ b/indexer/services/ender/src/caches/candle-cache.ts
@@ -45,11 +45,7 @@ export function getCandle(
   ticker: string,
   resolution: CandleResolution,
 ): CandleFromDatabase | undefined {
-  if (ticker in candlesMap && resolution in candlesMap[ticker]) {
-    return candlesMap[ticker][resolution];
-  }
-
-  return undefined;
+  return candlesMap[ticker]?.[resolution];
 }
 
 export function updateCandleCacheWithCandle(candle: CandleFromDatabase): void {


### PR DESCRIPTION
## Summary

- Eliminate redundant `DateTime.toISO()` calls by pre-computing ISO string timestamps once during `CandlesGenerator` initialization.
- Refactor `getCandle` to use optional chaining, simplifying cache lookup logic.
- Minor cleanups: remove intermediate variable `blockCandleUpdatesMap` from `updateCandles` scope, inline `perpetualMarkets` lookup.

## Details

**Performance optimization:**
- Add `resolutionStartTimesISO: Map<CandleResolution, string>` field to cache ISO timestamp strings alongside the existing `resolutionStartTimes` map.
- Update all candle create/update methods to accept pre-computed `startedAtISO: string` instead of `DateTime` objects, removing 10+ `.toISO()` calls per block.
- Pass pre-computed ISO strings to `getOpenInterestMap` to avoid repeated conversions in tight loops.

**Code simplification:**
- Replace conditional cache lookup in `getCandle` with optional chaining: `candlesMap[ticker]?.[resolution]`.
- Move `blockCandleUpdatesMap` generation inline in `createOrUpdatePostgresCandles` to clarify data flow.
- Extract `perpetualMarkets` array and `perpetualMarketTickers` to avoid repeated map value retrievals.

## Risk & Impact

**Low risk: internal refactor with no behavior change.**

- Optimization reduces string allocations and `toISO()` overhead during candle generation for each block.
- No changes to public APIs, database schema, or Kafka message formats.
- Logic remains functionally equivalent; only representation and timing of ISO conversion changes.

## Testing

No new tests added; existing coverage reused.
Deployed to testnet and internal-mainnet.