### PR TITLE
chore: info to debug logs

### DIFF
--- a/indexer/services/comlink/src/request-helpers/request-logger.ts
+++ b/indexer/services/comlink/src/request-helpers/request-logger.ts
@@ -19,7 +19,7 @@ export default (
     // Don't log GET requests unless configured to
     const shouldLogMethod: boolean = request.method !== 'GET' || config.LOG_GETS;
     if (shouldLogMethod || response.statusCode !== 200) {
-      logger.info({
+      logger.debug({
         at: 'requestLogger#logRequest',
         message: {
           request: {

--- a/indexer/services/ender/src/caches/block-cache.ts
+++ b/indexer/services/ender/src/caches/block-cache.ts
@@ -59,7 +59,7 @@ export async function shouldSkipBlock(
     });
     return true;
   } else if (isNextBlock(blockHeight)) {
-    logger.info({
+    logger.debug({
       at: 'block-cache#shouldSkipBlock',
       message: 'Block will be processed',
       blockHeight,

--- a/indexer/services/ender/src/caches/orderbook-mid-price-memory-cache.ts
+++ b/indexer/services/ender/src/caches/orderbook-mid-price-memory-cache.ts
@@ -46,7 +46,7 @@ export async function updateOrderbookMidPrices(): Promise<void> {
 
     // Log out each median price for each market
     Object.entries(orderbookMidPriceCache).forEach(([ticker, price]) => {
-      logger.info({
+      logger.debug({
         at: 'orderbook-mid-price-cache#updateOrderbookMidPrices',
         message: `Median price for market ${ticker}`,
         ticker,

--- a/indexer/services/ender/src/lib/block-processor.ts
+++ b/indexer/services/ender/src/lib/block-processor.ts
@@ -227,7 +227,7 @@ export class BlockProcessor {
         ...this.block.events[eventProto.blockEventIndex],
         subtype: SKIPPED_EVENT_SUBTYPE,
       };
-      logger.info({
+      logger.debug({
         at: 'onMessage#shouldSkipSql',
         message: 'Excluded event from sql processing',
         eventProto,
@@ -236,7 +236,7 @@ export class BlockProcessor {
     if (validator.shouldSkipHandlers()) {
       // If handlers should be skipped, set handlers to empty.
       handlers = [];
-      logger.info({
+      logger.debug({
         at: 'onMessage#shouldSkipHandlers',
         message: 'Excluded event from handler processing',
         eventProto,

--- a/indexer/services/ender/src/lib/on-message.ts
+++ b/indexer/services/ender/src/lib/on-message.ts
@@ -73,7 +73,7 @@ export async function onMessage(message: KafkaMessage): Promise<void> {
     },
   );
 
-  logger.info({
+  logger.debug({
     at: 'onMessage#onMessage',
     message: 'Processing message',
     offset,
@@ -121,7 +121,7 @@ export async function onMessage(message: KafkaMessage): Promise<void> {
       );
     }
 
-    logger.info({
+    logger.debug({
       at: 'onMessage#onMessage',
       message: 'Successfully processed block',
       height: blockHeight,
@@ -186,7 +186,7 @@ function getIndexerTendermintBlock(
   }
   try {
     const messageValueBinary: Uint8Array = new Uint8Array(message.value);
-    logger.info({
+    logger.debug({
       at: 'onMessage#getIndexerTendermintBlock',
       message: 'Received message',
       offset: message.offset,
@@ -195,7 +195,7 @@ function getIndexerTendermintBlock(
     const block: IndexerTendermintBlock = IndexerTendermintBlock.decode(
       messageValueBinary,
     );
-    logger.info({
+    logger.debug({
       at: 'onMessage#getIndexerTendermintBlock',
       message: 'Parsed message',
       offset: message.offset,

--- a/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
+++ b/indexer/services/roundtable/src/helpers/pnl-ticks-helper.ts
@@ -80,7 +80,7 @@ export async function getPnlTicksCreateObjects(
     mostRecentPnlTicks,
     (pnlTick: PnlTicksCreateObject) => pnlTick.blockTime,
   );
-  logger.info({
+  logger.debug({
     at: 'pnl-ticks-helper#getPnlTicksCreateObjects',
     message: 'Account to last updated block time',
     accountToLastUpdatedBlockTime,
@@ -94,7 +94,7 @@ export async function getPnlTicksCreateObjects(
     ...getAccountsToUpdate(accountToLastUpdatedBlockTime, blockTime),
     ...newSubaccountIds,
   ].slice(0, config.PNL_TICK_MAX_ACCOUNTS_PER_RUN);
-  logger.info({
+  logger.debug({
     at: 'pnl-ticks-helper#getPnlTicksCreateObjects',
     message: 'Accounts to update',
     accountsToUpdate,
@@ -203,7 +203,7 @@ export async function getPnlTicksCreateObjects(
       });
     }
   });
-  logger.info({
+  logger.debug({
     at: 'pnl-ticks-helper#getPnlTicksCreateObjects',
     message: 'New ticks to create',
     subaccountIds: _.map(newTicksToCreate, 'subaccountId'),
@@ -315,7 +315,7 @@ export function getNewPnlTick(
   lastUpdatedFundingIndexMap: FundingIndexMap,
   currentFundingIndexMap: FundingIndexMap,
 ): PnlTicksCreateObject {
-  logger.info({
+  logger.debug({
     at: 'createPnlTicks#getNewPnlTick',
     message: 'Creating new PNL tick',
     subaccountId,
@@ -334,7 +334,7 @@ export function getNewPnlTick(
     currentEquity,
     subaccountTotalTransfersMap[subaccountId][USDC_ASSET_ID],
   );
-  logger.info({
+  logger.debug({
     at: 'createPnlTicks#getNewPnlTick',
     message: 'Calculated equity and total pnl',
     subaccountId,
@@ -376,7 +376,7 @@ export function getNewPnlTick(
     blockHeight: latestBlockHeight,
     blockTime: latestBlockTime,
   };
-  logger.info({
+  logger.debug({
     at: 'createPnlTicks#getNewPnlTick',
     message: 'New PNL tick',
     subaccountId,

--- a/indexer/services/socks/src/lib/message-forwarder.ts
+++ b/indexer/services/socks/src/lib/message-forwarder.ts
@@ -141,7 +141,7 @@ export class MessageForwarder {
       // also prevent disconnecting from the broker due to inactivity.
       const now: number = Date.now();
       if (now - lastCommitTime > config.KAFKA_BATCH_PROCESSING_COMMIT_FREQUENCY_MS) {
-        logger.info({
+        logger.debug({
           at: 'on-batch#onBatch',
           message: 'Committing offsets and sending heart beat',
           ...batchInfo,
@@ -404,7 +404,7 @@ export class MessageForwarder {
   ): void {
     const connection: Connection = this.index.connections[connectionId];
     if (!connection) {
-      logger.info({
+      logger.debug({
         at: 'message-forwarder#forwardToClientBatch',
         message: 'Attempted to forward batched messages, but connection did not exist',
         connectionId,
@@ -466,7 +466,7 @@ export class MessageForwarder {
   public forwardToClient(message: MessageToForward, connectionId: string): number {
     const connection: Connection = this.index.connections[connectionId];
     if (!connection) {
-      logger.info({
+      logger.debug({
         at: 'message-forwarder#forwardToClient',
         message: 'Attempted to forward message, but connection did not exist',
         connectionId,

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -777,7 +777,7 @@ export class Subscriptions {
     });
 
     if (Object.keys(maxSubscriptionsByChannel).length > 0) {
-      logger.info({
+      logger.debug({
         at: 'Subscriptions#emitSubscriptionMetrics',
         message: 'Max subscriptions by channel',
         maxSubscriptionsByChannel,
@@ -785,7 +785,7 @@ export class Subscriptions {
     }
 
     if (Object.keys(maxIdByChannel).length > 0) {
-      logger.info({
+      logger.debug({
         at: 'Subscriptions#emitSubscriptionMetrics',
         message: 'Max id by channel',
         maxIdByChannel,

--- a/indexer/services/socks/src/websocket/index.ts
+++ b/indexer/services/socks/src/websocket/index.ts
@@ -98,7 +98,7 @@ export class Index {
     const connection: Connection = this.connections[connectionId];
 
     const numConcurrentConnections: number = Object.keys(this.connections).length;
-    logger.info({
+    logger.debug({
       at: 'index#onConnection',
       message: 'Received websocket connection',
       url: ws.url,
@@ -160,7 +160,7 @@ export class Index {
       // TODO remove use as developer indicates
       const reasonStr = safeJsonStringify(reason);
 
-      logger.info({
+      logger.debug({
         at: 'index#onClose',
         message: 'Connection closed',
         connectionId,
@@ -232,7 +232,7 @@ export class Index {
       },
     );
     if (!connection) {
-      logger.info({
+      logger.debug({
         at: 'index#onMessage',
         message: 'Received message for closed connection',
         connectionId,
@@ -269,7 +269,7 @@ export class Index {
           return;
         }
 
-        logger.info({
+        logger.debug({
           at: 'index#onSubscribe',
           message: 'Received websocket subscribe',
           connectionId,
@@ -359,7 +359,7 @@ export class Index {
     }
 
     try {
-      logger.info({
+      logger.debug({
         at: 'index#heartbeat',
         message: 'Sending heartbeat ping',
         connectionId,
@@ -422,7 +422,7 @@ export class Index {
       return;
     }
     try {
-      logger.info({
+      logger.debug({
         at: 'index#disconnect',
         message: 'Disconnecting websocket connection',
         connectionId,

--- a/indexer/services/vulcan/src/handlers/order-place-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-place-handler.ts
@@ -48,7 +48,7 @@ import { Handler } from './handler';
  */
 export class OrderPlaceHandler extends Handler {
   protected async handle(update: OffChainUpdateV1, headers: IHeaders): Promise<void> {
-    logger.info({
+    logger.debug({
       at: 'OrderPlaceHandler#handle',
       message: 'Received OffChainUpdate with OrderPlace.',
       update,
@@ -84,7 +84,7 @@ export class OrderPlaceHandler extends Handler {
     await this.removeOrderFromCanceledOrdersCache(
       OrderTable.orderIdToUuid(redisOrder.order?.orderId!),
     );
-    logger.info({
+    logger.debug({
       at: 'OrderPlaceHandler#handle',
       message: 'OrderPlace processed',
       order,

--- a/indexer/services/vulcan/src/handlers/order-remove-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-remove-handler.ts
@@ -76,7 +76,7 @@ import { getStateRemainingQuantums } from './helpers';
 export class OrderRemoveHandler extends Handler {
   // eslint-disable-next-line @typescript-eslint/require-await
   protected async handle(update: OffChainUpdateV1, headers: IHeaders): Promise<void> {
-    logger.info({
+    logger.debug({
       at: 'OrderRemoveHandler#handle',
       message: 'Received OffChainUpdate with OrderRemove.',
       update,
@@ -113,7 +113,7 @@ export class OrderRemoveHandler extends Handler {
       }),
       this.generateTimingStatsOptions('remove_order'),
     );
-    logger.info({
+    logger.debug({
       at: 'OrderRemoveHandler#handle',
       message: 'OrderRemove processed',
       orderRemove,
@@ -128,7 +128,7 @@ export class OrderRemoveHandler extends Handler {
         1,
         { instance: getInstanceId() },
       );
-      logger.info({
+      logger.debug({
         at: 'OrderRemoveHandler#handle',
         message: 'Order was expired by Indexer',
         orderRemove,
@@ -794,7 +794,7 @@ export class OrderRemoveHandler extends Handler {
     const status: OrderRemoveV1_OrderRemovalStatus = orderRemove.removalStatus;
     const reason: OrderRemovalReason = orderRemove.reason;
 
-    logger.info({
+    logger.debug({
       at: 'orderRemoveHandler#shouldSendSubaccountMessage',
       message: 'Compared state filled quantums and size',
       stateRemainingQuantums: stateRemainingQuantums.toFixed(),

--- a/indexer/services/vulcan/src/handlers/order-update-handler.ts
+++ b/indexer/services/vulcan/src/handlers/order-update-handler.ts
@@ -52,7 +52,7 @@ import { Handler } from './handler';
  */
 export class OrderUpdateHandler extends Handler {
   protected async handle(update: OffChainUpdateV1, headers: IHeaders): Promise<void> {
-    logger.info({
+    logger.debug({
       at: 'OrderUpdateHandler#handle',
       message: 'Received OffChainUpdate with OrderUpdate.',
       update,
@@ -71,7 +71,7 @@ export class OrderUpdateHandler extends Handler {
       this.generateTimingStatsOptions('update_order_cache_update'),
     );
 
-    logger.info({
+    logger.debug({
       at: 'OrderUpdateHandler#handle',
       message: 'OrderUpdate processed',
       orderUpdate,


### PR DESCRIPTION
### Changelist
Switch high-frequency `logger.info` calls to `logger.debug` to cut log noise across
ender, vulcan, socks, comlink, and roundtable — block/message processing, order
place/update/remove handlers, websocket connection lifecycle, request logging, and
PnL tick creation.

Note: these lines are only suppressed once the deployed `LOG_LEVEL` is `info`. The
default is `debug`, so the ECS task definitions for the affected services must set
`LOG_LEVEL=info` for this to take effect (see Deployment note).

### Deployment note
Set `LOG_LEVEL=info` on the indexer task definitions for: **ender, comlink, socks,
roundtable, vulcan**. Without this the change is a no-op (debug logs still emit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity across indexer services to reduce standard log output while preserving detailed debug-level logging for troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->