### PR TITLE
fix(lib): keep the fraction when rounding a big.Rat to a multiple

### DIFF
--- a/protocol/lib/quantums.go
+++ b/protocol/lib/quantums.go
@@ -91,22 +91,17 @@ func QuoteToBaseQuantums(
 
 // BigRatRoundToMultiple rounds a big.Rat to the nearest multiple of the given number.
 // If roundUp is true, it rounds up to the nearest multiple, otherwise it rounds down.
+// This function expects `multiple` to be positive.
 func BigRatRoundToMultiple(
 	value *big.Rat,
 	multiple *big.Int,
 	roundUp bool,
 ) *big.Int {
-	// Convert the value to a big.Int
-	valueInt := new(big.Int).Div(value.Num(), value.Denom())
-
-	// Calculate the remainder
-	remainder := new(big.Int).Mod(valueInt, multiple)
-
-	if roundUp && remainder.Sign() != 0 {
-		valueInt.Add(valueInt, new(big.Int).Sub(multiple, remainder))
-	} else {
-		valueInt.Sub(valueInt, remainder)
-	}
-
-	return valueInt
+	// Round `value / multiple` to an integer and scale it back up, so that the
+	// fractional part of `value` takes part in the rounding decision. Rounding
+	// `value` to an integer first would discard it, and a value such as `10.5`
+	// would then never round up past the multiple its floor already sits on.
+	quotient := new(big.Rat).Quo(value, new(big.Rat).SetInt(multiple))
+	rounded := BigRatRound(quotient, roundUp)
+	return rounded.Mul(rounded, multiple)
 }

--- a/protocol/lib/quantums.go
+++ b/protocol/lib/quantums.go
@@ -91,12 +91,18 @@ func QuoteToBaseQuantums(
 
 // BigRatRoundToMultiple rounds a big.Rat to the nearest multiple of the given number.
 // If roundUp is true, it rounds up to the nearest multiple, otherwise it rounds down.
-// This function expects `multiple` to be positive.
+// This function always expects the `multiple` parameter to be positive, otherwise it will panic.
 func BigRatRoundToMultiple(
 	value *big.Rat,
 	multiple *big.Int,
 	roundUp bool,
 ) *big.Int {
+	// A zero multiple divides by zero and a negative one silently reverses the
+	// rounding direction, so reject both up front like BigIntRoundToMultiple does.
+	if multiple.Sign() <= 0 {
+		panic("BigRatRoundToMultiple: multiple must be positive")
+	}
+
 	// Round `value / multiple` to an integer and scale it back up, so that the
 	// fractional part of `value` takes part in the rounding decision. Rounding
 	// `value` to an integer first would discard it, and a value such as `10.5`

--- a/protocol/lib/quantums_test.go
+++ b/protocol/lib/quantums_test.go
@@ -288,6 +288,7 @@ func TestBigRatRoundToMultiple(t *testing.T) {
 		multiple       *big.Int
 		roundUp        bool
 		expectedResult *big.Int
+		shouldPanic    bool
 	}{
 		// The fractional part must survive to the rounding decision. In these cases the
 		// floor of the value already sits on a multiple, so discarding it before rounding
@@ -372,9 +373,29 @@ func TestBigRatRoundToMultiple(t *testing.T) {
 			roundUp:        true,
 			expectedResult: big.NewInt(0),
 		},
+		// A zero multiple divides by zero and a negative one reverses the rounding
+		// direction, so both are rejected rather than silently answered.
+		"Panics on a zero multiple": {
+			value:       big.NewRat(21, 2),
+			multiple:    big.NewInt(0),
+			roundUp:     true,
+			shouldPanic: true,
+		},
+		"Panics on a negative multiple": {
+			value:       big.NewRat(21, 2),
+			multiple:    big.NewInt(-10),
+			roundUp:     true,
+			shouldPanic: true,
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			if tc.shouldPanic {
+				require.Panics(t, func() {
+					lib.BigRatRoundToMultiple(tc.value, tc.multiple, tc.roundUp)
+				})
+				return
+			}
 			result := lib.BigRatRoundToMultiple(tc.value, tc.multiple, tc.roundUp)
 			require.Equal(t, tc.expectedResult, result)
 		})

--- a/protocol/lib/quantums_test.go
+++ b/protocol/lib/quantums_test.go
@@ -281,3 +281,102 @@ func BenchmarkQuoteToBaseQuantums(b *testing.B) {
 	expected2, _ := new(big.Int).SetString("1494", 10)
 	require.Equal(b, expected2, result2)
 }
+
+func TestBigRatRoundToMultiple(t *testing.T) {
+	tests := map[string]struct {
+		value          *big.Rat
+		multiple       *big.Int
+		roundUp        bool
+		expectedResult *big.Int
+	}{
+		// The fractional part must survive to the rounding decision. In these cases the
+		// floor of the value already sits on a multiple, so discarding it before rounding
+		// leaves the result a full multiple below the value it was asked to round up past.
+		"Rounds up when the value's floor is already a multiple": {
+			value:          big.NewRat(2001, 2), // 1000.5
+			multiple:       big.NewInt(10),
+			roundUp:        true,
+			expectedResult: big.NewInt(1010),
+		},
+		"Rounds up to the next integer when the multiple is one": {
+			value:          big.NewRat(21, 2), // 10.5
+			multiple:       big.NewInt(1),
+			roundUp:        true,
+			expectedResult: big.NewInt(11),
+		},
+		"Rounds a value below the multiple up to the multiple": {
+			value:          big.NewRat(1, 2), // 0.5
+			multiple:       big.NewInt(10),
+			roundUp:        true,
+			expectedResult: big.NewInt(10),
+		},
+		"Rounds up when the value's floor is not a multiple": {
+			value:          big.NewRat(2011, 2), // 1005.5
+			multiple:       big.NewInt(10),
+			roundUp:        true,
+			expectedResult: big.NewInt(1010),
+		},
+		"Rounds down": {
+			value:          big.NewRat(2011, 2), // 1005.5
+			multiple:       big.NewInt(10),
+			roundUp:        false,
+			expectedResult: big.NewInt(1000),
+		},
+		"Leaves an exact multiple unchanged when rounding up": {
+			value:          big.NewRat(1000, 1),
+			multiple:       big.NewInt(10),
+			roundUp:        true,
+			expectedResult: big.NewInt(1000),
+		},
+		"Leaves an exact multiple unchanged when rounding down": {
+			value:          big.NewRat(1000, 1),
+			multiple:       big.NewInt(10),
+			roundUp:        false,
+			expectedResult: big.NewInt(1000),
+		},
+		"Rounds an integer value up to the next multiple": {
+			value:          big.NewRat(7, 1),
+			multiple:       big.NewInt(3),
+			roundUp:        true,
+			expectedResult: big.NewInt(9),
+		},
+		"Rounds an integer value down to the previous multiple": {
+			value:          big.NewRat(7, 1),
+			multiple:       big.NewInt(3),
+			roundUp:        false,
+			expectedResult: big.NewInt(6),
+		},
+		// Rounding up means towards positive infinity, so a negative value rounds
+		// towards zero.
+		"Rounds a negative value up towards zero": {
+			value:          big.NewRat(-2001, 2), // -1000.5
+			multiple:       big.NewInt(10),
+			roundUp:        true,
+			expectedResult: big.NewInt(-1000),
+		},
+		"Rounds a negative value down away from zero": {
+			value:          big.NewRat(-2001, 2), // -1000.5
+			multiple:       big.NewInt(10),
+			roundUp:        false,
+			expectedResult: big.NewInt(-1010),
+		},
+		"Rounds a negative value down when the multiple is one": {
+			value:          big.NewRat(-21, 2), // -10.5
+			multiple:       big.NewInt(1),
+			roundUp:        false,
+			expectedResult: big.NewInt(-11),
+		},
+		"Zero is unchanged": {
+			value:          big.NewRat(0, 1),
+			multiple:       big.NewInt(10),
+			roundUp:        true,
+			expectedResult: big.NewInt(0),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := lib.BigRatRoundToMultiple(tc.value, tc.multiple, tc.roundUp)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
### Changelist

`lib.BigRatRoundToMultiple` rounds its `big.Rat` down to a `big.Int` *before* looking at the remainder:

```go
valueInt := new(big.Int).Div(value.Num(), value.Denom())
remainder := new(big.Int).Mod(valueInt, multiple)

if roundUp && remainder.Sign() != 0 {
    valueInt.Add(valueInt, new(big.Int).Sub(multiple, remainder))
} else {
    valueInt.Sub(valueInt, remainder)
}
```

The fractional part is discarded before it can affect the rounding decision. When the floor of the value already sits on a multiple, the remainder is zero, the round-up branch is skipped, and the function returns the floor — a full multiple below the correct answer:

| call | returns | expected |
|---|---|---|
| `BigRatRoundToMultiple(1000.5, 10, roundUp=true)` | `1000` | `1010` |
| `BigRatRoundToMultiple(0.5, 10, roundUp=true)` | `0` | `10` |
| `BigRatRoundToMultiple(10.5, 1, roundUp=true)` | `10` | `11` |

The `multiple = 1` case is the clearest statement of the problem: every integer is a multiple of 1, so the round-up branch is unreachable and the function is just `floor`.

Rounding **down** was already correct — the `else` branch floors to the multiple, and negative values work out because `Div`/`Mod` are Euclidean. Only round-up is affected.

The fix rounds `value / multiple` in rational space and scales back up, reusing the existing `BigRatRound`, so the fraction takes part in the decision.

#### Impact

The only caller is `calculateSuborderSubticks` in `x/clob/keeper/twap_order_state.go`, which rounds a TWAP suborder's limit price with:

```go
priceTolerancePpm >= 0, // round up for positive adjustments, down for negative
```

Buys round up and sells round down so the suborder stays marketable. When a buy's adjusted oracle price lands just above a tick boundary — i.e. `floor(adjustedPrice)` is a multiple of `SubticksPerTick` — the price is rounded *down* instead, one full tick below the intended limit, making the suborder correspondingly less likely to fill. Sells are unaffected.

I suspect this survived because `BigRatRoundToMultiple` had no test coverage at all, unlike its sibling `BigIntRoundToMultiple`.

### Test Plan

Added `TestBigRatRoundToMultiple` to `protocol/lib/quantums_test.go` — 13 cases in the same table-driven style as `TestBigIntRoundToMultiple`, covering round-up/round-down, exact multiples, `multiple = 1`, negatives, and zero.

Three of them fail on `main`:

```
--- FAIL: TestBigRatRoundToMultiple/Rounds_up_when_the_value's_floor_is_already_a_multiple
        expected: 1010   actual: 1000
--- FAIL: TestBigRatRoundToMultiple/Rounds_up_to_the_next_integer_when_the_multiple_is_one
        expected: 11     actual: 10
--- FAIL: TestBigRatRoundToMultiple/Rounds_a_value_below_the_multiple_up_to_the_multiple
        expected: 10     actual: 0
```

Run with the pinned toolchain (`GOTOOLCHAIN=go1.23.3`):

| check | result |
|---|---|
| `go test ./lib/...` | all packages **ok** |
| `go test ./x/clob/keeper/` | **ok** (22.7s) — no existing test encoded the old behaviour |
| `go vet ./lib/` | clean |
| `gofmt -l lib/` | clean |

One note in case it comes up: on Go 1.26 the pre-existing `TestBigDivCeil` fails two subtests with `expected: 0, actual: 0`, from a change in `big.Int`'s internal representation (`abs: nil` vs `[]Word{}`). It reproduces on a clean checkout of `main` and disappears under the repo's pinned Go 1.23.3, so it is unrelated to this change.

### Author/Reviewer Checklist
- [x] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
  - **This is state-breaking.** TWAP buy suborders that hit the affected case will be placed at a different limit price than before, so it needs the label and to go out with an upgrade rather than as a patch to running nodes. I can't add labels on this repo — flagging it here.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [x] Manually add any of the following labels: `refactor`, `chore`, `bug`. → `bug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rounding of fractional values to the nearest configured multiple.
  * Corrected rounding behavior for positive, negative, zero, and exact values.
  * Added validation to reject zero or negative rounding multiples.

* **Tests**
  * Added comprehensive coverage for multiple-based rounding scenarios.
  * Added tests confirming invalid multiples are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->