### PR TITLE
Block protected module accounts as transfer sources in sending, vest, and rewards

### DIFF
--- a/protocol/app/app.go
+++ b/protocol/app/app.go
@@ -1073,6 +1073,7 @@ func New(
 	app.VestKeeper = *vestmodulekeeper.NewKeeper(
 		appCodec,
 		keys[vestmoduletypes.StoreKey],
+		app.AccountKeeper,
 		app.BankKeeper,
 		app.BlockTimeKeeper,
 		// set the governance and delaymsg module accounts as the authority for conducting upgrades

--- a/protocol/lib/protectedaccounts/protected_accounts.go
+++ b/protocol/lib/protectedaccounts/protected_accounts.go
@@ -1,0 +1,20 @@
+// Package protectedaccounts defines module accounts whose balances back
+// protocol invariants (staked funds, subaccount collateral) and therefore must
+// never be configurable as the source of outbound transfers (gov-directed
+// sends, vest entries, reward treasuries).
+package protectedaccounts
+
+import (
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
+)
+
+var protectedModuleNames = map[string]bool{
+	stakingtypes.BondedPoolName:    true,
+	stakingtypes.NotBondedPoolName: true,
+	satypes.ModuleName:             true,
+}
+
+func IsProtectedModuleName(moduleName string) bool {
+	return protectedModuleNames[moduleName]
+}

--- a/protocol/testutil/keeper/vest.go
+++ b/protocol/testutil/keeper/vest.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
 	blocktimekeeper "github.com/dydxprotocol/v4-chain/protocol/x/blocktime/keeper"
@@ -44,6 +45,7 @@ func VestKeepers(
 			stateStore,
 			db,
 			cdc,
+			accountKeeper,
 			bankKeeper,
 			blocktimeKeeper,
 			authorities,
@@ -57,12 +59,13 @@ func createVestKeeper(
 	stateStore storetypes.CommitMultiStore,
 	db *dbm.MemDB,
 	cdc codec.BinaryCodec,
+	accountKeeper *authkeeper.AccountKeeper,
 	bankKeeper *bankkeeper.BaseKeeper,
 	blocktimeKeeper *blocktimekeeper.Keeper,
 	authorities []string,
 ) (*keeper.Keeper, *storetypes.KVStoreKey) {
 	vestStoreKey := storetypes.NewKVStoreKey(types.StoreKey)
-	vestKeeper := keeper.NewKeeper(cdc, vestStoreKey, bankKeeper, blocktimeKeeper, authorities)
+	vestKeeper := keeper.NewKeeper(cdc, vestStoreKey, accountKeeper, bankKeeper, blocktimeKeeper, authorities)
 	stateStore.MountStoreWithDB(vestStoreKey, storetypes.StoreTypeIAVL, db)
 	return vestKeeper, vestStoreKey
 }

--- a/protocol/x/rewards/keeper/keeper.go
+++ b/protocol/x/rewards/keeper/keeper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/dydxprotocol/v4-chain/protocol/dtypes"
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	"github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
@@ -370,7 +371,10 @@ func (k Keeper) ProcessRewardsForBlock(
 	rewardTokenAmount := new(big.Int).Div(rewardTokenAmountPpm, lib.BigIntOneMillion())
 
 	// Calculate value of `T`, the reward tokens balance in the `treasury_account`.
-	rewardTokenBalance := k.bankKeeper.GetBalance(ctx, types.TreasuryModuleAddress, params.Denom)
+	// Read from the same account that distribution debits below, so the cap
+	// always bounds the actual outflow.
+	treasuryModuleAddress := authtypes.NewModuleAddress(params.TreasuryAccount)
+	rewardTokenBalance := k.bankKeeper.GetBalance(ctx, treasuryModuleAddress, params.Denom)
 
 	// Get tokenToDistribute as the min(F, T).
 	tokensToDistribute := lib.BigMin(rewardTokenBalance.Amount.BigInt(), rewardTokenAmount)
@@ -446,7 +450,7 @@ func (k Keeper) ProcessRewardsForBlock(
 	)
 
 	// Measure treasury balance after distribution.
-	remainingTreasuryBalance := k.bankKeeper.GetBalance(ctx, types.TreasuryModuleAddress, params.Denom)
+	remainingTreasuryBalance := k.bankKeeper.GetBalance(ctx, treasuryModuleAddress, params.Denom)
 	telemetry.SetGauge(
 		metrics.GetMetricValueFromBigInt(remainingTreasuryBalance.Amount.BigInt()),
 		types.ModuleName,

--- a/protocol/x/rewards/keeper/params_test.go
+++ b/protocol/x/rewards/keeper/params_test.go
@@ -45,6 +45,14 @@ func TestParams_Validate(t *testing.T) {
 			expErrMsg: "treasury account cannot have empty name",
 		},
 		{
+			name: "protected treasury account",
+			input: types.Params{
+				TreasuryAccount: "bonded_tokens_pool",
+				Denom:           "foo",
+			},
+			expErrMsg: "is a protected module account",
+		},
+		{
 			name: "invalid denom",
 			input: types.Params{
 				TreasuryAccount: "treasury_account",

--- a/protocol/x/rewards/types/params.go
+++ b/protocol/x/rewards/types/params.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/protectedaccounts"
 )
 
 // DefaultParams returns a default set of parameters
@@ -22,6 +23,14 @@ func DefaultParams() Params {
 func (p Params) Validate() error {
 	if p.TreasuryAccount == "" {
 		return errorsmod.Wrap(ErrInvalidTreasuryAccount, "treasury account cannot have empty name")
+	}
+
+	if protectedaccounts.IsProtectedModuleName(p.TreasuryAccount) {
+		return errorsmod.Wrapf(
+			ErrInvalidTreasuryAccount,
+			"treasury account '%s' is a protected module account",
+			p.TreasuryAccount,
+		)
 	}
 
 	if p.FeeMultiplierPpm > lib.OneMillion {

--- a/protocol/x/sending/keeper/transfer.go
+++ b/protocol/x/sending/keeper/transfer.go
@@ -7,9 +7,11 @@ import (
 	indexerevents "github.com/dydxprotocol/v4-chain/protocol/indexer/events"
 	indexer_manager "github.com/dydxprotocol/v4-chain/protocol/indexer/indexer_manager"
 
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dydxprotocol/v4-chain/protocol/lib/metrics"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/protectedaccounts"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
 	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	gometrics "github.com/hashicorp/go-metrics"
@@ -208,6 +210,16 @@ func (k Keeper) SendFromModuleToAccount(
 ) (err error) {
 	if err = msg.ValidateBasic(); err != nil {
 		return err
+	}
+
+	// Also enforced in ValidateBasic; re-checked next to the bank call so the
+	// guard survives refactors of msg validation.
+	if protectedaccounts.IsProtectedModuleName(msg.GetSenderModuleName()) {
+		return errorsmod.Wrapf(
+			types.ErrBlockedSenderModule,
+			"sender module '%s'",
+			msg.GetSenderModuleName(),
+		)
 	}
 
 	return k.bankKeeper.SendCoinsFromModuleToAccount(

--- a/protocol/x/sending/keeper/transfer_test.go
+++ b/protocol/x/sending/keeper/transfer_test.go
@@ -16,6 +16,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	keepertest "github.com/dydxprotocol/v4-chain/protocol/testutil/keeper"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/sample"
@@ -599,6 +600,26 @@ func TestSendFromModuleToAccount_InvalidMsg(t *testing.T) {
 	ks := keepertest.SendingKeepers(t)
 	err := ks.SendingKeeper.SendFromModuleToAccount(ks.Ctx, msgEmptySender)
 	require.ErrorContains(t, err, "Module name is empty")
+}
+
+func TestSendFromModuleToAccount_BlockedSenderModule(t *testing.T) {
+	ks := keepertest.SendingKeepers(t)
+	for _, senderModule := range []string{
+		stakingtypes.BondedPoolName,
+		stakingtypes.NotBondedPoolName,
+		satypes.ModuleName,
+	} {
+		err := ks.SendingKeeper.SendFromModuleToAccount(
+			ks.Ctx,
+			&types.MsgSendFromModuleToAccount{
+				Authority:        lib.GovModuleAddress.String(),
+				SenderModuleName: senderModule,
+				Recipient:        constants.AliceAccAddress.String(),
+				Coin:             sdk.NewCoin("adv4tnt", sdkmath.NewInt(100)),
+			},
+		)
+		require.ErrorIs(t, err, types.ErrBlockedSenderModule)
+	}
 }
 
 func TestSendFromModuleToAccount_NonExistentSenderModule(t *testing.T) {

--- a/protocol/x/sending/types/errors.go
+++ b/protocol/x/sending/types/errors.go
@@ -18,6 +18,11 @@ var (
 	ErrInvalidAccountAddress              = errorsmod.Register(ModuleName, 6, "Account address is invalid")
 	ErrEmptyModuleName                    = errorsmod.Register(ModuleName, 7, "Module name is empty")
 	ErrInvalidAuthority                   = errorsmod.Register(ModuleName, 8, "Authority is invalid")
+	ErrBlockedSenderModule                = errorsmod.Register(
+		ModuleName,
+		9,
+		"Module is not allowed to send funds via MsgSendFromModuleToAccount",
+	)
 	ErrNonUsdcAssetTransferNotImplemented = errorsmod.Register(
 		ModuleName,
 		1101,

--- a/protocol/x/sending/types/message_send_from_module_to_account.go
+++ b/protocol/x/sending/types/message_send_from_module_to_account.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/protectedaccounts"
 )
 
 var _ sdk.Msg = &MsgSendFromModuleToAccount{}
@@ -41,6 +42,11 @@ func (msg *MsgSendFromModuleToAccount) ValidateBasic() error {
 	// Validate sender module name is non-empty.
 	if len(msg.SenderModuleName) == 0 {
 		return ErrEmptyModuleName
+	}
+
+	// Validate sender module is not a protected module account.
+	if protectedaccounts.IsProtectedModuleName(msg.SenderModuleName) {
+		return errorsmod.Wrapf(ErrBlockedSenderModule, "sender module '%s'", msg.SenderModuleName)
 	}
 
 	// Validate account recipient.

--- a/protocol/x/sending/types/message_send_from_module_to_account_test.go
+++ b/protocol/x/sending/types/message_send_from_module_to_account_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/dydxprotocol/v4-chain/protocol/testutil/constants"
 	"github.com/dydxprotocol/v4-chain/protocol/x/sending/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,6 +52,33 @@ func TestMsgSendFromModuleToAccount_ValidateBasic(t *testing.T) {
 				Coin:             sdk.NewCoin("adv4tnt", sdkmath.NewInt(100)),
 			},
 			err: types.ErrEmptyModuleName,
+		},
+		"Blocked sender module name - bonded_tokens_pool": {
+			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
+				SenderModuleName: stakingtypes.BondedPoolName,
+				Recipient:        constants.BobAccAddress.String(),
+				Coin:             sdk.NewCoin("adv4tnt", sdkmath.NewInt(100)),
+			},
+			err: types.ErrBlockedSenderModule,
+		},
+		"Blocked sender module name - not_bonded_tokens_pool": {
+			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
+				SenderModuleName: stakingtypes.NotBondedPoolName,
+				Recipient:        constants.BobAccAddress.String(),
+				Coin:             sdk.NewCoin("adv4tnt", sdkmath.NewInt(100)),
+			},
+			err: types.ErrBlockedSenderModule,
+		},
+		"Blocked sender module name - subaccounts": {
+			msg: types.MsgSendFromModuleToAccount{
+				Authority:        validAuthority,
+				SenderModuleName: satypes.ModuleName,
+				Recipient:        constants.BobAccAddress.String(),
+				Coin:             sdk.NewCoin("adv4tnt", sdkmath.NewInt(100)),
+			},
+			err: types.ErrBlockedSenderModule,
 		},
 		"Invalid recipient address": {
 			msg: types.MsgSendFromModuleToAccount{

--- a/protocol/x/vest/keeper/keeper.go
+++ b/protocol/x/vest/keeper/keeper.go
@@ -24,6 +24,7 @@ type (
 	Keeper struct {
 		cdc             codec.BinaryCodec
 		storeKey        storetypes.StoreKey
+		accountKeeper   types.AccountKeeper
 		bankKeeper      types.BankKeeper
 		blockTimeKeeper types.BlockTimeKeeper
 		authorities     map[string]struct{}
@@ -33,6 +34,7 @@ type (
 func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeKey storetypes.StoreKey,
+	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
 	blockTimeKeeper types.BlockTimeKeeper,
 	authorities []string,
@@ -40,6 +42,7 @@ func NewKeeper(
 	return &Keeper{
 		cdc:             cdc,
 		storeKey:        storeKey,
+		accountKeeper:   accountKeeper,
 		bankKeeper:      bankKeeper,
 		blockTimeKeeper: blockTimeKeeper,
 		authorities:     lib.UniqueSliceToSet(authorities),
@@ -107,6 +110,21 @@ func (k Keeper) ProcessVesting(ctx sdk.Context) {
 		}
 
 		if !vestAmount.IsZero() {
+			// An unregistered module account makes SendCoinsFromModuleToModule panic,
+			// which would halt the chain since this runs in BeginBlocker. Skip instead.
+			if k.accountKeeper.GetModuleAddress(entry.VesterAccount) == nil ||
+				k.accountKeeper.GetModuleAddress(entry.TreasuryAccount) == nil {
+				log.ErrorLog(
+					ctx,
+					"unexpected internal error: vest entry references unregistered module account",
+					"vester_account",
+					entry.VesterAccount,
+					"treasury_account",
+					entry.TreasuryAccount,
+				)
+				telemetry.IncrCounter(1, metrics.ProcessVesting, metrics.AccountTransfer, metrics.Error)
+				continue
+			}
 			// Transfer vest_amount from vester_account to treasury_account.
 			// Since `vest_amount = min(vest_proportion, 1) * vester_balance`,
 			// we must have `vest_amount <= vester_balance`

--- a/protocol/x/vest/keeper/keeper_test.go
+++ b/protocol/x/vest/keeper/keeper_test.go
@@ -250,6 +250,20 @@ func TestProcessVesting(t *testing.T) {
 			expectedTreasuryBalance: sdkmath.NewInt(0),
 			expectedVesterBalance:   sdkmath.NewInt(0),
 		},
+		"unregistered module accounts are skipped without panicking": {
+			vesterBalance: sdkmath.NewInt(1_000_000),
+			vestEntry: types.VestEntry{
+				VesterAccount:   "unregistered_vester",
+				TreasuryAccount: "unregistered_treasury",
+				Denom:           testVestTokenDenom,
+				StartTime:       time.Unix(0, 0).In(time.UTC),
+				EndTime:         time.Unix(2000, 0).In(time.UTC),
+			},
+			prevBlockTime:           time.Unix(1000, 0),
+			blockTime:               time.Unix(1001, 0),
+			expectedVesterBalance:   sdkmath.NewInt(1_000_000),
+			expectedTreasuryBalance: sdkmath.NewInt(0),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			tApp := testapp.NewTestAppBuilder(t).WithGenesisDocFn(func() (genesis cometbfttypes.GenesisDoc) {
@@ -289,7 +303,7 @@ func TestProcessVesting(t *testing.T) {
 			require.Equal(t,
 				tc.expectedVesterBalance,
 				tApp.App.BankKeeper.GetBalance(
-					ctx, authtypes.NewModuleAddress(testVesterAccount),
+					ctx, authtypes.NewModuleAddress(tc.vestEntry.VesterAccount),
 					testVestTokenDenom,
 				).Amount,
 			)
@@ -297,7 +311,7 @@ func TestProcessVesting(t *testing.T) {
 			require.Equal(t,
 				tc.expectedTreasuryBalance,
 				tApp.App.BankKeeper.GetBalance(
-					ctx, authtypes.NewModuleAddress(testTreasuryAccount),
+					ctx, authtypes.NewModuleAddress(tc.vestEntry.TreasuryAccount),
 					testVestTokenDenom,
 				).Amount,
 			)

--- a/protocol/x/vest/types/expected_keepers.go
+++ b/protocol/x/vest/types/expected_keepers.go
@@ -12,6 +12,12 @@ type BankKeeper interface {
 	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
 }
 
+// AccountKeeper defines the expected interface for checking module account registration.
+type AccountKeeper interface {
+	// GetModuleAddress returns nil iff the module account is not registered.
+	GetModuleAddress(name string) sdk.AccAddress
+}
+
 type BlockTimeKeeper interface {
 	GetPreviousBlockInfo(ctx sdk.Context) blocktimetypes.BlockInfo
 }

--- a/protocol/x/vest/types/vest_entry.go
+++ b/protocol/x/vest/types/vest_entry.go
@@ -3,6 +3,7 @@ package types
 import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dydxprotocol/v4-chain/protocol/lib/protectedaccounts"
 )
 
 func (entry VestEntry) Validate() error {
@@ -12,6 +13,22 @@ func (entry VestEntry) Validate() error {
 
 	if entry.TreasuryAccount == "" {
 		return errorsmod.Wrap(ErrInvalidTreasuryAccount, "treasury account cannot be empty")
+	}
+
+	if protectedaccounts.IsProtectedModuleName(entry.VesterAccount) {
+		return errorsmod.Wrapf(
+			ErrInvalidVesterAccount,
+			"vester account '%s' is a protected module account",
+			entry.VesterAccount,
+		)
+	}
+
+	if protectedaccounts.IsProtectedModuleName(entry.TreasuryAccount) {
+		return errorsmod.Wrapf(
+			ErrInvalidTreasuryAccount,
+			"treasury account '%s' is a protected module account",
+			entry.TreasuryAccount,
+		)
 	}
 
 	if err := sdk.ValidateDenom(entry.Denom); err != nil {

--- a/protocol/x/vest/types/vest_entry_test.go
+++ b/protocol/x/vest/types/vest_entry_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	time "time"
 
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	satypes "github.com/dydxprotocol/v4-chain/protocol/x/subaccounts/types"
 	"github.com/dydxprotocol/v4-chain/protocol/x/vest/types"
 	"github.com/stretchr/testify/require"
 )
@@ -45,6 +47,28 @@ func TestValidate(t *testing.T) {
 				Denom:           "testdenom",
 				StartTime:       now.Add(-1 * time.Hour).In(time.UTC),
 				EndTime:         now.In(time.UTC),
+			},
+			expectedErr: types.ErrInvalidTreasuryAccount,
+		},
+		{
+			desc: "protected vester account",
+			entry: types.VestEntry{
+				VesterAccount:   stakingtypes.BondedPoolName,
+				TreasuryAccount: "test_treasury",
+				Denom:           "testdenom",
+				StartTime:       now.Add(-1 * time.Hour).In(time.UTC),
+				EndTime:         now,
+			},
+			expectedErr: types.ErrInvalidVesterAccount,
+		},
+		{
+			desc: "protected treasury account",
+			entry: types.VestEntry{
+				VesterAccount:   "test_vester",
+				TreasuryAccount: satypes.ModuleName,
+				Denom:           "testdenom",
+				StartTime:       now.Add(-1 * time.Hour).In(time.UTC),
+				EndTime:         now,
 			},
 			expectedErr: types.ErrInvalidTreasuryAccount,
 		},


### PR DESCRIPTION
Add lib/protectedaccounts defining module accounts whose balances back protocol invariants (bonded_tokens_pool, not_bonded_tokens_pool, subaccounts) and enforce it wherever governance can configure an outbound transfer source:

- x/sending: MsgSendFromModuleToAccount rejects protected senders in ValidateBasic and again in the keeper next to the bank call.
- x/vest: VestEntry.Validate rejects protected vester/treasury accounts; ProcessVesting skips entries referencing unregistered module accounts instead of panicking in BeginBlocker (vest keeper now takes an account keeper).
- x/rewards: Params.Validate rejects a protected treasury, and the distribution cap now reads the balance of the account actually debited (params.TreasuryAccount) rather than the hardcoded treasury.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented transfers from protected protocol accounts that back staking and collateral.
  - Rejected treasury, vester, and vesting account configurations that use protected module accounts.
  - Improved vesting reliability by safely skipping entries when required module accounts are not registered, instead of failing unexpectedly.
  - Treasury reward processing now uses the configured treasury account consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->