### PR TITLE
Purge Go module cache from cosmovisor-installing images

### DIFF
--- a/protocol/testing/containertest/Dockerfile
+++ b/protocol/testing/containertest/Dockerfile
@@ -9,7 +9,11 @@ COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 COPY ./testing/version/. /dydxprotocol/
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/containertest.sh
 

--- a/protocol/testing/e2etest-local/Dockerfile
+++ b/protocol/testing/e2etest-local/Dockerfile
@@ -6,7 +6,11 @@ COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/local.sh
 

--- a/protocol/testing/mainnet/Dockerfile
+++ b/protocol/testing/mainnet/Dockerfile
@@ -1,7 +1,11 @@
 FROM dydxprotocol-base
 
 RUN apk add --no-cache bash jq aws-cli
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 COPY ./testing/version/. /dydxprotocol/
 COPY ./testing/mainnet/. /dydxprotocol/

--- a/protocol/testing/snapshotting/Dockerfile.snapshot
+++ b/protocol/testing/snapshotting/Dockerfile.snapshot
@@ -2,7 +2,11 @@ FROM dydxprotocol-base
 
 COPY ./testing/snapshotting/snapshot.sh /dydxprotocol/snapshot.sh
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 RUN apk add --no-cache bash jq aws-cli
 
 ENTRYPOINT ["/dydxprotocol/snapshot.sh"]

--- a/protocol/testing/testnet-dev/Dockerfile
+++ b/protocol/testing/testnet-dev/Dockerfile
@@ -6,7 +6,11 @@ COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/dev.sh
 

--- a/protocol/testing/testnet-local/Dockerfile
+++ b/protocol/testing/testnet-local/Dockerfile
@@ -6,7 +6,11 @@ COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/local.sh
 

--- a/protocol/testing/testnet-staging/Dockerfile
+++ b/protocol/testing/testnet-staging/Dockerfile
@@ -6,7 +6,11 @@ COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/staging.sh
 

--- a/protocol/testing/testnet/Dockerfile
+++ b/protocol/testing/testnet/Dockerfile
@@ -1,7 +1,11 @@
 FROM dydxprotocol-base
 
 RUN apk add --no-cache bash jq aws-cli
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 COPY ./testing/version/. /dydxprotocol/
 COPY ./testing/testnet/. /dydxprotocol/


### PR DESCRIPTION
## What it is

Strips the Go module cache out of the container images that install `cosmovisor`, so downloaded module *source* (including npm lockfiles like cosmos-sdk's `docs/package-lock.json`) is never committed into the shipped image.

The `RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0` step resolves cosmovisor's dependency graph and writes full module source into `/go/pkg/mod`, which persists in the image layer. That tree carries build-time npm manifests that SCA scanners flag even though the code is never installed (`node_modules`), loaded, or run at runtime.

Concretely this closes the Wiz finding for **axios `0.25.0`** (CVE-2026-42043) at `/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.46.0-beta2.../docs/package-lock.json` in `mainnet-full-node`. Dependency chain: `cosmovisor v1.5.0 (indirect)` → cosmos-sdk module source → `docs/` Docusaurus 2.4.1 → `@docusaurus/core` → `wait-on@6.0.1` → `axios@0.25.0`. None of that is on the node's runtime path.

The base image (`dydxprotocol-base`, from the multi-stage `protocol/Dockerfile`) already ships only the compiled binary with a cache-mounted modcache — so the `go install cosmovisor` layer is the sole source of these artifacts.

## The change

Append `&& go clean -modcache` to the cosmovisor install, in the **same RUN layer**:

```dockerfile
RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
```

The cosmovisor binary lands in `/go/bin` (on PATH) and survives; the module cache is wiped before the layer is committed. Same-layer is required — scanners inspect per-layer, so a cleanup in a later layer would leave the artifact in the earlier one.

| Property | Delivered |
|---|---|
| Runtime behavior | Unchanged — cosmovisor binary present and on PATH |
| Image contents | `/go/pkg/mod` no longer committed; source manifests gone |
| Finding class | Removes all SCA-in-Go-module-cache findings from these images, not just axios |
| Scope | Build/packaging only; no Go deps, no app code touched |

## Reviewer brief

Eight `protocol/testing/*/Dockerfile`s, identical one-line change each. The load-bearing one is `mainnet/Dockerfile` (builds `mainnet-full-node`). No source or dependency changes.

## Out of scope

- `protocol/scripts/create_full_node.sh` — installs cosmovisor on a **host VM**, not a container layer; intentionally left unchanged.
- Upgrading the cosmos-sdk fork's `docs/` off Docusaurus 2.4.1 (which is what actually pulls axios) — separate hygiene follow-up; not required to close this finding.

## Test plan

- [ ] Rebuild `mainnet-full-node` and confirm `cosmovisor` runs (entrypoint unaffected)
- [ ] Confirm `/go/pkg/mod` is absent in the built image
- [ ] Wiz rescan shows the axios / CVE-2026-42043 finding cleared


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced leftover build artifacts in several testing and deployment images by cleaning the Go module cache during installation.
  * This helps keep generated images smaller and avoids carrying unnecessary downloaded sources into the final image layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->