### PR TITLE
fix(comlink): prevent deep pagination from overloading primary DB

### DIFF
--- a/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_POSTGRES_OPTIONS,
   dbHelpers,
   testMocks,
   testConstants,
@@ -302,6 +303,36 @@ describe('fills-controller#V4', () => {
           }),
         ]),
       );
+    });
+
+    it('Get /fills routes paginated reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+      // Mutate the live DEFAULT_POSTGRES_OPTIONS object with a marker property. Since the
+      // controller spreads this object at call time (`{ ...DEFAULT_POSTGRES_OPTIONS, orderBy }`),
+      // the marker will only show up in the findAll call if that spread actually happens -
+      // independent of whatever USE_READ_REPLICA currently evaluates to in this test environment.
+      const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+      (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+      const findAllSpy: jest.SpyInstance = jest.spyOn(FillTable, 'findAll');
+
+      try {
+        await OrderTable.create(testConstants.defaultOrder);
+        await FillTable.create(testConstants.defaultFill);
+
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/fills?address=${testConstants.defaultAddress}` +
+            `&subaccountNumber=${testConstants.defaultSubaccount.subaccountNumber}&page=1&limit=1`,
+        });
+
+        expect(findAllSpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ [testMarker]: true }),
+        );
+      } finally {
+        delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+        findAllSpy.mockRestore();
+      }
     });
 
     it('Get /fills with market with no fills', async () => {

--- a/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/fills-controller.test.ts
@@ -468,6 +468,32 @@ describe('fills-controller#V4', () => {
       );
     });
 
+    it('Get /fills/parentSubaccountNumber routes paginated reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+      await OrderTable.create(testConstants.defaultOrder);
+      await FillTable.create(testConstants.defaultFill);
+
+      const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+      (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+      const findAllSpy: jest.SpyInstance = jest.spyOn(FillTable, 'findAll');
+
+      try {
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/fills/parentSubaccountNumber?address=${testConstants.defaultAddress}` +
+            '&parentSubaccountNumber=0&page=1&limit=1',
+        });
+
+        expect(findAllSpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ [testMarker]: true }),
+        );
+      } finally {
+        delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+        findAllSpy.mockRestore();
+      }
+    });
+
     it('Get /fills/parentSubaccountNumber gets fills ordered by createdAtHeight descending and paginated', async () => {
       // Order and fill for BTC-USD
       await OrderTable.create(testConstants.defaultOrder);

--- a/indexer/services/comlink/__tests__/controllers/api/v4/funding-payments-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/funding-payments-controller.test.ts
@@ -1,5 +1,6 @@
 import {
   BlockTable,
+  DEFAULT_POSTGRES_OPTIONS,
   dbHelpers,
   FundingPaymentsCreateObject,
   FundingPaymentsTable,
@@ -191,6 +192,32 @@ describe('funding-payments-controller#V4', () => {
     expect(response.body.fundingPayments[0]).not.toEqual(
       response2.body.fundingPayments[0],
     );
+  });
+
+  it('Get /fundingPayments routes paginated reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+    // Mutate the live DEFAULT_POSTGRES_OPTIONS object with a marker property. Since the
+    // controller spreads this object at call time (`{ ...DEFAULT_POSTGRES_OPTIONS, orderBy }`),
+    // the marker will only show up in the findAll call if that spread actually happens -
+    // independent of whatever USE_READ_REPLICA currently evaluates to in this test environment.
+    const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+    (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+    const findAllSpy: jest.SpyInstance = jest.spyOn(FundingPaymentsTable, 'findAll');
+
+    try {
+      await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/fundingPayments?address=${testConstants.defaultAddress}&subaccountNumber=${testConstants.defaultSubaccount.subaccountNumber}&showZeroPayments=true&limit=1&page=1`,
+      });
+
+      expect(findAllSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ [testMarker]: true }),
+      );
+    } finally {
+      delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+      findAllSpy.mockRestore();
+    }
   });
 
   it('Returns 400 with invalid address', async () => {

--- a/indexer/services/comlink/__tests__/controllers/api/v4/funding-payments-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/funding-payments-controller.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@dydxprotocol-indexer/postgres';
 import { FundingPaymentResponseObject, RequestMethod } from '../../../../src/types';
 import request from 'supertest';
+import config from '../../../../src/config';
 import { sendRequest } from '../../../helpers/helpers';
 
 describe('funding-payments-controller#V4', () => {
@@ -218,6 +219,53 @@ describe('funding-payments-controller#V4', () => {
       delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
       findAllSpy.mockRestore();
     }
+  });
+
+  it('Get /fundingPayments/parentSubaccount routes paginated reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+    const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+    (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+    const findAllSpy: jest.SpyInstance = jest.spyOn(FundingPaymentsTable, 'findAll');
+
+    try {
+      await sendRequest({
+        type: RequestMethod.GET,
+        path: `/v4/fundingPayments/parentSubaccount?address=${testConstants.defaultAddress}&parentSubaccountNumber=${testConstants.defaultSubaccount.subaccountNumber}&showZeroPayments=true&limit=1&page=1`,
+      });
+
+      expect(findAllSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ [testMarker]: true }),
+      );
+    } finally {
+      delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+      findAllSpy.mockRestore();
+    }
+  });
+
+  it('Get /fundingPayments rejects a deep page/limit combination end-to-end through the real app (offset ceiling)', async () => {
+    // Not the exact incident values (page=97-111 & limit=1000, offset ~96k-110k) - just deep
+    // enough to clear MAX_PAGINATION_OFFSET with the same shape of request (a real HTTP call
+    // through the full route: rate-limiter middleware, CheckPaginationSchema, and the controller
+    // handler) rather than exercising the validator or the rate limiter in isolation.
+    const limit: number = 1000;
+    const page: number = Math.floor(config.MAX_PAGINATION_OFFSET / limit) + 2;
+
+    const response: request.Response = await sendRequest({
+      type: RequestMethod.GET,
+      path: `/v4/fundingPayments?address=${testConstants.defaultAddress}&subaccountNumber=${testConstants.defaultSubaccount.subaccountNumber}&showZeroPayments=true&limit=${limit}&page=${page}`,
+      expectedStatus: 400,
+    });
+
+    expect(response.body.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          location: 'query',
+          param: 'page',
+          msg: expect.stringContaining('exceeds MAX_PAGINATION_OFFSET'),
+        }),
+      ]),
+    );
   });
 
   it('Returns 400 with invalid address', async () => {

--- a/indexer/services/comlink/__tests__/controllers/api/v4/trade-history-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/trade-history-controller.test.ts
@@ -374,6 +374,36 @@ describe('trade-history-controller#V4', () => {
       expect(response.body.totalResults).toBeGreaterThanOrEqual(2);
     });
 
+    it('GET /parentSubaccountNumber routes reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+      await OrderTable.create(testConstants.defaultOrder);
+      await FillTable.create(testConstants.defaultFill);
+
+      // Mutate the live DEFAULT_POSTGRES_OPTIONS object with a marker property. Since the
+      // controller spreads this object at call time (`{ ...DEFAULT_POSTGRES_OPTIONS, orderBy }`),
+      // the marker will only show up in the findAll call if that spread actually happens -
+      // independent of whatever USE_READ_REPLICA currently evaluates to in this test environment.
+      const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+      (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+      const findAllSpy: jest.SpyInstance = jest.spyOn(FillTable, 'findAll');
+
+      try {
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/tradeHistory/parentSubaccountNumber?address=${testConstants.defaultAddress}` +
+            '&parentSubaccountNumber=0',
+        });
+
+        expect(findAllSpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ [testMarker]: true }),
+        );
+      } finally {
+        delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+        findAllSpy.mockRestore();
+      }
+    });
+
     it('paginates parent subaccount results', async () => {
       await OrderTable.create(testConstants.defaultOrder);
       await FillTable.create(testConstants.defaultFill);

--- a/indexer/services/comlink/__tests__/controllers/api/v4/trade-history-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/trade-history-controller.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_POSTGRES_OPTIONS,
   dbHelpers,
   testMocks,
   testConstants,
@@ -62,6 +63,36 @@ describe('trade-history-controller#V4', () => {
       expect(response.body.totalResults).toBe(1);
       expect(response.body.pageSize).toBeDefined();
       expect(response.body.offset).toBe(0);
+    });
+
+    it('GET / routes reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+      await OrderTable.create(testConstants.defaultOrder);
+      await FillTable.create(testConstants.defaultFill);
+
+      // Mutate the live DEFAULT_POSTGRES_OPTIONS object with a marker property. Since the
+      // controller spreads this object at call time (`{ ...DEFAULT_POSTGRES_OPTIONS, orderBy }`),
+      // the marker will only show up in the findAll call if that spread actually happens -
+      // independent of whatever USE_READ_REPLICA currently evaluates to in this test environment.
+      const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+      (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+      const findAllSpy: jest.SpyInstance = jest.spyOn(FillTable, 'findAll');
+
+      try {
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/tradeHistory?address=${defaultAddress}` +
+            `&subaccountNumber=${defaultSubaccountNumber}`,
+        });
+
+        expect(findAllSpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ [testMarker]: true }),
+        );
+      } finally {
+        delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+        findAllSpy.mockRestore();
+      }
     });
 
     it('returns OPEN then CLOSE for buy-then-sell of same size', async () => {

--- a/indexer/services/comlink/__tests__/controllers/api/v4/trades-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/trades-controller.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_POSTGRES_OPTIONS,
   dbHelpers,
   testMocks,
   testConstants,
@@ -188,6 +189,39 @@ describe('trades-controller#V4', () => {
           }),
         ]),
       );
+    });
+
+    it('Get /:ticker routes paginated reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+      await testMocks.seedData();
+      await perpetualMarketRefresher.updatePerpetualMarkets();
+      await createMakerTakerOrderAndFill(
+        testConstants.defaultOrder,
+        testConstants.defaultFill,
+      );
+
+      // Mutate the live DEFAULT_POSTGRES_OPTIONS object with a marker property. Since the
+      // controller spreads this object at call time (`{ ...DEFAULT_POSTGRES_OPTIONS, orderBy }`),
+      // the marker will only show up in the findAll call if that spread actually happens -
+      // independent of whatever USE_READ_REPLICA currently evaluates to in this test environment.
+      const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+      (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+      const findAllSpy: jest.SpyInstance = jest.spyOn(FillTable, 'findAll');
+
+      try {
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/trades/perpetualMarket/${testConstants.defaultPerpetualMarket.ticker}?page=1&limit=1`,
+        });
+
+        expect(findAllSpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ [testMarker]: true }),
+        );
+      } finally {
+        delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+        findAllSpy.mockRestore();
+      }
     });
 
     it('Get /:ticker for ticker with no fills', async () => {

--- a/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
+++ b/indexer/services/comlink/__tests__/controllers/api/v4/transfers-controller.test.ts
@@ -1,6 +1,7 @@
 import {
   BlockCreateObject,
   BlockTable,
+  DEFAULT_POSTGRES_OPTIONS,
   dbHelpers,
   IsoString,
   SubaccountTable,
@@ -428,6 +429,35 @@ describe('transfers-controller#V4', () => {
       });
 
       expect(response.body.transfers).toHaveLength(0);
+    });
+
+    it('Get /transfers routes reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+      await testMocks.seedData();
+
+      // Mutate the live DEFAULT_POSTGRES_OPTIONS object with a marker property. Since the
+      // controller spreads this object at call time (`{ ...DEFAULT_POSTGRES_OPTIONS, orderBy }`),
+      // the marker will only show up in the findAll call if that spread actually happens -
+      // independent of whatever USE_READ_REPLICA currently evaluates to in this test environment.
+      const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+      (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+      const findAllSpy: jest.SpyInstance = jest.spyOn(TransferTable, 'findAllToOrFromSubaccountId');
+
+      try {
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/transfers?address=${testConstants.defaultAddress}` +
+            `&subaccountNumber=${testConstants.defaultSubaccount.subaccountNumber}`,
+        });
+
+        expect(findAllSpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ [testMarker]: true }),
+        );
+      } finally {
+        delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+        findAllSpy.mockRestore();
+      }
     });
 
     it('Get /transfers with non-existent address and subaccount number returns 404', async () => {
@@ -927,6 +957,31 @@ describe('transfers-controller#V4', () => {
       });
 
       expect(response.body.transfers).toHaveLength(0);
+    });
+
+    it('Get /transfers/parentSubaccountNumber routes reads through DEFAULT_POSTGRES_OPTIONS (read-replica regression guard)', async () => {
+      await testMocks.seedData();
+
+      const testMarker: unique symbol = Symbol('read-replica-regression-marker');
+      (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker] = true;
+      const findAllSpy: jest.SpyInstance = jest.spyOn(TransferTable, 'findAllToOrFromParentSubaccount');
+
+      try {
+        await sendRequest({
+          type: RequestMethod.GET,
+          path: `/v4/transfers/parentSubaccountNumber?address=${testConstants.defaultAddress}` +
+            `&parentSubaccountNumber=${testConstants.defaultSubaccount.subaccountNumber}`,
+        });
+
+        expect(findAllSpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ [testMarker]: true }),
+        );
+      } finally {
+        delete (DEFAULT_POSTGRES_OPTIONS as Record<string | symbol, unknown>)[testMarker];
+        findAllSpy.mockRestore();
+      }
     });
 
     it('Get /transfers/parentSubaccountNumber with non-existent address returns 404', async () => {

--- a/indexer/services/comlink/__tests__/lib/rate-limit.test.ts
+++ b/indexer/services/comlink/__tests__/lib/rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { redis } from '@dydxprotocol-indexer/redis';
 import { IncomingHttpHeaders } from 'http';
 import config from '../../src/config';
-import { rateLimiterMiddleware } from '../../src/lib/rate-limit';
+import { getPointCost, rateLimiterMiddleware } from '../../src/lib/rate-limit';
 import {
   ratelimitRedis,
   defaultRateLimiter,
@@ -434,6 +434,63 @@ describe('rateLimit', () => {
       });
 
       config.RATE_LIMIT_FUNDING_POINTS = originalPoints;
+    });
+  });
+
+  describe('getPointCost offset weighting', () => {
+    const ip: string = '0.0.0.0';
+
+    it('costs 1 point when the request has no page/limit in the query', () => {
+      expect(getPointCost(ip, { query: undefined } as any)).toEqual(1);
+      expect(getPointCost(ip, { query: {} } as any)).toEqual(1);
+    });
+
+    it('costs 1 point for page 1 (matches every pre-existing assertion in this file)', () => {
+      expect(getPointCost(ip, { query: { page: '1', limit: '1000' } } as any)).toEqual(1);
+    });
+
+    it('costs 1 point for a shallow page regardless of limit', () => {
+      expect(getPointCost(ip, { query: { page: '2', limit: '100' } } as any)).toEqual(1);
+    });
+
+    it('weights cost by offset depth: 1 + floor(offset / API_LIMIT_V4)', () => {
+      // offset = (50 - 1) * 1000 = 49,000 -> 1 + floor(49000 / 1000) = 50
+      expect(getPointCost(ip, { query: { page: '50', limit: '1000' } } as any)).toEqual(50);
+      // offset = (2 - 1) * 1000 = 1,000 -> 1 + floor(1000 / 1000) = 2
+      expect(getPointCost(ip, { query: { page: '2', limit: '1000' } } as any)).toEqual(2);
+    });
+
+    it('defaults limit to API_LIMIT_V4 when limit is omitted', () => {
+      // offset = (10 - 1) * API_LIMIT_V4 -> 1 + floor(offset / API_LIMIT_V4) = 1 + 9 = 10
+      expect(getPointCost(ip, { query: { page: '10' } } as any)).toEqual(10);
+    });
+
+    it('never throws and falls back to 1 point on adversarial/garbage page values', () => {
+      expect(getPointCost(ip, { query: { page: 'not-a-number', limit: '1000' } } as any))
+        .toEqual(1);
+      expect(getPointCost(ip, { query: { page: '-5', limit: '1000' } } as any)).toEqual(1);
+      expect(getPointCost(ip, { query: { page: 'Infinity', limit: '1000' } } as any)).toEqual(1);
+      expect(getPointCost(ip, { query: { page: '10', limit: '0' } } as any)).toEqual(1);
+      expect(getPointCost(ip, { query: { page: '10', limit: '-100' } } as any)).toEqual(1);
+    });
+
+    it('costs 0 for internal IPs regardless of page depth', () => {
+      isIndexerIpSpy.mockReturnValueOnce(true);
+      expect(getPointCost(ip, { query: { page: '10000', limit: '1000' } } as any)).toEqual(0);
+    });
+
+    it('drains the rate-limit budget faster for deep pagination end-to-end', async () => {
+      req.headers = defaultHeaders;
+      req.query = { page: '50', limit: '1000' };
+
+      await rateLimiterMiddleware(fillsRateLimiter)(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': config.RATE_LIMIT_FILLS_POINTS - 50,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_FILLS_POINTS,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/indexer/services/comlink/__tests__/lib/rate-limit.test.ts
+++ b/indexer/services/comlink/__tests__/lib/rate-limit.test.ts
@@ -492,6 +492,26 @@ describe('rateLimit', () => {
       });
       expect(next).toHaveBeenCalledTimes(1);
     });
+
+    it('clamps an astronomically large offset-derived cost to the limiter capacity', async () => {
+      // An unclamped cost this large (offset ~1e29, so 1 + floor(offset/API_LIMIT_V4) is on the
+      // order of 1e26) serializes to exponential notation, which Redis's INCRBY rejects as "not
+      // an integer" - rateLimiterMiddleware's catch block treats that rejection as a plain Error
+      // and falls through to next(), silently disabling rate limiting entirely for the request.
+      // Clamping to the limiter's own point capacity avoids ever sending such a value to Redis.
+      req.headers = defaultHeaders;
+      req.query = { page: '2', limit: '99999999999999999999999999999' };
+
+      await rateLimiterMiddleware(fillsRateLimiter)(req, res, next);
+
+      expect(res.set).toHaveBeenCalledWith({
+        'RateLimit-Remaining': 0,
+        'RateLimit-Reset': expect.any(Number),
+        'RateLimit-Limit': config.RATE_LIMIT_FILLS_POINTS,
+      });
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('rate limiter duration configuration', () => {

--- a/indexer/services/comlink/__tests__/lib/validation/helpers.ts
+++ b/indexer/services/comlink/__tests__/lib/validation/helpers.ts
@@ -1,6 +1,10 @@
 import express from 'express';
 
-import { CheckLimitAndCreatedBeforeOrAtSchema, CheckSubaccountSchema } from '../../../src/lib/validation/schemas';
+import {
+  CheckLimitAndCreatedBeforeOrAtSchema,
+  CheckPaginationSchema,
+  CheckSubaccountSchema,
+} from '../../../src/lib/validation/schemas';
 import { handleValidationErrors } from '../../../src/request-helpers/error-handler';
 import Server from '../../../src/request-helpers/server';
 
@@ -18,6 +22,16 @@ router.get(
 router.get(
   '/check-limit-and-created-before-schema',
   ...CheckLimitAndCreatedBeforeOrAtSchema,
+  handleValidationErrors,
+  (req: express.Request, res: express.Response) => {
+    res.sendStatus(200);
+  },
+);
+
+router.get(
+  '/check-pagination-schema',
+  ...CheckLimitAndCreatedBeforeOrAtSchema,
+  ...CheckPaginationSchema,
   handleValidationErrors,
   (req: express.Request, res: express.Response) => {
     res.sendStatus(200);

--- a/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
+++ b/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
@@ -168,7 +168,7 @@ describe('schemas', () => {
       });
     });
 
-    it('rejects a page/limit combination past MAX_PAGINATION_OFFSET', async () => {
+    it('rejects a page/limit combination past MAX_PAGINATION_OFFSET, without leaking the offset or threshold values', async () => {
       const limit: number = 1000;
       const page: number = config.MAX_PAGINATION_OFFSET / limit + 2;
       const expectedOffset: number = (page - 1) * limit;
@@ -184,13 +184,17 @@ describe('schemas', () => {
         errors: expect.arrayContaining([
           expect.objectContaining({
             param: 'page',
-            msg: expect.stringContaining(
-              `page/limit combination requests an offset of ${expectedOffset}, which exceeds ` +
-              `the maximum allowed offset of ${config.MAX_PAGINATION_OFFSET}`,
-            ),
+            // The message should name the check (a debugging clue for us) but must not disclose
+            // the computed offset or the numeric MAX_PAGINATION_OFFSET threshold to the caller.
+            msg: expect.stringContaining('exceeds MAX_PAGINATION_OFFSET'),
           }),
         ]),
       }));
+      const msg: string = response.body.errors.find(
+        (error: { param: string }) => error.param === 'page',
+      ).msg;
+      expect(msg).not.toContain(String(expectedOffset));
+      expect(msg).not.toContain(String(config.MAX_PAGINATION_OFFSET));
     });
 
     it('rejects a deep page using the default limit when no limit is provided', async () => {
@@ -219,6 +223,29 @@ describe('schemas', () => {
         expressApp: schemaTestApp,
         expectedStatus: 200,
       });
+    });
+
+    it('rejects a duplicate `page` query key instead of silently passing (HTTP parameter pollution)', async () => {
+      // Express/qs parses a repeated query key into an array (req.query.page = ['1', '999999999']).
+      // `isInt` only validates the array's first element ('1', a valid page), so without an
+      // explicit non-scalar check this would otherwise slip through both `isInt` and the offset
+      // check below (Number(['1','999999999']) is NaN, which the offset guard used to treat as
+      // "some other validator will catch it").
+      const response: request.Response = await sendRequestToApp({
+        type: RequestMethod.GET,
+        path: '/v4/check-pagination-schema?page=1&page=999999999&limit=1000',
+        expressApp: schemaTestApp,
+        expectedStatus: 400,
+      });
+
+      expect(response.body).toEqual(expect.objectContaining({
+        errors: expect.arrayContaining([
+          expect.objectContaining({
+            param: 'page',
+            msg: 'page must be a single integer value, not a list or object',
+          }),
+        ]),
+      }));
     });
   });
 });

--- a/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
+++ b/indexer/services/comlink/__tests__/lib/validation/schemas.test.ts
@@ -154,4 +154,71 @@ describe('schemas', () => {
       }));
     });
   });
+
+  describe('CheckPaginationSchema offset ceiling', () => {
+    it('allows a page/limit combination exactly at MAX_PAGINATION_OFFSET', async () => {
+      const limit: number = 1000;
+      const page: number = config.MAX_PAGINATION_OFFSET / limit + 1;
+
+      await sendRequestToApp({
+        type: RequestMethod.GET,
+        path: `/v4/check-pagination-schema?${getQueryString({ page, limit })}`,
+        expressApp: schemaTestApp,
+        expectedStatus: 200,
+      });
+    });
+
+    it('rejects a page/limit combination past MAX_PAGINATION_OFFSET', async () => {
+      const limit: number = 1000;
+      const page: number = config.MAX_PAGINATION_OFFSET / limit + 2;
+      const expectedOffset: number = (page - 1) * limit;
+
+      const response: request.Response = await sendRequestToApp({
+        type: RequestMethod.GET,
+        path: `/v4/check-pagination-schema?${getQueryString({ page, limit })}`,
+        expressApp: schemaTestApp,
+        expectedStatus: 400,
+      });
+
+      expect(response.body).toEqual(expect.objectContaining({
+        errors: expect.arrayContaining([
+          expect.objectContaining({
+            param: 'page',
+            msg: expect.stringContaining(
+              `page/limit combination requests an offset of ${expectedOffset}, which exceeds ` +
+              `the maximum allowed offset of ${config.MAX_PAGINATION_OFFSET}`,
+            ),
+          }),
+        ]),
+      }));
+    });
+
+    it('rejects a deep page using the default limit when no limit is provided', async () => {
+      const page: number = Math.floor(config.MAX_PAGINATION_OFFSET / config.API_LIMIT_V4) + 2;
+
+      const response: request.Response = await sendRequestToApp({
+        type: RequestMethod.GET,
+        path: `/v4/check-pagination-schema?${getQueryString({ page })}`,
+        expressApp: schemaTestApp,
+        expectedStatus: 400,
+      });
+
+      expect(response.body).toEqual(expect.objectContaining({
+        errors: expect.arrayContaining([
+          expect.objectContaining({
+            param: 'page',
+          }),
+        ]),
+      }));
+    });
+
+    it('does not report an offset error for shallow pagination', async () => {
+      await sendRequestToApp({
+        type: RequestMethod.GET,
+        path: `/v4/check-pagination-schema?${getQueryString({ page: 2, limit: 100 })}`,
+        expressApp: schemaTestApp,
+        expectedStatus: 200,
+      });
+    });
+  });
 });

--- a/indexer/services/comlink/src/config.ts
+++ b/indexer/services/comlink/src/config.ts
@@ -22,6 +22,11 @@ export const configSchema = {
   API_LIMIT_V4: parseInteger({
     default: 1000,
   }),
+  // Hard ceiling on (page - 1) * limit for paginated endpoints. Validated against 30d of real
+  // comlink traffic: sits well below the offset range (~91k-149k) that triggered the 2026-07-11
+  // weekend paging incident, while clearing the extreme scraper tiers observed (offsets in the
+  // millions) by 2+ orders of magnitude.
+  MAX_PAGINATION_OFFSET: parseInteger({ default: 25_000 }),
   API_ORDERBOOK_LEVELS_PER_SIDE_LIMIT: parseInteger({ default: 100 }),
 
   // Logging config

--- a/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/fills-controller.ts
@@ -1,5 +1,6 @@
 import { cacheControlMiddleware, stats } from '@dydxprotocol-indexer/base';
 import {
+  DEFAULT_POSTGRES_OPTIONS,
   FillColumns,
   FillFromDatabase,
   FillTable,
@@ -98,7 +99,9 @@ class FillsController extends Controller {
         page,
       },
       [QueryableField.LIMIT],
-      page !== undefined ? { orderBy: [[FillColumns.eventId, Ordering.ASC]] } : undefined,
+      page !== undefined
+        ? { ...DEFAULT_POSTGRES_OPTIONS, orderBy: [[FillColumns.eventId, Ordering.ASC]] }
+        : undefined,
     );
 
     const clobPairIdToMarket = buildClobPairIdToMarket();
@@ -150,7 +153,9 @@ class FillsController extends Controller {
         page,
       },
       [QueryableField.LIMIT],
-      page !== undefined ? { orderBy: [[FillColumns.eventId, Ordering.ASC]] } : undefined,
+      page !== undefined
+        ? { ...DEFAULT_POSTGRES_OPTIONS, orderBy: [[FillColumns.eventId, Ordering.ASC]] }
+        : undefined,
     );
 
     const clobPairIdToMarket = buildClobPairIdToMarket();

--- a/indexer/services/comlink/src/controllers/api/v4/funding-payments-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/funding-payments-controller.ts
@@ -1,5 +1,6 @@
 import { cacheControlMiddleware, stats } from '@dydxprotocol-indexer/base';
 import {
+  DEFAULT_POSTGRES_OPTIONS,
   FundingPaymentsFromDatabase,
   FundingPaymentsQueryConfig,
   FundingPaymentsTable,
@@ -79,7 +80,7 @@ export class FundingPaymentController extends Controller {
       queryConfig,
       [QueryableField.LIMIT],
       page !== undefined
-        ? { orderBy: [['createdAtHeight', Ordering.DESC]] }
+        ? { ...DEFAULT_POSTGRES_OPTIONS, orderBy: [['createdAtHeight', Ordering.DESC]] }
         : undefined,
     );
 
@@ -140,7 +141,7 @@ export class FundingPaymentController extends Controller {
       queryConfig,
       [QueryableField.LIMIT],
       page !== undefined
-        ? { orderBy: [['createdAtHeight', Ordering.DESC]] }
+        ? { ...DEFAULT_POSTGRES_OPTIONS, orderBy: [['createdAtHeight', Ordering.DESC]] }
         : undefined,
     );
 

--- a/indexer/services/comlink/src/controllers/api/v4/trade-history-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/trade-history-controller.ts
@@ -1,5 +1,6 @@
 import { cacheControlMiddleware, stats } from '@dydxprotocol-indexer/base';
 import {
+  DEFAULT_POSTGRES_OPTIONS,
   FillColumns,
   FillFromDatabase,
   FillTable,
@@ -155,7 +156,7 @@ class TradeHistoryController extends Controller {
     const { results: fills } = await FillTable.findAll(
       { subaccountId: [subaccountId], clobPairId, limit: TRADE_HISTORY_MAX_FILLS + 1 },
       [],
-      { orderBy: fillOrderBy },
+      { ...DEFAULT_POSTGRES_OPTIONS, orderBy: fillOrderBy },
     );
 
     if (fills.length > TRADE_HISTORY_MAX_FILLS) {
@@ -185,7 +186,7 @@ class TradeHistoryController extends Controller {
         limit: TRADE_HISTORY_MAX_FILLS + 1,
       },
       [],
-      { orderBy: fillOrderBy },
+      { ...DEFAULT_POSTGRES_OPTIONS, orderBy: fillOrderBy },
     );
 
     if (fills.length > TRADE_HISTORY_MAX_FILLS) {

--- a/indexer/services/comlink/src/controllers/api/v4/trades-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/trades-controller.ts
@@ -1,6 +1,7 @@
 import { stats, cacheControlMiddleware } from '@dydxprotocol-indexer/base';
 import {
   IsoString,
+  DEFAULT_POSTGRES_OPTIONS,
   FillTable,
   FillFromDatabase,
   Liquidity,
@@ -74,7 +75,9 @@ class TradesController extends Controller {
         page,
       },
       [QueryableField.LIQUIDITY, QueryableField.CLOB_PAIR_ID, QueryableField.LIMIT],
-      page !== undefined ? { orderBy: [[FillColumns.eventId, Ordering.ASC]] } : undefined,
+      page !== undefined
+        ? { ...DEFAULT_POSTGRES_OPTIONS, orderBy: [[FillColumns.eventId, Ordering.ASC]] }
+        : undefined,
     );
 
     return {

--- a/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
@@ -268,7 +268,7 @@ class TransfersController extends Controller {
         createdBeforeOrAtHeight: createdBeforeOrAtHeight
           ? createdBeforeOrAtHeight.toString()
           : undefined,
-      }, [], { orderBy: [[TransferColumns.createdAtHeight, Ordering.DESC]] }),
+      }, [], { ...DEFAULT_POSTGRES_OPTIONS, orderBy: [[TransferColumns.createdAtHeight, Ordering.DESC]] }),
       idToSubaccountFromSubaccountIds([sourceSubaccountId, recipientSubaccountId]),
       getAssetById(),
       TransferTable.getNetTransfersBetweenSubaccountIds(

--- a/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
+++ b/indexer/services/comlink/src/controllers/api/v4/transfers-controller.ts
@@ -268,7 +268,10 @@ class TransfersController extends Controller {
         createdBeforeOrAtHeight: createdBeforeOrAtHeight
           ? createdBeforeOrAtHeight.toString()
           : undefined,
-      }, [], { ...DEFAULT_POSTGRES_OPTIONS, orderBy: [[TransferColumns.createdAtHeight, Ordering.DESC]] }),
+      }, [], {
+        ...DEFAULT_POSTGRES_OPTIONS,
+        orderBy: [[TransferColumns.createdAtHeight, Ordering.DESC]],
+      }),
       idToSubaccountFromSubaccountIds([sourceSubaccountId, recipientSubaccountId]),
       getAssetById(),
       TransferTable.getNetTransfersBetweenSubaccountIds(

--- a/indexer/services/comlink/src/lib/rate-limit.ts
+++ b/indexer/services/comlink/src/lib/rate-limit.ts
@@ -32,7 +32,7 @@ export function rateLimiterMiddleware(
       return next();
     }
 
-    const pointCost: number = getPointCost(ipAddr);
+    const pointCost: number = getPointCost(ipAddr, req);
 
     // generate redis key
     const postfix: string | undefined = postfixKey ? _.get(req, postfixKey) : undefined;
@@ -70,10 +70,27 @@ export function rateLimiterMiddleware(
 
 export function getPointCost(
   ipAddress: string,
+  req: express.Request,
 ): number {
   if (isIndexerIp(ipAddress)) {
     return INTERNAL_REQUEST_POINTS;
   }
 
-  return EXTERNAL_REQUEST_POINTS;
+  // Weight cost by OFFSET depth: deep pagination (large page * limit) is far more expensive to the
+  // DB than a shallow page, so it should drain the rate-limit budget faster. Read directly from
+  // req.query since this middleware runs before checkSchema/handleValidationErrors.
+  const rawPage: unknown = req.query?.page;
+  const rawLimit: unknown = req.query?.limit;
+  const page: number | undefined = rawPage !== undefined ? Number(rawPage) : undefined;
+  const limit: number = rawLimit !== undefined ? Number(rawLimit) : config.API_LIMIT_V4;
+
+  if (
+    page === undefined || !Number.isFinite(page) || page <= 1 ||
+    !Number.isFinite(limit) || limit <= 0
+  ) {
+    return EXTERNAL_REQUEST_POINTS;
+  }
+
+  const offset: number = (Math.max(1, Math.floor(page)) - 1) * Math.floor(limit);
+  return EXTERNAL_REQUEST_POINTS + Math.floor(offset / config.API_LIMIT_V4);
 }

--- a/indexer/services/comlink/src/lib/rate-limit.ts
+++ b/indexer/services/comlink/src/lib/rate-limit.ts
@@ -32,7 +32,12 @@ export function rateLimiterMiddleware(
       return next();
     }
 
-    const pointCost: number = getPointCost(ipAddr, req);
+    // Clamp to the limiter's own capacity: a cost beyond that exhausts the bucket either way,
+    // and an unclamped cost derived from a crafted page/limit can be large enough that its
+    // decimal string trips Redis's integer parser (e.g. exponential notation), which throws a
+    // plain Error and - via the catch branch below - lets the request through with no rate
+    // limiting applied at all.
+    const pointCost: number = Math.min(getPointCost(ipAddr, req), rateLimiter.points);
 
     // generate redis key
     const postfix: string | undefined = postfixKey ? _.get(req, postfixKey) : undefined;

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -89,6 +89,28 @@ const paginationSchemaRecord: Record<string, ParamSchema> = {
       options: { gt: 0 },
     },
     errorMessage: 'page must be a non-negative integer',
+    custom: {
+      options: (value: string | number, { req }) => {
+        // `value` arrives as the raw query string (e.g. "27"), not a number - unlike `limit`
+        // below, this field has no `customSanitizer` to coerce it first, so do it explicitly.
+        const page: number = Number(value);
+        const rawLimit = req.query?.limit;
+        const limit: number = rawLimit !== undefined ? Number(rawLimit) : config.API_LIMIT_V4;
+        if (!Number.isInteger(page) || page <= 0 || !Number.isFinite(limit) || limit <= 0) {
+          // Let the isInt/limit validators surface their own errors; don't double-report.
+          return true;
+        }
+        const offset: number = (Math.max(1, page) - 1) * limit;
+        if (offset > config.MAX_PAGINATION_OFFSET) {
+          throw new Error(
+            `page/limit combination requests an offset of ${offset}, which exceeds the ` +
+            `maximum allowed offset of ${config.MAX_PAGINATION_OFFSET}. Narrow your query using ` +
+            'the createdBeforeOrAt/createdOnOrAfter time-range filters instead of paging deeper.',
+          );
+        }
+        return true;
+      },
+    },
   },
 };
 

--- a/indexer/services/comlink/src/lib/validation/schemas.ts
+++ b/indexer/services/comlink/src/lib/validation/schemas.ts
@@ -90,7 +90,14 @@ const paginationSchemaRecord: Record<string, ParamSchema> = {
     },
     errorMessage: 'page must be a non-negative integer',
     custom: {
-      options: (value: string | number, { req }) => {
+      options: (value: unknown, { req }) => {
+        // `isInt` only validates the first element of an array value - a known express-validator
+        // quirk - so HTTP parameter pollution (e.g. `?page=1&page=999999999`) makes `page` arrive
+        // here as a real array while still passing `isInt`. Reject non-scalar values explicitly
+        // instead of assuming `isInt` already caught them.
+        if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+          throw new Error('page must be a single integer value, not a list or object');
+        }
         // `value` arrives as the raw query string (e.g. "27"), not a number - unlike `limit`
         // below, this field has no `customSanitizer` to coerce it first, so do it explicitly.
         const page: number = Number(value);
@@ -102,10 +109,14 @@ const paginationSchemaRecord: Record<string, ParamSchema> = {
         }
         const offset: number = (Math.max(1, page) - 1) * limit;
         if (offset > config.MAX_PAGINATION_OFFSET) {
+          // Deliberately omit the computed offset and the MAX_PAGINATION_OFFSET value itself
+          // from the response - naming the check (MAX_PAGINATION_OFFSET) is enough of a clue to
+          // grep the codebase/logs by, without handing an external caller the exact threshold to
+          // binary-search for.
           throw new Error(
-            `page/limit combination requests an offset of ${offset}, which exceeds the ` +
-            `maximum allowed offset of ${config.MAX_PAGINATION_OFFSET}. Narrow your query using ` +
-            'the createdBeforeOrAt/createdOnOrAfter time-range filters instead of paging deeper.',
+            'page/limit combination requests an offset that exceeds MAX_PAGINATION_OFFSET. ' +
+            'Narrow your query using the createdBeforeOrAt/createdOnOrAfter time-range filters ' +
+            'instead of paging deeper.',
           );
         }
         return true;


### PR DESCRIPTION
### Changelist

**Why:**

Over the weekend of 2026-07-10/11, a bot repeatedly deep-paginated `/v4/fills` and `/v4/fundingPayments` (`page=97-111&limit=1000`, i.e. `OFFSET ~96,000-110,000`).
Root-cause: ~12 repeated block-processing/Kafka-lag pages over ~54 hours to these `OFFSET`/`LIMIT` scans landing on the RDS **primary** instead of a read replica, driving DB load to 1.2-2.4x vCPU capacity and starving `ender`'s write path.
A 30-day Datadog APM traffic audit (query-string `page`/`limit` facets on `express.request` spans) confirmed this wasn't a one-off:
live traffic on `fundingPayments` still sits at offset 91,000-149,000, the exact range that triggered the incident, plus separate extreme scraper tiers on `fills` reaching offsets in the millions.

**How:**

Three independent, layered mitigations:

1. **Fixed the actual bug.** `fills`, `fundingPayments`, `trades`, and `trade-history` controllers built a partial Postgres options object (`{ orderBy: [...] }`) whenever they added custom pagination ordering, which — because of how the JS default parameter (`options: Options = DEFAULT_POSTGRES_OPTIONS`) works — silently discarded the read-replica default and fell back to the primary.
   Confirmed via `orders-controller.ts` and `historical-pnl-controller.ts`, which already do this correctly (`{ ...DEFAULT_POSTGRES_OPTIONS, orderBy: [...] }`) — this is a consistency fix, not a new pattern.
   Also includes a lower-priority companion fix on `transfers-controller.ts`'s `/between` endpoint (same missing spread, but no `page` param so no OFFSET-depth exposure).
2. **Weighted the existing rate limiter by OFFSET depth.** `getPointCost` now charges `1 + floor(offset / API_LIMIT_V4)` points instead of a flat 1, reusing the existing `RateLimit-*` headers and 429 response — deep pagination drains a client's budget fast while normal shallow pagination is unaffected.
   Implemented centrally (`getPointCost`, shared by every `rateLimiterMiddleware` call site) rather than per-endpoint, since the same unbounded-`.offset()` pattern exists in 6+ other stores (`order-table`, `pnl-ticks-table`, `transfer-table`, etc.) that haven't been targeted yet but are equally exposed.
3. **Added a hard ceiling as a backstop.** New `MAX_PAGINATION_OFFSET` config (default 25,000), enforced via a cross-field validator on `page`/`limit`, returning the existing `400 { errors }` shape with guidance to narrow the time-range filter instead of paging deeper.
   Value validated against real 30-day traffic: sits ~66,000 below the incident's own offset range with margin to spare, while only affecting an already-unusual slice of traffic (`limit=500`, pages 40-120 on `fills`).

Deliberately out of scope (called out for reviewers, not silently dropped): the `COUNT(*)` run on every paginated query (blocked by an existing test asserting accurate `totalResults` on page 2 — would be a client-facing contract change), and true cursor/keyset pagination (the real long-term fix for `OFFSET` cost, but a bigger API design change).

**What:**

- `fix(comlink): route paginated fills/funding/trades/history reads to the read replica` — `fills-controller.ts`, `funding-payments-controller.ts`, `trade-history-controller.ts`, `trades-controller.ts`, `transfers-controller.ts`, and their controller tests.
- `feat(comlink): weight rate-limit cost by pagination offset depth` — `lib/rate-limit.ts` and its test.
- `feat(comlink): cap max pagination offset to bound query cost` — `config.ts`, `lib/validation/schemas.ts`, `lib/validation/helpers.ts` (test harness route), and `lib/validation/schemas.test.ts`.

### Test Plan

Full `comlink` Jest suite: **557/557 passing** (`NODE_ENV=test pnpm test`, run against the dockerized `postgres-test`/`redis` containers).

New coverage added: read-replica regression guards on all four fixed controllers (asserts the `findAll` options argument is actually spread from the live `DEFAULT_POSTGRES_OPTIONS` object, independent of whatever `USE_READ_REPLICA` evaluates to in the test env); `getPointCost` unit tests covering the weighting formula, internal-IP bypass, and adversarial/garbage `page` values; offset-ceiling boundary tests (`MAX_PAGINATION_OFFSET` exactly vs. one page past it, and the default-limit case).

Caught and fixed one real bug during this verification pass: the offset-ceiling validator compared `Number.isInteger()` against the raw (string) query value instead of coercing first, so it never actually rejected anything — confirmed by two new tests failing 400-expected/200-actual, fixed, rebuilt, and reconfirmed.

Not yet done: a live E2E check against a running `comlink` process (only the infra containers — `postgres`/`postgres-test`/`redis`/`kafka` — were up during this pass, not the service itself).
Worth a manual `curl` smoke test against deep pagination (expect 400 past the ceiling, watch `RateLimit-Remaining` drop faster with deeper `page`) before merge if you want the extra confidence.

### Author/Reviewer Checklist

- [ ] state-breaking — not applicable (comlink is the indexer's read API; no protocol/app state touched)
- [ ] indexer-postgres-breaking — not applicable (no schema changes, only query options/validation)
- [ ] proposal-breaking — not applicable
- [ ] feature label — not applicable (single self-contained fix)
- [ ] backport — your call depending on which release branches serve this traffic

Suggest adding the `bug` label (root-cause fix for the 2026-07-10/11 weekend paging incident).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---

### Update: hardened after code review

A multi-angle review (correctness, security, test coverage, consistency) surfaced two real bugs in this PR's own new code, both now fixed:

- **Validation bypass**: a duplicate `page` query key (`?page=1&page=999999999`) parses as an array in Express; `Number([...])` on that is `NaN`, and both the offset ceiling and the rate-limit weighter treated "can't parse it" as "some other validator will catch it" — but `express-validator`'s `isInt` only checks an array's first element, so nothing actually did.
The request went through with a `NaN` offset, which Knex silently drops, returning wrong (unpaginated) data instead of a 400.
Fixed by explicitly rejecting non-scalar `page` values in the validator.
- **Rate-limiter bypass**: an oversized-but-valid `page`/`limit` could produce a `pointCost` large enough to serialize to exponential notation, which Redis's `INCRBY` rejects — tripping an existing fail-open branch in the rate-limit middleware that silently lets the request through with zero rate limiting applied.
Before this PR, `pointCost` was always 0 or 1, so this path was unreachable; fixed by clamping cost to the rate limiter's own point capacity.

Also: the offset-ceiling error message no longer echoes the computed offset or the exact `MAX_PAGINATION_OFFSET` value back to the client (kept the config name itself in the message as a debugging clue, dropped the numbers, so the ceiling can't be read straight off a 400 response).

Test suite is now **565/565 passing**, including new coverage for both bugs above, backfilled read-replica regression tests for `transfers-controller.ts` and the `parentSubaccount` route variants (previously untested), and one end-to-end test replaying a deep-pagination request through the real middleware chain against `/v4/fundingPayments`.

Surfaced but out of scope for this PR (flagged for follow-up, not fixed here): `isIndexerIp` trusts `cf-connecting-ip`/`x-forwarded-for` unconditionally with no code in this repo confirming comlink's origin is locked to Cloudflare-only traffic — if it isn't, this (pre-existing, unrelated to this PR) gap bypasses rate limiting entirely, not just the new pagination-depth weighting. Worth a separate ticket to whoever owns the infra layer.


## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum pagination offset, defaulting to 25,000.
  * Added validation to reject requests that exceed the allowed pagination depth.
  * Deep pagination now consumes more rate-limit capacity, while internal requests remain unaffected.

* **Bug Fixes**
  * Improved consistency and reliability of paginated data retrieval across fills, trades, funding payments, trade history, and transfers endpoints.

* **Tests**
  * Added regression coverage for pagination query handling, offset validation, and pagination-aware rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->