### PR TITLE
ci: bind indexer workflow inputs via env before shell

### DIFF
--- a/.github/workflows/indexer-build-and-push-lambda.yml
+++ b/.github/workflows/indexer-build-and-push-lambda.yml
@@ -58,11 +58,12 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ENVIRONMENT }}-indexer-${{ inputs.SERVICE }}
+          SERVICE: ${{ inputs.SERVICE }}
         run: |
           current_time=$(date '+%Y%m%d%H%M')
           commit_hash=$(git rev-parse --short HEAD)
           DOCKER_BUILDKIT=1 docker build \
             --platform amd64 \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$commit_hash \
-            -f Dockerfile.${{ inputs.SERVICE }}.remote .
+            -f "Dockerfile.${SERVICE}.remote" .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags

--- a/.github/workflows/indexer-reusable-build-and-run-with-pg-redis-kafka.yml
+++ b/.github/workflows/indexer-reusable-build-and-run-with-pg-redis-kafka.yml
@@ -59,9 +59,10 @@ jobs:
           pnpm run build:all
 
       - name: Run command
-        run: ${{ inputs.COMMAND }}
         env:
+          COMMAND: ${{ inputs.COMMAND }}
           DB_PORT: 5432
           REDIS_URL: redis://localhost:6379
           REDIS_READONLY_URL: redis://localhost:6379
           RATE_LIMIT_REDIS_URL: redis://localhost:6379
+        run: bash -lc "$COMMAND"


### PR DESCRIPTION
## Summary
- Bind `inputs.COMMAND` through `env:` and run via `bash -lc` in the reusable pg/redis/kafka workflow (instead of `run: ${{ inputs.COMMAND }}`).
- Bind `inputs.SERVICE` through `env:` before `Dockerfile.${SERVICE}.remote` in the lambda build/push workflow.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Reusable command workflow still executes caller-provided COMMAND with DB/Redis env
- [ ] Lambda image build still selects the correct service Dockerfile


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated service image builds by correctly selecting the Dockerfile for the specified service.
  * Improved reusable workflow command execution for more reliable environment handling.
* **Chores**
  * Preserved existing image tagging, publishing, database, and Redis configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->