### PR TITLE
feat(socks): drop connections that spam the subscription limit

### DIFF
--- a/indexer/services/socks/__tests__/helpers/header-utils.test.ts
+++ b/indexer/services/socks/__tests__/helpers/header-utils.test.ts
@@ -1,9 +1,21 @@
 import { IncomingMessage as IncomingMessageHttp } from 'http';
 import { Socket } from 'net';
 
+import config from '../../src/config';
 import { getClientIp } from '../../src/helpers/header-utils';
 
 describe('getClientIp', () => {
+  const defaultTrust: boolean = config.TRUST_FORWARDED_HEADERS;
+
+  beforeEach(() => {
+    // Most cases describe behaviour once ingress is locked to the trusted proxy chain.
+    config.TRUST_FORWARDED_HEADERS = true;
+  });
+
+  afterEach(() => {
+    config.TRUST_FORWARDED_HEADERS = defaultTrust;
+  });
+
   function requestWithHeaders(
     headers: { [key: string]: string | string[] },
     remoteAddress?: string,
@@ -67,5 +79,38 @@ describe('getClientIp', () => {
     const req = requestWithHeaders({ 'x-forwarded-for': '' }, '10.0.1.5');
 
     expect(getClientIp(req)).toEqual('10.0.1.5');
+  });
+
+  describe('when forwarded headers are not trusted', () => {
+    beforeEach(() => {
+      config.TRUST_FORWARDED_HEADERS = false;
+    });
+
+    it('refuses to believe cf-connecting-ip', () => {
+      // Otherwise anyone reaching the load balancer directly could name a victim address and
+      // have that address penalised.
+      const req = requestWithHeaders({ 'cf-connecting-ip': '203.0.113.7' }, '10.0.1.5');
+
+      expect(getClientIp(req)).toBeUndefined();
+    });
+
+    it('refuses to believe x-forwarded-for', () => {
+      const req = requestWithHeaders({ 'x-forwarded-for': '203.0.113.7' }, '10.0.1.5');
+
+      expect(getClientIp(req)).toBeUndefined();
+    });
+
+    it('does not fall back to the socket address, which would be the shared proxy', () => {
+      const req = requestWithHeaders({ 'x-forwarded-for': '203.0.113.7' }, '10.0.1.5');
+
+      // Penalising the proxy address would refuse every client behind it.
+      expect(getClientIp(req)).not.toEqual('10.0.1.5');
+    });
+
+    it('still uses the socket address when no proxy is in the path', () => {
+      const req = requestWithHeaders({}, '10.0.1.5');
+
+      expect(getClientIp(req)).toEqual('10.0.1.5');
+    });
   });
 });

--- a/indexer/services/socks/__tests__/helpers/header-utils.test.ts
+++ b/indexer/services/socks/__tests__/helpers/header-utils.test.ts
@@ -1,0 +1,71 @@
+import { IncomingMessage as IncomingMessageHttp } from 'http';
+import { Socket } from 'net';
+
+import { getClientIp } from '../../src/helpers/header-utils';
+
+describe('getClientIp', () => {
+  function requestWithHeaders(
+    headers: { [key: string]: string | string[] },
+    remoteAddress?: string,
+  ): IncomingMessageHttp {
+    const socket: Socket = new Socket();
+    if (remoteAddress !== undefined) {
+      Object.defineProperty(socket, 'remoteAddress', { value: remoteAddress });
+    }
+    const req: IncomingMessageHttp = new IncomingMessageHttp(socket);
+    Object.entries(headers).forEach(([key, value]) => {
+      req.headers[key] = value;
+    });
+    return req;
+  }
+
+  it('prefers cf-connecting-ip, which is the only header carrying the real client past Cloudflare', () => {
+    const req = requestWithHeaders({
+      'cf-connecting-ip': '203.0.113.7',
+      'x-forwarded-for': '198.51.100.1, 172.68.0.1',
+    }, '10.0.1.5');
+
+    expect(getClientIp(req)).toEqual('203.0.113.7');
+  });
+
+  it('falls back to the left-most x-forwarded-for entry', () => {
+    const req = requestWithHeaders({
+      'x-forwarded-for': '198.51.100.1, 172.68.0.1',
+    }, '10.0.1.5');
+
+    expect(getClientIp(req)).toEqual('198.51.100.1');
+  });
+
+  it('trims whitespace around the forwarded address', () => {
+    const req = requestWithHeaders({ 'x-forwarded-for': '  198.51.100.1  ,172.68.0.1' });
+
+    expect(getClientIp(req)).toEqual('198.51.100.1');
+  });
+
+  it('handles a repeated x-forwarded-for header', () => {
+    const req = requestWithHeaders({ 'x-forwarded-for': ['198.51.100.1', '172.68.0.1'] });
+
+    expect(getClientIp(req)).toEqual('198.51.100.1');
+  });
+
+  it('falls back to the socket address when no proxy headers are present', () => {
+    const req = requestWithHeaders({}, '10.0.1.5');
+
+    expect(getClientIp(req)).toEqual('10.0.1.5');
+  });
+
+  it('ignores an empty cf-connecting-ip', () => {
+    const req = requestWithHeaders({
+      'cf-connecting-ip': '   ',
+      'x-forwarded-for': '198.51.100.1',
+    });
+
+    expect(getClientIp(req)).toEqual('198.51.100.1');
+  });
+
+  it('ignores an empty x-forwarded-for', () => {
+    const req = requestWithHeaders({ 'x-forwarded-for': '' }, '10.0.1.5');
+
+    expect(getClientIp(req)).toEqual('10.0.1.5');
+  });
+});

--- a/indexer/services/socks/__tests__/helpers/verify-client.test.ts
+++ b/indexer/services/socks/__tests__/helpers/verify-client.test.ts
@@ -1,0 +1,110 @@
+import { IncomingMessage as IncomingMessageHttp, OutgoingHttpHeaders } from 'http';
+import { Socket } from 'net';
+
+import config from '../../src/config';
+import { verifyClientNotPenalized } from '../../src/helpers/wss';
+import {
+  RATE_LIMIT_REASON_HEADER,
+  RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
+} from '../../src/lib/constants';
+import { reconnectPenalty } from '../../src/lib/reconnect-penalty';
+
+describe('verifyClientNotPenalized', () => {
+  const clientIp: string = '203.0.113.7';
+  const defaultPenaltyMs: number = config.RECONNECT_PENALTY_MS;
+
+  function infoForIp(ip?: string): {
+    origin: string, secure: boolean, req: IncomingMessageHttp,
+  } {
+    const req: IncomingMessageHttp = new IncomingMessageHttp(new Socket());
+    if (ip !== undefined) {
+      req.headers['cf-connecting-ip'] = ip;
+    }
+    return { origin: 'https://dydx.trade', secure: true, req };
+  }
+
+  let nowMs: number = 1_700_000_000_000;
+
+  function advanceTime(ms: number): void {
+    nowMs += ms;
+  }
+
+  beforeEach(() => {
+    nowMs = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    config.RECONNECT_PENALTY_ENABLED = true;
+    config.RECONNECT_PENALTY_MS = defaultPenaltyMs;
+    reconnectPenalty.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    reconnectPenalty.clear();
+    config.RECONNECT_PENALTY_MS = defaultPenaltyMs;
+  });
+
+  it('accepts the upgrade for a client with no penalty', () => {
+    const callback: jest.Mock = jest.fn();
+
+    verifyClientNotPenalized(infoForIp(clientIp), callback);
+
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('rejects the upgrade with HTTP 429 while the client is penalised', () => {
+    reconnectPenalty.penalizeClient(clientIp, RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE);
+    const callback: jest.Mock = jest.fn();
+
+    verifyClientNotPenalized(infoForIp(clientIp), callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    const [result, code, statusMessage, headers] = callback.mock.calls[0] as [
+      boolean, number, string, OutgoingHttpHeaders,
+    ];
+    expect(result).toEqual(false);
+    // The 429 is the signal Cloudflare can see; a websocket close frame is not.
+    expect(code).toEqual(429);
+    expect(statusMessage).toEqual('Too Many Requests');
+    expect(headers['Retry-After']).toEqual(String(config.RECONNECT_PENALTY_MS / 1000));
+    expect(headers[RATE_LIMIT_REASON_HEADER])
+      .toEqual(RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE);
+  });
+
+  it('rounds Retry-After up to the next whole second', () => {
+    config.RECONNECT_PENALTY_MS = 1500;
+    reconnectPenalty.penalizeClient(clientIp, RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE);
+    const callback: jest.Mock = jest.fn();
+
+    verifyClientNotPenalized(infoForIp(clientIp), callback);
+
+    expect(callback.mock.calls[0][3]['Retry-After']).toEqual('2');
+  });
+
+  it('accepts the upgrade again once the penalty expires', () => {
+    reconnectPenalty.penalizeClient(clientIp, RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE);
+    advanceTime(config.RECONNECT_PENALTY_MS);
+    const callback: jest.Mock = jest.fn();
+
+    verifyClientNotPenalized(infoForIp(clientIp), callback);
+
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('does not penalise a different client', () => {
+    reconnectPenalty.penalizeClient(clientIp, RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE);
+    const callback: jest.Mock = jest.fn();
+
+    verifyClientNotPenalized(infoForIp('198.51.100.1'), callback);
+
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('accepts the upgrade when the client address cannot be determined', () => {
+    reconnectPenalty.penalizeClient(clientIp, RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE);
+    const callback: jest.Mock = jest.fn();
+
+    verifyClientNotPenalized(infoForIp(undefined), callback);
+
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+});

--- a/indexer/services/socks/__tests__/helpers/verify-client.test.ts
+++ b/indexer/services/socks/__tests__/helpers/verify-client.test.ts
@@ -12,6 +12,7 @@ import { reconnectPenalty } from '../../src/lib/reconnect-penalty';
 describe('verifyClientNotPenalized', () => {
   const clientIp: string = '203.0.113.7';
   const defaultPenaltyMs: number = config.RECONNECT_PENALTY_MS;
+  const defaultTrust: boolean = config.TRUST_FORWARDED_HEADERS;
 
   function infoForIp(ip?: string): {
     origin: string, secure: boolean, req: IncomingMessageHttp,
@@ -32,6 +33,9 @@ describe('verifyClientNotPenalized', () => {
   beforeEach(() => {
     nowMs = 1_700_000_000_000;
     jest.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    // These cases describe a deployment whose ingress is locked to the trusted proxy chain, so
+    // the forwarded client address can be believed.
+    config.TRUST_FORWARDED_HEADERS = true;
     config.RECONNECT_PENALTY_ENABLED = true;
     config.RECONNECT_PENALTY_MS = defaultPenaltyMs;
     reconnectPenalty.clear();
@@ -41,6 +45,19 @@ describe('verifyClientNotPenalized', () => {
     jest.restoreAllMocks();
     reconnectPenalty.clear();
     config.RECONNECT_PENALTY_MS = defaultPenaltyMs;
+    config.TRUST_FORWARDED_HEADERS = defaultTrust;
+  });
+
+  it('accepts the upgrade when forwarded headers are not trusted', () => {
+    config.TRUST_FORWARDED_HEADERS = false;
+    reconnectPenalty.penalizeClient(clientIp, RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE);
+    const callback: jest.Mock = jest.fn();
+
+    // The address cannot be established safely, so the cooldown must not be applied to a
+    // caller-supplied value.
+    verifyClientNotPenalized(infoForIp(clientIp), callback);
+
+    expect(callback).toHaveBeenCalledWith(true);
   });
 
   it('accepts the upgrade for a client with no penalty', () => {

--- a/indexer/services/socks/__tests__/lib/reconnect-penalty.test.ts
+++ b/indexer/services/socks/__tests__/lib/reconnect-penalty.test.ts
@@ -130,6 +130,46 @@ describe('ReconnectPenalty', () => {
     expect(penalty.getRemainingPenaltyMs('203.0.113.19')).toBeGreaterThan(0);
   });
 
+  it('still evicts a client that was penalised more than once', () => {
+    // Map.set on an existing key updates in place and does NOT move it to the back, so a naive
+    // refresh would leave an entry holding a later expiry at an earlier position and defeat the
+    // front-to-back sweep. Re-penalising must re-anchor the entry.
+    config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS = 3;
+
+    penalty.penalizeClient('203.0.113.1', reason);
+    advanceTime(1);
+    penalty.penalizeClient('203.0.113.2', reason);
+    advanceTime(1);
+    // Re-penalise the oldest entry; it must now be the newest.
+    penalty.penalizeClient('203.0.113.1', reason);
+    advanceTime(1);
+
+    penalty.penalizeClient('203.0.113.3', reason);
+    advanceTime(1);
+    penalty.penalizeClient('203.0.113.4', reason);
+
+    // 203.0.113.2 is now the oldest and should have been evicted first, not the re-penalised .1
+    expect(penalty.getRemainingPenaltyMs('203.0.113.1')).toBeGreaterThan(0);
+    expect(penalty.getRemainingPenaltyMs('203.0.113.2')).toEqual(0);
+  });
+
+  it('sweeps expired entries rather than letting them accumulate', () => {
+    config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS = 1000;
+
+    for (let i = 0; i < 5; i += 1) {
+      penalty.penalizeClient(`198.51.100.${i}`, reason);
+    }
+
+    // Everything above has expired; a later penalty should reclaim it without a full scan.
+    advanceTime(config.RECONNECT_PENALTY_MS + 1);
+    penalty.penalizeClient('203.0.113.200', reason);
+
+    for (let i = 0; i < 5; i += 1) {
+      expect(penalty.getRemainingPenaltyMs(`198.51.100.${i}`)).toEqual(0);
+    }
+    expect(penalty.getRemainingPenaltyMs('203.0.113.200')).toBeGreaterThan(0);
+  });
+
   it('clears all state', () => {
     penalty.trackConnection(connectionId, clientIp);
     penalty.penalizeConnection(connectionId, reason);

--- a/indexer/services/socks/__tests__/lib/reconnect-penalty.test.ts
+++ b/indexer/services/socks/__tests__/lib/reconnect-penalty.test.ts
@@ -1,0 +1,140 @@
+import { ReconnectPenalty } from '../../src/lib/reconnect-penalty';
+import config from '../../src/config';
+
+describe('ReconnectPenalty', () => {
+  let penalty: ReconnectPenalty;
+
+  const connectionId: string = 'connectionId';
+  const clientIp: string = '203.0.113.7';
+  const reason: string = 'subscription-limit-abuse';
+
+  const defaultPenaltyMs: number = config.RECONNECT_PENALTY_MS;
+  const defaultEnabled: boolean = config.RECONNECT_PENALTY_ENABLED;
+  const defaultMaxTracked: number = config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS;
+
+  // Fake timers are unusable under this jest/node combination, and this class only depends on
+  // Date.now, so drive the clock directly.
+  let nowMs: number = 1_700_000_000_000;
+
+  function advanceTime(ms: number): void {
+    nowMs += ms;
+  }
+
+  beforeEach(() => {
+    nowMs = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    config.RECONNECT_PENALTY_ENABLED = true;
+    config.RECONNECT_PENALTY_MS = defaultPenaltyMs;
+    config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS = defaultMaxTracked;
+    penalty = new ReconnectPenalty();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    config.RECONNECT_PENALTY_ENABLED = defaultEnabled;
+    config.RECONNECT_PENALTY_MS = defaultPenaltyMs;
+    config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS = defaultMaxTracked;
+  });
+
+  it('reports no penalty for an untracked client', () => {
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(0);
+  });
+
+  it('reports no penalty for an undefined client address', () => {
+    expect(penalty.getRemainingPenaltyMs(undefined)).toEqual(0);
+  });
+
+  it('penalizes the client behind a tracked connection', () => {
+    penalty.trackConnection(connectionId, clientIp);
+    penalty.penalizeConnection(connectionId, reason);
+
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(config.RECONNECT_PENALTY_MS);
+  });
+
+  it('does not penalize other clients', () => {
+    penalty.trackConnection(connectionId, clientIp);
+    penalty.penalizeConnection(connectionId, reason);
+
+    expect(penalty.getRemainingPenaltyMs('198.51.100.1')).toEqual(0);
+  });
+
+  it('is a no-op when the connection has no known client address', () => {
+    penalty.penalizeConnection('unknownConnectionId', reason);
+
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(0);
+  });
+
+  it('counts the penalty down and expires it', () => {
+    penalty.trackConnection(connectionId, clientIp);
+    penalty.penalizeConnection(connectionId, reason);
+
+    advanceTime(config.RECONNECT_PENALTY_MS - 1000);
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(1000);
+
+    advanceTime(1000);
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(0);
+  });
+
+  it('outlives the connection that earned it', () => {
+    penalty.trackConnection(connectionId, clientIp);
+    penalty.penalizeConnection(connectionId, reason);
+    penalty.removeConnection(connectionId);
+
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(config.RECONNECT_PENALTY_MS);
+  });
+
+  it('stops mapping a removed connection to its client address', () => {
+    penalty.trackConnection(connectionId, clientIp);
+    penalty.removeConnection(connectionId);
+    penalty.penalizeConnection(connectionId, reason);
+
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(0);
+  });
+
+  it('extends an existing penalty on a repeat offence', () => {
+    penalty.trackConnection(connectionId, clientIp);
+    penalty.penalizeConnection(connectionId, reason);
+
+    advanceTime(config.RECONNECT_PENALTY_MS - 1000);
+    penalty.penalizeConnection(connectionId, reason);
+
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(config.RECONNECT_PENALTY_MS);
+  });
+
+  it('does nothing when disabled', () => {
+    config.RECONNECT_PENALTY_ENABLED = false;
+    penalty.trackConnection(connectionId, clientIp);
+    penalty.penalizeConnection(connectionId, reason);
+
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(0);
+  });
+
+  it('bounds the number of tracked clients', () => {
+    config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS = 4;
+
+    for (let i = 0; i < 20; i += 1) {
+      penalty.penalizeClient(`203.0.113.${i}`, reason);
+      // Stagger so that eviction of the soonest-expiring entry is well defined.
+      advanceTime(1);
+    }
+
+    let tracked: number = 0;
+    for (let i = 0; i < 20; i += 1) {
+      if (penalty.getRemainingPenaltyMs(`203.0.113.${i}`) > 0) {
+        tracked += 1;
+      }
+    }
+
+    expect(tracked).toBeLessThanOrEqual(config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS);
+    // The most recent offender must still be penalised.
+    expect(penalty.getRemainingPenaltyMs('203.0.113.19')).toBeGreaterThan(0);
+  });
+
+  it('clears all state', () => {
+    penalty.trackConnection(connectionId, clientIp);
+    penalty.penalizeConnection(connectionId, reason);
+    penalty.clear();
+
+    expect(penalty.getRemainingPenaltyMs(clientIp)).toEqual(0);
+  });
+});

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -55,6 +55,7 @@ describe('Subscriptions', () => {
   const validTickers: string[] = [btcTicker, ethTicker];
   const defaultDropEnabled: boolean = config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED;
   const defaultAbusePoints: number = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+  const defaultMaxTrackedConns: number = config.SUBSCRIPTION_LIMIT_ABUSE_MAX_TRACKED_CONNECTIONS;
   const initialMsgId: number = 1;
   const defaultId: string = 'id';
   const defaultId1: string = 'id1';
@@ -156,6 +157,7 @@ describe('Subscriptions', () => {
     jest.useRealTimers();
     config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = defaultDropEnabled;
     config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS = defaultAbusePoints;
+    config.SUBSCRIPTION_LIMIT_ABUSE_MAX_TRACKED_CONNECTIONS = defaultMaxTrackedConns;
     reconnectPenalty.clear();
     decrementSubscriptionsSpy.mockRestore();
     incrementSubscriptionsSpy.mockRestore();
@@ -653,6 +655,113 @@ describe('Subscriptions', () => {
         'socks-test.subscriptions_limit_abuse_connections',
         1,
         expect.objectContaining({ enforcing: 'true' }),
+      );
+      gaugeSpy.mockRestore();
+    });
+
+    it('bounds how many connections it tracks and counts the rest as overflow', async () => {
+      config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = false;
+      config.SUBSCRIPTION_LIMIT_ABUSE_MAX_TRACKED_CONNECTIONS = 2;
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      const gaugeSpy = jest.spyOn(stats, 'gauge');
+
+      // Four distinct connections all exceed the allowance; only two fit.
+      for (const id of ['connA', 'connB', 'connC', 'connD']) {
+        for (let i = 0; i <= allowedHits; i += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await subscriptions.subscribe(
+            mockWs,
+            Channel.V4_ORDERBOOK,
+            id,
+            initialMsgId + i,
+            validTickers[i % validTickers.length],
+            false,
+          );
+        }
+      }
+
+      jest.advanceTimersByTime(config.SUBSCRIPTION_METRIC_INTERVAL_MS);
+
+      expect(gaugeSpy).toHaveBeenCalledWith(
+        'socks-test.subscriptions_limit_abuse_connections',
+        2,
+        expect.objectContaining({ enforcing: 'false' }),
+      );
+      // The excess is reported rather than silently dropped, so the gauge is never read as
+      // "only two connections affected" when in fact there were four.
+      expect(gaugeSpy).toHaveBeenCalledWith(
+        'socks-test.subscriptions_limit_abuse_connections_overflow',
+        2,
+        expect.objectContaining({ instance: expect.any(String) }),
+      );
+      gaugeSpy.mockRestore();
+    });
+
+    it('does not count a repeat offender past the cap as new overflow', async () => {
+      config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = false;
+      config.SUBSCRIPTION_LIMIT_ABUSE_MAX_TRACKED_CONNECTIONS = 1;
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      const gaugeSpy = jest.spyOn(stats, 'gauge');
+
+      // connA fills the single slot, then keeps offending; it must not inflate overflow.
+      for (const id of ['connA', 'connA', 'connA']) {
+        for (let i = 0; i <= allowedHits; i += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await subscriptions.subscribe(
+            mockWs,
+            Channel.V4_ORDERBOOK,
+            id,
+            initialMsgId + i,
+            validTickers[i % validTickers.length],
+            false,
+          );
+        }
+      }
+
+      jest.advanceTimersByTime(config.SUBSCRIPTION_METRIC_INTERVAL_MS);
+
+      expect(gaugeSpy).toHaveBeenCalledWith(
+        'socks-test.subscriptions_limit_abuse_connections_overflow',
+        0,
+        expect.objectContaining({ instance: expect.any(String) }),
+      );
+      gaugeSpy.mockRestore();
+    });
+
+    it('resets the overflow count each interval', async () => {
+      config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = false;
+      config.SUBSCRIPTION_LIMIT_ABUSE_MAX_TRACKED_CONNECTIONS = 1;
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+
+      for (const id of ['connA', 'connB']) {
+        for (let i = 0; i <= allowedHits; i += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await subscriptions.subscribe(
+            mockWs,
+            Channel.V4_ORDERBOOK,
+            id,
+            initialMsgId + i,
+            validTickers[i % validTickers.length],
+            false,
+          );
+        }
+      }
+
+      jest.advanceTimersByTime(config.SUBSCRIPTION_METRIC_INTERVAL_MS);
+
+      const gaugeSpy = jest.spyOn(stats, 'gauge');
+      jest.advanceTimersByTime(config.SUBSCRIPTION_METRIC_INTERVAL_MS);
+
+      expect(gaugeSpy).toHaveBeenCalledWith(
+        'socks-test.subscriptions_limit_abuse_connections_overflow',
+        0,
+        expect.objectContaining({ instance: expect.any(String) }),
       );
       gaugeSpy.mockRestore();
     });

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -566,6 +566,97 @@ describe('Subscriptions', () => {
       expect(mockWs.terminate).toHaveBeenCalledTimes(1);
     });
 
+    it('counts connections that would be dropped even while the drop is disabled', async () => {
+      config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = false;
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      const gaugeSpy = jest.spyOn(stats, 'gauge');
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      // Nothing was disconnected, but the connection is counted so the blast radius of enabling
+      // the drop can be measured in production first.
+      expect(mockWs.close).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(config.SUBSCRIPTION_METRIC_INTERVAL_MS);
+      expect(gaugeSpy).toHaveBeenCalledWith(
+        'socks-test.subscriptions_limit_abuse_connections',
+        1,
+        expect.objectContaining({ enforcing: 'false' }),
+      );
+      gaugeSpy.mockRestore();
+    });
+
+    it('counts distinct connections, not individual rejections', async () => {
+      config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = false;
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      const gaugeSpy = jest.spyOn(stats, 'gauge');
+
+      // Two connections, each well past the allowance.
+      for (const id of ['connA', 'connB']) {
+        for (let i = 0; i <= allowedHits * 2; i += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await subscriptions.subscribe(
+            mockWs,
+            Channel.V4_ORDERBOOK,
+            id,
+            initialMsgId + i,
+            validTickers[i % validTickers.length],
+            false,
+          );
+        }
+      }
+
+      jest.advanceTimersByTime(config.SUBSCRIPTION_METRIC_INTERVAL_MS);
+      expect(gaugeSpy).toHaveBeenCalledWith(
+        'socks-test.subscriptions_limit_abuse_connections',
+        2,
+        expect.objectContaining({ enforcing: 'false' }),
+      );
+      gaugeSpy.mockRestore();
+    });
+
+    it('still counts a connection that the drop disconnected', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      const gaugeSpy = jest.spyOn(stats, 'gauge');
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      expect(mockWs.close).toHaveBeenCalledTimes(1);
+      // The drop tears the connection down, which must not erase it from the measurement.
+      jest.advanceTimersByTime(config.SUBSCRIPTION_METRIC_INTERVAL_MS);
+      expect(gaugeSpy).toHaveBeenCalledWith(
+        'socks-test.subscriptions_limit_abuse_connections',
+        1,
+        expect.objectContaining({ enforcing: 'true' }),
+      );
+      gaugeSpy.mockRestore();
+    });
+
     it('leaves no counter entry behind immediately after the drop', async () => {
       const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
       const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -562,6 +562,133 @@ describe('Subscriptions', () => {
       expect(mockWs.terminate).toHaveBeenCalledTimes(1);
     });
 
+    it('does not resurrect subscription state when a drop lands mid initial-response', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+
+      // Hold the initial response open so the subscribe is still in flight when the drop lands.
+      let releaseInitialResponse: (value: string) => void = () => {};
+      const deferred: Promise<string> = new Promise((resolve) => {
+        releaseInitialResponse = resolve;
+      });
+      axiosRequestMock.mockImplementationOnce(() => deferred);
+
+      const inFlight: Promise<void> = subscriptions.subscribe(
+        mockWs,
+        Channel.V4_ORDERBOOK,
+        connectionId,
+        initialMsgId,
+        btcTicker,
+        false,
+      );
+
+      // A later request trips the abuse limiter and tears the connection down.
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + 1 + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+      expect(mockWs.close).toHaveBeenCalledTimes(1);
+
+      // Socket-close cleanup runs, as it would on the close event.
+      subscriptions.remove(connectionId);
+
+      // Only now does the in-flight request resolve.
+      releaseInitialResponse(JSON.stringify(initialMessage));
+      await inFlight;
+
+      // Nothing may have been recreated: after cleanup there is no later cleanup to undo it, so
+      // any resurrected entry would forward and serialize for a dead connection forever.
+      expect(subscriptions.subscriptionLists[connectionId]).toBeUndefined();
+      const orderbookSubs = subscriptions.subscriptions[Channel.V4_ORDERBOOK] ?? {};
+      Object.values(orderbookSubs).forEach((subs) => {
+        expect(subs.map((sub) => sub.connectionId)).not.toContain(connectionId);
+      });
+      expect(subscriptions.subsByChannelByConnectionId[Channel.V4_ORDERBOOK]?.[connectionId])
+        .toBeUndefined();
+    });
+
+    it('does not resurrect subscription state when the client disconnects mid initial-response', async () => {
+      // The same race on the ordinary disconnect path, which predates the abuse drop.
+      let releaseInitialResponse: (value: string) => void = () => {};
+      const deferred: Promise<string> = new Promise((resolve) => {
+        releaseInitialResponse = resolve;
+      });
+      axiosRequestMock.mockImplementationOnce(() => deferred);
+
+      const inFlight: Promise<void> = subscriptions.subscribe(
+        mockWs,
+        Channel.V4_TRADES,
+        connectionId,
+        initialMsgId,
+        btcTicker,
+        false,
+      );
+
+      subscriptions.remove(connectionId);
+
+      releaseInitialResponse(JSON.stringify(initialMessage));
+      await inFlight;
+
+      expect(subscriptions.subscriptionLists[connectionId]).toBeUndefined();
+      const tradeSubs = subscriptions.subscriptions[Channel.V4_TRADES] ?? {};
+      Object.values(tradeSubs).forEach((subs) => {
+        expect(subs.map((sub) => sub.connectionId)).not.toContain(connectionId);
+      });
+    });
+
+    it('still completes a subscription that is not interrupted', async () => {
+      let releaseInitialResponse: (value: string) => void = () => {};
+      const deferred: Promise<string> = new Promise((resolve) => {
+        releaseInitialResponse = resolve;
+      });
+      axiosRequestMock.mockImplementationOnce(() => deferred);
+
+      const inFlight: Promise<void> = subscriptions.subscribe(
+        mockWs,
+        Channel.V4_TRADES,
+        connectionId,
+        initialMsgId,
+        btcTicker,
+        false,
+      );
+
+      releaseInitialResponse(JSON.stringify(initialMessage));
+      await inFlight;
+
+      expect(subscriptions.subscriptionLists[connectionId]).toHaveLength(1);
+    });
+
+    it('keeps the close reason within the websocket 123 byte limit', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      // ws throws if the close reason exceeds 123 bytes, which would downgrade this to a reasonless
+      // 1006 and lose the explanation the client needs.
+      const closeReason: string = (mockWs.close as jest.Mock).mock.calls[0][1];
+      expect(Buffer.byteLength(closeReason)).toBeLessThanOrEqual(123);
+    });
+
     it('sends error message if rate limit exceeded', async () => {
       rateLimiterSpy.mockImplementation(() => 1);
       await subscriptions.subscribe(

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -53,6 +53,7 @@ describe('Subscriptions', () => {
   const connectionId: string = 'connectionId';
   const clientIp: string = '203.0.113.7';
   const validTickers: string[] = [btcTicker, ethTicker];
+  const defaultDropEnabled: boolean = config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED;
   const initialMsgId: number = 1;
   const defaultId: string = 'id';
   const defaultId1: string = 'id1';
@@ -132,6 +133,7 @@ describe('Subscriptions', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = true;
     (WebSocket as unknown as jest.Mock).mockClear();
     subscriptions = new Subscriptions();
     subscriptions.start(jest.fn());
@@ -149,6 +151,7 @@ describe('Subscriptions', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = defaultDropEnabled;
     reconnectPenalty.clear();
     decrementSubscriptionsSpy.mockRestore();
     incrementSubscriptionsSpy.mockRestore();
@@ -452,6 +455,111 @@ describe('Subscriptions', () => {
       expect(mockWs.close).toHaveBeenCalledTimes(1);
       expect((mockWs.close as jest.Mock).mock.calls[0][0])
         .toEqual(WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE);
+    });
+
+    it('is inert when the drop flag is disabled', async () => {
+      config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = false;
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      reconnectPenalty.clear();
+      reconnectPenalty.trackConnection(connectionId, clientIp);
+
+      // Well past the allowance; without the flag this must stay at the old behaviour.
+      for (let i = 0; i < config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS * 4; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      expect(mockWs.close).not.toHaveBeenCalled();
+      expect(mockWs.terminate).not.toHaveBeenCalled();
+      expect(reconnectPenalty.getRemainingPenaltyMs(clientIp)).toEqual(0);
+      expect(sendMessageMock).toHaveBeenLastCalledWith(
+        mockWs,
+        connectionId,
+        expect.objectContaining({
+          message: expect.stringContaining('Per-connection subscription limit reached'),
+        }),
+      );
+    });
+
+    it('unsubscribes the connection immediately rather than waiting for the close event', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      const removeSpy = jest.spyOn(Subscriptions.prototype, 'remove');
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      // Otherwise the forwarder keeps serializing market data for this connection for the whole
+      // of the ws close-handshake window.
+      expect(removeSpy).toHaveBeenCalledWith(connectionId);
+      removeSpy.mockRestore();
+    });
+
+    it('destroys the socket if the close handshake cannot be initiated', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      (mockWs.close as jest.Mock).mockImplementation(() => {
+        throw new Error('socket already destroyed');
+      });
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      // A close that never happened would otherwise leave the abusive connection fully live.
+      expect(mockWs.terminate).toHaveBeenCalledTimes(1);
+    });
+
+    it('destroys the socket when the peer never completes the close handshake', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      expect(mockWs.terminate).not.toHaveBeenCalled();
+
+      // ws would otherwise wait 30s before destroying an uncooperative peer.
+      jest.advanceTimersByTime(config.SUBSCRIPTION_LIMIT_ABUSE_FORCE_TERMINATE_MS);
+
+      expect(mockWs.terminate).toHaveBeenCalledTimes(1);
     });
 
     it('sends error message if rate limit exceeded', async () => {

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -562,6 +562,32 @@ describe('Subscriptions', () => {
       expect(mockWs.terminate).toHaveBeenCalledTimes(1);
     });
 
+    it('leaves no counter entry behind immediately after the drop', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      expect(mockWs.close).toHaveBeenCalledTimes(1);
+
+      // Asserted before any close-event cleanup: the drop must leave the connection fully torn
+      // down on its own, not rely on a later pass to tidy up after it.
+      expect(subscriptions.subsByChannelByConnectionId[Channel.V4_ORDERBOOK]?.[connectionId])
+        .toBeUndefined();
+      expect(subscriptions.subscriptionLists[connectionId]).toBeUndefined();
+    });
+
     it('does not resurrect subscription state when a drop lands mid initial-response', async () => {
       const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
       const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -54,6 +54,7 @@ describe('Subscriptions', () => {
   const clientIp: string = '203.0.113.7';
   const validTickers: string[] = [btcTicker, ethTicker];
   const defaultDropEnabled: boolean = config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED;
+  const defaultAbusePoints: number = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
   const initialMsgId: number = 1;
   const defaultId: string = 'id';
   const defaultId1: string = 'id1';
@@ -134,6 +135,8 @@ describe('Subscriptions', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = true;
+    // Keep the allowance small so the tests stay fast and independent of the production default.
+    config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS = 5;
     (WebSocket as unknown as jest.Mock).mockClear();
     subscriptions = new Subscriptions();
     subscriptions.start(jest.fn());
@@ -152,6 +155,7 @@ describe('Subscriptions', () => {
   afterEach(() => {
     jest.useRealTimers();
     config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED = defaultDropEnabled;
+    config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS = defaultAbusePoints;
     reconnectPenalty.clear();
     decrementSubscriptionsSpy.mockRestore();
     incrementSubscriptionsSpy.mockRestore();

--- a/indexer/services/socks/__tests__/lib/subscriptions.test.ts
+++ b/indexer/services/socks/__tests__/lib/subscriptions.test.ts
@@ -21,6 +21,12 @@ import {
   AxiosSafeServerError, makeAxiosSafeServerError, stats, setInstanceId,
 } from '@dydxprotocol-indexer/base';
 import { BlockedError } from '../../src/lib/errors';
+import {
+  RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
+  SUBSCRIPTION_LIMIT_ABUSE_CLOSE_REASON,
+  WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE,
+} from '../../src/lib/constants';
+import { reconnectPenalty } from '../../src/lib/reconnect-penalty';
 import config from '../../src/config';
 
 import 'jest-extended';
@@ -45,6 +51,8 @@ describe('Subscriptions', () => {
   let axiosRequestMock: jest.Mock;
 
   const connectionId: string = 'connectionId';
+  const clientIp: string = '203.0.113.7';
+  const validTickers: string[] = [btcTicker, ethTicker];
   const initialMsgId: number = 1;
   const defaultId: string = 'id';
   const defaultId1: string = 'id1';
@@ -141,6 +149,7 @@ describe('Subscriptions', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    reconnectPenalty.clear();
     decrementSubscriptionsSpy.mockRestore();
     incrementSubscriptionsSpy.mockRestore();
     removeSubscriptionsSpy.mockRestore();
@@ -318,6 +327,131 @@ describe('Subscriptions', () => {
 
       expect(decrementSubscriptionsSpy).toHaveBeenCalledTimes(2);
       expect(decrementSubscriptionsSpy).toHaveBeenCalledWith(Channel.V4_ACCOUNTS, connectionId);
+    });
+
+    it('drops the connection once the subscription limit is hit repeatedly', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      reconnectPenalty.clear();
+      reconnectPenalty.trackConnection(connectionId, clientIp);
+
+      // Every hit up to the allowance is answered with an ordinary error, connection intact.
+      for (let i = 0; i < allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+      expect(mockWs.close).not.toHaveBeenCalled();
+      expect(reconnectPenalty.getRemainingPenaltyMs(clientIp)).toEqual(0);
+
+      // The hit past the allowance drops the connection instead.
+      await subscriptions.subscribe(
+        mockWs,
+        Channel.V4_ORDERBOOK,
+        connectionId,
+        initialMsgId + allowedHits,
+        validTickers[allowedHits % validTickers.length],
+        false,
+      );
+
+      expect(mockWs.close).toHaveBeenCalledTimes(1);
+      const [closeCode, closeReason] = (mockWs.close as jest.Mock).mock.calls[0];
+      expect(closeCode).toEqual(WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE);
+      expect(JSON.parse(closeReason)).toEqual(expect.objectContaining({
+        message: SUBSCRIPTION_LIMIT_ABUSE_CLOSE_REASON,
+        reason: RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
+      }));
+      expect(JSON.parse(closeReason).retryAfterSeconds).toBeGreaterThan(0);
+    });
+
+    it('tells the client why it was dropped and when it may reconnect', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      expect(sendMessageMock).toHaveBeenLastCalledWith(
+        mockWs,
+        connectionId,
+        expect.objectContaining({
+          message: expect.stringContaining(
+            `Repeatedly exceeded the per-connection subscription limit for ${Channel.V4_ORDERBOOK}`,
+          ),
+        }),
+      );
+      expect(sendMessageMock).toHaveBeenLastCalledWith(
+        mockWs,
+        connectionId,
+        expect.objectContaining({
+          message: expect.stringContaining('will be refused'),
+        }),
+      );
+    });
+
+    it('penalises the dropped client so its reconnect handshake is refused', async () => {
+      const limit = config.V4_ORDERBOOK_CHANNEL_LIMIT;
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      incrementSubscriptionsSpy.mockImplementation(() => limit + 1);
+      reconnectPenalty.clear();
+      reconnectPenalty.trackConnection(connectionId, clientIp);
+
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          Channel.V4_ORDERBOOK,
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      expect(reconnectPenalty.getRemainingPenaltyMs(clientIp)).toBeGreaterThan(0);
+    });
+
+    it('spends the allowance across channels, not per channel', async () => {
+      // The incident pattern: a client cycling through many distinct channels and markets. The
+      // per-channel+id subscribe limiter never trips on this, so the abuse limiter must.
+      incrementSubscriptionsSpy.mockImplementation(() => 1000);
+      reconnectPenalty.clear();
+      reconnectPenalty.trackConnection(connectionId, clientIp);
+
+      const channels = [Channel.V4_ORDERBOOK, Channel.V4_TRADES];
+      const allowedHits = config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS;
+      for (let i = 0; i <= allowedHits; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await subscriptions.subscribe(
+          mockWs,
+          channels[i % channels.length],
+          connectionId,
+          initialMsgId + i,
+          validTickers[i % validTickers.length],
+          false,
+        );
+      }
+
+      expect(mockWs.close).toHaveBeenCalledTimes(1);
+      expect((mockWs.close as jest.Mock).mock.calls[0][0])
+        .toEqual(WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE);
     });
 
     it('sends error message if rate limit exceeded', async () => {

--- a/indexer/services/socks/__tests__/websocket/index.test.ts
+++ b/indexer/services/socks/__tests__/websocket/index.test.ts
@@ -22,6 +22,14 @@ jest.mock('../../src/helpers/wss');
 jest.mock('../../src/lib/subscription');
 jest.mock('../../src/lib/invalid-message');
 
+function setReadyState(ws: WebSocket, readyState: number): void {
+  Object.defineProperty(ws, 'readyState', {
+    value: readyState,
+    configurable: true,
+    writable: true,
+  });
+}
+
 describe('Index', () => {
   let index: Index;
   let mockWss: Wss;
@@ -58,6 +66,9 @@ describe('Index', () => {
     (sendMessage as unknown as jest.Mock).mockClear();
     mockWss = new Wss();
     websocket = new WebSocket(null as any as string, [], { autoPong: true } as any);
+    // A connection handed to `Index` by the ws server is always OPEN. The bare constructor used
+    // here leaves it CONNECTING, which would trip the guard that drops work for doomed sockets.
+    setReadyState(websocket, WebSocket.OPEN);
     wsCloseSpy = jest.spyOn(websocket, 'close');
     wsOnSpy = jest.spyOn(websocket, 'on');
     wsPingSpy = jest.spyOn(websocket, 'ping').mockImplementation(jest.fn());
@@ -244,6 +255,54 @@ describe('Index', () => {
             type: OutgoingMessageType.UNSUBSCRIBED,
           },
         );
+      });
+    });
+
+    describe('doomed connections', () => {
+      it('does no work for a peer that ignores the close frame and keeps sending', () => {
+        (mockSub.subscribe as jest.Mock).mockClear();
+        invalidMsgHandlerSpy.mockClear();
+
+        // The server has sent a close frame; `ws` keeps delivering the peer's messages until the
+        // close handshake completes or times out.
+        setReadyState(websocket, WebSocket.CLOSING);
+
+        const subMessage = {
+          type: IncomingMessageType.SUBSCRIBE,
+          channel: Channel.V4_TRADES,
+          id: 'BTC-USD',
+        };
+        for (let i = 0; i < 25; i += 1) {
+          websocket.emit(WebsocketEvent.MESSAGE, JSON.stringify(subMessage));
+        }
+
+        expect(mockSub.subscribe).not.toHaveBeenCalled();
+        expect(mockSub.unsubscribe).not.toHaveBeenCalled();
+        expect(invalidMsgHandlerSpy).not.toHaveBeenCalled();
+      });
+
+      it('does not parse payloads from a socket that is no longer open', () => {
+        invalidMsgHandlerSpy.mockClear();
+
+        setReadyState(websocket, WebSocket.CLOSING);
+
+        // Malformed payloads would normally reach the invalid-message handler and spend its
+        // allowance; a doomed connection must not get that far.
+        websocket.emit(WebsocketEvent.MESSAGE, 'not json at all');
+
+        expect(invalidMsgHandlerSpy).not.toHaveBeenCalled();
+      });
+
+      it('still serves a healthy connection', () => {
+        (mockSub.subscribe as jest.Mock).mockClear();
+
+        websocket.emit(WebsocketEvent.MESSAGE, JSON.stringify({
+          type: IncomingMessageType.SUBSCRIBE,
+          channel: Channel.V4_TRADES,
+          id: 'BTC-USD',
+        }));
+
+        expect(mockSub.subscribe).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -55,6 +55,14 @@ forced-termination fallback. Inbound messages are discarded without being parsed
 is no longer `OPEN`, so a client that ignores the close frame gets no further work done on its
 behalf.
 
+A subscribe request that is already awaiting its initial response from comlink when the drop
+lands is invalidated rather than allowed to complete. Every connection carries an epoch that is
+captured before the await and re-checked after it; teardown drops the epoch. Without that check
+a late-resolving request would recreate the exact structures teardown had just deleted, and
+because teardown has already run, nothing would ever clean them up — leaving a dead connection
+being serialized for indefinitely. The same race exists on the ordinary disconnect path and is
+covered by the same guard.
+
 ### 2. The client is refused at the handshake for a cooldown
 
 A websocket close frame is invisible to Cloudflare — it proxies the tunnelled connection but does
@@ -74,6 +82,13 @@ x-dydx-ratelimit-reason: subscription-limit-abuse
 That gives three things at once: a well-behaved client learns exactly how long to wait without
 needing any Cloudflare involvement; the offending client cannot immediately re-establish and
 resume hammering; and Cloudflare gets a countable, matchable signal.
+
+The fixed cooldown is deliberate. A self-clearing, rate-proportional penalty is generally
+preferable — AWS WAF's rate-based rules and Cloudflare's `mitigation_timeout: 0` both work that
+way — but it is not available at this layer: a rate cannot be measured for a connection that is
+being refused before it is accepted. A hard stop is required, and Kraken makes the same call at
+the same layer, banning a client IP for 10 minutes after too many connection attempts. 30s is
+deliberately at the conservative end of the range implied by comparable systems.
 
 The penalty is per-instance and in-memory by design. Its job is to stop one instance being
 monopolised and to emit the edge signal. Cross-instance enforcement belongs at the edge, below.
@@ -107,6 +122,14 @@ cooldown, since a client only ever enters it by being dropped.
 
 ### Note on shared addresses
 
+Scoping abuse enforcement to a client address is a known-imperfect fallback, and both Cloudflare
+and Google Cloud publish that caveat: a shared NAT or VPN egress pools unrelated users into one
+bucket, and an attacker with an address range can rotate out of it. The accepted mitigation is to
+key on an authenticated principal where one exists and fall back to address only where none does.
+socks has no credential at the handshake, so address is the only key available at that point —
+which is why the cooldown is deliberately short and confined to connection establishment rather
+than applied to ongoing usage.
+
 The penalty is applied per client address. Clients behind a shared NAT or corporate egress can
 therefore be caught by another party's behaviour. The 30s default and the requirement that a
 single *connection* first exceed its allowance keep this narrow, and
@@ -126,6 +149,7 @@ penalty enabled and watch `socks.connection_rejected_penalty`; a rate much highe
 
 | `socks.subscriptions_limit_abuse_force_terminate` | `reason`, `instance` | A dropped socket was destroyed without a completed close handshake |
 | `socks.message_dropped_not_open` | `readyState`, `instance` | An inbound message was discarded because the socket was no longer open |
+| `socks.subscription_abandoned_stale_connection` | `channel`, `instance` | An initial response resolved after its connection was torn down |
 
 Drops also appear on the existing `socks.num_disconnects` counter tagged `code: "4008"`.
 
@@ -146,13 +170,13 @@ reaching origin at all, and to make the timeout long enough that a client has to
 
 **Rate limiting rule — "socks subscription-limit abuse"**
 
-- Match: `(http.host eq "indexer.dydx.trade" and starts_with(http.request.uri.path, "/v4/ws"))`
+- Match: `(http.host eq "indexer.dydx.trade" and http.request.uri.path eq "/v4/ws")`
 - Counting characteristic: client IP
 - **Counting expression — must repeat host and path:**
 
   ```
   http.host eq "indexer.dydx.trade"
-  and starts_with(http.request.uri.path, "/v4/ws")
+  and http.request.uri.path eq "/v4/ws"
   and http.response.code eq 429
   and any(http.response.headers["x-dydx-ratelimit-reason"][*] eq "subscription-limit-abuse")
   ```
@@ -161,12 +185,14 @@ reaching origin at all, and to make the timeout long enough that a client has to
   evaluates it independently, so host and path have to be restated or the counter will increment
   on unrelated traffic.
 
-  The reason header is not optional hardening here, it is what makes the rule correct. The ALB
-  routes exactly `/v4/ws` to socks and everything else under `/v4/*` to comlink, which runs its
-  own rate limiter and returns its own 429s. A counting expression of "status 429" alone — or one
-  scoped only by a `/v4/ws` prefix, which still covers `/v4/ws...` paths the ALB hands to comlink
-  — would count comlink's rate-limit responses and block those clients out of the websocket
-  entirely. socks is the only origin that emits this header.
+  Exact path equality, not a prefix. The ALB routes exactly `/v4/ws` to socks and everything else
+  under `/v4/*` to comlink, which runs its own rate limiter and returns its own 429s. A prefix
+  match would still cover `/v4/ws...` paths the ALB hands to comlink; equality mirrors the ALB
+  rule exactly and keeps the blast radius to the one endpoint at issue.
+
+  The reason header is the second, independent guard: socks is the only origin that emits it, so
+  even a misconfigured path condition cannot make the counter fire on comlink's rate-limit
+  responses. Counting on status alone would block those clients out of the websocket entirely.
 - Threshold: 5 requests per 60 seconds
 - Action: **Block**, duration **300 seconds** (deliberately an order of magnitude longer than the
   origin's 30s penalty — the origin cooldown is a nudge, the edge block is the consequence)
@@ -180,7 +206,8 @@ reaching origin at all, and to make the timeout long enough that a client has to
 }
 ```
 
-Confirm the actual websocket path before applying — the match above assumes `/v4/ws`.
+The path is `/v4/ws`, matching `aws_lb_listener_rule.public_https_socks` in `v4-infrastructure`
+(`indexer/load_balancer.tf`), which forwards exactly that path to the socks target group.
 
 **Prerequisite.** Counting on response fields requires a Business plan or above. Confirm the
 zone's tier before building the rule. If response-based counting is unavailable, the fallback is

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -37,11 +37,15 @@ Being at the limit stays a normal, recoverable condition: the first
 `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS` hits within
 `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS` are answered with the usual error and the
 connection is left alone. Past that, the connection is closed with close code
-**4008** (`WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE`) and a body of:
+**4008** (`WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE`) and a close-reason payload of:
 
 ```json
 { "message": "Subscription limit abuse", "reason": "subscription-limit-abuse", "retryAfterSeconds": 30 }
 ```
+
+`retryAfterSeconds` is derived from the remaining limiter delay and `RECONNECT_PENALTY_MS`,
+whichever is longer; `30` above is what the default configuration produces, not a fixed value.
+The payload must stay within the 123-byte close-reason limit, which a test asserts.
 
 A distinct close code matters: 1008 is already used for the generic rate-limit drops, and we
 want dashboards and clients to be able to tell the two apart.
@@ -73,7 +77,7 @@ So a dropped client is put in a short in-memory penalty box (`src/lib/reconnect-
 keyed by client address. While the penalty is live, `verifyClientNotPenalized` refuses the
 websocket upgrade with:
 
-```
+```http
 HTTP/1.1 429 Too Many Requests
 Retry-After: 30
 x-dydx-ratelimit-reason: subscription-limit-abuse
@@ -94,6 +98,27 @@ The penalty is per-instance and in-memory by design. Its job is to stop one inst
 monopolised and to emit the edge signal. Cross-instance enforcement belongs at the edge, below.
 
 ### 3. Client address derivation
+
+`cf-connecting-ip` and `x-forwarded-for` are supplied by the caller, and the load balancer
+forwards whatever it was handed. What makes them trustworthy here is an operational property
+rather than anything in the request: **origin ingress accepts connections from Cloudflare proxies
+alone**, so the caller is always Cloudflare and `cf-connecting-ip` is Cloudflare's own view of
+the client.
+
+That property is load-bearing, and `TRUST_FORWARDED_HEADERS` exists to withdraw the trust if it
+ever stops holding. Were the origin to become directly reachable, a caller could present a
+victim's address, trip the limit deliberately, and have that address's upgrades refused for the
+cooldown — turning this control into a way to deny service to arbitrary clients. Setting the
+switch to `false` makes a request carrying a forwarded header yield no client address at all, so
+the address cooldown goes inert. It deliberately does not fall back to the socket address,
+because behind a proxy that is the proxy itself, shared by every client — penalising it would
+refuse everyone. A request with no forwarded headers still uses the socket address, which is
+genuinely the peer.
+
+The per-connection drop is unaffected either way: it keys on the connection, which cannot be
+spoofed. Only the address-based cooldown depends on this.
+
+
 
 `getClientIp` (`src/helpers/header-utils.ts`) prefers `cf-connecting-ip`, then the left-most
 `x-forwarded-for` entry, then the socket address. This matches comlink's `getIpAddr`.
@@ -158,6 +183,7 @@ This costs nothing to run and turns the decision into a reading rather than an a
 | `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS` | `5` | Limit hits allowed per connection before it is dropped |
 | `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS` | `10000` | Window over which those hits are counted |
 | `SUBSCRIPTION_LIMIT_ABUSE_FORCE_TERMINATE_MS` | `1000` | Grace period after the close frame before the socket is destroyed |
+| `TRUST_FORWARDED_HEADERS` | `true` | Whether `cf-connecting-ip` / `x-forwarded-for` may be believed. True because origin ingress accepts Cloudflare proxies only. Set false if that ever stops holding; the address cooldown then goes inert. |
 | `RECONNECT_PENALTY_ENABLED` | `true` | Kill switch for handshake refusal only. The connection drop stays active. |
 | `RECONNECT_PENALTY_MS` | `30000` | How long a dropped client's upgrades are refused |
 | `RECONNECT_PENALTY_MAX_TRACKED_CLIENTS` | `100000` | Bound on the penalty map |
@@ -222,8 +248,8 @@ reaching origin at all, and to make the timeout long enough that a client has to
 - Counting characteristic: client IP
 - **Counting expression — must repeat host and path:**
 
-  ```
-  http.host eq "indexer.dydx.trade"
+  ```txt
+  raw.http.host eq "indexer.dydx.trade"
   and http.request.uri.path eq "/v4/ws"
   and http.response.code eq 429
   and any(http.response.headers["x-dydx-ratelimit-reason"][*] eq "subscription-limit-abuse")
@@ -232,6 +258,16 @@ reaching origin at all, and to make the timeout long enough that a client has to
   A custom counting expression does **not** inherit the rule's matching expression. Cloudflare
   evaluates it independently, so host and path have to be restated or the counter will increment
   on unrelated traffic.
+
+  `raw.http.host` rather than `http.host`, because rate limiting runs in the `http_ratelimit`
+  phase, after Origin Rules run in `http_request_origin`. If an Origin Rule rewrites the `Host`
+  header for this hostname, `http.host` holds the rewritten value by the time the counting
+  expression is evaluated and would silently stop matching, so the counter would never increment
+  and the rule would appear to work while doing nothing. The `raw.` fields are immutable and
+  unaffected by earlier transformations. Confirm whether any Host rewrite exists for this
+  hostname when applying the rule; if `raw.http.host` is unavailable in this phase, drop the host
+  condition and rely on the exact path plus the reason header, both of which are already
+  sufficient to isolate socks.
 
   Exact path equality, not a prefix. The ALB routes exactly `/v4/ws` to socks and everything else
   under `/v4/*` to comlink, which runs its own rate limiter and returns its own 429s. A prefix

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -3,7 +3,7 @@
 ## Background
 
 On 2026-08-26 between roughly 05:15Z and 05:25Z a single client held ~693 `v4_orderbook` and
-~706 `v4_trades` subscriptions against one socks instance (10.0.1.170) while continuously
+~706 `v4_trades` subscriptions against a single socks instance while continuously
 re-sending `subscribe` requests. CPU saturated on socket writes and JSON serialization, Kafka
 consumption fell behind, and every other client that happened to land on that instance saw stale
 market data. Trading was unaffected; comlink was unaffected.

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -103,11 +103,48 @@ This ordering is load-bearing rather than cosmetic. `indexer.dydx.trade` is Clou
 ever see Cloudflare edge addresses. `cf-connecting-ip` is the only header that carries the real
 client. This is also why the incident could not be attributed from S3 ALB logs.
 
+## Threshold sizing: measured, and why the drop is still disabled
+
+Measured on mainnet (dYdX Indexer org, ap1) for 2026-08-26 04:30-06:30Z. Note that the socks
+metrics there have tag grouping disabled for cardinality control, so these are fleet-wide totals;
+no per-channel or per-instance breakdown is available.
+
+| Signal | Baseline | Peak in window |
+|---|---|---|
+| `socks.message_received_subscribe` | ~300k/min | 1.31M/min (05:22) |
+| `socks.subscriptions_limit_reached` | ~200k/min | 635k/min (05:11) |
+| Rejected share of all subscribes | ~45-65% | ~57% |
+| `socks.num_concurrent_connections` | ~3,700 | ~4,270 |
+| Implied per-connection rejections | ~54/min (~9 per 10s) | ~171/min (~29 per 10s) |
+
+Two things follow, and both argue against turning the drop on as configured.
+
+**The defaults would disconnect much of the customer base.** The allowance is 5 rejections per
+10s per connection. The *average* mainnet connection produces about 9 per 10s while nothing is
+wrong, and about 29 per 10s during a busy period. Enabling the drop today would therefore drop a
+large share of healthy connections on a rolling basis, and place their addresses in a reconnect
+cooldown. This is the reason the feature ships disabled, and it is not fixed by simply raising
+the number.
+
+**The signal itself is questionable on mainnet.** `socks.on_message` tracks
+`socks.message_received_subscribe` almost exactly, so essentially all inbound websocket traffic
+is subscribe requests, and roughly half of them are rejected for hitting the per-connection cap
+at all times. "Repeatedly hits the subscription limit" is the steady state of this system, not a
+marker of abuse. A threshold set safely above normal would have to sit so far above 171/min per
+connection that it would rarely constrain anything.
+
+Before enabling, the open question is why normal clients subscribe 80-350 times per minute and
+are refused about half the time -- most plausibly because they want more markets than the
+per-channel cap of 32 permits and retry in a loop. If that is the cause, raising the cap, or
+making the refusal cacheable so clients stop retrying, addresses more of the load than dropping
+connections does. A per-connection limit on subscribe *attempts*, independent of outcome, is also
+a better-targeted control than punishing limit hits.
+
 ## Configuration
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED` | `false` | Kill switch for the connection drop, independent of `RATE_LIMIT_ENABLED`. Ships off; enable once thresholds are sized. |
+| `SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED` | `false` | Kill switch for the connection drop, independent of `RATE_LIMIT_ENABLED`. Ships off. Do not enable without first reading the threshold-sizing section above. |
 | `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS` | `5` | Limit hits allowed per connection before it is dropped |
 | `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS` | `10000` | Window over which those hits are counted |
 | `SUBSCRIPTION_LIMIT_ABUSE_FORCE_TERMINATE_MS` | `1000` | Grace period after the close frame before the socket is destroyed |

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -87,7 +87,7 @@ client. This is also why the incident could not be attributed from S3 ALB logs.
 | `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS` | `10000` | Window over which those hits are counted |
 | `RECONNECT_PENALTY_ENABLED` | `true` | Kill switch for handshake refusal only. The connection drop stays active. |
 | `RECONNECT_PENALTY_MS` | `30000` | How long a dropped client's upgrades are refused |
-| `RECONNECT_PENALTY_MAX_TRACKED_CLIENTS` | `10000` | Bound on the penalty map |
+| `RECONNECT_PENALTY_MAX_TRACKED_CLIENTS` | `100000` | Bound on the penalty map |
 
 The existing global `RATE_LIMIT_ENABLED` kill switch is honoured inside `RateLimiter` itself, so
 setting it to `false` disables the drop as well.

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -1,0 +1,159 @@
+# Subscription-limit abuse: dropping connections and the Cloudflare contract
+
+## Background
+
+On 2026-08-26 between roughly 05:15Z and 05:25Z a single client held ~693 `v4_orderbook` and
+~706 `v4_trades` subscriptions against one socks instance (10.0.1.170) while continuously
+re-sending `subscribe` requests. CPU saturated on socket writes and JSON serialization, Kafka
+consumption fell behind, and every other client that happened to land on that instance saw stale
+market data. Trading was unaffected; comlink was unaffected.
+
+## Why the existing limits did not stop it
+
+Two separate controls existed, and the incident slipped between them.
+
+1. `CHANNEL_CONNECTION_LIMITS` (`src/lib/subscription.ts`) caps subscriptions per channel per
+   connection — 32 for `v4_orderbook` and `v4_trades`. When a connection is over the cap,
+   `subscribe` sent an error and returned. **The connection stayed open and nothing was
+   charged for the attempt**, so a retry loop was free.
+2. `subscribeRateLimiter` did close connections, but it is keyed on `channel + subscriptionId`.
+   A client cycling through hundreds of *distinct* markets gets a fresh allowance per market and
+   never trips it.
+
+Critically, the limit branch `return`ed *before* the rate limiter was ever consulted. So the
+exact pattern in the incident — many distinct markets, all over the cap, retried in a loop — was
+the one case that neither control covered.
+
+## What changed
+
+### 1. Repeated limit hits now drop the connection
+
+`Subscriptions` gained `subscriptionLimitReachedRateLimiter`, keyed on a single per-connection
+constant (`subscriptionLimitReached`) rather than on `channel + id`. The allowance is therefore
+spent across every channel and market a connection touches, which is what makes the incident
+pattern trip it.
+
+Being at the limit stays a normal, recoverable condition: the first
+`RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS` hits within
+`RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS` are answered with the usual error and the
+connection is left alone. Past that, the connection is closed with close code
+**4008** (`WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE`) and a body of:
+
+```json
+{ "message": "Subscription limit abuse", "reason": "subscription-limit-abuse", "retryAfterSeconds": 30 }
+```
+
+A distinct close code matters: 1008 is already used for the generic rate-limit drops, and we
+want dashboards and clients to be able to tell the two apart.
+
+### 2. The client is refused at the handshake for a cooldown
+
+A websocket close frame is invisible to Cloudflare — it proxies the tunnelled connection but does
+not inspect its frames, so "this client was dropped" is not something an edge rate-limiting rule
+can ever match on. The handshake, however, is ordinary HTTP.
+
+So a dropped client is put in a short in-memory penalty box (`src/lib/reconnect-penalty.ts`)
+keyed by client address. While the penalty is live, `verifyClientNotPenalized` refuses the
+websocket upgrade with:
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 30
+x-dydx-ratelimit-reason: subscription-limit-abuse
+```
+
+That gives three things at once: a well-behaved client learns exactly how long to wait without
+needing any Cloudflare involvement; the offending client cannot immediately re-establish and
+resume hammering; and Cloudflare gets a countable, matchable signal.
+
+The penalty is per-instance and in-memory by design. Its job is to stop one instance being
+monopolised and to emit the edge signal. Cross-instance enforcement belongs at the edge, below.
+
+### 3. Client address derivation
+
+`getClientIp` (`src/helpers/header-utils.ts`) prefers `cf-connecting-ip`, then the left-most
+`x-forwarded-for` entry, then the socket address. This matches comlink's `getIpAddr`.
+
+This ordering is load-bearing rather than cosmetic. `indexer.dydx.trade` is Cloudflare-proxied
+(its A records resolve into published Cloudflare ranges), so the ALB — and ALB access logs — only
+ever see Cloudflare edge addresses. `cf-connecting-ip` is the only header that carries the real
+client. This is also why the incident could not be attributed from S3 ALB logs.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS` | `5` | Limit hits allowed per connection before it is dropped |
+| `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS` | `10000` | Window over which those hits are counted |
+| `RECONNECT_PENALTY_ENABLED` | `true` | Kill switch for handshake refusal only. The connection drop stays active. |
+| `RECONNECT_PENALTY_MS` | `30000` | How long a dropped client's upgrades are refused |
+| `RECONNECT_PENALTY_MAX_TRACKED_CLIENTS` | `10000` | Bound on the penalty map |
+
+The existing global `RATE_LIMIT_ENABLED` kill switch is honoured inside `RateLimiter` itself, so
+setting it to `false` disables the drop as well.
+
+### Note on shared addresses
+
+The penalty is applied per client address. Clients behind a shared NAT or corporate egress can
+therefore be caught by another party's behaviour. The 30s default and the requirement that a
+single *connection* first exceed its allowance keep this narrow, and
+`RECONNECT_PENALTY_ENABLED=false` disables the handshake refusal alone while leaving the
+connection drop — the part that actually protects the instance — in place. Start with the
+penalty enabled and watch `socks.connection_rejected_penalty`; a rate much higher than
+`socks.subscriptions_limit_abuse_disconnect` would suggest shared-address collateral.
+
+## Metrics
+
+| Metric | Tags | Meaning |
+|---|---|---|
+| `socks.subscriptions_limit_reached` | `channel`, `instance` | Pre-existing. A limit hit. Normal at low rates. |
+| `socks.subscriptions_limit_abuse_disconnect` | `channel`, `instance` | A connection was dropped for repeated hits |
+| `socks.reconnect_penalty_applied` | `reason`, `instance` | A client entered the penalty box |
+| `socks.connection_rejected_penalty` | `instance` | An upgrade was refused with 429 |
+
+Drops also appear on the existing `socks.num_disconnects` counter tagged `code: "4008"`.
+
+Worth alerting on: a sustained non-zero `socks.subscriptions_limit_abuse_disconnect` means a
+client is in a retry loop and not backing off, which is the signal that the edge rule below
+should be escalating.
+
+## Cloudflare configuration
+
+There is no Cloudflare terraform in `v4-infrastructure`, so these are console changes.
+
+The origin does the per-instance protection; Cloudflare's job is to stop the reconnect storm from
+reaching origin at all, and to make the timeout long enough that a client has to notice.
+
+**Rate limiting rule — "socks subscription-limit abuse"**
+
+- Match: `(http.host eq "indexer.dydx.trade" and starts_with(http.request.uri.path, "/v4/ws"))`
+- Counting characteristic: client IP
+- Count only responses where: `origin response status eq 429` **or**, if response-header matching
+  is available on the plan, response header `x-dydx-ratelimit-reason` eq `subscription-limit-abuse`.
+  The header form is the more precise of the two — it will not count 429s emitted for any other
+  reason.
+- Threshold: 5 requests per 60 seconds
+- Action: **Block**, duration **300 seconds** (deliberately an order of magnitude longer than the
+  origin's 30s penalty — the origin cooldown is a nudge, the edge block is the consequence)
+- Custom response: status `429`, content type `application/json`, body:
+
+```json
+{
+  "error": "subscription_limit_abuse",
+  "message": "Your connection was closed because it repeatedly exceeded the per-connection subscription limit and continued retrying. Unsubscribe before subscribing again, or distribute subscriptions across additional connections. Reconnections are blocked for 5 minutes.",
+  "docs": "https://docs.dydx.exchange/api_integration-indexer/indexer_websocket"
+}
+```
+
+Confirm the actual websocket path before applying — the match above assumes `/v4/ws`.
+
+**Verifying it**
+
+1. Confirm `socks.subscriptions_limit_abuse_disconnect` is non-zero for the offender.
+2. Confirm the 429s reach the edge — Cloudflare Analytics, filtered to the socks path, grouped by
+   origin status.
+3. Confirm the rule fires and that the custom body is what the client actually receives.
+
+**Attribution**, for the next incident: because the ALB only sees Cloudflare addresses, identify
+the offender from Cloudflare's own analytics/logs, or from the socks-side logs which now carry
+the `cf-connecting-ip`-derived address. S3 ALB access logs will not tell you who it was.

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -46,6 +46,15 @@ connection is left alone. Past that, the connection is closed with close code
 A distinct close code matters: 1008 is already used for the generic rate-limit drops, and we
 want dashboards and clients to be able to tell the two apart.
 
+The close frame is only the start of the drop. `ws` keeps an uncooperative peer's socket alive
+for up to 30 seconds waiting for a close frame that may never come, and goes on delivering that
+peer's messages for the whole window. So the drop also, in order: unsubscribes the connection
+immediately rather than waiting for the close event, so the forwarder stops serializing market
+data for it; destroys the socket outright if `close()` itself throws; and arms a short
+forced-termination fallback. Inbound messages are discarded without being parsed once the socket
+is no longer `OPEN`, so a client that ignores the close frame gets no further work done on its
+behalf.
+
 ### 2. The client is refused at the handshake for a cooldown
 
 A websocket close frame is invisible to Cloudflare — it proxies the tunnelled connection but does
@@ -83,14 +92,18 @@ client. This is also why the incident could not be attributed from S3 ALB logs.
 
 | Variable | Default | Meaning |
 |---|---|---|
+| `SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED` | `false` | Kill switch for the connection drop, independent of `RATE_LIMIT_ENABLED`. Ships off; enable once thresholds are sized. |
 | `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS` | `5` | Limit hits allowed per connection before it is dropped |
 | `RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS` | `10000` | Window over which those hits are counted |
+| `SUBSCRIPTION_LIMIT_ABUSE_FORCE_TERMINATE_MS` | `1000` | Grace period after the close frame before the socket is destroyed |
 | `RECONNECT_PENALTY_ENABLED` | `true` | Kill switch for handshake refusal only. The connection drop stays active. |
 | `RECONNECT_PENALTY_MS` | `30000` | How long a dropped client's upgrades are refused |
 | `RECONNECT_PENALTY_MAX_TRACKED_CLIENTS` | `100000` | Bound on the penalty map |
 
-The existing global `RATE_LIMIT_ENABLED` kill switch is honoured inside `RateLimiter` itself, so
-setting it to `false` disables the drop as well.
+`SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED` gates the drop on its own, so it can be rolled back
+without touching the subscribe, ping and invalid-message limiters. The global `RATE_LIMIT_ENABLED`
+switch still disables everything, including the drop. Disabling the drop also disables the
+cooldown, since a client only ever enters it by being dropped.
 
 ### Note on shared addresses
 
@@ -111,7 +124,14 @@ penalty enabled and watch `socks.connection_rejected_penalty`; a rate much highe
 | `socks.reconnect_penalty_applied` | `reason`, `instance` | A client entered the penalty box |
 | `socks.connection_rejected_penalty` | `instance` | An upgrade was refused with 429 |
 
+| `socks.subscriptions_limit_abuse_force_terminate` | `reason`, `instance` | A dropped socket was destroyed without a completed close handshake |
+| `socks.message_dropped_not_open` | `readyState`, `instance` | An inbound message was discarded because the socket was no longer open |
+
 Drops also appear on the existing `socks.num_disconnects` counter tagged `code: "4008"`.
+
+A steady `socks.subscriptions_limit_abuse_force_terminate` tagged `close_timeout` means clients
+are ignoring close frames rather than disconnecting, which is itself a sign of a badly behaved
+integration.
 
 Worth alerting on: a sustained non-zero `socks.subscriptions_limit_abuse_disconnect` means a
 client is in a retry loop and not backing off, which is the signal that the edge rule below
@@ -128,10 +148,25 @@ reaching origin at all, and to make the timeout long enough that a client has to
 
 - Match: `(http.host eq "indexer.dydx.trade" and starts_with(http.request.uri.path, "/v4/ws"))`
 - Counting characteristic: client IP
-- Count only responses where: `origin response status eq 429` **or**, if response-header matching
-  is available on the plan, response header `x-dydx-ratelimit-reason` eq `subscription-limit-abuse`.
-  The header form is the more precise of the two — it will not count 429s emitted for any other
-  reason.
+- **Counting expression — must repeat host and path:**
+
+  ```
+  http.host eq "indexer.dydx.trade"
+  and starts_with(http.request.uri.path, "/v4/ws")
+  and http.response.code eq 429
+  and any(http.response.headers["x-dydx-ratelimit-reason"][*] eq "subscription-limit-abuse")
+  ```
+
+  A custom counting expression does **not** inherit the rule's matching expression. Cloudflare
+  evaluates it independently, so host and path have to be restated or the counter will increment
+  on unrelated traffic.
+
+  The reason header is not optional hardening here, it is what makes the rule correct. The ALB
+  routes exactly `/v4/ws` to socks and everything else under `/v4/*` to comlink, which runs its
+  own rate limiter and returns its own 429s. A counting expression of "status 429" alone — or one
+  scoped only by a `/v4/ws` prefix, which still covers `/v4/ws...` paths the ALB hands to comlink
+  — would count comlink's rate-limit responses and block those clients out of the websocket
+  entirely. socks is the only origin that emits this header.
 - Threshold: 5 requests per 60 seconds
 - Action: **Block**, duration **300 seconds** (deliberately an order of magnitude longer than the
   origin's 30s penalty — the origin cooldown is a nudge, the edge block is the consequence)
@@ -146,6 +181,12 @@ reaching origin at all, and to make the timeout long enough that a client has to
 ```
 
 Confirm the actual websocket path before applying — the match above assumes `/v4/ws`.
+
+**Prerequisite.** Counting on response fields requires a Business plan or above. Confirm the
+zone's tier before building the rule. If response-based counting is unavailable, the fallback is
+a request-rate rule on the `/v4/ws` path per client IP with no response condition — cruder, since
+it cannot distinguish an abusive reconnect storm from a legitimate one, so it needs a threshold
+set well above normal reconnect behaviour.
 
 **Verifying it**
 

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -117,28 +117,38 @@ no per-channel or per-instance breakdown is available.
 | `socks.num_concurrent_connections` | ~3,700 | ~4,270 |
 | Implied per-connection rejections | ~54/min (~9 per 10s) | ~171/min (~29 per 10s) |
 
-Two things follow, and both argue against turning the drop on as configured.
+The per-connection row is a fleet average, and how it should be read depends entirely on how the
+rejections are distributed -- which these metrics cannot show, because tag grouping is disabled
+on them.
 
-**The defaults would disconnect much of the customer base.** The allowance is 5 rejections per
-10s per connection. The *average* mainnet connection produces about 9 per 10s while nothing is
-wrong, and about 29 per 10s during a busy period. Enabling the drop today would therefore drop a
-large share of healthy connections on a rolling basis, and place their addresses in a reconnect
-cooldown. This is the reason the feature ships disabled, and it is not fixed by simply raising
-the number.
+**The working assumption is that rejections are heavily concentrated.** A well-behaved client
+subscribes once per market when it connects and then stays subscribed; in steady state it
+produces no rejections at all. Producing them continuously requires continuously re-subscribing,
+which is the pathological pattern by definition. The baseline is also flat rather than tracking
+connection churn, which is what a bulk-subscribe-at-connect explanation would predict. On that
+reading the ~200k/min comes from a small number of offenders, the typical connection sits at or
+near zero, and an allowance of 5 per 10s does not endanger healthy clients.
 
-**The signal itself is questionable on mainnet.** `socks.on_message` tracks
-`socks.message_received_subscribe` almost exactly, so essentially all inbound websocket traffic
-is subscribe requests, and roughly half of them are rejected for hitting the per-connection cap
-at all times. "Repeatedly hits the subscription limit" is the steady state of this system, not a
-marker of abuse. A threshold set safely above normal would have to sit so far above 171/min per
-connection that it would rarely constrain anything.
+The alternative reading -- that the load is spread evenly -- would mean the average connection
+sits at roughly twice the allowance while nothing is wrong, and enabling the drop would
+disconnect a large share of the customer base on a rolling basis. The two readings are the same
+numbers and lead to opposite decisions, so the distribution has to be measured rather than
+assumed.
 
-Before enabling, the open question is why normal clients subscribe 80-350 times per minute and
-are refused about half the time -- most plausibly because they want more markets than the
-per-channel cap of 32 permits and retry in a loop. If that is the cause, raising the cap, or
-making the refusal cacheable so clients stop retrying, addresses more of the load than dropping
-connections does. A per-connection limit on subscribe *attempts*, independent of outcome, is also
-a better-targeted control than punishing limit hits.
+**How to measure it before enabling anything.** The abuse allowance is evaluated even when
+`SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED` is off, and every connection that exceeds it is counted.
+`socks.subscriptions_limit_abuse_connections` reports the number of *distinct* connections that
+would have been dropped in each metrics interval, tagged `enforcing:false` while the drop is
+disabled. Deploy with the drop off and compare that gauge against
+`socks.num_concurrent_connections`:
+
+- A handful of connections against several thousand confirms concentration. Enable the drop.
+- A large fraction means the behaviour is normal for this system, and dropping connections is the
+  wrong control -- raising the per-channel cap, making the refusal cacheable so clients stop
+  retrying, or limiting subscribe *attempts* regardless of outcome would each address more of the
+  load without disconnecting anyone.
+
+This costs nothing to run and turns the decision into a reading rather than an argument.
 
 ## Configuration
 
@@ -187,6 +197,7 @@ penalty enabled and watch `socks.connection_rejected_penalty`; a rate much highe
 | `socks.subscriptions_limit_abuse_force_terminate` | `reason`, `instance` | A dropped socket was destroyed without a completed close handshake |
 | `socks.message_dropped_not_open` | `readyState`, `instance` | An inbound message was discarded because the socket was no longer open |
 | `socks.subscription_abandoned_stale_connection` | `channel`, `instance` | An initial response resolved after its connection was torn down |
+| `socks.subscriptions_limit_abuse_connections` | `enforcing`, `instance` | Distinct connections over the abuse allowance per interval, counted whether or not the drop is enabled |
 
 Drops also appear on the existing `socks.num_disconnects` counter tagged `code: "4008"`.
 

--- a/indexer/services/socks/docs/subscription-limit-abuse.md
+++ b/indexer/services/socks/docs/subscription-limit-abuse.md
@@ -249,7 +249,7 @@ reaching origin at all, and to make the timeout long enough that a client has to
 - **Counting expression — must repeat host and path:**
 
   ```txt
-  raw.http.host eq "indexer.dydx.trade"
+  http.host eq "indexer.dydx.trade"
   and http.request.uri.path eq "/v4/ws"
   and http.response.code eq 429
   and any(http.response.headers["x-dydx-ratelimit-reason"][*] eq "subscription-limit-abuse")
@@ -259,15 +259,8 @@ reaching origin at all, and to make the timeout long enough that a client has to
   evaluates it independently, so host and path have to be restated or the counter will increment
   on unrelated traffic.
 
-  `raw.http.host` rather than `http.host`, because rate limiting runs in the `http_ratelimit`
-  phase, after Origin Rules run in `http_request_origin`. If an Origin Rule rewrites the `Host`
-  header for this hostname, `http.host` holds the rewritten value by the time the counting
-  expression is evaluated and would silently stop matching, so the counter would never increment
-  and the rule would appear to work while doing nothing. The `raw.` fields are immutable and
-  unaffected by earlier transformations. Confirm whether any Host rewrite exists for this
-  hostname when applying the rule; if `raw.http.host` is unavailable in this phase, drop the host
-  condition and rely on the exact path plus the reason header, both of which are already
-  sufficient to isolate socks.
+  Substitute the hostname for the environment the rule is being applied to. The host condition is
+  belt-and-braces: the exact path and the reason header already isolate socks on their own.
 
   Exact path equality, not a prefix. The ALB routes exactly `/v4/ws` to socks and everything else
   under `/v4/*` to comlink, which runs its own rate limiter and returns its own 429s. A prefix

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -65,6 +65,12 @@ export const configSchema = {
   // After a connection is dropped for subscription-limit abuse, reject new websocket upgrades
   // from the same client for this long with an HTTP 429. The 429 is the only part of this the
   // edge (Cloudflare) can observe, and is what its rate limiting rule counts on.
+  // `cf-connecting-ip` and `x-forwarded-for` are supplied by the caller, so they are only
+  // meaningful because origin ingress accepts connections from Cloudflare proxies alone. That
+  // property is what makes the forwarded address trustworthy, and this switch exists to turn the
+  // address cooldown off if it ever stops holding -- if the origin became directly reachable, a
+  // caller could name a victim address and have that address's upgrades refused.
+  TRUST_FORWARDED_HEADERS: parseBoolean({ default: true }),
   RECONNECT_PENALTY_ENABLED: parseBoolean({ default: true }),
   RECONNECT_PENALTY_MS: parseInteger({ default: 30_000 }),
   RECONNECT_PENALTY_MAX_TRACKED_CLIENTS: parseInteger({ default: 100_000 }),

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -61,6 +61,10 @@ export const configSchema = {
   // for a peer that never replies, and keeps delivering that peer's messages for the whole
   // window; an abusive client must not get 30s of free work.
   SUBSCRIPTION_LIMIT_ABUSE_FORCE_TERMINATE_MS: parseInteger({ default: 1_000 }),
+  // Cap on how many distinct connections are recorded per metrics interval. Sits well above the
+  // total concurrent connection count, so reaching it means connection churn far beyond normal
+  // -- which is itself worth knowing, hence the companion overflow gauge.
+  SUBSCRIPTION_LIMIT_ABUSE_MAX_TRACKED_CONNECTIONS: parseInteger({ default: 10_000 }),
 
   // After a connection is dropped for subscription-limit abuse, reject new websocket upgrades
   // from the same client for this long with an HTTP 429. The 429 is the only part of this the

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -49,8 +49,10 @@ export const configSchema = {
   // also disabling the subscribe, ping and invalid-message limiters. Staged off until the
   // thresholds below have been sized against production telemetry.
   SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED: parseBoolean({ default: false }),
-  // NOT YET SIZED against mainnet telemetry -- see the threshold-sizing note in
-  // docs/subscription-limit-abuse.md. The drop ships disabled for this reason.
+  // These are NOT safe to enable as-is. Measured on mainnet, the average connection produces
+  // ~9 subscription-limit rejections per 10s while nothing is wrong, so this allowance of 5
+  // would disconnect a large share of healthy clients. See the threshold-sizing section in
+  // docs/subscription-limit-abuse.md before changing SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED.
   RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS: parseNumber({ default: 5 }),
   RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS: parseInteger({ default: 10_000 }),
   // How long to wait after sending the close frame before destroying the socket. `ws` waits 30s

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -41,6 +41,19 @@ export const configSchema = {
   RATE_LIMIT_INVALID_MESSAGE_POINTS: parseNumber({ default: 2 }),
   RATE_LIMIT_INVALID_MESSAGE_DURATION_MS: parseInteger({ default: 1000 }),
 
+  // A client that keeps re-sending subscribe requests after being told it is at the
+  // per-connection subscription limit is ignoring the contract. Once it exceeds these points
+  // within the window, the connection is dropped rather than answered with another error.
+  RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS: parseNumber({ default: 5 }),
+  RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS: parseInteger({ default: 10_000 }),
+
+  // After a connection is dropped for subscription-limit abuse, reject new websocket upgrades
+  // from the same client for this long with an HTTP 429. The 429 is the only part of this the
+  // edge (Cloudflare) can observe, and is what its rate limiting rule counts on.
+  RECONNECT_PENALTY_ENABLED: parseBoolean({ default: true }),
+  RECONNECT_PENALTY_MS: parseInteger({ default: 30_000 }),
+  RECONNECT_PENALTY_MAX_TRACKED_CLIENTS: parseInteger({ default: 10_000 }),
+
   MESSAGE_FORWARDER_STATSD_SAMPLE_RATE: parseNumber({ default: 1.0 }),
   ENABLE_ORDERBOOK_LOGS: parseBoolean({ default: true }),
   PERPETUAL_MARKETS_REFRESHER_INTERVAL_MS: parseInteger({ default: 300_000 }), // 5 minutes

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -49,10 +49,12 @@ export const configSchema = {
   // also disabling the subscribe, ping and invalid-message limiters. Staged off until the
   // thresholds below have been sized against production telemetry.
   SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED: parseBoolean({ default: false }),
-  // These are NOT safe to enable as-is. Measured on mainnet, the average connection produces
-  // ~9 subscription-limit rejections per 10s while nothing is wrong, so this allowance of 5
-  // would disconnect a large share of healthy clients. See the threshold-sizing section in
-  // docs/subscription-limit-abuse.md before changing SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED.
+  // These assume subscription-limit rejections are concentrated in a small number of
+  // misbehaving clients, with well-behaved clients producing close to none. That holds only if
+  // the fleet-wide rejection rate measured on mainnet comes from a few offenders rather than
+  // being spread across every connection. Confirm with
+  // socks.subscriptions_limit_abuse_connections, which counts distinct affected connections
+  // while the drop is still disabled, before enabling. See docs/subscription-limit-abuse.md.
   RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS: parseNumber({ default: 5 }),
   RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS: parseInteger({ default: 10_000 }),
   // How long to wait after sending the close frame before destroying the socket. `ws` waits 30s

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -49,6 +49,8 @@ export const configSchema = {
   // also disabling the subscribe, ping and invalid-message limiters. Staged off until the
   // thresholds below have been sized against production telemetry.
   SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED: parseBoolean({ default: false }),
+  // NOT YET SIZED against mainnet telemetry -- see the threshold-sizing note in
+  // docs/subscription-limit-abuse.md. The drop ships disabled for this reason.
   RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS: parseNumber({ default: 5 }),
   RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS: parseInteger({ default: 10_000 }),
   // How long to wait after sending the close frame before destroying the socket. `ws` waits 30s

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -52,7 +52,7 @@ export const configSchema = {
   // edge (Cloudflare) can observe, and is what its rate limiting rule counts on.
   RECONNECT_PENALTY_ENABLED: parseBoolean({ default: true }),
   RECONNECT_PENALTY_MS: parseInteger({ default: 30_000 }),
-  RECONNECT_PENALTY_MAX_TRACKED_CLIENTS: parseInteger({ default: 10_000 }),
+  RECONNECT_PENALTY_MAX_TRACKED_CLIENTS: parseInteger({ default: 100_000 }),
 
   MESSAGE_FORWARDER_STATSD_SAMPLE_RATE: parseNumber({ default: 1.0 }),
   ENABLE_ORDERBOOK_LOGS: parseBoolean({ default: true }),

--- a/indexer/services/socks/src/config.ts
+++ b/indexer/services/socks/src/config.ts
@@ -44,8 +44,17 @@ export const configSchema = {
   // A client that keeps re-sending subscribe requests after being told it is at the
   // per-connection subscription limit is ignoring the contract. Once it exceeds these points
   // within the window, the connection is dropped rather than answered with another error.
+  //
+  // Gated independently of RATE_LIMIT_ENABLED so this can be rolled back on its own without
+  // also disabling the subscribe, ping and invalid-message limiters. Staged off until the
+  // thresholds below have been sized against production telemetry.
+  SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED: parseBoolean({ default: false }),
   RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS: parseNumber({ default: 5 }),
   RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS: parseInteger({ default: 10_000 }),
+  // How long to wait after sending the close frame before destroying the socket. `ws` waits 30s
+  // for a peer that never replies, and keeps delivering that peer's messages for the whole
+  // window; an abusive client must not get 30s of free work.
+  SUBSCRIPTION_LIMIT_ABUSE_FORCE_TERMINATE_MS: parseInteger({ default: 1_000 }),
 
   // After a connection is dropped for subscription-limit abuse, reject new websocket upgrades
   // from the same client for this long with an HTTP 429. The 429 is the only part of this the

--- a/indexer/services/socks/src/helpers/header-utils.ts
+++ b/indexer/services/socks/src/helpers/header-utils.ts
@@ -2,6 +2,7 @@ import { IncomingMessage as IncomingMessageHttp } from 'http';
 
 import { GeoOriginHeaders } from '@dydxprotocol-indexer/compliance';
 
+import config from '../config';
 import { IncomingMessage } from '../types';
 
 export function getGeoOriginHeaders(req: IncomingMessage): GeoOriginHeaders {
@@ -16,21 +17,38 @@ export function getGeoOriginHeaders(req: IncomingMessage): GeoOriginHeaders {
 /**
  * Derives the client address for a websocket request.
  *
- * socks sits behind Cloudflare and an AWS load balancer, so the socket's remote address is a
- * proxy, not the client. `cf-connecting-ip` is set by Cloudflare and is the most trustworthy
- * value when traffic is proxied; otherwise fall back to the left-most `x-forwarded-for` entry,
- * and finally to the socket address for direct connections (local/dev, or health checks).
+ * `cf-connecting-ip` and `x-forwarded-for` are set by the caller, and a load balancer forwards
+ * whatever it was given. They are believable here because origin ingress accepts connections
+ * from Cloudflare proxies alone, so the caller is always Cloudflare.
+ * `TRUST_FORWARDED_HEADERS` exists to withdraw that trust if the origin ever becomes directly
+ * reachable, since a caller could then name an arbitrary victim and have that address penalised.
+ *
+ * When a forwarded header is present but not trusted, this returns undefined rather than the
+ * socket address. Behind a proxy the socket address is the proxy itself, shared by every client,
+ * so keying a penalty on it would refuse everyone. Returning undefined makes the address-based
+ * cooldown inert, which is the safe failure mode; the per-connection drop is unaffected.
  *
  * @param req HTTP request accompanying the websocket upgrade.
- * @returns the client address, or undefined if it cannot be determined.
+ * @returns the client address, or undefined if it cannot be established safely.
  */
 export function getClientIp(req: IncomingMessageHttp): string | undefined {
   const cfConnectingIp = req.headers['cf-connecting-ip'];
+  const forwardedFor = req.headers['x-forwarded-for'];
+  const hasForwardedHeaders: boolean = cfConnectingIp !== undefined || forwardedFor !== undefined;
+
+  if (!hasForwardedHeaders) {
+    // No proxy in the path, so the peer is the client.
+    return req.socket?.remoteAddress;
+  }
+
+  if (!config.TRUST_FORWARDED_HEADERS) {
+    return undefined;
+  }
+
   if (typeof cfConnectingIp === 'string' && cfConnectingIp.trim().length > 0) {
     return cfConnectingIp.trim();
   }
 
-  const forwardedFor = req.headers['x-forwarded-for'];
   const forwardedForStr = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
   if (typeof forwardedForStr === 'string') {
     const first = forwardedForStr.split(',')[0].trim();

--- a/indexer/services/socks/src/helpers/header-utils.ts
+++ b/indexer/services/socks/src/helpers/header-utils.ts
@@ -1,3 +1,5 @@
+import { IncomingMessage as IncomingMessageHttp } from 'http';
+
 import { GeoOriginHeaders } from '@dydxprotocol-indexer/compliance';
 
 import { IncomingMessage } from '../types';
@@ -9,4 +11,33 @@ export function getGeoOriginHeaders(req: IncomingMessage): GeoOriginHeaders {
     'geo-origin-region': geoOriginHeaders['geo-origin-region'],
     'geo-origin-status': geoOriginHeaders['geo-origin-status'],
   } as GeoOriginHeaders;
+}
+
+/**
+ * Derives the client address for a websocket request.
+ *
+ * socks sits behind Cloudflare and an AWS load balancer, so the socket's remote address is a
+ * proxy, not the client. `cf-connecting-ip` is set by Cloudflare and is the most trustworthy
+ * value when traffic is proxied; otherwise fall back to the left-most `x-forwarded-for` entry,
+ * and finally to the socket address for direct connections (local/dev, or health checks).
+ *
+ * @param req HTTP request accompanying the websocket upgrade.
+ * @returns the client address, or undefined if it cannot be determined.
+ */
+export function getClientIp(req: IncomingMessageHttp): string | undefined {
+  const cfConnectingIp = req.headers['cf-connecting-ip'];
+  if (typeof cfConnectingIp === 'string' && cfConnectingIp.trim().length > 0) {
+    return cfConnectingIp.trim();
+  }
+
+  const forwardedFor = req.headers['x-forwarded-for'];
+  const forwardedForStr = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
+  if (typeof forwardedForStr === 'string') {
+    const first = forwardedForStr.split(',')[0].trim();
+    if (first.length > 0) {
+      return first;
+    }
+  }
+
+  return req.socket?.remoteAddress;
 }

--- a/indexer/services/socks/src/helpers/wss.ts
+++ b/indexer/services/socks/src/helpers/wss.ts
@@ -1,3 +1,5 @@
+import { IncomingMessage as IncomingMessageHttp, OutgoingHttpHeaders } from 'http';
+
 import { stats, getInstanceId, logger } from '@dydxprotocol-indexer/base';
 import WebSocket from 'ws';
 
@@ -5,9 +7,17 @@ import config from '../config';
 import {
   WS_CLOSE_CODE_ABNORMAL_CLOSURE,
   ERR_WRITE_STREAM_DESTROYED,
+  RATE_LIMIT_REASON_HEADER,
+  RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
   WEBSOCKET_NOT_OPEN,
 } from '../lib/constants';
+import { reconnectPenalty } from '../lib/reconnect-penalty';
 import { IncomingMessage, OutgoingMessage, WebsocketEvent } from '../types';
+import { getClientIp } from './header-utils';
+
+// Status returned for a websocket upgrade refused because the client is in the reconnect
+// penalty box. It is an ordinary HTTP response, which is what makes it visible to Cloudflare.
+const HTTP_TOO_MANY_REQUESTS: number = 429;
 
 function incrementSendErrorStats(instanceId: string, error: WssError): void {
   stats.increment(
@@ -43,6 +53,59 @@ function incrementWriteEpipeErrorStats(instanceId: string): void {
   );
 }
 
+/**
+ * Refuses a websocket upgrade from a client that is serving a reconnect penalty.
+ *
+ * Rejecting at the handshake, rather than accepting and immediately closing, is what makes the
+ * penalty legible to the edge: Cloudflare cannot inspect websocket frames, but it can count HTTP
+ * 429 responses and match on the reason header, and escalate to a longer block of its own.
+ * `Retry-After` tells a well-behaved client how long to wait without needing any of that.
+ */
+export function verifyClientNotPenalized(
+  info: { origin: string, secure: boolean, req: IncomingMessageHttp },
+  callback: (
+    result: boolean,
+    code?: number,
+    statusMessage?: string,
+    headers?: OutgoingHttpHeaders,
+  ) => void,
+): void {
+  const clientIp: string | undefined = getClientIp(info.req);
+  const remainingPenaltyMs: number = reconnectPenalty.getRemainingPenaltyMs(clientIp);
+
+  if (remainingPenaltyMs <= 0) {
+    callback(true);
+    return;
+  }
+
+  const retryAfterSeconds: number = Math.ceil(remainingPenaltyMs / 1000);
+
+  stats.increment(
+    `${config.SERVICE_NAME}.connection_rejected_penalty`,
+    1,
+    undefined,
+    {
+      instance: getInstanceId(),
+    },
+  );
+
+  logger.info({
+    at: 'wss#verifyClientNotPenalized',
+    message: 'Rejected websocket upgrade for client serving a reconnect penalty',
+    retryAfterSeconds,
+  });
+
+  callback(
+    false,
+    HTTP_TOO_MANY_REQUESTS,
+    'Too Many Requests',
+    {
+      'Retry-After': String(retryAfterSeconds),
+      [RATE_LIMIT_REASON_HEADER]: RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
+    },
+  );
+}
+
 export class Wss {
   private wss: WebSocket.Server;
   private started: boolean;
@@ -56,6 +119,7 @@ export class Wss {
       port: config.WS_PORT,
       allowSynchronousEvents: true,
       autoPong: true,
+      verifyClient: verifyClientNotPenalized,
     };
     this.wss = new WebSocket.Server(serverOptions);
   }

--- a/indexer/services/socks/src/lib/constants.ts
+++ b/indexer/services/socks/src/lib/constants.ts
@@ -9,6 +9,18 @@ export const WS_CLOSE_HEARTBEAT_TIMEOUT: number = 1011;
 export const WS_CLOSE_CODE_ABNORMAL_CLOSURE: number = 4000;
 export const WS_CLOSE_CODE_POLICY_VIOLATION: number = 1008;
 export const WS_CLOSE_CODE_SERVICE_RESTART: number = 1012;
+// Private-use close code (4000-4999) signalling that the connection was dropped because the
+// client repeatedly ignored the per-connection subscription limit. A distinct code lets clients
+// (and our own dashboards) tell this apart from a generic policy violation.
+export const WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE: number = 4008;
+
+// Reason sent in the close frame when a connection is dropped for subscription-limit abuse.
+export const SUBSCRIPTION_LIMIT_ABUSE_CLOSE_REASON: string = 'Subscription limit abuse';
+
+// Header returned on a rejected websocket upgrade so that edge proxies (Cloudflare) and clients
+// can identify why the handshake was refused.
+export const RATE_LIMIT_REASON_HEADER: string = 'x-dydx-ratelimit-reason';
+export const RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE: string = 'subscription-limit-abuse';
 
 // https://github.com/nodejs/node/blob/master/lib/internal/errors.js#L1537
 // Error code for writing to a destroyed stream

--- a/indexer/services/socks/src/lib/message-forwarder.ts
+++ b/indexer/services/socks/src/lib/message-forwarder.ts
@@ -13,6 +13,8 @@ import {
 import _ from 'lodash';
 
 import config from '../config';
+import { MAX_TIMEOUT_INTEGER } from './constants';
+import { Subscriptions } from './subscription';
 import {
   getChannels,
   getMessagesToForward,
@@ -30,8 +32,6 @@ import {
   WebsocketTopic,
 } from '../types';
 import { Index } from '../websocket/index';
-import { MAX_TIMEOUT_INTEGER } from './constants';
-import { Subscriptions } from './subscription';
 
 const BATCH_SEND_INTERVAL_MS: number = config.BATCH_SEND_INTERVAL_MS;
 const BUFFER_KEY_SEPARATOR: string = ':';

--- a/indexer/services/socks/src/lib/message-forwarder.ts
+++ b/indexer/services/socks/src/lib/message-forwarder.ts
@@ -13,8 +13,6 @@ import {
 import _ from 'lodash';
 
 import config from '../config';
-import { MAX_TIMEOUT_INTEGER } from './constants';
-import { Subscriptions } from './subscription';
 import {
   getChannels,
   getMessagesToForward,
@@ -32,6 +30,8 @@ import {
   WebsocketTopic,
 } from '../types';
 import { Index } from '../websocket/index';
+import { MAX_TIMEOUT_INTEGER } from './constants';
+import { Subscriptions } from './subscription';
 
 const BATCH_SEND_INTERVAL_MS: number = config.BATCH_SEND_INTERVAL_MS;
 const BUFFER_KEY_SEPARATOR: string = ':';

--- a/indexer/services/socks/src/lib/reconnect-penalty.ts
+++ b/indexer/services/socks/src/lib/reconnect-penalty.ts
@@ -2,6 +2,10 @@ import { getInstanceId, logger, stats } from '@dydxprotocol-indexer/base';
 
 import config from '../config';
 
+// Upper bound on how many expired entries a single penalty application will sweep. Keeps the
+// sweep constant-time regardless of how large the map has grown.
+const EVICTION_SWEEP_LIMIT: number = 8;
+
 /**
  * Tracks clients that were disconnected for abusing the subscription limit, so that their
  * reconnection attempts can be refused at the websocket handshake.
@@ -17,14 +21,19 @@ import config from '../config';
  */
 export class ReconnectPenalty {
   // Client address -> epoch ms at which the penalty expires.
-  private penaltyExpiryMs: { [clientIp: string]: number };
+  //
+  // A Map rather than an object so that iteration order is insertion order. Every penalty uses
+  // the same duration, so insertion order is also expiry order, which makes both the expiry
+  // sweep and the capacity eviction O(1) amortized from the front. That matters because
+  // eviction runs precisely when the map is full -- i.e. while under attack.
+  private penaltyExpiryMs: Map<string, number>;
   // Connection id -> client address, so a connection can be penalised by the code that drops it
   // without having to thread request headers through the subscription layer.
-  private clientIpByConnectionId: { [connectionId: string]: string };
+  private clientIpByConnectionId: Map<string, string>;
 
   constructor() {
-    this.penaltyExpiryMs = {};
-    this.clientIpByConnectionId = {};
+    this.penaltyExpiryMs = new Map();
+    this.clientIpByConnectionId = new Map();
   }
 
   /**
@@ -34,7 +43,7 @@ export class ReconnectPenalty {
     if (clientIp === undefined) {
       return;
     }
-    this.clientIpByConnectionId[connectionId] = clientIp;
+    this.clientIpByConnectionId.set(connectionId, clientIp);
   }
 
   /**
@@ -42,14 +51,14 @@ export class ReconnectPenalty {
    * in place, since it must outlive the connection that earned it.
    */
   public removeConnection(connectionId: string): void {
-    delete this.clientIpByConnectionId[connectionId];
+    this.clientIpByConnectionId.delete(connectionId);
   }
 
   /**
    * Places the client behind `connectionId` in the penalty box.
    */
   public penalizeConnection(connectionId: string, reason: string): void {
-    const clientIp: string | undefined = this.clientIpByConnectionId[connectionId];
+    const clientIp: string | undefined = this.clientIpByConnectionId.get(connectionId);
     if (clientIp === undefined) {
       return;
     }
@@ -61,9 +70,13 @@ export class ReconnectPenalty {
       return;
     }
 
-    this.evictIfFull();
+    // Re-insert rather than update, so a re-offending client moves to the back and the
+    // insertion-order-equals-expiry-order invariant holds.
+    this.penaltyExpiryMs.delete(clientIp);
+    this.evictExpired();
+    this.evictToCapacity();
 
-    this.penaltyExpiryMs[clientIp] = Date.now() + config.RECONNECT_PENALTY_MS;
+    this.penaltyExpiryMs.set(clientIp, Date.now() + config.RECONNECT_PENALTY_MS);
 
     logger.info({
       at: 'reconnect-penalty#penalizeClient',
@@ -92,14 +105,14 @@ export class ReconnectPenalty {
       return 0;
     }
 
-    const expiryMs: number | undefined = this.penaltyExpiryMs[clientIp];
+    const expiryMs: number | undefined = this.penaltyExpiryMs.get(clientIp);
     if (expiryMs === undefined) {
       return 0;
     }
 
     const remainingMs: number = expiryMs - Date.now();
     if (remainingMs <= 0) {
-      delete this.penaltyExpiryMs[clientIp];
+      this.penaltyExpiryMs.delete(clientIp);
       return 0;
     }
 
@@ -107,27 +120,33 @@ export class ReconnectPenalty {
   }
 
   /**
-   * Drops expired entries, and if the map is still at capacity, the entry expiring soonest. This
-   * bounds memory so a client cycling through addresses cannot grow the map without limit.
+   * Drops entries that have already expired, from the front and bounded per call, so the sweep
+   * never scales with the size of the map.
    */
-  private evictIfFull(): void {
-    if (Object.keys(this.penaltyExpiryMs).length < config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS) {
-      return;
-    }
-
+  private evictExpired(): void {
     const now: number = Date.now();
-    Object.entries(this.penaltyExpiryMs).forEach(([clientIp, expiryMs]: [string, number]) => {
-      if (expiryMs <= now) {
-        delete this.penaltyExpiryMs[clientIp];
-      }
-    });
+    let swept: number = 0;
 
-    const entries: [string, number][] = Object.entries(this.penaltyExpiryMs);
-    if (entries.length >= config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS && entries.length > 0) {
-      const soonest: [string, number] = entries.reduce(
-        (a: [string, number], b: [string, number]) => (a[1] <= b[1] ? a : b),
-      );
-      delete this.penaltyExpiryMs[soonest[0]];
+    for (const [clientIp, expiryMs] of this.penaltyExpiryMs) {
+      if (expiryMs > now || swept >= EVICTION_SWEEP_LIMIT) {
+        break;
+      }
+      this.penaltyExpiryMs.delete(clientIp);
+      swept += 1;
+    }
+  }
+
+  /**
+   * Makes room for one more entry by dropping the oldest, which under a uniform penalty duration
+   * is also the soonest to expire.
+   */
+  private evictToCapacity(): void {
+    while (this.penaltyExpiryMs.size >= config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS) {
+      const oldest: string | undefined = this.penaltyExpiryMs.keys().next().value;
+      if (oldest === undefined) {
+        return;
+      }
+      this.penaltyExpiryMs.delete(oldest);
     }
   }
 
@@ -135,8 +154,8 @@ export class ReconnectPenalty {
    * Clears all tracked state. Used to reset between tests.
    */
   public clear(): void {
-    this.penaltyExpiryMs = {};
-    this.clientIpByConnectionId = {};
+    this.penaltyExpiryMs = new Map();
+    this.clientIpByConnectionId = new Map();
   }
 }
 

--- a/indexer/services/socks/src/lib/reconnect-penalty.ts
+++ b/indexer/services/socks/src/lib/reconnect-penalty.ts
@@ -1,0 +1,145 @@
+import { getInstanceId, logger, stats } from '@dydxprotocol-indexer/base';
+
+import config from '../config';
+
+/**
+ * Tracks clients that were disconnected for abusing the subscription limit, so that their
+ * reconnection attempts can be refused at the websocket handshake.
+ *
+ * This exists because a websocket close frame is invisible to the edge: Cloudflare proxies the
+ * tunnelled connection but does not inspect its frames, so it cannot rate limit on "was dropped".
+ * The handshake is HTTP, so refusing it with a 429 gives Cloudflare something it can count and
+ * escalate on, and gives the client an unambiguous, documented reason for the refusal.
+ *
+ * Penalties are held in memory and are per-socks-instance. That is deliberate: the goal is to
+ * stop a single instance from being monopolised, and to surface a durable signal to the edge,
+ * which is where cross-instance enforcement belongs.
+ */
+export class ReconnectPenalty {
+  // Client address -> epoch ms at which the penalty expires.
+  private penaltyExpiryMs: { [clientIp: string]: number };
+  // Connection id -> client address, so a connection can be penalised by the code that drops it
+  // without having to thread request headers through the subscription layer.
+  private clientIpByConnectionId: { [connectionId: string]: string };
+
+  constructor() {
+    this.penaltyExpiryMs = {};
+    this.clientIpByConnectionId = {};
+  }
+
+  /**
+   * Associates a connection with the client address it originated from.
+   */
+  public trackConnection(connectionId: string, clientIp?: string): void {
+    if (clientIp === undefined) {
+      return;
+    }
+    this.clientIpByConnectionId[connectionId] = clientIp;
+  }
+
+  /**
+   * Stops tracking a closed connection. Any penalty on the client address is intentionally left
+   * in place, since it must outlive the connection that earned it.
+   */
+  public removeConnection(connectionId: string): void {
+    delete this.clientIpByConnectionId[connectionId];
+  }
+
+  /**
+   * Places the client behind `connectionId` in the penalty box.
+   */
+  public penalizeConnection(connectionId: string, reason: string): void {
+    const clientIp: string | undefined = this.clientIpByConnectionId[connectionId];
+    if (clientIp === undefined) {
+      return;
+    }
+    this.penalizeClient(clientIp, reason);
+  }
+
+  public penalizeClient(clientIp: string, reason: string): void {
+    if (!config.RECONNECT_PENALTY_ENABLED) {
+      return;
+    }
+
+    this.evictIfFull();
+
+    this.penaltyExpiryMs[clientIp] = Date.now() + config.RECONNECT_PENALTY_MS;
+
+    logger.info({
+      at: 'reconnect-penalty#penalizeClient',
+      message: 'Client placed in reconnect penalty box',
+      reason,
+      penaltyMs: config.RECONNECT_PENALTY_MS,
+    });
+
+    stats.increment(
+      `${config.SERVICE_NAME}.reconnect_penalty_applied`,
+      1,
+      undefined,
+      {
+        reason,
+        instance: getInstanceId(),
+      },
+    );
+  }
+
+  /**
+   * @returns the number of milliseconds remaining on the client's penalty, or 0 if the client is
+   * not penalised.
+   */
+  public getRemainingPenaltyMs(clientIp?: string): number {
+    if (!config.RECONNECT_PENALTY_ENABLED || clientIp === undefined) {
+      return 0;
+    }
+
+    const expiryMs: number | undefined = this.penaltyExpiryMs[clientIp];
+    if (expiryMs === undefined) {
+      return 0;
+    }
+
+    const remainingMs: number = expiryMs - Date.now();
+    if (remainingMs <= 0) {
+      delete this.penaltyExpiryMs[clientIp];
+      return 0;
+    }
+
+    return remainingMs;
+  }
+
+  /**
+   * Drops expired entries, and if the map is still at capacity, the entry expiring soonest. This
+   * bounds memory so a client cycling through addresses cannot grow the map without limit.
+   */
+  private evictIfFull(): void {
+    if (Object.keys(this.penaltyExpiryMs).length < config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS) {
+      return;
+    }
+
+    const now: number = Date.now();
+    Object.entries(this.penaltyExpiryMs).forEach(([clientIp, expiryMs]: [string, number]) => {
+      if (expiryMs <= now) {
+        delete this.penaltyExpiryMs[clientIp];
+      }
+    });
+
+    const entries: [string, number][] = Object.entries(this.penaltyExpiryMs);
+    if (entries.length >= config.RECONNECT_PENALTY_MAX_TRACKED_CLIENTS && entries.length > 0) {
+      const soonest: [string, number] = entries.reduce(
+        (a: [string, number], b: [string, number]) => (a[1] <= b[1] ? a : b),
+      );
+      delete this.penaltyExpiryMs[soonest[0]];
+    }
+  }
+
+  /**
+   * Clears all tracked state. Used to reset between tests.
+   */
+  public clear(): void {
+    this.penaltyExpiryMs = {};
+    this.clientIpByConnectionId = {};
+  }
+}
+
+// Shared instance. The subscription layer writes to it when it drops a connection, and the
+// websocket server reads from it when verifying an upgrade.
+export const reconnectPenalty: ReconnectPenalty = new ReconnectPenalty();

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -29,9 +29,17 @@ import {
   SubscriptionInfo,
 } from '../types';
 import { axiosRequest } from './axios';
-import { V4_BLOCK_HEIGHT_ID, V4_MARKETS_ID, WS_CLOSE_CODE_POLICY_VIOLATION } from './constants';
+import {
+  RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
+  SUBSCRIPTION_LIMIT_ABUSE_CLOSE_REASON,
+  V4_BLOCK_HEIGHT_ID,
+  V4_MARKETS_ID,
+  WS_CLOSE_CODE_POLICY_VIOLATION,
+  WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE,
+} from './constants';
 import { BlockedError, InvalidChannelError } from './errors';
 import { RateLimiter } from './rate-limit';
+import { reconnectPenalty } from './reconnect-penalty';
 
 const COMLINK_URL: string = `http://${config.COMLINK_URL}`;
 const EMPTY_INITIAL_RESPONSE: string = '{}';
@@ -42,6 +50,10 @@ const VALID_ORDER_STATUS_FOR_INITIAL_SUBACCOUNT_RESPONSE: APIOrderStatus[] = [
 ];
 
 const VALID_ORDER_STATUS: string = VALID_ORDER_STATUS_FOR_INITIAL_SUBACCOUNT_RESPONSE.join(',');
+
+// Single key for the subscription-limit-abuse limiter, so the allowance is spent across every
+// channel and id a connection touches rather than being refreshed per market.
+const SUBSCRIPTION_LIMIT_REACHED_RATE_LIMIT_KEY: string = 'subscriptionLimitReached';
 
 const CHANNEL_CONNECTION_LIMITS: { [channel: string]: number } = {
   [Channel.V4_ACCOUNTS]: config.V4_ACCOUNTS_CHANNEL_LIMIT,
@@ -57,6 +69,7 @@ export class Subscriptions {
   private forwardMessage?: (message: MessageToForward, connectionId: string) => number;
   private subscriptionMetricsInterval?: NodeJS.Timeout;
   private subscribeRateLimiter: RateLimiter;
+  private subscriptionLimitReachedRateLimiter: RateLimiter;
   public batchedSubscriptions: { [channel: string]: { [id: string]: SubscriptionInfo[] } };
   public subsByChannelByConnectionId: { [channel: string]: { [connectionId: string]: number } };
   public subscriptionLists: { [connectionId: string]: Subscription[] };
@@ -69,6 +82,13 @@ export class Subscriptions {
     this.subscribeRateLimiter = new RateLimiter({
       points: config.RATE_LIMIT_SUBSCRIBE_POINTS,
       durationMs: config.RATE_LIMIT_SUBSCRIBE_DURATION_MS,
+    });
+    // Deliberately keyed per-connection rather than per channel+id: a client cycling through
+    // hundreds of distinct markets must trip this, and it is exactly that pattern which
+    // otherwise slips past `subscribeRateLimiter`.
+    this.subscriptionLimitReachedRateLimiter = new RateLimiter({
+      points: config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_POINTS,
+      durationMs: config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS,
     });
     this.subsByChannelByConnectionId = {};
     this.forwardMessage = undefined;
@@ -105,6 +125,95 @@ export class Subscriptions {
       if (this.subsByChannelByConnectionId[channel][connectionId] !== undefined) {
         delete this.subsByChannelByConnectionId[channel][connectionId];
       }
+    });
+  }
+
+  /**
+   * Drops a connection that keeps re-subscribing after being told it is at the per-connection
+   * subscription limit.
+   *
+   * The client is told, in the close frame and in a final error message, exactly which contract
+   * it violated and how long to wait, so a well-behaved client can correct itself. The client is
+   * also placed in the reconnect penalty box, which makes subsequent handshakes fail with an
+   * HTTP 429 -- the signal Cloudflare can see and escalate on, since it cannot inspect websocket
+   * close frames.
+   *
+   * @param ws websocket connection to drop
+   * @param channel channel whose limit was breached
+   * @param connectionId id of the websocket connection
+   * @param messageId message id for the final error message
+   * @param channelSubscriptionsLimit the limit that was breached
+   * @param retryAfterMs how long the client should wait before retrying
+   */
+  private dropConnectionForSubscriptionLimitAbuse(
+    ws: WebSocket,
+    channel: Channel,
+    connectionId: string,
+    messageId: number,
+    channelSubscriptionsLimit: number,
+    retryAfterMs: number,
+  ): void {
+    const retryAfterSeconds: number = Math.ceil(
+      Math.max(retryAfterMs, config.RECONNECT_PENALTY_MS) / 1000,
+    );
+
+    stats.increment(
+      `${config.SERVICE_NAME}.subscriptions_limit_abuse_disconnect`,
+      1,
+      undefined,
+      { channel, instance: getInstanceId() },
+    );
+
+    try {
+      sendMessage(
+        ws,
+        connectionId,
+        createErrorMessage(
+          `Repeatedly exceeded the per-connection subscription limit for ${channel} ` +
+          `(limit=${channelSubscriptionsLimit}). Unsubscribe before subscribing again, or open ` +
+          'an additional connection. Closing this connection; reconnecting sooner than ' +
+          `${retryAfterSeconds}s will be refused.`,
+          connectionId,
+          messageId,
+        ),
+      );
+    } catch (error) {
+      logger.info({
+        at: 'subscription#dropConnectionForSubscriptionLimitAbuse',
+        message: `Failed to send subscription limit abuse message: ${error.message}`,
+        connectionId,
+      });
+    }
+
+    reconnectPenalty.penalizeConnection(
+      connectionId,
+      RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
+    );
+
+    try {
+      ws.close(
+        WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE,
+        JSON.stringify({
+          message: SUBSCRIPTION_LIMIT_ABUSE_CLOSE_REASON,
+          reason: RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
+          retryAfterSeconds,
+        }),
+      );
+    } catch (error) {
+      logger.info({
+        at: 'subscription#dropConnectionForSubscriptionLimitAbuse',
+        message: `Failed to close connection: ${error.message}`,
+        connectionId,
+      });
+    }
+
+    logger.info({
+      at: 'subscription#dropConnectionForSubscriptionLimitAbuse',
+      message: 'Connection closed for repeatedly exceeding the subscription limit',
+      channel,
+      channelSubscriptionsLimit,
+      retryAfterSeconds,
+      connectionId,
     });
   }
 
@@ -161,6 +270,27 @@ export class Subscriptions {
         undefined,
         { channel, instance: getInstanceId() },
       );
+
+      // Being at the limit is a normal condition and is answered with an error. Repeatedly
+      // hitting it is not: it means the client is retrying instead of respecting the limit, and
+      // answering it again just funds the retry loop. Past the allowance, drop the connection.
+      const limitAbuseDurationMs: number = this.subscriptionLimitReachedRateLimiter.rateLimit({
+        connectionId,
+        key: SUBSCRIPTION_LIMIT_REACHED_RATE_LIMIT_KEY,
+      });
+
+      if (limitAbuseDurationMs > 0) {
+        this.dropConnectionForSubscriptionLimitAbuse(
+          ws,
+          channel,
+          connectionId,
+          messageId,
+          channelSubscriptionsLimit,
+          limitAbuseDurationMs,
+        );
+        this.decrementSubscriptions(channel, connectionId);
+        return;
+      }
 
       sendMessage(
         ws,
@@ -415,6 +545,7 @@ export class Subscriptions {
     }
     this.removeSubscriptions(connectionId);
     this.subscribeRateLimiter.removeConnection(connectionId);
+    this.subscriptionLimitReachedRateLimiter.removeConnection(connectionId);
   }
 
   /**

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -107,6 +107,11 @@ export class Subscriptions {
   private subscriptionMetricsInterval?: NodeJS.Timeout;
   private subscribeRateLimiter: RateLimiter;
   private subscriptionLimitReachedRateLimiter: RateLimiter;
+  // Connection id -> epoch. `subscribe` awaits an initial-response fetch, and the connection can
+  // be torn down during that await. The epoch is captured before the await and re-checked after,
+  // so a late-resolving request can tell that the connection it belongs to is gone.
+  private connectionEpochs: Map<string, number>;
+  private nextConnectionEpoch: number;
   public batchedSubscriptions: { [channel: string]: { [id: string]: SubscriptionInfo[] } };
   public subsByChannelByConnectionId: { [channel: string]: { [connectionId: string]: number } };
   public subscriptionLists: { [connectionId: string]: Subscription[] };
@@ -128,6 +133,8 @@ export class Subscriptions {
       durationMs: config.RATE_LIMIT_SUBSCRIPTION_LIMIT_REACHED_DURATION_MS,
     });
     this.subsByChannelByConnectionId = {};
+    this.connectionEpochs = new Map();
+    this.nextConnectionEpoch = 1;
     this.forwardMessage = undefined;
   }
 
@@ -155,6 +162,30 @@ export class Subscriptions {
       this.subsByChannelByConnectionId[channel][connectionId] = 0;
     }
     return this.subsByChannelByConnectionId[channel][connectionId];
+  }
+
+  /**
+   * Returns the connection's current epoch, assigning one if this is its first subscription.
+   */
+  private currentConnectionEpoch(connectionId: string): number {
+    let epoch: number | undefined = this.connectionEpochs.get(connectionId);
+    if (epoch === undefined) {
+      epoch = this.nextConnectionEpoch;
+      this.nextConnectionEpoch += 1;
+      this.connectionEpochs.set(connectionId, epoch);
+    }
+    return epoch;
+  }
+
+  /**
+   * Whether the connection a request began on has since been torn down.
+   *
+   * `remove` drops the epoch, so any request that captured one before the teardown will see a
+   * mismatch. Without this, an initial-response fetch that resolves after teardown would
+   * recreate the very structures `remove` deleted, and nothing would ever clean them up again.
+   */
+  private isStaleConnection(connectionId: string, epoch: number): boolean {
+    return this.connectionEpochs.get(connectionId) !== epoch;
   }
 
   public removeSubscriptions(connectionId: string): void {
@@ -296,6 +327,9 @@ export class Subscriptions {
     batched?: boolean,
     geoOriginHeaders?: GeoOriginHeaders,
   ): Promise<void> {
+    // Captured before the initial-response await so that a late resolution can detect that the
+    // connection was torn down while it was in flight.
+    const connectionEpoch: number = this.currentConnectionEpoch(connectionId);
     const activeSubscriptions = this.incrementSubscriptions(channel, connectionId);
 
     if (this.forwardMessage === undefined) {
@@ -400,6 +434,11 @@ export class Subscriptions {
     try {
       initialResponse = await this.getInitialResponsesForChannels(channel, id, geoOriginHeaders);
     } catch (error) {
+      if (this.isStaleConnection(connectionId, connectionEpoch)) {
+        // The connection is already gone; do not touch its counters or write to its socket.
+        return;
+      }
+
       logger.info({
         at: 'Subscription#subscribe',
         message: `Making initial request threw error: ${error.message}`,
@@ -446,6 +485,26 @@ export class Subscriptions {
         undefined,
         { channel, instance: getInstanceId() },
       );
+    }
+
+    // The connection may have been dropped or disconnected while the initial response was in
+    // flight. Everything below recreates subscription state, so bail before it resurrects a
+    // connection that has already been cleaned up and will never be cleaned up again.
+    if (this.isStaleConnection(connectionId, connectionEpoch)) {
+      stats.increment(
+        `${config.SERVICE_NAME}.subscription_abandoned_stale_connection`,
+        1,
+        undefined,
+        { channel, instance: getInstanceId() },
+      );
+
+      logger.info({
+        at: 'Subscription#subscribe',
+        message: 'Abandoned subscription for a connection that was removed while in flight',
+        channel,
+        connectionId,
+      });
+      return;
     }
 
     const subscription: Subscription = {
@@ -604,6 +663,8 @@ export class Subscriptions {
     this.removeSubscriptions(connectionId);
     this.subscribeRateLimiter.removeConnection(connectionId);
     this.subscriptionLimitReachedRateLimiter.removeConnection(connectionId);
+    // Invalidate any subscribe request still awaiting its initial response.
+    this.connectionEpochs.delete(connectionId);
   }
 
   /**

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -380,7 +380,8 @@ export class Subscriptions {
           channelSubscriptionsLimit,
           limitAbuseDurationMs,
         );
-        this.decrementSubscriptions(channel, connectionId);
+        // No decrement here: the drop tears the connection down entirely, and decrementing
+        // afterwards would recreate the zero-valued counter that teardown just deleted.
         return;
       }
 

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -65,6 +65,43 @@ const CHANNEL_CONNECTION_LIMITS: { [channel: string]: number } = {
   [Channel.V4_TRADES]: config.V4_TRADES_CHANNEL_LIMIT,
 };
 
+/**
+ * Destroys a websocket without waiting for the close handshake, and records why.
+ *
+ * `terminate` is safe to call on an already-closed socket, so callers do not need to track
+ * whether the peer cooperated.
+ */
+function forceTerminate(ws: WebSocket, connectionId: string, reason: string): void {
+  try {
+    if (ws.readyState === WebSocket.CLOSED) {
+      return;
+    }
+
+    ws.terminate();
+
+    stats.increment(
+      `${config.SERVICE_NAME}.subscriptions_limit_abuse_force_terminate`,
+      1,
+      undefined,
+      { reason, instance: getInstanceId() },
+    );
+
+    logger.info({
+      at: 'subscription#forceTerminate',
+      message: 'Connection destroyed without a completed close handshake',
+      reason,
+      connectionId,
+    });
+  } catch (error) {
+    logger.info({
+      at: 'subscription#forceTerminate',
+      message: `Failed to terminate connection: ${error.message}`,
+      reason,
+      connectionId,
+    });
+  }
+}
+
 export class Subscriptions {
   private forwardMessage?: (message: MessageToForward, connectionId: string) => number;
   private subscriptionMetricsInterval?: NodeJS.Timeout;
@@ -190,6 +227,12 @@ export class Subscriptions {
       RATE_LIMIT_REASON_SUBSCRIPTION_LIMIT_ABUSE,
     );
 
+    // Unsubscribe now rather than waiting for the close event. `ws` keeps the socket alive until
+    // the peer acknowledges the close frame, and the message forwarder would otherwise go on
+    // serializing market data for this connection for the whole of that window -- which is the
+    // cost that caused the incident in the first place.
+    this.remove(connectionId);
+
     try {
       ws.close(
         WS_CLOSE_CODE_SUBSCRIPTION_LIMIT_ABUSE,
@@ -205,7 +248,20 @@ export class Subscriptions {
         message: `Failed to close connection: ${error.message}`,
         connectionId,
       });
+      // A close that never happened leaves the abusive connection fully live, so destroy it now
+      // instead of waiting for a handshake that will not complete.
+      forceTerminate(ws, connectionId, 'close_failed');
+      return;
     }
+
+    // A peer that never returns a close frame keeps its socket -- and its inbound messages --
+    // alive for the `ws` close timeout of 30s. Destroy it well before then. `terminate` is a
+    // no-op once the socket is already closed, so the cooperative case is unaffected.
+    const forceTerminateTimer: NodeJS.Timeout = setTimeout(
+      () => forceTerminate(ws, connectionId, 'close_timeout'),
+      config.SUBSCRIPTION_LIMIT_ABUSE_FORCE_TERMINATE_MS,
+    );
+    forceTerminateTimer.unref();
 
     logger.info({
       at: 'subscription#dropConnectionForSubscriptionLimitAbuse',
@@ -274,10 +330,12 @@ export class Subscriptions {
       // Being at the limit is a normal condition and is answered with an error. Repeatedly
       // hitting it is not: it means the client is retrying instead of respecting the limit, and
       // answering it again just funds the retry loop. Past the allowance, drop the connection.
-      const limitAbuseDurationMs: number = this.subscriptionLimitReachedRateLimiter.rateLimit({
-        connectionId,
-        key: SUBSCRIPTION_LIMIT_REACHED_RATE_LIMIT_KEY,
-      });
+      const limitAbuseDurationMs: number = config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED
+        ? this.subscriptionLimitReachedRateLimiter.rateLimit({
+          connectionId,
+          key: SUBSCRIPTION_LIMIT_REACHED_RATE_LIMIT_KEY,
+        })
+        : 0;
 
       if (limitAbuseDurationMs > 0) {
         this.dropConnectionForSubscriptionLimitAbuse(

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -115,7 +115,13 @@ export class Subscriptions {
   // Connections that exceeded the abuse allowance since the last metrics emit. Counted whether
   // or not the drop is enabled: the size of this set is how many connections the drop would
   // disconnect per interval, which is the number that decides whether it is safe to enable.
+  //
+  // Bounded, because entries are retained until the next emit and a client churning connections
+  // would otherwise grow it unchecked -- most easily while the drop is disabled, since then no
+  // reconnect cooldown slows the churn down. Anything past the cap is counted separately rather
+  // than dropped silently, so the gauge is never quietly understated.
   private subscriptionLimitAbuseCandidates: Set<string>;
+  private subscriptionLimitAbuseOverflow: number;
   public batchedSubscriptions: { [channel: string]: { [id: string]: SubscriptionInfo[] } };
   public subsByChannelByConnectionId: { [channel: string]: { [connectionId: string]: number } };
   public subscriptionLists: { [connectionId: string]: Subscription[] };
@@ -140,6 +146,7 @@ export class Subscriptions {
     this.connectionEpochs = new Map();
     this.nextConnectionEpoch = 1;
     this.subscriptionLimitAbuseCandidates = new Set();
+    this.subscriptionLimitAbuseOverflow = 0;
     this.forwardMessage = undefined;
   }
 
@@ -167,6 +174,25 @@ export class Subscriptions {
       this.subsByChannelByConnectionId[channel][connectionId] = 0;
     }
     return this.subsByChannelByConnectionId[channel][connectionId];
+  }
+
+  /**
+   * Records a connection that exceeded the abuse allowance, up to a bounded cardinality.
+   *
+   * Past the cap the connection is counted as overflow instead. Truncating silently would
+   * understate the very gauge used to decide whether the drop is safe to enable, which could turn
+   * a widespread problem into one that looks confined to a handful of clients.
+   */
+  private recordSubscriptionLimitAbuseCandidate(connectionId: string): void {
+    const maxTracked: number = config.SUBSCRIPTION_LIMIT_ABUSE_MAX_TRACKED_CONNECTIONS;
+    if (this.subscriptionLimitAbuseCandidates.size < maxTracked) {
+      this.subscriptionLimitAbuseCandidates.add(connectionId);
+      return;
+    }
+
+    if (!this.subscriptionLimitAbuseCandidates.has(connectionId)) {
+      this.subscriptionLimitAbuseOverflow += 1;
+    }
   }
 
   /**
@@ -377,7 +403,7 @@ export class Subscriptions {
       });
 
       if (limitAbuseDurationMs > 0) {
-        this.subscriptionLimitAbuseCandidates.add(connectionId);
+        this.recordSubscriptionLimitAbuseCandidate(connectionId);
       }
 
       if (limitAbuseDurationMs > 0 && config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED) {
@@ -1028,7 +1054,15 @@ export class Subscriptions {
         instance: instanceId,
       },
     );
+    stats.gauge(
+      `${config.SERVICE_NAME}.subscriptions_limit_abuse_connections_overflow`,
+      this.subscriptionLimitAbuseOverflow,
+      {
+        instance: instanceId,
+      },
+    );
     this.subscriptionLimitAbuseCandidates.clear();
+    this.subscriptionLimitAbuseOverflow = 0;
 
     Object.entries(maxSubscriptionsByChannel).forEach(([channel, count]) => {
       stats.gauge(

--- a/indexer/services/socks/src/lib/subscription.ts
+++ b/indexer/services/socks/src/lib/subscription.ts
@@ -112,6 +112,10 @@ export class Subscriptions {
   // so a late-resolving request can tell that the connection it belongs to is gone.
   private connectionEpochs: Map<string, number>;
   private nextConnectionEpoch: number;
+  // Connections that exceeded the abuse allowance since the last metrics emit. Counted whether
+  // or not the drop is enabled: the size of this set is how many connections the drop would
+  // disconnect per interval, which is the number that decides whether it is safe to enable.
+  private subscriptionLimitAbuseCandidates: Set<string>;
   public batchedSubscriptions: { [channel: string]: { [id: string]: SubscriptionInfo[] } };
   public subsByChannelByConnectionId: { [channel: string]: { [connectionId: string]: number } };
   public subscriptionLists: { [connectionId: string]: Subscription[] };
@@ -135,6 +139,7 @@ export class Subscriptions {
     this.subsByChannelByConnectionId = {};
     this.connectionEpochs = new Map();
     this.nextConnectionEpoch = 1;
+    this.subscriptionLimitAbuseCandidates = new Set();
     this.forwardMessage = undefined;
   }
 
@@ -364,14 +369,18 @@ export class Subscriptions {
       // Being at the limit is a normal condition and is answered with an error. Repeatedly
       // hitting it is not: it means the client is retrying instead of respecting the limit, and
       // answering it again just funds the retry loop. Past the allowance, drop the connection.
-      const limitAbuseDurationMs: number = config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED
-        ? this.subscriptionLimitReachedRateLimiter.rateLimit({
-          connectionId,
-          key: SUBSCRIPTION_LIMIT_REACHED_RATE_LIMIT_KEY,
-        })
-        : 0;
+      // Evaluated even when the drop is disabled, so that the number of connections this would
+      // affect can be measured in production before anyone turns it on.
+      const limitAbuseDurationMs: number = this.subscriptionLimitReachedRateLimiter.rateLimit({
+        connectionId,
+        key: SUBSCRIPTION_LIMIT_REACHED_RATE_LIMIT_KEY,
+      });
 
       if (limitAbuseDurationMs > 0) {
+        this.subscriptionLimitAbuseCandidates.add(connectionId);
+      }
+
+      if (limitAbuseDurationMs > 0 && config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED) {
         this.dropConnectionForSubscriptionLimitAbuse(
           ws,
           channel,
@@ -666,6 +675,9 @@ export class Subscriptions {
     this.subscriptionLimitReachedRateLimiter.removeConnection(connectionId);
     // Invalidate any subscribe request still awaiting its initial response.
     this.connectionEpochs.delete(connectionId);
+    // Deliberately not pruning subscriptionLimitAbuseCandidates here. The drop itself calls this
+    // method, so removing the entry would undercount exactly the connections being measured. The
+    // set is cleared wholesale on every metrics emit, so it stays bounded either way.
   }
 
   /**
@@ -1004,6 +1016,19 @@ export class Subscriptions {
       });
 
     const instanceId = getInstanceId();
+
+    // Distinct connections over the abuse allowance this interval. Compare against
+    // num_concurrent_connections: a handful means the behaviour is confined to a few bad
+    // clients and the drop is safe to enable; a large fraction means it is not.
+    stats.gauge(
+      `${config.SERVICE_NAME}.subscriptions_limit_abuse_connections`,
+      this.subscriptionLimitAbuseCandidates.size,
+      {
+        enforcing: String(config.SUBSCRIPTION_LIMIT_ABUSE_DROP_ENABLED),
+        instance: instanceId,
+      },
+    );
+    this.subscriptionLimitAbuseCandidates.clear();
 
     Object.entries(maxSubscriptionsByChannel).forEach(([channel, count]) => {
       stats.gauge(

--- a/indexer/services/socks/src/types.ts
+++ b/indexer/services/socks/src/types.ts
@@ -127,6 +127,9 @@ export interface Connection {
   heartbeat?: NodeJS.Timeout,
   disconnect?: NodeJS.Timeout,
   geoOriginHeaders?: GeoOriginHeaders,
+  // Client address as seen past Cloudflare / the load balancer. Used to apply a reconnect
+  // penalty to a client whose connection was dropped for abuse.
+  clientIp?: string,
   id: string,
 }
 

--- a/indexer/services/socks/src/websocket/index.ts
+++ b/indexer/services/socks/src/websocket/index.ts
@@ -6,11 +6,12 @@ import {
 import WebSocket from 'ws';
 
 import config from '../config';
-import { getGeoOriginHeaders } from '../helpers/header-utils';
+import { getClientIp, getGeoOriginHeaders } from '../helpers/header-utils';
 import { createConnectedMessage, createErrorMessage, createUnsubscribedMessage } from '../helpers/message';
 import { sendMessage, Wss } from '../helpers/wss';
 import { ERR_INVALID_WEBSOCKET_FRAME, WS_CLOSE_CODE_SERVICE_RESTART, WS_CLOSE_HEARTBEAT_TIMEOUT } from '../lib/constants';
 import { InvalidMessageHandler } from '../lib/invalid-message';
+import { reconnectPenalty } from '../lib/reconnect-penalty';
 import { Subscriptions } from '../lib/subscription';
 import {
   ALL_CHANNELS,
@@ -89,12 +90,17 @@ export class Index {
     const instanceId: string = getInstanceId();
 
     const connectionId: string = randomUUID();
+    const clientIp: string | undefined = getClientIp(req);
     this.connections[connectionId] = {
       ws,
       messageId: 0,
       id: connectionId,
       geoOriginHeaders: getGeoOriginHeaders(req),
+      clientIp,
     } as Connection;
+    // Record the address so that whichever layer drops this connection can penalise the client
+    // without having to carry the request headers around.
+    reconnectPenalty.trackConnection(connectionId, clientIp);
     const connection: Connection = this.connections[connectionId];
 
     const numConcurrentConnections: number = Object.keys(this.connections).length;
@@ -437,6 +443,7 @@ export class Index {
 
       this.subscriptions.remove(connectionId);
       this.invalidMessageHandler.handleDisconnect(connectionId);
+      reconnectPenalty.removeConnection(connectionId);
       delete this.connections[connectionId];
     } catch (error) {
       logger.error({

--- a/indexer/services/socks/src/websocket/index.ts
+++ b/indexer/services/socks/src/websocket/index.ts
@@ -247,6 +247,22 @@ export class Index {
       return;
     }
 
+    // A peer that ignores our close frame keeps delivering messages until `ws` gives up on the
+    // close handshake. Once the socket is no longer OPEN the connection is doomed, so do no
+    // further work for it -- not even parsing the payload.
+    if (connection.ws.readyState !== WebSocket.OPEN) {
+      stats.increment(
+        `${config.SERVICE_NAME}.message_dropped_not_open`,
+        1,
+        config.MESSAGE_FORWARDER_STATSD_SAMPLE_RATE,
+        {
+          instance: instanceId,
+          readyState: String(connection.ws.readyState),
+        },
+      );
+      return;
+    }
+
     let parsed: IncomingMessage;
     try {
       parsed = JSON.parse(message.toString());


### PR DESCRIPTION
Drops socks websocket connections that repeatedly ignore the per-connection subscription limit, and refuses their reconnect handshakes with an HTTP 429 so Cloudflare can throttle the retry storm. Supersedes the previous behaviour, where an over-limit subscribe was answered with an error and the connection was left open at no cost to the client.

## What it is

On 2026-08-26 05:15–05:25Z a single client held ~693 orderbook and ~706 trades subscriptions against one socks instance while continuously re-sending subscribe requests. CPU saturated on socket writes and JSON serialization, Kafka consumption fell behind, and every other client that landed on that instance saw stale market data. Trading and comlink were unaffected.

Two controls existed and the pattern slipped between them:

- The per-channel subscription cap answered each over-limit subscribe with an error, left the connection open, and returned before the subscribe rate limiter was consulted.
- The subscribe rate limiter does close connections, but its counter is scoped per channel-and-market. A client cycling through hundreds of distinct markets gets a fresh allowance for each and never trips it.

Where enforcement now sits:

```
client ──▶ Cloudflare ──▶ ALB ──▶ socks
              │                     │
              │                     │  (1) close 4008 after
              │                     │      repeated limit hits
              │                     │
              │  (2) 429 + reason header on
              │      reconnect handshake
              └───── edge rule counts the 429s,
                     blocks for longer than the origin cooldown
```

(1) and the origin half of (2) are in this PR. The matching Cloudflare rule is console-managed and specified in the doc added here.

A websocket close frame is invisible to the edge — Cloudflare proxies the tunnelled connection without inspecting frames, so "this client was dropped" is not something a rate-limiting rule can match on. The handshake is ordinary HTTP, so refusing it with a 429 is what gives the edge something countable.

Deployment shape: no infrastructure change required. New behaviour is on by default with in-code defaults, and every threshold is env-tunable without shipping a new image.

## Capabilities

| Property | What the system delivers |
|---|---|
| Abuse detection scope | Per connection, across every channel and market it touches — not per channel/market pair |
| Normal-path behaviour | Reaching the limit stays recoverable; a bounded number of hits is answered with an error, connection intact |
| Enforcement action | Connection closed with a dedicated close code, distinct from the generic rate-limit close, carrying the reason and retry delay |
| Client feedback | Machine-readable reason and retry delay in both the close frame and the refused handshake |
| Edge integration | Refused reconnects surface as HTTP 429 with a retry hint and a reason header — countable and matchable by an edge rate-limiting rule |
| Client attribution | Cloudflare-supplied client address, falling back to the left-most forwarded address, then the socket peer |
| Cooldown scope | Per-instance, in-memory; cross-instance enforcement delegated to the edge |
| Memory bound | Cooldown tracking is capped, evicting expired entries first, then the soonest to expire |
| Failure isolation | Send and close failures during a drop are contained and cannot abort the drop or the request path |
| Kill switches | Handshake refusal disables independently of the connection drop; the existing global rate-limit switch disables both |
| Observability | Separate counters for drops, cooldown entries, and refused handshakes; drops are also attributable through the existing disconnect counter by close code |

## Testing

**Unit — new (jest, `services/socks`).** 25 cases across three surfaces: cooldown lifecycle (apply, expiry, extension on repeat, per-client isolation, survival past the connection that earned it, eviction bound, disabled); client-address derivation precedence (Cloudflare header, forwarded list, repeated header, socket fallback, empty values); handshake verification (accept, 429 shape, retry-hint rounding, expiry, non-offender, unknown address).

**Unit — existing suite, extended.** 4 cases on the drop path: allowance respected then exceeded, close code and payload contents, client-facing message, cooldown applied, and allowance spent across channels rather than refreshed per channel.

**Regression.** Full socks suite, 122/122 across 8 suites, with Postgres and Kafka running.

**Static.** eslint clean on changed files; no new type errors.

Environment note for reviewers: this checkout's fake timers are incompatible with Node 20/22 and fail on pre-existing, untouched lines — run the suite under Node 16. The new tests do not use fake timers.

## Reviewer brief

Load-bearing:

- `indexer/services/socks/src/lib/subscription.ts` — the enforcement branch and drop path. Confirm the abuse counter is consulted before the error is sent, and that the subscription counter is decremented on every exit path.
- `indexer/services/socks/src/lib/reconnect-penalty.ts` — cooldown state, eviction, connection-to-address mapping. Confirm the cooldown outlives the connection that earned it.
- `indexer/services/socks/src/helpers/wss.ts` — handshake verification. Confirm a fault here cannot reject legitimate traffic.
- `indexer/services/socks/docs/subscription-limit-abuse.md` — the Cloudflare rule spec.

Everything else is mechanical.

Risks worth a second look:

- **Shared-address collateral.** The cooldown is keyed on client address, so NAT and corporate egress users can be caught by another party's behaviour. Bounded by a short default and by requiring a single connection to exhaust its allowance first, and the handshake refusal has its own kill switch — but this is the change's main blast-radius question.
- **Threshold sizing.** Defaults were chosen on judgement, not measured against the offender's observed retry rate; Datadog was not reachable during this work. Worth sizing against the existing limit-reached counter before rollout.
- **Forwarded-address trust.** The forwarded-address fallback is trusted, and is only reached when the Cloudflare header is absent — which should not occur for proxied traffic. The socket fallback covers direct and health-check traffic.
- **Close-code choice.** 4008 is in the private-use range and deliberately distinct from the 1008 used by existing rate-limit closes.

## Out of scope

- Applying the Cloudflare rate-limiting rule. `dydx.trade` is not a zone in `cloudflare-terraform`, so this is a console change; the spec is in the doc and needs a follow-up ticket.
- Cross-instance cooldown sharing — delegated to the edge by design.
- Attribution for the 2026-08-26 incident. ALB access logs record Cloudflare edge addresses only, so the offender is not identifiable from them; that requires Cloudflare analytics. The `danger-prod` credentials are separately invalid and need rotation.
- Tuning thresholds against production telemetry.

## Test plan

- [x] New unit tests pass
- [x] Full socks suite passes (122/122)
- [x] Lint and type checks clean on changed files
- [ ] Thresholds sized against the production limit-reached rate
- [ ] Cloudflare rule applied and verified end to end
- [ ] 429s confirmed visible in Cloudflare analytics for the socks path

https://claude.ai/code/session_016Safgxa1oY9vGVD8MUaB1r


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protection against repeated subscription-limit violations on WebSocket connections.
  * Excessive violations close connections with an abuse reason and temporarily block reconnect attempts.
  * Blocked reconnects return HTTP 429 responses with retry timing and rate-limit details.
  * Added configurable abuse thresholds, penalty duration, client tracking, forced termination, and forwarded-header trust.
  * Improved client address detection through proxy and Cloudflare headers.
  * Closed connections no longer process incoming messages or stale subscription responses.
* **Documentation**
  * Expanded guidance on abuse handling, proxy detection, metrics, and rate limiting.
* **Tests**
  * Expanded coverage for penalties, reconnects, subscriptions, address detection, and teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->