### PR TITLE
fix(x/prices): normalize pair case on the governance listing path

### DIFF
--- a/protocol/x/prices/keeper/msg_server_create_oracle_market.go
+++ b/protocol/x/prices/keeper/msg_server_create_oracle_market.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	pricefeedmetrics "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
@@ -43,6 +44,13 @@ func (k msgServer) CreateOracleMarket(
 	}
 
 	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
+
+	// Normalize the pair to match the permissionless listing path (x/listing
+	// uppercases tickers before creation). Without this, a governance proposal
+	// that passes a non-canonical case (e.g. "btc-usd") stores the pair
+	// verbatim, while the pricefeed daemon keys its exchange-config lookup on
+	// the exact stored string, so the market is created but never priced.
+	msg.Params.Pair = strings.ToUpper(msg.Params.Pair)
 
 	exponent, err := k.Keeper.GetExponent(ctx, msg.Params.Pair)
 	if err != nil {

--- a/protocol/x/prices/keeper/msg_server_create_oracle_market_test.go
+++ b/protocol/x/prices/keeper/msg_server_create_oracle_market_test.go
@@ -185,3 +185,41 @@ func TestMarketPriceExponentIsFromMarketmap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int32(-8), marketPrice.Exponent)
 }
+
+func TestCreateOracleMarketNormalizesPairCase(t *testing.T) {
+	ctx, pricesKeeper, _, _, _, _, marketMapKeeper := keepertest.PricesKeepers(t)
+	msgServer := keeper.NewMsgServerImpl(pricesKeeper)
+
+	currencyPair, err := slinky.MarketPairToCurrencyPair(constants.BtcUsdPair)
+	require.NoError(t, err)
+
+	err = marketMapKeeper.CreateMarket(ctx, marketmaptypes.Market{
+		Ticker: marketmaptypes.Ticker{
+			CurrencyPair:     currencyPair,
+			Decimals:         uint64(8),
+			MinProviderCount: 1,
+		},
+		ProviderConfigs: []marketmaptypes.ProviderConfig{},
+	})
+	require.NoError(t, err)
+
+	// Governance passes a non-canonical case; the permissionless listing path
+	// uppercases tickers, so the gov path must too. Otherwise the pair is
+	// stored verbatim and the pricefeed daemon, which keys its exchange-config
+	// lookup on the exact stored string, never prices the market.
+	testMarket := pricestest.GenerateMarketParamPrice(
+		pricestest.WithId(1),
+		pricestest.WithPair("btc-usd"),
+		pricestest.WithPriceValue(0),
+	)
+
+	_, err = msgServer.CreateOracleMarket(ctx, &pricestypes.MsgCreateOracleMarket{
+		Authority: lib.GovModuleAddress.String(),
+		Params:    testMarket.Param,
+	})
+	require.NoError(t, err)
+
+	marketParam, exists := pricesKeeper.GetMarketParam(ctx, 1)
+	require.True(t, exists)
+	require.Equal(t, constants.BtcUsdPair, marketParam.Pair)
+}


### PR DESCRIPTION
## Summary

`x/listing` uppercases tickers before creating markets (`listing.go`: `ticker = strings.ToUpper(ticker)`), but the governance path (`MsgCreateOracleMarket`) stores the pair verbatim. The pricefeed daemon keys its exchange-config lookup on the exact stored string (`price_feed_mutable_market_configs.go`: `marketNameToId[param.Pair] = param.Id`), so a governance proposal that passes a non-canonical case (e.g. `btc-usd`) creates a market the daemon can never price. The market is governance-approved but silently receives no price updates.

The case-insensitive duplicate check in `CreateMarket` (`strings.EqualFold`) prevents collisions, so normalization here cannot conflict with existing markets.

## Fix

Uppercase `msg.Params.Pair` in the gov msg server, matching the listing path.

## Test plan

- [x] New test: gov path with `btc-usd` stores `BTC-USD` (matching `x/listing` behavior)
- [x] Full `x/prices` suite passes (4/4 packages); `go vet` clean

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Oracle markets created with lowercase trading pairs are now normalized to uppercase, ensuring consistent market creation and exponent handling.

* **Tests**
  * Added coverage to verify lowercase pairs are stored in their canonical uppercase form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->