### PR TITLE
fix(x/listing): enforce markets hard cap with >= (off-by-one)

### DIFF
--- a/protocol/x/listing/keeper/msg_create_market_permissionless.go
+++ b/protocol/x/listing/keeper/msg_create_market_permissionless.go
@@ -13,9 +13,9 @@ func (k msgServer) CreateMarketPermissionless(
 ) (*types.MsgCreateMarketPermissionlessResponse, error) {
 	ctx := lib.UnwrapSDKContext(goCtx, types.ModuleName)
 
-	// Check if the number of listed markets is above the hard cap
+	// Reject when already at or above HardCapForMarkets (`>` was off-by-one).
 	numPerpetuals := len(k.PerpetualsKeeper.GetAllPerpetuals(ctx))
-	if uint32(numPerpetuals) > k.Keeper.GetMarketsHardCap(ctx) {
+	if uint32(numPerpetuals) >= k.Keeper.GetMarketsHardCap(ctx) {
 		return nil, types.ErrMarketsHardCapReached
 	}
 

--- a/protocol/x/listing/keeper/msg_create_market_permissionless_test.go
+++ b/protocol/x/listing/keeper/msg_create_market_permissionless_test.go
@@ -42,6 +42,15 @@ func TestMsgCreateMarketPermissionless(t *testing.T) {
 
 			expectedErr: types.ErrMarketsHardCapReached,
 		},
+		// hardCap equal to the current perpetual count must reject. A `>` check
+		// would admit one more listing and leave the chain at hardCap+1.
+		"failure - hard cap equal to current perpetual count": {
+			ticker:  "TEST2-USD",
+			hardCap: 0, // overwritten below to len(GetAllPerpetuals)
+			balance: big.NewInt(10_000_000_000),
+
+			expectedErr: types.ErrMarketsHardCapReached,
+		},
 		"failure - ticker not found": {
 			ticker:  "INVALID-USD",
 			hardCap: 300,
@@ -112,8 +121,14 @@ func TestMsgCreateMarketPermissionless(t *testing.T) {
 				k := tApp.App.ListingKeeper
 				ms := keeper.NewMsgServerImpl(k)
 
+				hardCap := tc.hardCap
+				if name == "failure - hard cap equal to current perpetual count" {
+					hardCap = uint32(len(k.PerpetualsKeeper.GetAllPerpetuals(ctx)))
+					require.Greater(t, hardCap, uint32(0))
+				}
+
 				// Set hard cap
-				err := k.SetMarketsHardCap(ctx, tc.hardCap)
+				err := k.SetMarketsHardCap(ctx, hardCap)
 				require.NoError(t, err)
 
 				// Add TEST2-USD market to market map


### PR DESCRIPTION
## Summary

Sibling of the pair-case listing hardenings (#3375 / #3376). Distinct root cause.

`MsgCreateMarketPermissionless` rejected only when `numPerpetuals > HardCapForMarkets`. When the count already equalled the governance hard cap, a signed lister could still create one more market, leaving the chain at `hardCap+1`. Proto text describes a hard cap on the total number of markets listed.

## Fix

Use `>=` so equality rejects with `ErrMarketsHardCapReached`.

## Testing

```bash
cd protocol
go test ./x/listing/keeper/ -count=1 -run 'TestMsgCreateMarketPermissionless$' -timeout 120s
```

Includes a new case: hard cap equal to current perpetual count must fail.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected market creation limits to prevent new perpetual markets from being created when the configured hard cap has already been reached.
  * Added regression coverage to verify the hard-cap boundary condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->