### PR TITLE
Purge Go module cache from cosmovisor images (v9.x backport of #3355)

### DIFF
--- a/protocol/testing/containertest/Dockerfile
+++ b/protocol/testing/containertest/Dockerfile
@@ -9,7 +9,11 @@ COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 COPY ./testing/version/. /dydxprotocol/
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/containertest.sh
 

--- a/protocol/testing/e2etest-local/Dockerfile
+++ b/protocol/testing/e2etest-local/Dockerfile
@@ -6,7 +6,11 @@ COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/local.sh
 

--- a/protocol/testing/mainnet/Dockerfile
+++ b/protocol/testing/mainnet/Dockerfile
@@ -1,7 +1,11 @@
 FROM dydxprotocol-base
 
 RUN apk add --no-cache bash jq aws-cli
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 COPY ./testing/version/. /dydxprotocol/
 COPY ./testing/mainnet/. /dydxprotocol/

--- a/protocol/testing/snapshotting/Dockerfile.snapshot
+++ b/protocol/testing/snapshotting/Dockerfile.snapshot
@@ -2,7 +2,11 @@ FROM dydxprotocol-base
 
 COPY ./testing/snapshotting/snapshot.sh /dydxprotocol/snapshot.sh
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 RUN apk add --no-cache bash jq aws-cli
 
 ENTRYPOINT ["/dydxprotocol/snapshot.sh"]

--- a/protocol/testing/testnet-dev/Dockerfile
+++ b/protocol/testing/testnet-dev/Dockerfile
@@ -6,7 +6,11 @@ COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/dev.sh
 

--- a/protocol/testing/testnet-local/Dockerfile
+++ b/protocol/testing/testnet-local/Dockerfile
@@ -6,7 +6,11 @@ COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/local.sh
 

--- a/protocol/testing/testnet-staging/Dockerfile
+++ b/protocol/testing/testnet-staging/Dockerfile
@@ -6,7 +6,11 @@ COPY ./testing/start.sh /dydxprotocol/start.sh
 COPY ./daemons/pricefeed/client/constants/testdata /dydxprotocol/exchange_config
 COPY ./testing/delaymsg_config /dydxprotocol/delaymsg_config
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 RUN /dydxprotocol/staging.sh
 

--- a/protocol/testing/testnet/Dockerfile
+++ b/protocol/testing/testnet/Dockerfile
@@ -1,7 +1,11 @@
 FROM dydxprotocol-base
 
 RUN apk add --no-cache bash jq aws-cli
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+# Install cosmovisor, then purge the Go module cache in the SAME layer so the
+# downloaded module source (which includes npm lockfiles like cosmos-sdk's
+# docs/package-lock.json) is never committed into the shipped image. Must be
+# same-layer: image scanners inspect per-layer, so a later cleanup wouldn't help.
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0 && go clean -modcache
 
 COPY ./testing/version/. /dydxprotocol/
 COPY ./testing/testnet/. /dydxprotocol/


### PR DESCRIPTION
## What it is

Release-branch (`release/protocol/v9.x`) backport of the Go-module-cache purge from #3355, so the RC image for `mainnet-full-node` no longer ships build-time npm lockfiles in `/go/pkg/mod`.

Prepared as an RC on the v9.x line because that is the lineage actually running on mainnet: the deployed `mainnet-full-node@sha256:299fe966…` is tagged `213eef5` = `protocol/v9.6.1`, released from this branch. `main` is not an ancestor of this branch, so a `main + fix` build would be the wrong lineage.

## The change

Cherry-pick of a527ae044 (`-x`), unchanged: append `&& go clean -modcache` to the `go install cosmovisor` step in the 8 `protocol/testing/*` Dockerfiles, same-layer, so the cosmovisor binary survives in `/go/bin` while the module source cache is never committed.

Closes the Wiz finding for axios 0.25.0 (CVE-2026-42043) at `…/cosmos-sdk@…/docs/package-lock.json`, a build-time transitive dep never installed or run.

| Property | Delivered |
|---|---|
| Runtime behavior | Unchanged — cosmovisor present, on PATH |
| Image contents | `/go/pkg/mod` no longer committed |
| Finding class | Removes all SCA-in-Go-module-cache findings from these images |
| Lineage | Based on `release/protocol/v9.x` tip (v9.6.3), correct for a mainnet RC |

## Reviewer brief

Identical to #3355 — 8 one-line Dockerfile edits, `mainnet/Dockerfile` load-bearing. No source or dependency changes.

## Test plan

- [ ] Build the RC `mainnet-full-node` image; confirm cosmovisor runs and `/go/pkg/mod` is absent
- [ ] Wiz rescan clears CVE-2026-42043
- [ ] Tag/cut `protocol/v9.6.4-rc0` per release process (team decision — not done here)
