### PR TITLE
fix(indexer): resolve compilation and migration issues in local deployment

### DIFF
--- a/indexer/Dockerfile.postgres-package.local
+++ b/indexer/Dockerfile.postgres-package.local
@@ -40,7 +40,7 @@ RUN chown dydx -R /home/dydx/app
 USER dydx
 
 # Install npm modules using pnpm
-RUN pnpm i --loglevel warn --production --frozen-lockfile --unsafe-perm
+RUN pnpm i --loglevel warn --frozen-lockfile --unsafe-perm
 
 WORKDIR /home/dydx/app/packages/postgres
 

--- a/indexer/tsconfig.json
+++ b/indexer/tsconfig.json
@@ -13,6 +13,7 @@
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "inlineSourceMap": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## Description
This Pull Request resolves two universal issues encountered when compiling and setting up the local Indexer environment.

### 1. Enable `skipLibCheck` in tsconfig compiler options
- **Problem**: During TypeScript compilation, type conflicts inside third-party dependency declaration files (`.d.ts`) often cause the build to fail.
- **Solution**: Added `"skipLibCheck": true` under `"compilerOptions"` in `indexer/tsconfig.json`. This instructs the TypeScript compiler to skip type checking of declaration files (.d.ts) from third-party libraries, which is standard practice to avoid dependency-level type mismatches.

### 2. Remove `--production` flag from pnpm install in `Dockerfile.postgres-package.local`
- **Problem**: In `indexer/Dockerfile.postgres-package.local`, `NODE_ENV` is set to `development`, yet `pnpm install` is executed with the `--production` flag. This prevents devDependencies (such as `typescript` and `ts-node`) from being installed. Consequently, the container fails to execute database migrations because `ts-node` cannot be found.
- **Solution**: Removed the `--production` flag from the local deployment Dockerfile to ensure that devDependencies required for local migration runs are properly installed.

---

## Test Plan
- Build and run local indexer: `docker compose -f indexer/docker-compose-local-deployment.yml up --build`
- Verify that `postgres-package-1` builds successfully, compiles typescript schemas, and exits with code `0` after successfully completing migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build configuration updated so images are produced with the full set of project dependencies.
* **Performance**
  * Type-checking of external declaration files is skipped to reduce compilation time and speed up local and CI builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->