### PR TITLE
refactor: remove redundant err checks

### DIFF
--- a/protocol/scripts/vault/get_vault.go
+++ b/protocol/scripts/vault/get_vault.go
@@ -56,9 +56,6 @@ func main() {
 		Type:   vaultType,
 		Number: vaultNumber,
 	}
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	vault := vaultId.ToSubaccountId()
 

--- a/protocol/x/sending/client/cli/tx_create_transfer.go
+++ b/protocol/x/sending/client/cli/tx_create_transfer.go
@@ -41,10 +41,6 @@ func CmdCreateTransfer() *cobra.Command {
 				return err
 			}
 
-			if err != nil {
-				return err
-			}
-
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err


### PR DESCRIPTION
### Changelist
Removed redundant `if err != nil` checks from `protocol/scripts/vault/get_vault.go` and `protocol/x/sending/client/cli/tx_create_transfer.go` that were checking for errors when none could have been produced by the preceding line.

### Test Plan
Code linting and compilation locally.

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [X] Manually add any of the following labels: `refactor`, `chore`, `bug`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code cleanup and optimization in vault and transfer-related scripts to improve maintainability and reduce redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->