### PR TITLE
upgrade cosmos-sdk and cometbft version for height poisoning fix

### DIFF
--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -470,9 +470,9 @@ replace (
 	// Use dYdX fork of Cosmos SDK/store
 	cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d
 	// Use dYdX fork of CometBFT
-	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20260126154011-467083c7ba0b
+	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20260428184537-904204b11c9e
 	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20260126162345-69ba38d4ae69
+	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20260428191449-a212821dc2c3
 	github.com/cosmos/iavl => github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85
 )
 

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -956,10 +956,10 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20260126154011-467083c7ba0b h1:zimy9cByNdNEXMtcq0MLgS1/1SNudK2t9gGIW/Rv9co=
-github.com/dydxprotocol/cometbft v0.38.6-0.20260126154011-467083c7ba0b/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20260126162345-69ba38d4ae69 h1:yppKvzPXeXJeTnJQGm4q3W2QykVs9ogKAzPdoBwntLk=
-github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20260126162345-69ba38d4ae69/go.mod h1:LPTAFgqFNHEbp7hQG16uSIEw5GpwXT5QMbX+oI0CMfA=
+github.com/dydxprotocol/cometbft v0.38.6-0.20260428184537-904204b11c9e h1:Ybo23Wpsi9KIZXz5tXPc6Dtg8thjdkVTkjGhvaebUFw=
+github.com/dydxprotocol/cometbft v0.38.6-0.20260428184537-904204b11c9e/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20260428191449-a212821dc2c3 h1:F0Ob6YZsLRVpZ+n1yEsN7K73GrpZB4b2D/qH5iq5VSM=
+github.com/dydxprotocol/cosmos-sdk v0.50.6-0.20260428191449-a212821dc2c3/go.mod h1:PH4z05Kzu2tZJG1wBpJCwo1LnHNkgvYjHkaono8EKNs=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d h1:HgLu1FD2oDFzlKW6/+SFXlH5Os8cwNTbplQIrQOWx8w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326192503-dd116391188d/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/dydxprotocol/iavl v1.1.1-0.20240509161911-1c8b8e787e85 h1:5B/yGZyTBX/OZASQQMnk6Ms/TZja56MYd8OBaVc0Mho=


### PR DESCRIPTION
see https://github.com/dydxprotocol/cometbft/pull/57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying protocol dependencies to newer versions for stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->