### PR TITLE
fix(x/prices): normalize pair case on MsgUpdateMarketParam

### DIFF
--- a/protocol/x/prices/keeper/msg_server_update_market_param.go
+++ b/protocol/x/prices/keeper/msg_server_update_market_param.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	pricefeedmetrics "github.com/dydxprotocol/v4-chain/protocol/daemons/pricefeed/metrics"
@@ -43,6 +44,14 @@ func (k msgServer) UpdateMarketParam(
 	}
 
 	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
+
+	// Normalize the pair to match x/listing and MsgCreateOracleMarket.
+	// Without this, a governance update that passes a non-canonical case
+	// (e.g. "btc-usd") stores the pair verbatim, while the pricefeed daemon
+	// keys its exchange-config lookup on the exact stored string
+	// (marketNameToId[param.Pair]), so AdjustByMarket / ticker mapping breaks
+	// and the market stops receiving prices.
+	msg.MarketParam.Pair = strings.ToUpper(msg.MarketParam.Pair)
 
 	if _, err = k.Keeper.ModifyMarketParam(ctx, msg.MarketParam); err != nil {
 		return nil, err

--- a/protocol/x/prices/keeper/msg_server_update_market_param_test.go
+++ b/protocol/x/prices/keeper/msg_server_update_market_param_test.go
@@ -178,3 +178,46 @@ func TestUpdateMarketParam(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateMarketParamNormalizesPairCase(t *testing.T) {
+	ctx, pricesKeeper, _, _, mockTimeProvider, _, marketMapKeeper := keepertest.PricesKeepers(t)
+	mockTimeProvider.On("Now").Return(constants.TimeT)
+	msgServer := keeper.NewMsgServerImpl(pricesKeeper)
+
+	initial := *pricestest.GenerateMarketParamPrice(
+		pricestest.WithId(1),
+		pricestest.WithPair("BTC-USD"),
+		pricestest.WithExponent(-8),
+		pricestest.WithPriceValue(0),
+	)
+	_, err := keepertest.CreateTestMarket(t, ctx, pricesKeeper, initial.Param, initial.Price)
+	require.NoError(t, err)
+
+	// Target pair exists in marketmap under canonical case, but governance
+	// submits a non-canonical case — same class of bug as CreateOracleMarket
+	// before pair uppercasing (#3375).
+	newParam := pricestypes.MarketParam{
+		Id:                 initial.Param.Id,
+		Pair:               "newmarket-usd",
+		Exponent:           initial.Param.Exponent,
+		MinExchanges:       72,
+		MinPriceChangePpm:  2_023,
+		ExchangeConfigJson: `{"exchanges":[{"exchangeName":"XYZ","ticker":"PIKACHU"}]}`,
+	}
+	keepertest.CreateMarketsInMarketMapFromParams(
+		t,
+		ctx,
+		marketMapKeeper,
+		[]pricestypes.MarketParam{newParam},
+	)
+
+	_, err = msgServer.UpdateMarketParam(ctx, &pricestypes.MsgUpdateMarketParam{
+		Authority:   lib.GovModuleAddress.String(),
+		MarketParam: newParam,
+	})
+	require.NoError(t, err)
+
+	updated, exists := pricesKeeper.GetMarketParam(ctx, 1)
+	require.True(t, exists)
+	require.Equal(t, "NEWMARKET-USD", updated.Pair)
+}


### PR DESCRIPTION
## Summary

Sibling of [#3375](https://github.com/dydxprotocol/v4-chain/pull/3375) (`MsgCreateOracleMarket`).

`x/listing` uppercases tickers before creation, and #3375 does the same on the governance create path. `MsgUpdateMarketParam` still stored `MarketParam.Pair` verbatim. The pricefeed daemon builds `marketNameToId` from the exact stored string (`price_feed_mutable_market_configs.go`), so a governance update that renames (or re-asserts) a pair with non-canonical case (e.g. `newmarket-usd`) makes exchange-config / `AdjustByMarket` lookups miss and the market stops receiving prices.

MarketMap conversion already uppercases via `MarketPairToCurrencyPair`, so the marketmap enable/disable path still works; only the pricefeed string-keyed map breaks.

## Fix

Uppercase `msg.MarketParam.Pair` in the gov msg server before `ModifyMarketParam`, matching listing + CreateOracleMarket.

## Test plan

- [x] New test `TestUpdateMarketParamNormalizesPairCase`: update with `newmarket-usd` stores `NEWMARKET-USD`
- [x] Existing `TestUpdateMarketParam` suite still passes
- [x] Red/green: without `ToUpper`, new test fails (`newmarket-usd` stored); with fix, passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market pairs are now consistently stored in uppercase when market parameters are updated.
  * Lowercase market pair inputs are accepted and correctly matched with canonical market entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->