### PR TITLE
fix(kafka): force-exit consumer on unrecoverable crash instead of hanging

### DIFF
--- a/indexer/packages/kafka/__tests__/consumer.test.ts
+++ b/indexer/packages/kafka/__tests__/consumer.test.ts
@@ -1,44 +1,224 @@
-import {
-  consumer, startConsumer, updateOnMessageFunction, stopConsumer,
-} from '../src/consumer';
-import { producer } from '../src/producer';
-import { createKafkaMessage } from './helpers/kafka';
-import { KafkaMessage } from 'kafkajs';
-import { TO_ENDER_TOPIC } from '../src';
+import { execSync } from 'child_process';
+import path from 'path';
 
-// Skipping because timeout could cause tests to be flaky
-describe.skip('consumer', () => {
-  beforeAll(async () => {
-    await Promise.all([
-      consumer!.connect(),
-      producer.connect(),
-    ]);
-    await consumer!.subscribe({ topic: TO_ENDER_TOPIC });
-    await startConsumer();
+import { Admin, KafkaMessage } from 'kafkajs';
+
+import { admin } from '../src/admin';
+import config from '../src/config';
+import {
+  consumer,
+  getConsecutiveCrashes,
+  handleConsumerCrash,
+  initConsumer,
+  recordCrashAndDecideRestart,
+  resetConsecutiveCrashes,
+  startConsumer,
+  stopConsumer,
+  updateOnMessageFunction,
+} from '../src/consumer';
+import { kafka } from '../src/kafka';
+import { producer, disconnect as disconnectProducer } from '../src/producer';
+
+const COMPOSE_FILE: string = path.resolve(process.cwd(), '../../docker-compose.yml');
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+  intervalMs: number = 500,
+): Promise<void> {
+  const deadline: number = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(intervalMs);
+  }
+  if (!predicate()) {
+    throw new Error('waitFor timed out');
+  }
+}
+
+function mockProcessExit(): jest.SpyInstance {
+  return jest.spyOn(process, 'exit').mockImplementation(
+    (() => undefined) as unknown as (code?: number) => never,
+  );
+}
+
+describe('consumer crash handling', () => {
+  const originalMaxCrashes: number = config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES;
+  const originalExitOnCrash: boolean = config.KAFKA_EXIT_PROCESS_ON_CONSUMER_CRASH;
+
+  beforeEach(() => {
+    resetConsecutiveCrashes();
   });
+
+  afterEach(() => {
+    config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES = originalMaxCrashes;
+    config.KAFKA_EXIT_PROCESS_ON_CONSUMER_CRASH = originalExitOnCrash;
+  });
+
+  it('restarts internally until the consecutive-crash budget is exhausted', () => {
+    config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES = 3;
+    const error: Error = new Error('boom');
+
+    expect(recordCrashAndDecideRestart(error)).toBe(true); // crash 1
+    expect(recordCrashAndDecideRestart(error)).toBe(true); // crash 2
+    expect(recordCrashAndDecideRestart(error)).toBe(false); // crash 3 -> budget exhausted
+    expect(getConsecutiveCrashes()).toBe(3);
+  });
+
+  it('resets the crash count after progress, restoring the full budget', () => {
+    config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES = 3;
+
+    recordCrashAndDecideRestart(new Error('boom'));
+    expect(getConsecutiveCrashes()).toBe(1);
+
+    resetConsecutiveCrashes();
+    expect(getConsecutiveCrashes()).toBe(0);
+
+    // Budget is full again after a successful message reset the counter.
+    expect(recordCrashAndDecideRestart(new Error('boom'))).toBe(true);
+  });
+
+  it('force-exits the process on a fatal (non-restartable) crash', () => {
+    const exitSpy: jest.SpyInstance = mockProcessExit();
+
+    handleConsumerCrash({ error: new Error('fatal'), restart: false });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('does not exit while the crash is still restartable', () => {
+    const exitSpy: jest.SpyInstance = mockProcessExit();
+
+    handleConsumerCrash({ error: new Error('transient'), restart: true });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('does not exit when process-exit-on-crash is disabled', () => {
+    config.KAFKA_EXIT_PROCESS_ON_CONSUMER_CRASH = false;
+    const exitSpy: jest.SpyInstance = mockProcessExit();
+
+    handleConsumerCrash({ error: new Error('fatal'), restart: false });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+});
+
+describe('consumer (integration - requires kafka broker)', () => {
+  const originalMaxRetries: number = config.KAFKA_CONSUMER_MAX_RETRIES;
+  const originalMaxCrashes: number = config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES;
+  let startedBroker: boolean = false;
+  let topicCounter: number = 0;
+
+  async function isBrokerReachable(): Promise<boolean> {
+    const probe: Admin = kafka.admin();
+    try {
+      await probe.connect();
+      await probe.listTopics();
+      return true;
+    } catch (error) {
+      return false;
+    } finally {
+      await probe.disconnect().catch(() => undefined);
+    }
+  }
+
+  async function ensureBroker(): Promise<void> {
+    if (await isBrokerReachable()) {
+      return;
+    }
+    execSync(`docker compose -f "${COMPOSE_FILE}" up -d kafka`, { stdio: 'ignore' });
+    startedBroker = true;
+    for (let attempt: number = 0; attempt < 60; attempt += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      if (await isBrokerReachable()) {
+        return;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(1000);
+    }
+    throw new Error('Kafka broker did not become reachable after docker compose up');
+  }
+
+  async function createTestTopic(): Promise<string> {
+    const topic: string = `test-consumer-${Date.now()}-${topicCounter}`;
+    topicCounter += 1;
+    await admin.createTopics({ topics: [{ topic, numPartitions: 1 }], waitForLeaders: true });
+    return topic;
+  }
+
+  beforeAll(async () => {
+    await ensureBroker();
+    await admin.connect();
+    await producer.connect();
+  }, 120000);
 
   afterAll(async () => {
-    await Promise.all([
-      stopConsumer(),
-      producer.disconnect(),
-    ]);
-  });
+    config.KAFKA_CONSUMER_MAX_RETRIES = originalMaxRetries;
+    config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES = originalMaxCrashes;
+    await stopConsumer().catch(() => undefined);
+    await admin.disconnect().catch(() => undefined);
+    await disconnectProducer().catch(() => undefined);
+    if (startedBroker) {
+      execSync(`docker compose -f "${COMPOSE_FILE}" stop kafka`, { stdio: 'ignore' });
+    }
+  }, 60000);
 
-  it('is consuming message', async () => {
-    const onMessageFn: (topic: string, message: KafkaMessage) => Promise<void> = jest.fn();
-    updateOnMessageFunction(onMessageFn);
-    const kafkaMessage: KafkaMessage = createKafkaMessage(null);
+  it('consumes produced messages and keeps the crash count at zero', async () => {
+    const topic: string = await createTestTopic();
+    const received: KafkaMessage[] = [];
+    updateOnMessageFunction((_topic: string, message: KafkaMessage): Promise<void> => {
+      received.push(message);
+      return Promise.resolve();
+    });
 
-    await producer.send({
-      topic: TO_ENDER_TOPIC,
-      messages: [{
-        value: kafkaMessage.value,
-        timestamp: `${Date.now()}`,
-      }],
-    });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 2000);
-    });
-    expect(onMessageFn).toHaveBeenCalled();
-  });
+    await initConsumer();
+    await consumer!.subscribe({ topic, fromBeginning: true });
+    await startConsumer();
+
+    await producer.send({ topic, messages: [{ value: Buffer.from('hello') }] });
+
+    await waitFor(() => received.length > 0, 30000);
+    expect(received.length).toBeGreaterThan(0);
+    expect(getConsecutiveCrashes()).toBe(0);
+
+    await stopConsumer();
+  }, 60000);
+
+  it('force-exits the process after sustained processing failures', async () => {
+    // retries: 0 => crash on the first failure with no backoff; budget of 2 => exit on 2nd crash.
+    config.KAFKA_CONSUMER_MAX_RETRIES = 0;
+    config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES = 2;
+    const exitSpy: jest.SpyInstance = mockProcessExit();
+
+    const topic: string = await createTestTopic();
+    updateOnMessageFunction((): Promise<void> => Promise.reject(
+      new Error('simulated postgres outage'),
+    ));
+
+    await initConsumer();
+    await consumer!.subscribe({ topic, fromBeginning: true });
+    await startConsumer();
+
+    // The offset is never committed (processing always throws), so the same message is redelivered
+    // after each internal restart, driving repeated crashes until the budget is exhausted.
+    await producer.send({ topic, messages: [{ value: Buffer.from('poison') }] });
+
+    await waitFor(() => exitSpy.mock.calls.length > 0, 60000);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(getConsecutiveCrashes()).toBeGreaterThanOrEqual(2);
+
+    await stopConsumer().catch(() => undefined);
+    exitSpy.mockRestore();
+  }, 90000);
 });

--- a/indexer/packages/kafka/src/config.ts
+++ b/indexer/packages/kafka/src/config.ts
@@ -32,6 +32,19 @@ export const kafkaConfigSchema = {
   // If true, consumers will have unique group ids, and SERVICE_NAME will be a common prefix for
   // the consumer group ids.
   KAFKA_ENABLE_UNIQUE_CONSUMER_GROUP_IDS: parseBoolean({ default: false }),
+  // The number of consecutive KafkaJS consumer crashes (retries-exhausted events) tolerated
+  // before the process force-exits so the orchestrator (ECS) restarts the task with a fresh
+  // container. Prevents a downstream dependency outage (e.g. Postgres) from trapping the consumer
+  // in an unbounded, silent internal restart loop while the process still appears healthy.
+  // The counter resets after any message is processed successfully.
+  KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES: parseInteger({ default: 5 }),
+  // The number of times KafkaJS retries a failing message batch before emitting a crash. Kept at
+  // the KafkaJS default of 5; exposed so the crash/restart path can be exercised deterministically
+  // in tests (retries: 0 => crash on first failure with no backoff).
+  KAFKA_CONSUMER_MAX_RETRIES: parseInteger({ default: 5 }),
+  // Whether to force process.exit on a fatal (non-restartable) consumer crash. Should remain true
+  // in deployed environments so a stalled consumer is recycled rather than hanging indefinitely.
+  KAFKA_EXIT_PROCESS_ON_CONSUMER_CRASH: parseBoolean({ default: true }),
   // Set to a number smaller than the max message size for the Kafka broker
   KAFKA_MAX_BATCH_WEBSOCKET_MESSAGE_SIZE_BYTES: parseInteger({
     default: 900000, // ~900 kB, 100 kB smaller than the 1 MB default max size of messages in Kafka

--- a/indexer/packages/kafka/src/consumer.ts
+++ b/indexer/packages/kafka/src/consumer.ts
@@ -47,6 +47,75 @@ export function updateOnBatchFunction(
 // Whether the consumer is stopped.
 let stopped: boolean = false;
 
+// Number of consecutive consumer crashes (each fired after KafkaJS exhausts its per-batch
+// retries). Reset to 0 whenever a message is processed successfully. Used to distinguish a
+// transient blip from a sustained downstream outage that should recycle the task.
+let consecutiveCrashes: number = 0;
+
+/**
+ * @returns the current consecutive-crash count. Exposed for testing and observability.
+ */
+export function getConsecutiveCrashes(): number {
+  return consecutiveCrashes;
+}
+
+/**
+ * Reset the consecutive-crash count. Called after any successfully processed message/batch so a
+ * consumer that is making progress never accrues toward the force-exit threshold.
+ */
+export function resetConsecutiveCrashes(): void {
+  consecutiveCrashes = 0;
+}
+
+/**
+ * Record a consumer crash and decide whether KafkaJS should restart the consumer internally.
+ * Returns false once the consecutive-crash count reaches KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES,
+ * which makes KafkaJS emit a fatal `consumer.crash` (restart: false) instead of looping forever.
+ */
+export function recordCrashAndDecideRestart(error: Error): boolean {
+  consecutiveCrashes += 1;
+  const shouldRestart: boolean = consecutiveCrashes < config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES;
+  logger.error({
+    at: 'kafka-consumer#recordCrashAndDecideRestart',
+    message: shouldRestart
+      ? 'Kafka consumer crashed; restarting internally'
+      : 'Kafka consumer exceeded max consecutive crashes; not restarting internally',
+    groupId,
+    consecutiveCrashes,
+    maxConsecutiveCrashes: config.KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES,
+    error,
+  });
+  return shouldRestart;
+}
+
+/**
+ * Force the process to exit so the orchestrator (ECS) restarts the task with a fresh container.
+ * Used when the consumer can no longer make progress on its own; exiting non-zero is strictly
+ * safer than hanging, since Kafka offsets are committed and consumption resumes where it left off.
+ */
+function exitForRestart(reason: string, error?: Error): void {
+  logger.crit({
+    at: 'kafka-consumer#exitForRestart',
+    message: `Kafka consumer cannot make progress (${reason}); exiting process for orchestrator restart`,
+    groupId,
+    consecutiveCrashes,
+    error,
+  });
+  // Flush is best-effort; a hung process is worse than losing the tail of a log line.
+  process.exit(1);
+}
+
+/**
+ * Handle a KafkaJS `consumer.crash` event. When the crash is not restartable — either because the
+ * error is non-retriable or because recordCrashAndDecideRestart has hit the crash budget — the
+ * consumer would otherwise sit idle forever, so exit the process for an orchestrator restart.
+ */
+export function handleConsumerCrash(payload: { error: Error, restart: boolean }): void {
+  if (!payload.restart && config.KAFKA_EXIT_PROCESS_ON_CONSUMER_CRASH && !stopped) {
+    exitForRestart('fatal consumer.crash', payload.error);
+  }
+}
+
 export async function stopConsumer(): Promise<void> {
   logger.info({
     at: 'kafka-consumer#stop',
@@ -59,6 +128,9 @@ export async function stopConsumer(): Promise<void> {
 }
 
 export async function initConsumer(): Promise<void> {
+  // A fresh consumer is not shutting down; clear state left over from any prior lifecycle.
+  stopped = false;
+  resetConsecutiveCrashes();
   consumer = kafka.consumer({
     groupId,
     sessionTimeout: config.KAFKA_SESSION_TIMEOUT_MS,
@@ -68,7 +140,20 @@ export async function initConsumer(): Promise<void> {
     readUncommitted: false,
     maxBytes: 4194304, // 4MB
     rackId: await getAvailabilityZoneId(),
+    // Bound KafkaJS's internal restart loop. Without this, a retriable error (such as an
+    // unreachable Postgres during a disk-full event) causes the consumer to restart itself
+    // indefinitely while the process still looks healthy to ECS. Returning false once the crash
+    // budget is exhausted makes KafkaJS emit a fatal `consumer.crash` (restart: false), which
+    // handleConsumerCrash turns into a process exit so the task is recycled.
+    retry: {
+      retries: config.KAFKA_CONSUMER_MAX_RETRIES,
+      restartOnFailure: (error: Error): Promise<boolean> => Promise.resolve(
+        recordCrashAndDecideRestart(error),
+      ),
+    },
   });
+
+  consumer!.on('consumer.crash', (event) => handleConsumerCrash(event.payload));
 
   consumer!.on('consumer.disconnect', async () => {
     logger.info({
@@ -106,10 +191,16 @@ export async function startConsumer(batchProcessing: boolean = false): Promise<v
   };
 
   if (batchProcessing) {
-    consumerRunConfig.eachBatch = onBatchFunction;
+    consumerRunConfig.eachBatch = async (payload: EachBatchPayload) => {
+      await onBatchFunction(payload);
+      // A successful batch means the consumer is making progress; clear the crash counter so a
+      // later isolated failure gets the full crash budget rather than an inherited count.
+      resetConsecutiveCrashes();
+    };
   } else {
     consumerRunConfig.eachMessage = async ({ topic, message }) => {
       await onMessageFunction(topic, message);
+      resetConsecutiveCrashes();
     };
   }
 


### PR DESCRIPTION
## What it is

Makes the KafkaJS consumer **fail loud and get recycled** when it can no longer make progress, instead of silently looping forever. Supersedes the implicit default `restartOnFailure` behavior (unbounded internal restart).

Data path: `Kafka msg → eachMessage → onMessage → Postgres`. When Postgres fails for *every* message (as during the recent testnet RDS disk-full outage), KafkaJS exhausts retries → emits `consumer.crash` → default `restartOnFailure` restarts the runner internally, indefinitely. The Node process stays alive, ECS health checks pass, and the consumer sits wedged with zero consumption. Observed impact: ~14 days of indexer downtime with no automated recovery.

The fix lives in the shared `packages/kafka` module, so `ender`, `vulcan`, `socks`, and `roundtable` all inherit the behavior.

## Capabilities

| Property | Behavior |
|---|---|
| Transient failure recovery | Unchanged — KafkaJS retries the batch (`retries`, default 5) with backoff |
| Sustained failure recovery | Bounded internal restarts, then process exit → orchestrator (ECS) replaces the task with a fresh container |
| Failure detection | A non-restartable crash is surfaced as a non-zero process exit rather than a silent idle loop |
| Progress accounting | Consecutive-crash counter resets after any successfully processed message/batch; only *sustained* total failure reaches the exit threshold |
| Data safety | Offsets are committed; a restarted task resumes from the last committed offset (no loss, no skip) |
| Blast radius | Additive only — no consumer API signature changes; all downstream services inherit the behavior |
| Operability | New env knobs: `KAFKA_CONSUMER_MAX_CONSECUTIVE_CRASHES` (default 5), `KAFKA_EXIT_PROCESS_ON_CONSUMER_CRASH` (default true), `KAFKA_CONSUMER_MAX_RETRIES` (default 5, = prior implicit default) |

## Testing

- **Unit** (`packages/kafka`, no broker): crash-budget threshold, reset-on-progress, and all four `process.exit` branches (fatal exits; restartable does not; disabled flag does not).
- **Integration** (`packages/kafka`, real broker): (a) happy-path consumption keeps the crash count at zero; (b) end-to-end sustained-failure drives repeated real crashes until the budget is exhausted and asserts `process.exit(1)`. The broker lifecycle is managed by the test — it probes reachability, starts `docker compose kafka` only if absent, and tears it down only if it started it.
- Gates: `build` (tsc) ✅ · `lint` (eslint) ✅ · `test` (jest) ✅ **12/12**.
- Validated both against a pre-running broker and from a cold start (test managed full up/down lifecycle).

## Reviewer brief

- `packages/kafka/src/consumer.ts` — the load-bearing change: `recordCrashAndDecideRestart` (bounded restart decision), `handleConsumerCrash` (exit-on-fatal), counter reset wired into the `eachMessage`/`eachBatch` success paths, and `initConsumer` lifecycle reset. Worth a second look: the interaction between KafkaJS `retries` (per-batch) and the consecutive-crash budget (per-crash).
- `packages/kafka/src/config.ts` — three new tunables, defaults preserve prior behavior.
- CI needs no changes — the reusable indexer workflow already provisions a `blacktop/kafka` service; the integration test connects to it and never invokes `docker compose` when a broker is reachable.

## Test plan

- [x] Unit tests for crash budget, reset, and exit branches
- [x] Integration test: real crash → `process.exit(1)`
- [x] Integration test: happy-path consumption, counter stays 0
- [x] build / lint / test green locally
- [ ] CI green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable controls for Kafka consumer crash limits, message retries, and process-exit behavior.
  * Added automatic recovery for transient consumer failures.
  * Added process termination for sustained or non-restartable consumer crashes, enabling task-level recovery.
  * Successful message and batch processing now clears the consecutive-crash count.

* **Tests**
  * Expanded coverage for crash recovery, retry limits, fatal failures, and successful message consumption.
  * Added integration tests that manage a Kafka broker automatically when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->